### PR TITLE
Prepare public onboarding and release safeguards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Scan Git history for secrets
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: "false"
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
+          GITLEAKS_VERSION: "8.30.1"
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.12.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Plugin and connector checks
+        run: npm run test:plugin && npm run test:connector
+
+      - name: Style and accessibility guards
+        run: npm run check:css-tokens && npm run check:aria-controls
+
+      - name: Build distributables
+        run: npm run build:motif
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Browser workflows
+        run: npm run test:e2e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 0.2.1 — 2026-07-13
+
+- Added the Motif-owned Claude Science local connector, setup doctor, and
+  connector-created interactive HTML workbench.
+- Documented the exact folder grant, full relaunch, reconnect, and reliable
+  click-to-open workflow for current Claude Science builds.
+- Added bounded record identity summaries, deterministic plugin packaging,
+  complete bundled dependency license notices, and public support guidance.
+- Preserved the full Motif workbench across embedded, wide, narrow, light, and
+  dark layouts.
+
+## 0.2.0 — 2026-07-13
+
+- Added the full-workbench MCP App declaration, FASTA/GenBank input contracts,
+  and portable HTML fallback.
+- Kept the Motif identity visible across embedded frame sizes.
+
+## 0.1.0 — 2026-07-13
+
+- Introduced the standalone Motif molecular-biology workbench and Claude
+  plugin, including sequence/map review, MSA, Sanger traces, cloning design,
+  notes, typed results, and explicit checkpoint exports.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,17 @@
 
 Motif is a portable molecular-biology workbench built for the Claude Science
 hackathon. It turns sequence records and analysis results into one
-self-contained HTML workspace that can be opened locally or mounted as a
-Claude Science MCP App, inspected visually, edited with mouse and keyboard,
-checkpointed, and shared as an ordinary file.
+self-contained HTML workspace that can be opened locally or in Claude
+Science, inspected visually, edited with mouse and keyboard, checkpointed, and
+shared as an ordinary file. Motif also declares a live MCP App; whether a local
+connector mounts automatically depends on the Claude Science host build.
 
 This repository is the standalone Motif source. It contains no desktop shell
 or native database. Its optional `motif-local` connector is ephemeral and
 Motif-owned; it does not depend on another application checkout.
+
+Motif is an independent hackathon project and is not an Anthropic product or
+an official Claude Science integration.
 
 ## What is included
 
@@ -31,7 +35,7 @@ Motif-owned; it does not depend on another application checkout.
 Requires Node.js 22.12 or newer.
 
 ```bash
-npm install
+npm ci
 npm run preview:motif
 ```
 
@@ -40,6 +44,35 @@ Open `preview/motif-artifact.html`, or start an editable Vite session with:
 ```bash
 npm run dev
 ```
+
+## First success in Claude Science
+
+Install the local connector from a fixed checkout:
+
+```bash
+npm run claude-science:setup
+```
+
+Grant Claude Science access to that exact checkout, fully quit and reopen the
+app, then reconnect **motif-local**. The connector should expose exactly
+`motif_open_workbench` and `motif_create_workbench_artifact`.
+
+For the most reliable first visual result, attach the bundled synthetic
+[`examples/motif-demo.gb`](examples/motif-demo.gb) and ask Claude Science:
+
+```text
+Read the complete text of motif-demo.gb, including ORIGIN. Call motif-local's
+motif_create_workbench_artifact exactly once with filename "motif-demo.gb",
+the complete content, title "Motif demo — MOTIFDEMO", and outputFilename
+"motif-demo-workbench.html". Preserve the exact returned HTML as a Claude
+Science artifact and open it in the right pane. Report the record name,
+topology, and residue count.
+```
+
+Clicking the generated HTML once is normal. It opens the full interactive
+workbench as an immutable snapshot. See the
+[Claude Science quickstart](docs/CLAUDE_SCIENCE_QUICKSTART.md) for permission,
+verification, and optional live-App steps.
 
 ## Build the distributable
 
@@ -66,6 +99,10 @@ The HTML and MCP App are self-contained: Vite's JavaScript and CSS assets are
 inlined, and the plugin contains its compiled connector, App, standalone
 template, and artifact resource. The ZIP is deterministic and its file/archive
 SHA-256 values are recorded beside it.
+
+The plugin ZIP is for Claude/plugin hosts. It does not by itself install the
+Claude Science local connector; use `npm run claude-science:setup` from the
+source checkout for that workflow.
 
 To generate an additional repo-local artifact with preloaded data:
 
@@ -133,15 +170,21 @@ Known host errors, reload boundaries, and visual acceptance steps are in the
 
 ## Data safety
 
-Motif runs locally and does not transmit sequence data by itself. External MSA
-tools run only when explicitly invoked outside the HTML. Workspace exports are
-ordinary unencrypted files; keep sensitive data under an appropriate local
-storage and backup policy.
+Motif has no hosted backend and does not transmit sequence data by itself.
+External MSA tools run only when explicitly invoked outside the HTML. Data you
+provide to Claude Science remains subject to your Claude and organization data
+policies. Do not use sensitive or unpublished sequences without authorization.
+Workspace exports are ordinary unencrypted files; keep them under an
+appropriate local storage and backup policy.
 
 See the plugin [README](src/artifacts/motif-for-claude-science-plugin/README.md)
 for payload, MSA, Sanger, installation, and security details.
 The public [capability reference](docs/CAPABILITIES.md) distinguishes built-in
 analysis from externally produced results that Motif can store and display.
+
+For project support and release information, see [SUPPORT.md](SUPPORT.md),
+[SECURITY.md](SECURITY.md), [CHANGELOG.md](CHANGELOG.md), and
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please use the repository's
+[GitHub private vulnerability reporting form](https://github.com/jvogan/motif/security/advisories/new).
+Do not open a public issue for a suspected security problem or include sensitive
+details in any public discussion.
+
+Never include unpublished or sensitive sequence data, credentials, local MCP
+configuration, full filesystem paths, or Claude Science workspace exports in a
+report. Use a minimal synthetic sequence when a reproduction needs biological
+input.
+
+## Supported versions
+
+Security fixes target the latest tagged Motif release. Older artifacts are
+immutable snapshots and should be regenerated after updating Motif.
+
+## Data boundary
+
+Motif has no hosted backend and the local connector does not intentionally
+upload sequence data. Content supplied to Claude Science remains subject to
+the user's Claude and organization data policies. Database JSON, workspace ZIP,
+and generated HTML files are ordinary unencrypted files; protect them according
+to the sensitivity of their contents.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,28 @@
+# Support
+
+Start with the [Claude Science quickstart](docs/CLAUDE_SCIENCE_QUICKSTART.md)
+and [troubleshooting guide](docs/CLAUDE_SCIENCE_TROUBLESHOOTING.md).
+
+Before opening an issue, run:
+
+```bash
+npm run claude-science:check-local
+npm run claude-science:doctor
+```
+
+For a reproducible public issue, include:
+
+- Motif version or commit;
+- macOS, Node.js, and Claude Science versions;
+- whether both `motif-local` tools appear;
+- the failing step and exact public-safe error text; and
+- whether the connector-created HTML workbench opens in the right pane.
+
+Do not attach sequence payloads, workspace exports, connector configuration,
+credentials, private paths, or unredacted logs. Reproduce with a small public
+or synthetic record. A successful tool result without an automatically mounted
+live frame may be a Claude Science host limitation; the connector-created HTML
+workbench is the supported visual fallback.
+
+Security reports belong in GitHub's private vulnerability reporting flow, not
+in a public support issue. See [SECURITY.md](SECURITY.md).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,21 @@
+# Third-party notices
+
+Motif is distributed under the MIT License in `LICENSE`. The source repository
+depends on the open-source packages recorded in `package.json` and
+`package-lock.json`.
+
+Motif's self-contained browser artifact includes compiled portions of React,
+React DOM, and Lucide. The optional connector and MCP App additionally include
+compiled portions of the Model Context Protocol TypeScript SDK, MCP Apps SDK,
+Zod, Ajv, ajv-formats, fast-deep-equal, fast-uri, json-schema-traverse, and
+zod-to-json-schema.
+
+The canonical redistribution notices are maintained in
+[`src/artifacts/motif-for-claude-science-plugin/THIRD_PARTY_NOTICES.md`](src/artifacts/motif-for-claude-science-plugin/THIRD_PARTY_NOTICES.md).
+The generated plugin places the complete upstream license texts for connector
+dependencies under `server/licenses/`. Preserve that notice and license
+directory when redistributing the plugin or a rebranded build.
+
+MAFFT, MUSCLE, and Clustal Omega are optional external tools and are not
+bundled with Motif. Their separate licenses apply if they are installed or
+redistributed independently.

--- a/docs/CLAUDE_SCIENCE_INTEGRATION.md
+++ b/docs/CLAUDE_SCIENCE_INTEGRATION.md
@@ -58,7 +58,7 @@ environment and verifies:
 - the two exact tool names and their schemas;
 - standard MCP App metadata and the exact `ui://` resource;
 - the MCP App MIME type and self-contained HTML;
-- the Claude Science FASTA/GenBank artifact-viewer binding;
+- the declared Claude Science FASTA/GenBank artifact-viewer metadata;
 - a real FASTA open call and bounded record/residue counts;
 - the embedded standalone-HTML fallback and checksum metadata; and
 - privacy-safe tracing that does not echo sequence or inherited credentials.
@@ -99,34 +99,36 @@ npm run claude-science:doctor
 
 ## Exercise the in-window workflow
 
-Use the explicit tool path as the primary protocol test:
+Use the portable artifact path as the primary visual test:
 
 1. Give Claude Science the complete text of a real `.fasta`, `.fa`, `.fna`,
    `.faa`, `.gb`, `.gbk`, `.gbff`, `.genbank`, or `.seq` artifact.
-2. Call `motif_open_workbench` with that complete text as `content` and the
-   exact basename as `filename`.
-3. Verify the returned schema, source name, record count, residue count, and
-   bounded record names/IDs against the input.
-4. Separately confirm whether a frame mounted. A mounted frame visibly says
-   **Motif** and contains the intended records; a tool summary or `ui://` link
-   proves execution only.
+2. Call `motif_create_workbench_artifact` with that complete text as `content`,
+   the exact basename as `filename`, and a safe `.html` `outputFilename`.
+3. Verify the returned schema, source name, record count, residue count,
+   bounded record names/IDs, byte count, and checksum against the input.
+4. Save the exact returned HTML and click or open it in Claude Science's right
+   pane. Confirm the frame visibly says **Motif** and contains the intended
+   records.
+
+This route does not depend on a live App lifecycle. It provides the full
+interactive Motif UI, but the HTML is an immutable snapshot and must be
+regenerated after source or build changes.
 
 Current Claude Science local/custom connector builds may not register Motif as
 an artifact viewer. The viewer chooser is an optional shortcut only when Motif
 is actually listed. `Sequence viewer unavailable—showing as text` is the host's
 generic artifact fallback, not evidence of a Motif parse failure.
 
-If the host does not mount the MCP App, call
-`motif_create_workbench_artifact` with the same `content` and `filename` plus a
-safe `.html` `outputFilename`. Save the exact returned `text/html` resource and
-click or open it in Claude Science's right pane. This route does not depend on
-a live App lifecycle. It provides the full interactive Motif UI, but the HTML
-is an immutable snapshot and must be regenerated after source or build changes.
+After the portable artifact passes, optionally call `motif_open_workbench`
+with the same complete `content` and exact `filename`. Verify the returned
+source and counts, then separately confirm whether a live frame mounted. A tool
+summary or `ui://` link proves execution only.
 
 For visual acceptance, verify record name, molecule, topology, residue count,
 sequence content, annotations, selection drag, map selection, theme, and pane
 resizing in whichever Motif frame was actually opened. Record which route was
-used; do not describe the HTML fallback as a live MCP App.
+used; do not describe the HTML workbench as a live MCP App.
 
 ## Supported inputs and safety boundary
 

--- a/docs/CLAUDE_SCIENCE_QUICKSTART.md
+++ b/docs/CLAUDE_SCIENCE_QUICKSTART.md
@@ -1,7 +1,9 @@
 # Install Motif for Claude Science
 
-Motif uses a local-first connector: sequence data is validated and rendered on
-your machine, and no hosted Motif service is required.
+Motif uses a local-first connector and has no hosted Motif service. Sequence
+data you give to Claude Science is still subject to your Claude and
+organization data policies; do not use sensitive or unpublished sequences
+without authorization.
 
 ## Requirements
 
@@ -43,7 +45,12 @@ path:
 pwd -P
 ```
 
-Add that absolute path to `~/.claude-science/config.toml`:
+For the simplest setup, open **Customize → Permissions** in Claude Science and
+grant exactly that folder. Fully relaunching Claude Science is required before
+the new grant affects its connector sandbox.
+
+For a least-privilege manual grant, add the absolute path to
+`~/.claude-science/config.toml`:
 
 ```toml
 [sandbox]
@@ -58,9 +65,8 @@ private:
 chmod 600 ~/.claude-science/config.toml
 ```
 
-You may instead grant the exact folder through **Customize → Permissions** in
-Claude Science. The explicit TOML setting is read-only and therefore the
-least-privilege option for Motif's viewer connector.
+The explicit TOML setting is read-only and therefore the least-privilege option
+for Motif's viewer connector.
 
 ## 4. Relaunch and connect
 
@@ -83,41 +89,53 @@ npm run claude-science:check-local
 npm run claude-science:doctor
 ```
 
-Both commands must pass. Then attach a small FASTA or GenBank file and ask
-Claude Science to make the input explicit:
+Both commands must pass. Then attach the bundled synthetic
+[`examples/motif-demo.gb`](../examples/motif-demo.gb). The most reliable first
+visual result is the portable HTML workbench:
 
 ```text
-Read the complete text of sample.gb. Call motif-local's
-motif_open_workbench exactly once with filename set to sample.gb and content
-set to the complete GenBank text, including ORIGIN. Do not call it without the
-file content. Verify the returned source name, record count, residue count,
-and record names/IDs, then tell me whether a visible Motif frame mounted.
+Read the complete text of motif-demo.gb, including ORIGIN. Call motif-local's
+motif_create_workbench_artifact exactly once with filename "motif-demo.gb",
+content set to the complete GenBank text, title "Motif demo — MOTIFDEMO", and
+outputFilename "motif-demo-workbench.html". Preserve the exact returned HTML
+as a Claude Science artifact. Report its record count, residue count, and
+record names/IDs, then open it in the right pane.
 ```
 
-Replace `sample.gb` with the exact basename. For FASTA, likewise pass the
-complete FASTA text. A successful tool result proves execution and parsing; a
-text summary or `ui://` link does not prove that the MCP App mounted. Confirm a
-visible **Motif** identity and matching records before testing Inventory,
-Sequence, Map, and Tools with mouse and keyboard.
+The expected record is `MOTIFDEMO`, linear DNA, 180 bp, with `source` and
+`demo_cds` features spanning 1–180. Clicking the generated HTML once is normal.
+Confirm a visible **Motif** identity and these values before testing Inventory,
+Sequence, Map, and Tools with mouse and keyboard. This HTML is interactive but
+immutable; regenerate it after changing the input or Motif build.
 
-Current Claude Science local/custom connector builds may not register Motif as
-an artifact viewer. If Motif is actually listed in the viewer chooser, selecting
-it is a convenient shortcut. If Claude Science instead shows the message
-`Sequence viewer unavailable—showing as text`, that is its generic display
+## Optional live-App check
+
+After the HTML route works, you may test whether your Claude Science build
+mounts local MCP Apps automatically:
+
+```text
+Call motif-local's motif_open_workbench exactly once with filename set to
+motif-demo.gb and content set to the same complete GenBank text. Verify the
+returned source name, record count, residue count, and record names/IDs, then
+tell me whether a visible Motif frame mounted.
+```
+
+A successful result proves execution and parsing; a text summary or `ui://`
+link does not prove that the MCP App mounted. Current Claude Science
+local/custom connector builds may not register Motif as an artifact viewer. If
+Motif is actually listed in the viewer chooser, selecting it is a convenient
+shortcut. `Sequence viewer unavailable—showing as text` is the host's generic
 fallback, not a Motif parser failure.
 
-If no Motif frame appears, use the reliable portable fallback:
+## Tested compatibility
 
-```text
-Call motif-local's motif_create_workbench_artifact with filename set to
-sample.gb, content set to the same complete GenBank text, and outputFilename
-set to sample-motif.html. Preserve the exact returned HTML resource so I can
-save it and click or open it in Claude Science's right pane.
-```
-
-The opened HTML is a fully interactive Motif workbench, but it is an immutable
-snapshot. A later source edit or Motif rebuild requires a newly generated HTML
-artifact.
+| Component | Tested status |
+| --- | --- |
+| macOS | Supported local setup |
+| Node.js | 22.12 or newer |
+| Claude Science local connector | Two tools register and execute |
+| Connector-created HTML | Opens interactively in the right pane |
+| Automatic local MCP App mount | Host-build dependent; not required |
 
 ## Upgrade
 

--- a/docs/CLAUDE_SCIENCE_TROUBLESHOOTING.md
+++ b/docs/CLAUDE_SCIENCE_TROUBLESHOOTING.md
@@ -97,27 +97,26 @@ enabled is a reasonable review posture.
 
 ## Tool succeeds but no workbench appears
 
-A successful tool result, text summary, or `ui://` resource link proves MCP
-execution and parsing. It does not prove that Claude Science mounted a visible
-App frame.
+A successful `motif_open_workbench` result, text summary, or `ui://` resource
+link proves MCP execution and parsing. It does not prove that Claude Science
+mounted a visible App frame.
 
-Call `motif_open_workbench` with the complete FASTA or GenBank text in
-`content` and the exact basename in `filename`. Verify the returned source,
-record count, residue count, and bounded record names/IDs. Do not call the tool
-with only a path or filename, and do not report a mount until a frame visibly
-identifies itself as **Motif** and contains the intended records.
+For a dependable visual result, call `motif_create_workbench_artifact` with the
+complete FASTA or GenBank text in `content`, the exact basename in `filename`,
+and a safe `.html` `outputFilename`. Verify the returned source, counts,
+bounded record names/IDs, bytes, and checksum. Save the exact embedded HTML and
+click or open it in Claude Science's right pane. The workbench is interactive,
+but it is an immutable snapshot rather than a live MCP App.
 
 Current Claude Science local/custom connector builds may not register Motif as
 an artifact viewer. Use the viewer chooser only when Motif is actually listed.
 The message `Sequence viewer unavailable—showing as text` is Claude Science's
 generic artifact fallback; it does not mean that Motif rejected the sequence.
 
-If the direct call parses successfully but no frame appears, call
-`motif_create_workbench_artifact` with the same complete `content` and
-`filename`, plus a safe `.html` `outputFilename`. Save the exact embedded HTML
-resource and click or open it in Claude Science's right pane. The standalone
-workbench is interactive, but it is an immutable snapshot rather than a live
-MCP App.
+Use `motif_open_workbench` only as an optional live-App check. Pass the same
+complete `content` and exact `filename`; do not call it with only a path or
+filename. Do not report a mount until a frame visibly identifies itself as
+**Motif** and contains the intended records.
 
 Clicking a saved HTML artifact is normal. It does not mean the connector is
 disconnected. Regenerate the artifact after source or Motif changes.
@@ -173,11 +172,13 @@ portable checkpoint formats. Export before reload when edits matter.
 
 - Connector page loads both Motif tools without an MCP error.
 - Host chrome says `motif-local`; only Motif identities are visible.
-- Mounted frame visibly says **Motif**.
+- Opened workbench visibly says **Motif**.
 - Intended record name, type, topology, length, and sequence match the source.
 - Inventory, Sequence, Map, and Tools respond to mouse and keyboard.
 - Tools can minimize to the rail without covering the header.
-- A FASTA/GenBank viewer open works, and the HTML fallback opens when requested.
+- The connector-created HTML workbench opens and responds interactively.
+- Optional live mounting is reported separately and is not required for a
+  healthy local connector.
 - A newly generated artifact reflects the current build rather than stale
   saved bytes.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,20 @@
+# Public smoke-test record
+
+`motif-demo.gb` is a synthetic, public-safe record for installation checks,
+documentation, and automated verification. It is not an authoritative
+biological reference and must not be used for experimental design.
+
+Expected identity:
+
+| Field | Value |
+| --- | --- |
+| Filename | `motif-demo.gb` |
+| Record | `MOTIFDEMO` |
+| Molecule | DNA |
+| Topology | linear |
+| Length | 180 bp |
+| Features | `source` 1–180; `demo_cds` 1–180 |
+
+Use the exact prompt in
+[First success in Claude Science](../README.md#first-success-in-claude-science)
+and verify these values during the installation check.

--- a/examples/motif-demo.gb
+++ b/examples/motif-demo.gb
@@ -1,0 +1,21 @@
+LOCUS       MOTIFDEMO               180 bp    DNA     linear   SYN 13-JUL-2026
+DEFINITION  Synthetic demonstration construct for the Motif workbench.
+ACCESSION   MOTIFDEMO
+VERSION     MOTIFDEMO.1
+KEYWORDS    .
+SOURCE      synthetic construct
+  ORGANISM  synthetic construct
+FEATURES             Location/Qualifiers
+     source          1..180
+                     /label="source"
+                     /organism="synthetic construct"
+                     /mol_type="other DNA"
+                     /note="Synthetic public demo; not a reference sequence"
+     CDS             1..180
+                     /label="demo_cds"
+                     /product="synthetic fluorescent-protein fragment"
+ORIGIN
+        1 atggctagca aaggagaaga acttttcact ggagttgtcc caattcttgt tgaattagat
+       61 ggtgatgtta atgggcacaa attttctgtc agtggagagg gtgaaggtga tgctacatac
+      121 ggaaagctta cccttaaatt tatttgcact actggaaaac tacctgttcc atggccaaca
+//

--- a/scripts/build-claude-science-artifact.mjs
+++ b/scripts/build-claude-science-artifact.mjs
@@ -43,6 +43,17 @@ const publicPluginDocs = [
   'CLAUDE_SCIENCE_QUICKSTART.md',
   'CLAUDE_SCIENCE_TROUBLESHOOTING.md',
 ];
+const bundledConnectorLicenses = [
+  { packagePath: ['@modelcontextprotocol', 'ext-apps'], filename: 'mcp-ext-apps-LICENSE.txt' },
+  { packagePath: ['@modelcontextprotocol', 'sdk'], filename: 'mcp-sdk-LICENSE.txt' },
+  { packagePath: ['ajv'], filename: 'ajv-LICENSE.txt' },
+  { packagePath: ['ajv-formats'], filename: 'ajv-formats-LICENSE.txt' },
+  { packagePath: ['fast-deep-equal'], filename: 'fast-deep-equal-LICENSE.txt' },
+  { packagePath: ['fast-uri'], filename: 'fast-uri-LICENSE.txt' },
+  { packagePath: ['json-schema-traverse'], filename: 'json-schema-traverse-LICENSE.txt' },
+  { packagePath: ['zod'], filename: 'zod-LICENSE.txt' },
+  { packagePath: ['zod-to-json-schema'], filename: 'zod-to-json-schema-LICENSE.txt' },
+];
 
 const ZIP_UTF8_FLAG = 0x0800;
 const ZIP_STORE_METHOD = 0;
@@ -312,6 +323,23 @@ export function copyPublicPluginDocs(pluginPath) {
   for (const filename of publicPluginDocs) {
     copyFileSync(join(root, 'docs', filename), join(pluginDocsPath, filename));
   }
+  const pluginExamplesPath = join(pluginPath, 'examples');
+  mkdirSync(pluginExamplesPath, { recursive: true });
+  copyFileSync(
+    join(root, 'examples', 'motif-demo.gb'),
+    join(pluginExamplesPath, 'motif-demo.gb'),
+  );
+}
+
+export function copyBundledConnectorLicenses(pluginPath) {
+  const licensesPath = join(pluginPath, 'licenses');
+  mkdirSync(licensesPath, { recursive: true });
+  for (const license of bundledConnectorLicenses) {
+    copyFileSync(
+      join(root, 'node_modules', ...license.packagePath, 'LICENSE'),
+      join(licensesPath, license.filename),
+    );
+  }
 }
 
 function writePluginBundle(html) {
@@ -320,23 +348,12 @@ function writePluginBundle(html) {
   cpSync(pluginSourcePath, pluginDistPath, { recursive: true });
   mkdirSync(dirname(pluginResourcePath), { recursive: true });
   writeFileSync(pluginResourcePath, html);
-  mkdirSync(join(connectorPluginPath, 'licenses'), { recursive: true });
+  mkdirSync(connectorPluginPath, { recursive: true });
   copyFileSync(connectorServerPath, join(connectorPluginPath, 'motif-mcp-server.mjs'));
   copyFileSync(connectorAppPath, join(connectorPluginPath, 'motif-mcp-app.html'));
   copyFileSync(templateHtml, join(connectorPluginPath, 'motif-template.html'));
   copyPublicPluginDocs(pluginDistPath);
-  copyFileSync(
-    join(root, 'node_modules', '@modelcontextprotocol', 'ext-apps', 'LICENSE'),
-    join(connectorPluginPath, 'licenses', 'mcp-ext-apps-LICENSE.txt'),
-  );
-  copyFileSync(
-    join(root, 'node_modules', '@modelcontextprotocol', 'sdk', 'LICENSE'),
-    join(connectorPluginPath, 'licenses', 'mcp-sdk-LICENSE.txt'),
-  );
-  copyFileSync(
-    join(root, 'node_modules', 'zod', 'LICENSE'),
-    join(connectorPluginPath, 'licenses', 'zod-LICENSE.txt'),
-  );
+  copyBundledConnectorLicenses(connectorPluginPath);
 
   const zip = createDeterministicZipBuffer(pluginDistPath);
   writeFileSync(pluginZipPath, zip);

--- a/scripts/configure-motif-claude-science-local.mjs
+++ b/scripts/configure-motif-claude-science-local.mjs
@@ -74,6 +74,14 @@ export function parseConfigureArgs(args) {
   return options;
 }
 
+function printClaudeScienceNextSteps() {
+  process.stdout.write(`  Motif checkout: ${root}\n`);
+  process.stdout.write('  Next:\n');
+  process.stdout.write('    1. In Claude Science, grant this exact folder under Customize -> Permissions.\n');
+  process.stdout.write('    2. Fully quit Claude Science with Cmd-Q, then reopen it.\n');
+  process.stdout.write('    3. Open Customize -> Connectors -> motif-local and press Reconnect.\n');
+}
+
 export function runConfigure(options) {
   if (options.help) {
     process.stdout.write(usage());
@@ -105,6 +113,7 @@ export function runConfigure(options) {
   const action = options.mode === 'remove' ? 'removal' : 'registration';
   if (!result.changed) {
     process.stdout.write(`\u2713 ${MOTIF_LOCAL_CONNECTOR_NAME} ${action} is already up to date\n`);
+    if (options.mode === 'install') printClaudeScienceNextSteps();
     return { ok: true, ...result };
   }
   if (options.dryRun) {
@@ -113,7 +122,7 @@ export function runConfigure(options) {
   }
   process.stdout.write(`\u2713 ${MOTIF_LOCAL_CONNECTOR_NAME} ${action} written atomically\n`);
   if (result.backupPath) process.stdout.write('  previous config backed up with private file permissions\n');
-  process.stdout.write('  Restart Claude Science and reconnect the local connector to load the change.\n');
+  if (options.mode === 'install') printClaudeScienceNextSteps();
   return { ok: true, ...result };
 }
 

--- a/scripts/test-claude-science-plugin-packaging.mjs
+++ b/scripts/test-claude-science-plugin-packaging.mjs
@@ -18,6 +18,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildSync } from 'esbuild';
 import {
+  copyBundledConnectorLicenses,
   copyPublicPluginDocs,
   createDeterministicZipBuffer,
   parseBuildArgs,
@@ -192,6 +193,34 @@ check('public setup, troubleshooting, and capability docs ship with the plugin',
       assert.equal(packaged, canonical);
       assert.equal(packaged.toLowerCase().includes(legacyBrand), false);
       assert.doesNotMatch(packaged, /\/Users\/|github_3/iu);
+    }
+    assert.equal(
+      readFileSync(join(fixture, 'examples', 'motif-demo.gb'), 'utf8'),
+      readFileSync(join(root, 'examples', 'motif-demo.gb'), 'utf8'),
+    );
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+check('all bundled connector dependency licenses ship with the plugin', () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'motif-connector-licenses-'));
+  const expectedLicenses = [
+    'ajv-LICENSE.txt',
+    'ajv-formats-LICENSE.txt',
+    'fast-deep-equal-LICENSE.txt',
+    'fast-uri-LICENSE.txt',
+    'json-schema-traverse-LICENSE.txt',
+    'mcp-ext-apps-LICENSE.txt',
+    'mcp-sdk-LICENSE.txt',
+    'zod-LICENSE.txt',
+    'zod-to-json-schema-LICENSE.txt',
+  ];
+  try {
+    copyBundledConnectorLicenses(fixture);
+    assert.deepEqual(readdirSync(join(fixture, 'licenses')).sort(), expectedLicenses);
+    for (const filename of expectedLicenses) {
+      assert.ok(readFileSync(join(fixture, 'licenses', filename), 'utf8').trim().length > 0);
     }
   } finally {
     rmSync(fixture, { recursive: true, force: true });

--- a/src/artifacts/__tests__/motif-public-demo.test.ts
+++ b/src/artifacts/__tests__/motif-public-demo.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { parseGenBank } from '../../bio/genbank-parser';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+describe('public Motif demo record', () => {
+  it('keeps the documented synthetic identity and complete sequence', () => {
+    const content = readFileSync(resolve(root, 'examples/motif-demo.gb'), 'utf8');
+    const records = parseGenBank(content);
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      name: 'MOTIFDEMO',
+      length: 180,
+      topology: 'linear',
+      moleculeType: 'DNA',
+      truncated: undefined,
+    });
+    expect(records[0].sequence).toHaveLength(180);
+    expect(records[0].features.map((feature) => feature.name)).toEqual([
+      'source',
+      'demo_cds',
+    ]);
+  });
+});

--- a/src/artifacts/motif-for-claude-science-plugin/CHANGELOG.md
+++ b/src/artifacts/motif-for-claude-science-plugin/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Included bounded record names and IDs in connector summaries so agents can
   verify the intended records without guessing.
 - Aligned setup and launcher checks on Node.js 22.12 or newer.
+- Made the connector-created HTML workbench the documented first-success path
+  and completed license notices for every dependency bundled into the server.
 
 ## 0.2.0 — 2026-07-13
 

--- a/src/artifacts/motif-for-claude-science-plugin/THIRD_PARTY_NOTICES.md
+++ b/src/artifacts/motif-for-claude-science-plugin/THIRD_PARTY_NOTICES.md
@@ -71,20 +71,34 @@ The Feather-derived portions carry this MIT notice:
 
 Source: <https://github.com/lucide-icons/lucide>
 
-## Model Context Protocol SDK, MCP Apps, and Zod
+## Connector protocol and validation libraries
 
-The optional Motif connector bundles compiled portions of the Model Context
-Protocol TypeScript SDK, MCP Apps SDK, and Zod. The MCP TypeScript SDK and Zod
-are distributed under the MIT License. The MCP Apps package is undergoing an
-Apache-2.0/MIT licensing transition; its complete upstream license notice is
-included beside the bundled connector, along with the complete SDK and Zod
-license files.
+The optional Motif connector bundles compiled portions of these packages:
+
+- Model Context Protocol TypeScript SDK (MIT)
+- MCP Apps SDK (MIT)
+- Zod (MIT)
+- Ajv and ajv-formats (MIT)
+- fast-deep-equal (MIT)
+- fast-uri (BSD-3-Clause)
+- json-schema-traverse (MIT)
+- zod-to-json-schema (ISC)
+
+The complete upstream license text for every package in this list is included
+under `server/licenses/` in the distributed plugin. These files cover both the
+connector server and the small MCP App bridge bundled into the workbench.
 
 Sources:
 
 - <https://github.com/modelcontextprotocol/typescript-sdk>
 - <https://github.com/modelcontextprotocol/ext-apps>
 - <https://github.com/colinhacks/zod>
+- <https://github.com/ajv-validator/ajv>
+- <https://github.com/ajv-validator/ajv-formats>
+- <https://github.com/epoberezkin/fast-deep-equal>
+- <https://github.com/fastify/fast-uri>
+- <https://github.com/epoberezkin/json-schema-traverse>
+- <https://github.com/StefanTerdell/zod-to-json-schema>
 
 ## Reference sequence data and external tools
 


### PR DESCRIPTION
Summary

- Add a least-privilege, SHA-pinned CI gate covering secrets, types, lint, tests, packaging, accessibility guards, builds, and browser workflows.
- Add public security, support, changelog, notice, and bundled-license documentation with packaging verification.
- Improve Claude Science onboarding and troubleshooting around the reliable HTML workbench path and safer local connector setup.
- Keep the synthetic public smoke-test fixture while omitting recording-specific operational guidance from the public repository.

Validation

- Typecheck and lint passed.
- 56 test files and 641 unit tests passed.
- 3 connector files and 21 connector tests passed.
- Plugin packaging, CSS-token, ARIA-control, build, and strict plugin validation passed.
- Browser suite: 109 passed, 2 skipped because they require external real-Sanger fixtures.
- Full reachable history and branch-range Gitleaks scans passed.
- Plugin archive SHA-256: e7483ccc5e5cefbc2c791d060e7ab2f167db6ad9b9bffd32c26cf3c040b03a0c

Security

GitHub private vulnerability reporting is enabled for the repository.