### PR TITLE
Harden scientific trust loops and expand MSA analysis

### DIFF
--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -822,14 +822,14 @@ test.describe('Claude Science artifact campaign', () => {
       workflows: window.motifGetWorkflowResults?.().length,
     }))).toEqual({ records: 3, workflows: 1 });
 
-    await page.evaluate(() => window.motifRenderInventory?.([{
+    await page.evaluate(() => window.motifReplaceWorkspace?.({ records: [{
       id: 'replacement-record',
       name: 'Replacement record',
       molecule: 'dna',
       topology: 'linear',
       seq: 'ATGC',
       active: true,
-    }]));
+    }] }));
     await expect(assemblyWindow).toHaveCount(0);
   });
 
@@ -1233,7 +1233,7 @@ test.describe('Claude Science artifact campaign', () => {
       const ecoCount = api.motifAddRecords({ id: 'fresh-eco', type: 'dna', topology: 'linear', sequence: 'TTTGAATTCAAA' });
       api.motifSetRestrictionSources(['common']);
       const description = api.motifDescribe()?.text ?? '';
-      api.motifRenderInventory([]);
+      (window as unknown as { motifClearWorkspace: () => void }).motifClearWorkspace();
       const emptyCount = api.motifGetInventory().length;
       return { beforeIds, afterIds, invalidCode, proteinCount, proteinSequence, ecoCount, description, emptyCount };
     });
@@ -1597,6 +1597,7 @@ test.describe('Claude Science artifact campaign', () => {
   });
 
   test('desktop themes have no automatic WCAG A/AA violations', async ({ page }) => {
+    test.slow();
     await openArtifact(page, 1180, 900);
     const toolsToggle = page.getByRole('button', { name: /Tools/ }).first();
     if ((await toolsToggle.getAttribute('aria-pressed')) !== 'true') await toolsToggle.click();
@@ -3341,7 +3342,7 @@ test.describe('Claude Science artifact campaign', () => {
   test('MSA picker disambiguates duplicate preloaded and runtime result names', async ({ page }) => {
     await openArtifact(page, 1180, 820);
     await page.evaluate(() => {
-      window.motifRenderInventory({
+      window.motifReplaceWorkspace({
         inventory: { id: 'duplicate-picker-audit', title: 'Duplicate picker audit' },
         selectedRecordId: 'duplicate-source',
         records: [{ id: 'duplicate-source', name: 'Duplicate source', molecule: 'dna', topology: 'linear', seq: 'ACGTACGT' }],
@@ -3388,7 +3389,7 @@ test.describe('Claude Science artifact campaign', () => {
 
   test('MSA Edit inputs rehydrates linked records and clearly resets an unlinked result', async ({ page }) => {
     await openArtifact(page, 1180, 820);
-    await page.evaluate(() => window.motifRenderInventory({
+    await page.evaluate(() => window.motifReplaceWorkspace({
       inventory: { id: 'source-link-audit', title: 'Source-link audit' },
       selectedRecordId: 'source-alpha',
       records: [
@@ -3458,7 +3459,7 @@ test.describe('Claude Science artifact campaign', () => {
       });
     });
     await openArtifact(page, 1180, 820);
-    await page.evaluate(() => window.motifRenderInventory({
+    await page.evaluate(() => window.motifReplaceWorkspace({
       inventory: { id: 'fallback-audit', title: 'Fallback provenance audit' },
       selectedRecordId: 'fallback-alpha',
       records: [

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -3165,8 +3165,18 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(viewButton).toHaveAttribute('aria-expanded', 'true');
     await page.screenshot({ path: path.join(msaCampaignOutputDir, 'msa-view-menu-1180x820.png') });
 
-    for (const label of ['Overview', 'Alignment axis', 'Template axis', 'Row statistics', 'Conservation', 'Consensus']) {
-      await viewMenu.getByRole('checkbox', { name: label }).uncheck();
+    const defaultVisibleLabels = [
+      'Overview',
+      'Alignment axis',
+      'Template axis',
+      'Row statistics',
+      'Conservation marks',
+      'Conservation histogram',
+      'Consensus',
+    ];
+    const visibilityLabels = [...defaultVisibleLabels, 'Occupancy'];
+    for (const label of visibilityLabels) {
+      await viewMenu.getByRole('checkbox', { name: label, exact: true }).uncheck();
       await expect(viewMenu).toBeVisible();
     }
     const residueColors = viewMenu.getByRole('checkbox', { name: 'Residue colors' });
@@ -3176,6 +3186,7 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(dialog.locator('.motif-cs-msa-template-ruler-row')).toHaveCount(0);
     await expect(dialog.locator('.motif-cs-msa-row-stat')).toHaveCount(0);
     await expect(dialog.locator('.motif-cs-msa-conservation-row')).toHaveCount(0);
+    await expect(dialog.locator('.motif-cs-msa-hist-row')).toHaveCount(0);
     await expect(dialog.locator('.motif-cs-msa-consensus-row')).toHaveCount(0);
 
     await page.keyboard.press('Escape');
@@ -3190,6 +3201,7 @@ test.describe('Claude Science artifact campaign', () => {
 
     await expect(dialog.locator('.motif-cs-msa-overview-row')).toHaveCount(0);
     await expect(dialog.locator('.motif-cs-msa-template-ruler-row')).toHaveCount(0);
+    await expect(dialog.locator('.motif-cs-msa-hist-row')).toHaveCount(0);
     await viewButton.click();
     await viewMenu.getByRole('button', { name: 'Reset alignment view' }).click();
     const viewStatus = viewMenu.getByTestId('msa-view-menu-status');
@@ -3197,12 +3209,14 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(viewStatus).toHaveAttribute('aria-live', 'polite');
     await expect(viewStatus).toContainText(/alignment view reset/i);
     await expect(viewMenu).toBeVisible();
-    for (const label of ['Overview', 'Alignment axis', 'Template axis', 'Row statistics', 'Conservation', 'Consensus']) {
-      await expect(viewMenu.getByRole('checkbox', { name: label })).toBeChecked();
+    for (const label of defaultVisibleLabels) {
+      await expect(viewMenu.getByRole('checkbox', { name: label, exact: true })).toBeChecked();
     }
+    await expect(viewMenu.getByRole('checkbox', { name: 'Occupancy', exact: true })).not.toBeChecked();
     await expect(residueColors).not.toBeChecked();
     await expect(dialog.locator('.motif-cs-msa-overview-row')).toBeVisible();
     await expect(dialog.locator('.motif-cs-msa-template-ruler-row')).toBeVisible();
+    await expect(dialog.locator('.motif-cs-msa-hist-row')).toHaveCount(1);
     await expect(dialog.locator('.motif-cs-msa-row-stat').first()).toBeVisible();
     await expect(dialog.locator('.motif-cs-msa-conservation-row')).toBeVisible();
     await expect(dialog.locator('.motif-cs-msa-consensus-row')).toBeVisible();

--- a/e2e/claude-science-construct-verification.spec.ts
+++ b/e2e/claude-science-construct-verification.spec.ts
@@ -1,0 +1,329 @@
+import { expect, test } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const artifactUrl = process.env.MOTIF_ARTIFACT_URL;
+const outputDirectory = path.resolve('output/playwright/construct-verification');
+
+// Fixed pseudo-random sequence with no repeated 7-mers. Full-length evidence
+// therefore has one unambiguous locus while remaining deterministic in every run.
+const REFERENCE_SEQUENCE = 'TCCGGGTCCACTCAATAGGGCCTATGGTGTTAAATATGTGTCTCTTGTTCGCTAGGGTGATAGCAAAAAATATAGTGCCTGCTTTTGTGGATGTAAATAATAACTCGCCCCCCTCCCTCACGAGAGCGCTACGCAAACGTATTTGCCGCCCGCCCTTGGTCAGACATTAGCAGTCGTTTGCTAGATATCCCCTGAAGACTAATGCCCACATTGCGCGCCGATACCCCAGCGTAGGACGAA';
+const RECORD_IDS = {
+  reference: 'construct-e2e-reference',
+  forward: 'construct-e2e-forward',
+  reverse: 'construct-e2e-reverse',
+} as const;
+
+function reverseComplement(sequence: string): string {
+  const complement: Record<string, string> = { A: 'T', C: 'G', G: 'C', T: 'A' };
+  return Array.from(sequence).reverse().map((base) => complement[base]).join('');
+}
+
+test.describe('Claude Science construct verification trust loop', () => {
+  test.skip(!artifactUrl, 'Set MOTIF_ARTIFACT_URL to run the standalone artifact audit.');
+
+  test.beforeAll(async () => {
+    await mkdir(outputDirectory, { recursive: true });
+  });
+
+  test('verifies bidirectional Sanger evidence, saves a compact typed result, and marks it fresh', async ({ page }) => {
+    const diagnostics: string[] = [];
+    page.on('pageerror', (error) => diagnostics.push(`pageerror: ${error.message}`));
+    page.on('console', (message) => {
+      if (message.type() === 'error' || message.type() === 'warning') {
+        diagnostics.push(`console.${message.type()}: ${message.text()}`);
+      }
+    });
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.addInitScript(() => {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    });
+    await page.goto(artifactUrl!);
+    await expect(page.locator('.motif-cs-shell')).toBeVisible();
+
+    const reverseSequence = reverseComplement(REFERENCE_SEQUENCE);
+    const seeded = await page.evaluate(({ ids, reference, reverse }) => {
+      const trace = (baseCalls: string, sampleName: string) => ({
+        schema: 'motif.sanger-trace.v1',
+        version: 1,
+        baseCalls,
+        sequence: baseCalls,
+        qualityScores: Array.from({ length: baseCalls.length }, () => 40),
+        peakPositions: [],
+        channels: { A: [], C: [], G: [], T: [] },
+        sampleCount: 0,
+        dyeOrder: null,
+        storedReverseComplement: false,
+        warnings: [],
+        metadata: {
+          format: 'ABIF',
+          abifVersion: 101,
+          baseCallsTag: 'PBAS2',
+          qualityScoresTag: 'PCON2',
+          peakPositionsTag: null,
+          channelTags: {},
+          sampleName,
+        },
+      });
+      const before = window.motifGetInventory?.().length ?? 0;
+      const added = window.motifAddRecords?.([
+        {
+          id: ids.reference,
+          name: 'Predicted construct E2E',
+          type: 'dna',
+          topology: 'linear',
+          group: 'Construct verification E2E',
+          sequence: reference,
+        },
+        {
+          id: ids.forward,
+          name: 'Sanger forward E2E',
+          type: 'dna',
+          topology: 'linear',
+          group: 'Construct verification E2E',
+          sequence: reference,
+          sangerTrace: trace(reference, 'Sanger forward E2E'),
+        },
+        {
+          id: ids.reverse,
+          name: 'Sanger reverse E2E',
+          type: 'dna',
+          topology: 'linear',
+          group: 'Construct verification E2E',
+          sequence: reverse,
+          sangerTrace: trace(reverse, 'Sanger reverse E2E'),
+        },
+      ] as never);
+      return {
+        added,
+        before,
+        after: window.motifGetInventory?.().length ?? 0,
+        activeId: window.motifGetActiveRecord?.()?.id,
+      };
+    }, { ids: RECORD_IDS, reference: REFERENCE_SEQUENCE, reverse: reverseSequence });
+
+    expect(REFERENCE_SEQUENCE).toHaveLength(240);
+    expect(seeded).toEqual({
+      added: 3,
+      before: expect.any(Number),
+      after: seeded.before + 3,
+      activeId: RECORD_IDS.reference,
+    });
+
+    const tool = page.locator('details[data-rail-tool="construct-verification"]');
+    await tool.scrollIntoViewIfNeeded();
+    await tool.locator(':scope > summary').click();
+    await expect(tool).toHaveAttribute('open', '');
+    await tool.getByTestId('open-construct-verification').click();
+
+    const dialog = page.getByRole('dialog', { name: /Construct Verification/i });
+    const workspace = page.getByTestId('construct-verification-workspace');
+    await expect(dialog).toBeVisible();
+    await expect(workspace).toBeVisible();
+    await expect(workspace.getByTestId('construct-verification-reference')).toHaveValue(RECORD_IDS.reference);
+
+    const readList = workspace.getByTestId('construct-verification-read-list');
+    await expect(readList.locator('input[type="checkbox"]')).toHaveCount(2);
+    await expect(readList.locator('input[type="checkbox"]:checked')).toHaveCount(2);
+    await expect(readList).toContainText('Sanger forward E2E');
+    await expect(readList).toContainText('Sanger reverse E2E');
+    await expect(workspace).toContainText('2 of 2 reads selected');
+
+    const requireBothStrands = workspace.getByRole('checkbox', { name: 'Require both strands' });
+    const runButton = workspace.getByTestId('construct-verification-run');
+    const saveButton = workspace.getByTestId('construct-verification-save');
+    await expect(requireBothStrands).not.toBeChecked();
+    await expect(runButton).toBeEnabled();
+    await expect(saveButton).toBeDisabled();
+    await requireBothStrands.check();
+    await runButton.click();
+
+    const evidence = workspace.getByTestId('construct-verification-panel');
+    await expect(evidence).toBeVisible();
+    await expect(evidence.getByText('Consistent', { exact: true })).toBeVisible();
+    const facts = evidence.locator('.motif-cs-construct-verification-facts');
+    await expect(facts.locator('dd').nth(0)).toHaveText('100.0%');
+    await expect(facts.locator('dd').nth(1)).toHaveText('2 / 2');
+    await expect(facts.locator('dd').nth(2)).toHaveText('1 F · 1 R');
+    await expect(evidence.getByRole('progressbar', { name: 'Reference coverage 100.0%' }))
+      .toHaveAttribute('value', '100');
+    await expect(workspace.getByTestId('construct-verification-status')).toContainText('Verification complete');
+    await expect(saveButton).toBeEnabled();
+
+    await saveButton.click();
+    await expect(saveButton).toHaveText('Saved');
+    await expect(saveButton).toBeDisabled();
+    await expect(workspace.getByTestId('construct-verification-status')).toContainText('saved to Results');
+    await expect.poll(() => page.evaluate(() => (
+      window.motifGetAnalysisWorkspace?.().analysisResults.filter((result) => result.kind === 'construct_verification').length
+    ))).toBe(1);
+
+    const saved = await page.evaluate(() => {
+      const analysis = window.motifGetAnalysisWorkspace?.();
+      const result = analysis?.analysisResults.find((candidate) => candidate.kind === 'construct_verification');
+      const asset = result
+        ? analysis?.analysisAssets.find((candidate) => candidate.id === result.data.verificationReportAssetId)
+        : undefined;
+      const report = asset ? JSON.parse(asset.content) : null;
+      return {
+        result,
+        asset: asset ? {
+          id: asset.id,
+          name: asset.name,
+          mediaType: asset.mediaType,
+          sha256: asset.sha256,
+          contentBytes: new TextEncoder().encode(asset.content).byteLength,
+        } : null,
+        report,
+      };
+    });
+
+    expect(saved.result).toMatchObject({
+      kind: 'construct_verification',
+      status: 'complete',
+      inputRecordIds: [RECORD_IDS.reference, RECORD_IDS.forward, RECORD_IDS.reverse],
+      inputSha256s: [
+        expect.stringMatching(/^[0-9a-f]{64}$/),
+        expect.stringMatching(/^[0-9a-f]{64}$/),
+        expect.stringMatching(/^[0-9a-f]{64}$/),
+      ],
+      assetIds: [expect.any(String)],
+      parameters: {
+        topology: 'linear',
+        requestSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+        readEvidence: {
+          schema: 'motif.construct-read-evidence.v1',
+          sha256s: [
+            expect.stringMatching(/^[0-9a-f]{64}$/),
+            expect.stringMatching(/^[0-9a-f]{64}$/),
+          ],
+        },
+      },
+      data: {
+        referenceRecordId: RECORD_IDS.reference,
+        readRecordIds: [RECORD_IDS.forward, RECORD_IDS.reverse],
+        state: 'consistent',
+        referenceLength: 240,
+        coveredBases: 240,
+        coverageFraction: 1,
+        mappedReadCount: 2,
+        requiredRegionCount: 1,
+        passingRegionCount: 1,
+        observedVariantCount: 0,
+        expectedVariantCount: 0,
+        unexpectedVariantCount: 0,
+        missingExpectedVariantCount: 0,
+        reasonCodes: [],
+        verificationReportAssetId: expect.any(String),
+      },
+      provenance: {
+        operation: 'construct_verification',
+        engine: 'motif-construct-verification',
+        engineVersion: '1',
+        parentIds: [RECORD_IDS.reference, RECORD_IDS.forward, RECORD_IDS.reverse],
+      },
+    });
+    expect(saved.asset).toMatchObject({
+      name: 'construct-verification-report.json',
+      mediaType: 'application/json',
+      sha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+    });
+    expect(saved.asset?.contentBytes).toBeLessThan(64_000);
+    expect(saved.result?.assetIds).toEqual([saved.asset?.id]);
+    expect(saved.result?.data.verificationReportAssetId).toBe(saved.asset?.id);
+
+    expect(saved.report).toMatchObject({
+      schema: 'motif.construct-verification-report.v1',
+      version: 1,
+      state: 'consistent',
+      reasons: [],
+      reference: {
+        id: RECORD_IDS.reference,
+        length: 240,
+        topology: 'linear',
+        sha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+      },
+      reads: [
+        { id: RECORD_IDS.forward, status: 'mapped', mapping: { orientation: 'forward' } },
+        { id: RECORD_IDS.reverse, status: 'mapped', mapping: { orientation: 'reverse' } },
+      ],
+      coverage: {
+        coveredBasesAtAnyDepth: 240,
+        basesMeetingMinDepth: 240,
+        coverageFraction: 1,
+        requiredRegions: [{ status: 'covered', bothStrandsCoveredBases: 240 }],
+      },
+      consensus: { sequence: REFERENCE_SEQUENCE },
+      provenance: {
+        engine: 'motif-construct-verification',
+        engineVersion: '1',
+        requestSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+      },
+    });
+    expect(saved.report.reference).not.toHaveProperty('sequence');
+    expect(saved.report.coverage).not.toHaveProperty('depth');
+    expect(saved.report.coverage).not.toHaveProperty('forward');
+    expect(saved.report.coverage).not.toHaveProperty('reverse');
+    expect(saved.report.consensus).not.toHaveProperty('calls');
+    for (const read of saved.report.reads) {
+      expect(read).not.toHaveProperty('baseCalls');
+      expect(read).not.toHaveProperty('qualityScores');
+      expect(read.mapping).not.toHaveProperty('coordinateMap');
+    }
+
+    await page.screenshot({ path: path.join(outputDirectory, 'construct-verification-light.png'), fullPage: true });
+
+    await page.locator('select[name="artifact-theme"]').selectOption('claude-dark');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'claude-dark');
+    await page.setViewportSize({ width: 640, height: 900 });
+    await expect(dialog).toBeVisible();
+    expect(await workspace.evaluate((element) => element.scrollWidth)).toBeLessThanOrEqual(
+      await workspace.evaluate((element) => element.clientWidth + 2),
+    );
+    expect(await workspace.locator('.motif-cs-verification-workspace-body').evaluate((element) => element.scrollWidth))
+      .toBeLessThanOrEqual(await workspace.locator('.motif-cs-verification-workspace-body').evaluate((element) => element.clientWidth + 2));
+    expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(642);
+    const resizeReachability = await dialog.locator('.motif-cs-window-resize').evaluate((handle) => {
+      const rail = document.querySelector<HTMLElement>('.motif-cs-inspector[data-tools-pinned="false"]');
+      const handleRect = handle.getBoundingClientRect();
+      const railRect = rail?.getBoundingClientRect();
+      const hit = document.elementFromPoint(
+        handleRect.left + handleRect.width / 2,
+        handleRect.top + handleRect.height / 2,
+      );
+      return {
+        clearsRail: Boolean(railRect && handleRect.right <= railRect.left),
+        pointerHitsHandle: hit === handle || (hit !== null && handle.contains(hit)),
+      };
+    });
+    expect(resizeReachability).toEqual({ clearsRail: true, pointerHitsHandle: true });
+    await page.screenshot({ path: path.join(outputDirectory, 'construct-verification-compact-dark.png'), fullPage: true });
+
+    await dialog.getByRole('button', { name: /Close Construct Verification/i }).click();
+    await expect(dialog).toHaveCount(0);
+    const results = page.locator('details[data-rail-tool="analysis-results"]');
+    if ((await results.getAttribute('open')) === null) await results.locator(':scope > summary').click();
+    const resultId = saved.result?.id;
+    expect(resultId).toBeTruthy();
+    const resultRow = page.getByTestId(`analysis-result-${resultId}`);
+    await expect(resultRow).toBeVisible();
+    await expect(resultRow).toContainText('Construct verification');
+    const freshness = resultRow.locator('.motif-cs-agent-result-heading [data-freshness="fresh"]');
+    await expect(freshness).toBeVisible();
+    await expect(freshness).toContainText('Fresh');
+
+    await resultRow.getByRole('button', { name: /Remove Construct verification/i }).click();
+    await resultRow.getByRole('button', { name: 'Remove Result' }).click();
+    await expect(resultRow).toHaveCount(0);
+    await expect.poll(() => page.evaluate(({ resultId: removedResultId, assetId: removedAssetId }) => {
+      const analysis = window.motifGetAnalysisWorkspace?.();
+      return {
+        resultPresent: analysis?.analysisResults.some((result) => result.id === removedResultId) ?? false,
+        assetPresent: analysis?.analysisAssets.some((asset) => asset.id === removedAssetId) ?? false,
+      };
+    }, { resultId, assetId: saved.asset?.id })).toEqual({ resultPresent: false, assetPresent: false });
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/e2e/claude-science-msa-interactions.spec.ts
+++ b/e2e/claude-science-msa-interactions.spec.ts
@@ -1,0 +1,311 @@
+import { expect, test, type Page } from '@playwright/test';
+
+// Real-mouse interaction coverage for the MSA viewer: selection, hover readout,
+// context menu, colour/shade schemes, histogram tracks, and layout across widths.
+// Skipped unless MOTIF_MSA_E2E=1 so the shared claude-science-*.spec.ts run never
+// picks it up. Launch with e2e/playwright.msa.config.ts.
+test.describe('Motif MSA viewer interactions', () => {
+  test.skip(!process.env.MOTIF_MSA_E2E, 'Set MOTIF_MSA_E2E=1 and use e2e/playwright.msa.config.ts');
+
+  const fatal: string[] = [];
+  test.beforeEach(async ({ page }) => {
+    fatal.length = 0;
+    page.on('pageerror', (error) => fatal.push(`pageerror: ${error.message}`));
+    page.on('console', (message) => { if (message.type() === 'error') fatal.push(`console.error: ${message.text()}`); });
+  });
+  test.afterEach(() => { expect(fatal).toEqual([]); });
+
+  async function setup(page: Page, width = 1440, height = 980) {
+    await page.setViewportSize({ width, height });
+    await page.addInitScript(() => { window.localStorage.clear(); window.sessionStorage.clear(); });
+    await page.goto('/motif.html');
+    await expect(page.locator('.motif-cs-shell')).toBeVisible();
+    await page.evaluate(() => {
+      const AA = 'ACDEFGHIKLMNPQRSTVWY';
+      const L = 120;
+      const base = Array.from({ length: L }, (_, i) => AA[(i * 7) % 20]);
+      const fasta = ['ref', 'v1', 'v2', 'v3', 'v4'].map((name, row) => {
+        const seq = base.slice();
+        if (row > 0) for (let i = 0; i < L; i += 1) { if ((i * (row + 3)) % 5 === 0) seq[i] = AA[(i * (row + 1)) % 20]; }
+        if (row === 2) for (let i = 40; i < 50; i += 1) seq[i] = '-';
+        return `>${name}\n${seq.join('')}`;
+      }).join('\n') + '\n';
+      const api = (window as unknown as { motifAddAlignments?: (a: unknown) => number }).motifAddAlignments;
+      if (!api) throw new Error('motifAddAlignments unavailable');
+      api({ name: 'E2E protein panel', molecule: 'protein', alignedFasta: fasta });
+    });
+    // The launch button lives in the (collapsed) Tools rail; dispatch the click
+    // directly since this spec exercises the viewer, not rail navigation.
+    await page.getByTestId('msa-open-button').dispatchEvent('click');
+    await expect(page.getByTestId('msa-alignment-view')).toBeVisible();
+  }
+
+  async function setupDna(page: Page, width = 1440, height = 980) {
+    await page.setViewportSize({ width, height });
+    await page.addInitScript(() => { window.localStorage.clear(); window.sessionStorage.clear(); });
+    await page.goto('/motif.html');
+    await expect(page.locator('.motif-cs-shell')).toBeVisible();
+    await page.evaluate(() => {
+      const base = 'ATGGCTTGGAAAGATTTCCACCCTGTACGTGAATCA'.repeat(4).slice(0, 120); // 120 nt, starts ATG
+      const fasta = ['ref', 'v1', 'v2', 'v3'].map((name, row) => {
+        const seq = base.split('');
+        if (row > 0) for (let i = 0; i < seq.length; i += 1) { if ((i * (row + 3)) % 7 === 0) seq[i] = 'ACGT'[(i * (row + 1)) % 4]; }
+        return `>${name}\n${seq.join('')}`;
+      }).join('\n') + '\n';
+      const api = (window as unknown as { motifAddAlignments?: (a: unknown) => number }).motifAddAlignments;
+      if (!api) throw new Error('motifAddAlignments unavailable');
+      api({ name: 'E2E DNA panel', molecule: 'dna', alignedFasta: fasta });
+    });
+    await page.getByTestId('msa-open-button').dispatchEvent('click');
+    await expect(page.getByTestId('msa-alignment-view')).toBeVisible();
+  }
+
+  function cell(page: Page, rowIndex: number, column: number) {
+    return page.locator(`.motif-cs-msa-matrix-row[data-msa-row-index="${rowIndex}"] .motif-cs-msa-symbol`).nth(column);
+  }
+
+  async function center(page: Page, rowIndex: number, column: number) {
+    const box = await cell(page, rowIndex, column).boundingBox();
+    if (!box) throw new Error(`cell ${rowIndex},${column} has no box`);
+    return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  }
+
+  test('drag selects a rectangular block and reports selection stats', async ({ page }) => {
+    await setup(page);
+    const start = await center(page, 0, 8);
+    const end = await center(page, 3, 34);
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(end.x, end.y, { steps: 10 });
+    await page.mouse.up();
+
+    await expect(page.locator('.motif-cs-msa-selection-band')).toBeVisible();
+    const readout = page.getByTestId('msa-selection-readout');
+    await expect(readout).toContainText('Selected');
+    await expect(readout).toContainText(/cols \d+–\d+/);
+    await expect(readout).toContainText('4 rows');
+    // Rows 0..3 marked selected.
+    await expect(page.locator('.motif-cs-msa-matrix-row[data-selected="true"]')).toHaveCount(4);
+
+    // Escape clears the selection without closing the whole MSA window.
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.motif-cs-msa-selection-band')).toHaveCount(0);
+    await expect(page.getByTestId('msa-alignment-view')).toBeVisible();
+  });
+
+  test('clicking the alignment ruler selects a whole column', async ({ page }) => {
+    await setup(page);
+    const ruler = page.locator('.motif-cs-msa-ruler-window-clickable .motif-cs-msa-ruler-cell').nth(20);
+    await ruler.click({ force: true });
+    await expect(page.locator('.motif-cs-msa-selection-band')).toBeVisible();
+    // Whole column = every row selected.
+    await expect(page.locator('.motif-cs-msa-matrix-row[data-selected="true"]')).toHaveCount(5);
+  });
+
+  test('dragging across the ruler selects a full-height column range', async ({ page }) => {
+    await setup(page);
+    const cells = page.locator('.motif-cs-msa-ruler-window-clickable .motif-cs-msa-ruler-cell');
+    const a = await cells.nth(6).boundingBox();
+    const b = await cells.nth(28).boundingBox();
+    if (!a || !b) throw new Error('ruler cells not found');
+    await page.mouse.move(a.x + a.width / 2, a.y + a.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(b.x + b.width / 2, b.y + b.height / 2, { steps: 10 });
+    await page.mouse.up();
+    // A ruler drag selects a column range spanning every row.
+    await expect(page.locator('.motif-cs-msa-matrix-row[data-selected="true"]')).toHaveCount(5);
+    const readout = page.getByTestId('msa-selection-readout');
+    await expect(readout).toContainText('5 rows');
+    await expect(readout).toContainText(/cols \d+–\d+/);
+  });
+
+  test('hover shows a crosshair column and floating residue readout', async ({ page }) => {
+    await setup(page);
+    const spot = await center(page, 1, 18);
+    await page.mouse.move(spot.x, spot.y);
+    await expect(page.locator('.motif-cs-msa-hover-column')).toBeVisible();
+    const readout = page.locator('.motif-cs-msa-hover-readout');
+    await expect(readout).toBeVisible();
+    await expect(readout).toContainText('col 19');
+    await expect(page.locator('.motif-cs-msa-matrix-row[data-hover="true"]')).toHaveCount(1);
+  });
+
+  test('right-click opens the selection context menu', async ({ page }) => {
+    await setup(page);
+    const spot = await center(page, 0, 12);
+    await page.mouse.click(spot.x, spot.y, { button: 'right' });
+    const menu = page.getByRole('menu', { name: 'Alignment selection actions' });
+    await expect(menu).toBeVisible();
+    await expect(menu.getByRole('menuitem', { name: /Copy selection \(FASTA\)/ })).toBeVisible();
+    await expect(menu.getByRole('menuitem', { name: /Copy without gaps/ })).toBeVisible();
+    // Escape closes it.
+    await page.keyboard.press('Escape');
+    await expect(menu).toHaveCount(0);
+  });
+
+  test('conservation and occupancy histogram tracks render with bars', async ({ page }) => {
+    await setup(page);
+    // Conservation histogram is on by default; occupancy is opt-in.
+    await expect(page.locator('.motif-cs-msa-hist-bar-conservation').first()).toBeVisible();
+    await page.getByTestId('msa-view-menu-button').click();
+    await page.getByRole('checkbox', { name: 'Occupancy' }).check();
+    await expect(page.locator('.motif-cs-msa-hist-bar-occupancy').first()).toBeVisible();
+  });
+
+  test('colour scheme and mismatch shading apply to the matrix', async ({ page }) => {
+    await setup(page);
+    await page.getByTestId('msa-view-menu-button').click();
+    await page.getByRole('checkbox', { name: 'Residue colors' }).check();
+    await page.getByLabel('Colour scheme').selectOption('clustal');
+    await page.getByLabel('Shade columns').selectOption('mismatch');
+    const matrix = page.locator('.motif-cs-msa-matrix');
+    await expect(matrix).toHaveAttribute('data-color-scheme', 'clustal');
+    await expect(matrix).toHaveAttribute('data-shade', 'mismatch');
+    await expect(page.locator('.motif-cs-msa-symbol[data-color-key^="cl-"]').first()).toBeVisible();
+  });
+
+  const rowIdAt = (page: Page, index: number) =>
+    page.locator(`.motif-cs-msa-matrix-row[data-msa-row-index="${index}"]`).getAttribute('data-msa-row-id');
+  const gripForId = (page: Page, id: string) =>
+    page.locator(`.motif-cs-msa-matrix-row[data-msa-row-id="${id}"] .motif-cs-msa-row-grip`);
+
+  test('dragging a row grip reorders rows below the pinned template and offers a reset', async ({ page }) => {
+    await setup(page);
+    const templateId = await rowIdAt(page, 0);
+    const movingId = await rowIdAt(page, 3);
+    expect(movingId).not.toBe(templateId);
+    // The template row has no reorder grip (it stays pinned).
+    await expect(page.locator('.motif-cs-msa-matrix-row[data-msa-row-index="0"] .motif-cs-msa-row-grip')).toHaveCount(0);
+
+    const gripBox = await page.locator('.motif-cs-msa-matrix-row[data-msa-row-index="3"] .motif-cs-msa-row-grip').boundingBox();
+    const targetGrip = await page.locator('.motif-cs-msa-matrix-row[data-msa-row-index="1"] .motif-cs-msa-row-grip').boundingBox();
+    if (!gripBox || !targetGrip) throw new Error('row grips not found');
+
+    await page.mouse.move(gripBox.x + gripBox.width / 2, gripBox.y + gripBox.height / 2);
+    await page.mouse.down();
+    // Drop into the top half of row 1 → insert before it (just below the template).
+    await page.mouse.move(targetGrip.x + targetGrip.width / 2, targetGrip.y + 3, { steps: 12 });
+    await expect(page.locator('.motif-cs-msa-matrix-row[data-drop-before="true"]')).toHaveCount(1);
+    await page.mouse.up();
+
+    // The template is still pinned at 0; the dragged row lands just below it.
+    expect(await rowIdAt(page, 0)).toBe(templateId);
+    expect(await rowIdAt(page, 1)).toBe(movingId);
+    await expect(page.getByTestId('msa-order-note')).toBeVisible();
+    await expect(page.getByTestId('msa-reorder-status')).toContainText('position 2 of 5');
+
+    await page.getByTestId('msa-order-note').getByRole('button', { name: /reset order/i }).click();
+    await expect(page.getByTestId('msa-order-note')).toHaveCount(0);
+    expect(await rowIdAt(page, 0)).toBe(templateId);
+  });
+
+  test('arrow keys on a focused row grip reorder and announce the move', async ({ page }) => {
+    await setup(page);
+    const movingId = await rowIdAt(page, 1); // a non-template row
+    if (!movingId) throw new Error('no row id');
+
+    await gripForId(page, movingId).focus();
+    await page.keyboard.press('ArrowDown');
+    await gripForId(page, movingId).focus();
+    await page.keyboard.press('ArrowDown');
+
+    // The row that began at index 1 has stepped down to index 3.
+    expect(await rowIdAt(page, 3)).toBe(movingId);
+    await expect(page.getByTestId('msa-order-note')).toBeVisible();
+    await expect(page.getByTestId('msa-reorder-status')).toContainText('position 4 of 5');
+  });
+
+  async function setZoomPercent(page: Page, percent: number) {
+    await page.getByTestId('msa-zoom-range').evaluate((element, value) => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+      setter?.call(element, String(value));
+      element.dispatchEvent(new Event('input', { bubbles: true }));
+      element.dispatchEvent(new Event('change', { bubbles: true }));
+    }, percent);
+  }
+
+  test('zoom slider compresses columns into a birdseye blocks view', async ({ page }) => {
+    await setup(page);
+    const matrix = page.locator('.motif-cs-msa-matrix');
+    await expect(matrix).not.toHaveAttribute('data-blocks', 'true');
+
+    await setZoomPercent(page, 25);
+    await expect(page.getByTestId('msa-zoom-value')).toHaveText('25%');
+    await expect(matrix).toHaveAttribute('data-blocks', 'true');
+    await expect(page.getByTestId('msa-blocks-chip')).toBeVisible();
+    // Letters are dropped in blocks view; cells read as coloured tiles.
+    await expect(cell(page, 0, 0)).toHaveCSS('font-size', '0px');
+
+    await page.getByTestId('msa-zoom-reset').click();
+    await expect(page.getByTestId('msa-zoom-value')).toHaveText('100%');
+    await expect(matrix).not.toHaveAttribute('data-blocks', 'true');
+  });
+
+  test('Fit compresses the zoom so a wide alignment spans the window', async ({ page }) => {
+    await setup(page, 900, 860);
+    // 120 columns overflow the compact window at 100%, so a pan lane shows.
+    await expect(page.getByTestId('msa-horizontal-scroll-row')).toBeVisible();
+    await page.getByTestId('msa-zoom-fit').click();
+    const value = await page.getByTestId('msa-zoom-value').textContent();
+    expect(Number((value ?? '').replace('%', ''))).toBeLessThan(100);
+    // A non-default zoom exposes the 100% reset control.
+    await expect(page.getByTestId('msa-zoom-reset')).toBeVisible();
+  });
+
+  test('translation track renders amino-acid cells for a DNA alignment and follows the reading frame', async ({ page }) => {
+    await setupDna(page);
+    // Off by default (and only offered for nucleotide alignments).
+    await expect(page.locator('.motif-cs-msa-translation-row')).toHaveCount(0);
+
+    await page.getByTestId('msa-view-menu-button').click();
+    await page.getByRole('checkbox', { name: 'Translation (amino acids)' }).check();
+
+    await expect(page.locator('.motif-cs-msa-translation-row')).toBeVisible();
+    // The reference row starts with ATG → Met.
+    await expect(page.locator('.motif-cs-msa-aa[data-aa="M"]').first()).toBeVisible();
+
+    // Switching reading frame re-translates (frame +2 no longer starts at ATG).
+    await page.getByLabel('Translation reading frame').selectOption('1');
+    await expect(page.locator('.motif-cs-msa-translation-row')).toBeVisible();
+    await expect(page.locator('.motif-cs-msa-aa').first()).toBeVisible();
+  });
+
+  test('sequence search highlights motif matches and navigates them', async ({ page }) => {
+    await setup(page);
+    const input = page.getByTestId('msa-search-input');
+    const count = page.getByTestId('msa-search-count');
+
+    // The reference row begins with AIRCK (this motif repeats along the row).
+    await input.fill('AIRCK');
+    await expect(page.locator('.motif-cs-msa-symbol[data-search-match]').first()).toBeVisible();
+    await expect(count).toContainText(/\d+/);
+
+    // Enter focuses the first match; Next advances.
+    await input.press('Enter');
+    await expect(count).toContainText(/1 of \d+/);
+    await expect(page.locator('.motif-cs-msa-symbol[data-search-active]').first()).toBeVisible();
+    await page.getByTestId('msa-search-next').click();
+    await expect(count).toContainText(/2 of \d+/);
+
+    // Escape clears the query and all highlights (without touching selection).
+    await input.press('Escape');
+    await expect(count).not.toContainText('of');
+    await expect(page.locator('.motif-cs-msa-symbol[data-search-match]')).toHaveCount(0);
+  });
+
+  test('layout holds and stays scrollable at a narrow width', async ({ page }) => {
+    await setup(page, 700, 900);
+    await expect(page.getByTestId('msa-alignment-view')).toBeVisible();
+    await expect(page.locator('.motif-cs-msa-matrix-scroll')).toBeVisible();
+    // Sticky row label remains rendered so the row identity is never lost.
+    await expect(page.locator('.motif-cs-msa-sticky-label').first()).toBeVisible();
+    // A drag-select still works in the compact layout.
+    const start = await center(page, 0, 4);
+    const end = await center(page, 2, 12);
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(end.x, end.y, { steps: 6 });
+    await page.mouse.up();
+    await expect(page.getByTestId('msa-selection-readout')).toContainText('Selected');
+  });
+});

--- a/e2e/claude-science-pcr-materialization.spec.ts
+++ b/e2e/claude-science-pcr-materialization.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const artifactUrl = process.env.MOTIF_ARTIFACT_URL;
+const outputDir = path.resolve('output/playwright/pcr-materialization');
+
+test.describe('Claude Science PCR materialization', () => {
+  test.skip(!artifactUrl, 'Set MOTIF_ARTIFACT_URL to run the standalone artifact audit.');
+
+  test.beforeAll(async () => {
+    await mkdir(outputDir, { recursive: true });
+  });
+
+  test('keeps simulation result-only and creates one exact provenance-linked amplicon', async ({ page }) => {
+    const diagnostics: string[] = [];
+    page.on('pageerror', (error) => diagnostics.push(`pageerror: ${error.message}`));
+    page.on('console', (message) => {
+      if (message.type() === 'error' || message.type() === 'warning') {
+        diagnostics.push(`console.${message.type()}: ${message.text()}`);
+      }
+    });
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.addInitScript(() => {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    });
+    await page.goto(artifactUrl!);
+    await expect(page.locator('.motif-cs-shell')).toBeVisible();
+
+    const sourceBefore = await page.evaluate(() => {
+      const active = window.motifGetActiveRecord?.();
+      return {
+        id: active?.id,
+        sequence: active?.seq,
+        count: window.motifGetInventory?.().length,
+      };
+    });
+    expect(sourceBefore.id).toBeTruthy();
+
+    const primerPanel = page.locator('details[data-rail-tool="primer-design"]');
+    await primerPanel.locator(':scope > summary').click();
+    await primerPanel.getByTestId('open-primer-workspace').click();
+    const workspace = page.getByTestId('primer-workspace');
+    await expect(workspace.locator('.motif-cs-primer-pair-row').first()).toBeVisible();
+    const simulate = workspace.getByRole('button', { name: 'Simulate PCR' });
+    const create = workspace.getByRole('button', { name: 'Create amplicon record' });
+    await expect(simulate).toBeEnabled();
+    await expect(create).toBeEnabled();
+
+    await simulate.click();
+    await expect(page.locator('.motif-cs-workbench-notice')).toContainText('No sequence record was created');
+    const afterSimulation = await page.evaluate(() => ({
+      count: window.motifGetInventory?.().length,
+      simulations: window.motifGetAnalysisWorkspace?.().analysisResults.filter((result) => (
+        result.kind === 'pcr' && result.provenance.operation === 'pcr_simulation'
+      )),
+    }));
+    expect(afterSimulation.count).toBe(sourceBefore.count);
+    expect(afterSimulation.simulations).toHaveLength(1);
+    expect(afterSimulation.simulations?.[0]).toMatchObject({
+      parameters: { topology: expect.any(String) },
+      provenance: { metadata: { recordCreated: false } },
+    });
+    expect(afterSimulation.simulations?.[0].kind === 'pcr'
+      ? afterSimulation.simulations[0].data.products[0]
+      : null).not.toHaveProperty('recordId');
+
+    await create.click();
+    await expect(workspace).toHaveCount(0);
+    const materialized = await page.evaluate((sourceId) => {
+      const inventory = window.motifGetInventory?.() ?? [];
+      const source = inventory.find((record) => record.id === sourceId);
+      const active = window.motifGetActiveRecord?.();
+      const result = window.motifGetAnalysisWorkspace?.().analysisResults.find((candidate) => (
+        candidate.kind === 'pcr' && candidate.provenance.operation === 'pcr_materialization'
+      ));
+      return { inventory, source, active, result };
+    }, sourceBefore.id);
+    expect(materialized.inventory).toHaveLength((sourceBefore.count ?? 0) + 1);
+    expect(materialized.source?.seq).toBe(sourceBefore.sequence);
+    expect(materialized.active).toMatchObject({
+      molecule: 'dna',
+      topology: 'linear',
+      provenance: {
+        operation: 'pcr_materialization',
+        parentRecordId: sourceBefore.id,
+        templateSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+        productSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+      },
+    });
+    expect(materialized.result).toMatchObject({
+      kind: 'pcr',
+      status: 'complete',
+      inputRecordIds: [sourceBefore.id],
+      parameters: { topology: expect.any(String) },
+      data: {
+        templateRecordId: sourceBefore.id,
+        products: [{ recordId: materialized.active?.id, lengthBp: materialized.active?.seq?.length }],
+      },
+    });
+
+    const resultsPanel = page.locator('details[data-rail-tool="analysis-results"]');
+    await resultsPanel.locator(':scope > summary').click();
+    const materializedRow = resultsPanel.locator(`[data-testid="analysis-result-${materialized.result?.id}"]`);
+    await expect(materializedRow).toContainText('PCR');
+    await expect(materializedRow.locator('.motif-cs-agent-result-heading [data-freshness="fresh"]')).toBeVisible();
+    await page.screenshot({ path: path.join(outputDir, 'materialized-result-light.png'), fullPage: true });
+
+    await page.locator('select[name="artifact-theme"]').selectOption('claude-dark');
+    await page.setViewportSize({ width: 760, height: 900 });
+    await expect(materializedRow).toBeVisible();
+    expect(await resultsPanel.locator('.motif-cs-agent-results').evaluate((element) => element.scrollWidth <= element.clientWidth + 2)).toBe(true);
+    await page.screenshot({ path: path.join(outputDir, 'materialized-result-compact-dark.png'), fullPage: true });
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/e2e/claude-science-workspace-integrity.spec.ts
+++ b/e2e/claude-science-workspace-integrity.spec.ts
@@ -1,0 +1,178 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const artifactUrl = process.env.MOTIF_ARTIFACT_URL;
+
+const createdAt = '2026-07-12T12:00:00.000Z';
+const embeddedWorkspace = {
+  schema: 'motif.claude-science.inventory.v2',
+  inventory: { id: 'integrity-workspace', title: 'Integrity workspace', description: 'Atomic preload fixture' },
+  selectedRecordId: 'record-a',
+  records: [{ id: 'record-a', name: 'Original A', molecule: 'dna', topology: 'linear', seq: 'ATGGAATTCTAA' }],
+  alignments: [{
+    id: 'alignment-a',
+    name: 'Linked alignment',
+    molecule: 'dna',
+    referenceRowId: 'row-a',
+    rows: [
+      { id: 'row-a', name: 'Record A', aligned: 'ATGGAATTCTAA', sourceRecordId: 'record-a' },
+      { id: 'row-b', name: 'Variant', aligned: 'ATGGAA-TCTAA' },
+    ],
+    engine: { id: 'mafft', label: 'MAFFT', version: '7.526', mode: 'local-command' },
+  }],
+  notes: [{
+    id: 'note-a', body: 'Review record A.', format: 'plain', scope: 'record', recordId: 'record-a', createdAt, updatedAt: createdAt,
+  }],
+  workflowResults: [{
+    id: 'digest-a',
+    kind: 'digest',
+    name: 'Digest A',
+    inputRecordIds: ['record-a'],
+    outputRecordIds: ['record-a'],
+    parameters: { enzymes: ['EcoRI'] },
+    createdAt,
+    provenance: { source: 'motif-artifact', operation: 'digest' },
+  }],
+  analysisAssets: [{
+    id: 'asset-a',
+    name: 'report.txt',
+    mediaType: 'text/plain',
+    content: 'Inert report evidence.',
+    createdAt,
+    provenance: { source: 'claude-science-e2e', operation: 'report' },
+  }],
+  analysisResults: [{
+    id: 'report-a',
+    kind: 'report',
+    name: 'Linked report',
+    status: 'complete',
+    summary: 'A linked report.',
+    inputRecordIds: ['record-a'],
+    dependsOnResultIds: [],
+    assetIds: ['asset-a'],
+    parameters: {},
+    data: { format: 'plain', body: 'Review A.' },
+    createdAt,
+    provenance: { source: 'claude-science-e2e', operation: 'report' },
+  }],
+  artifactState: {
+    customEnzymes: [{
+      name: 'PreloadI', recognitionSequence: 'GAATTC', cutOffset: 1, complementCutOffset: 5, overhang: '5prime',
+    }],
+    translationLayersByRecord: {
+      'record-a': [{ id: 'layer-a', label: 'Layer A', start: 0, end: 6, strand: 1, frame: 0, source: 'layer' }],
+    },
+    enzymeSourcesByRecord: { 'record-a': ['common'] },
+    hiddenEnzymesByRecord: { 'record-a': ['EcoRI'] },
+    hiddenFeatureTranslationsByRecord: { 'record-a': ['feat:a'] },
+    restrictionLabelsByRecord: { 'record-a': true },
+    motifsByRecord: { 'record-a': 'GAATTC' },
+  },
+};
+
+async function openInjectedWorkspace(page: Page): Promise<void> {
+  await page.setViewportSize({ width: 1180, height: 900 });
+  await page.addInitScript(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+  await page.route(artifactUrl!, async (route) => {
+    const response = await route.fetch();
+    const source = await response.text();
+    const pattern = /(<script type="application\/json" id="motif-artifact-data">)([\s\S]*?)(<\/script>)/u;
+    expect(pattern.test(source)).toBe(true);
+    const body = source.replace(pattern, (_match, open, _payload, close) => (
+      `${open}${JSON.stringify(embeddedWorkspace)}${close}`
+    ));
+    await route.fulfill({ response, body });
+  });
+  await page.goto(artifactUrl!);
+  await expect(page.locator('.motif-cs-shell')).toBeVisible();
+  await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('Original A');
+}
+
+test.describe('Claude Science workspace integrity', () => {
+  test.skip(!artifactUrl, 'Set MOTIF_ARTIFACT_URL to run the standalone artifact audit.');
+
+  test('hydrates every durable field and keeps records-only updates transactional', async ({ page }) => {
+    const diagnostics: string[] = [];
+    page.on('pageerror', (error) => diagnostics.push(`pageerror: ${error.message}`));
+    page.on('console', (message) => {
+      if (message.type() === 'error' || message.type() === 'warning') {
+        diagnostics.push(`console.${message.type()}: ${message.text()}`);
+      }
+    });
+    await openInjectedWorkspace(page);
+
+    const initial = await page.evaluate(() => window.motifGetWorkspace?.());
+    expect(initial).toMatchObject({
+      inventory: { id: 'integrity-workspace' },
+      records: [{ id: 'record-a', name: 'Original A' }],
+      alignments: [{ id: 'alignment-a' }],
+      notes: [{ id: 'note-a', recordId: 'record-a' }],
+      workflowResults: [{ id: 'digest-a', inputRecordIds: ['record-a'] }],
+      analysisAssets: [{ id: 'asset-a' }],
+      analysisResults: [{ id: 'report-a', inputRecordIds: ['record-a'] }],
+      artifactState: {
+        customEnzymes: [{ name: 'PreloadI' }],
+        translationLayersByRecord: { 'record-a': [{ id: 'layer-a', source: 'layer' }] },
+        enzymeSourcesByRecord: { 'record-a': ['common'] },
+        hiddenEnzymesByRecord: { 'record-a': ['EcoRI'] },
+        hiddenFeatureTranslationsByRecord: { 'record-a': ['feat:a'] },
+        restrictionLabelsByRecord: { 'record-a': true },
+        motifsByRecord: { 'record-a': 'GAATTC' },
+      },
+    });
+
+    const compatible = await page.evaluate(() => {
+      const before = window.motifGetWorkspace?.() as Record<string, unknown>;
+      window.motifRenderInventory?.([{
+        id: 'record-a', name: 'Updated A', molecule: 'dna', topology: 'linear', seq: 'ATGGAATTCTAA',
+      }]);
+      const after = window.motifGetWorkspace?.() as Record<string, unknown>;
+      const sidecars = (workspace: Record<string, unknown>) => ({
+        alignments: workspace.alignments,
+        notes: workspace.notes,
+        workflowResults: workspace.workflowResults,
+        analysisResults: workspace.analysisResults,
+        analysisAssets: workspace.analysisAssets,
+        artifactState: workspace.artifactState,
+      });
+      return { before: sidecars(before), after: sidecars(after), records: after.records };
+    });
+    expect(compatible.records).toEqual([expect.objectContaining({ id: 'record-a', name: 'Updated A' })]);
+    expect(compatible.after).toEqual(compatible.before);
+
+    const orphanAttempt = await page.evaluate(() => {
+      const clean = (workspace: Record<string, unknown>) => {
+        const copy = structuredClone(workspace);
+        delete copy.exportedAt;
+        return copy;
+      };
+      const before = clean(window.motifGetWorkspace?.() as Record<string, unknown>);
+      let rejected: { code?: string; details?: Record<string, unknown>; message: string } | null = null;
+      try {
+        window.motifRenderInventory?.([{
+          id: 'record-b', name: 'Unrelated B', molecule: 'dna', topology: 'linear', seq: 'ATGGAATTCTAA',
+        }]);
+      } catch (error) {
+        rejected = {
+          code: (error as { code?: string }).code,
+          details: (error as { details?: Record<string, unknown> }).details,
+          message: error instanceof Error ? error.message : String(error),
+        };
+      }
+      const after = clean(window.motifGetWorkspace?.() as Record<string, unknown>);
+      return { before, after, rejected };
+    });
+    expect(orphanAttempt.rejected).toMatchObject({
+      code: 'MOTIF_INVALID_INVENTORY_REPLACEMENT',
+      details: { operation: 'motifRenderInventory', mutated: false },
+    });
+    const issueCategories = (orphanAttempt.rejected?.details?.issues as Array<{ category: string }>).map((issue) => issue.category);
+    expect(new Set(issueCategories)).toEqual(new Set([
+      'alignment', 'note', 'workflowResult', 'analysisResult', 'artifactState',
+    ]));
+    expect(orphanAttempt.after).toEqual(orphanAttempt.before);
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/e2e/playwright.msa.config.ts
+++ b/e2e/playwright.msa.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from '@playwright/test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Isolated Playwright config for the MSA interaction spec. It spins up its own
+// Vite dev server on a dedicated port so it never collides with the shared
+// artifact e2e run or a live dev server. Run with:
+//   MOTIF_MSA_E2E=1 npx playwright test --config e2e/playwright.msa.config.ts
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const port = Number(process.env.MOTIF_MSA_E2E_PORT ?? 5223);
+
+export default defineConfig({
+  testDir: resolve(root, 'e2e'),
+  testMatch: 'claude-science-msa-interactions.spec.ts',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  workers: 1,
+  reporter: process.env.CI ? 'line' : 'list',
+  outputDir: resolve(root, 'test-results/msa-interactions'),
+  timeout: 60_000,
+  use: {
+    browserName: 'chromium',
+    baseURL: `http://127.0.0.1:${port}`,
+    contextOptions: { reducedMotion: 'reduce' },
+    trace: 'on-first-retry',
+    launchOptions: {
+      args: ['--disable-gpu', '--force-color-profile=srgb', '--force-raster-color-profile=srgb'],
+    },
+  },
+  webServer: {
+    command: `node_modules/.bin/vite --config vite.claude-science.config.ts --port ${port} --strictPort --host 127.0.0.1`,
+    url: `http://127.0.0.1:${port}/motif.html`,
+    cwd: root,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/mcp/motif/payload.ts
+++ b/mcp/motif/payload.ts
@@ -3,6 +3,14 @@ import { basename } from 'node:path';
 import { parseFasta } from '../../src/bio/fasta-parser.js';
 import { parseGenBank } from '../../src/bio/genbank-parser.js';
 import type { Feature, SequenceType, Topology } from '../../src/bio/types.js';
+import { normalizeArtifactAnalysisWorkspace } from '../../src/artifacts/claude-science-analysis-results.js';
+import { normalizeArtifactAlignments } from '../../src/artifacts/claude-science-msa.js';
+import {
+  ARTIFACT_SANGER_MAX_WORKSPACE_SAMPLE_ENTRIES,
+  artifactSangerTraceSampleEntries,
+  normalizeArtifactSangerTrace,
+} from '../../src/artifacts/claude-science-sanger.js';
+import { normalizeArtifactWorkspaceEnvelope } from '../../src/artifacts/claude-science-workspace-envelope.js';
 
 import {
   MOTIF_WORKBENCH_RESULT_SCHEMA,
@@ -16,10 +24,18 @@ export const MOTIF_MCP_LIMITS = Object.freeze({
   maxPayloadBytes: 32 * 1024 * 1024,
   maxJsonDepth: 21,
   maxJsonNodes: 250_000,
+  maxMetadataJsonDepth: 16,
+  maxMetadataJsonNodes: 10_000,
+  maxMetadataJsonBytes: 1_048_576,
   maxRecords: 100,
   maxRecordResidues: 250_000,
   maxTotalResidues: 25_000_000,
   maxFeaturesPerRecord: 2_000,
+  maxSubRangesPerFeature: 2_000,
+  maxSitesPerRecord: 2_048,
+  maxHitsPerSite: 10_000,
+  maxTotalHitsPerRecord: 50_000,
+  maxOverhangLength: 64,
   maxTextLength: 16_384,
   maxShortTextLength: 1_024,
 });
@@ -34,6 +50,7 @@ const NUCLEOTIDE_ALPHABET = /^[ACGTUNRYSWKMBDHV]+$/u;
 const DNA_ALPHABET = /^[ACGTNRYSWKMBDHV]+$/u;
 const RNA_ALPHABET = /^[ACGUNRYSWKMBDHV]+$/u;
 const PROTEIN_ALPHABET = /^[ACDEFGHIKLMNPQRSTVWYOUJBXZ*]+$/u;
+const SAFE_FEATURE_COLOR = /^(?:#[0-9a-f]{3,8}|(?:rgb|hsl)a?\([\d\s.,%+\-/]+\)|[a-z]+)$/iu;
 
 type JsonBudget = { nodes: number };
 type RecordLike = Record<string, unknown>;
@@ -107,11 +124,103 @@ function boundedOptionalText(value: unknown, path: string, maximum: number): voi
   if (value.length > maximum) throw new Error(`${path} cannot exceed ${maximum.toLocaleString()} characters.`);
 }
 
+function validateMetadataJsonValue(
+  value: unknown,
+  path: string,
+  seen = new WeakSet<object>(),
+  depth = 0,
+  budget = { nodes: 0, bytes: 0 },
+): void {
+  budget.nodes += 1;
+  if (budget.nodes > MOTIF_MCP_LIMITS.maxMetadataJsonNodes) {
+    throw new Error(`${path} exceeds the maximum of ${MOTIF_MCP_LIMITS.maxMetadataJsonNodes.toLocaleString()} JSON nodes.`);
+  }
+  if (depth > MOTIF_MCP_LIMITS.maxMetadataJsonDepth) {
+    throw new Error(`${path} exceeds the maximum supported nesting depth of ${MOTIF_MCP_LIMITS.maxMetadataJsonDepth}.`);
+  }
+  if (value === null) {
+    budget.bytes += 4;
+  } else if (typeof value === 'string') {
+    if (value.length > MOTIF_MCP_LIMITS.maxTextLength) {
+      throw new Error(`${path} exceeds the maximum string length of ${MOTIF_MCP_LIMITS.maxTextLength.toLocaleString()} characters.`);
+    }
+    budget.bytes += utf8Bytes(JSON.stringify(value));
+  } else if (typeof value === 'boolean') {
+    budget.bytes += value ? 4 : 5;
+  } else if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error(`${path} must not contain NaN or Infinity.`);
+    budget.bytes += String(value).length;
+  } else {
+    if (typeof value !== 'object') throw new Error(`${path} must contain JSON-compatible values only.`);
+    if (seen.has(value)) throw new Error(`${path} must not contain circular references.`);
+    if (!Array.isArray(value) && !isPlainObject(value)) throw new Error(`${path} must contain plain JSON objects only.`);
+    seen.add(value);
+    budget.bytes += 2;
+    const entries = Array.isArray(value) ? value.entries() : Object.entries(value);
+    let entryCount = 0;
+    for (const [key, entry] of entries) {
+      if (!Array.isArray(value)) {
+        if (UNSAFE_OBJECT_KEYS.has(String(key))) throw new Error(`${path}.${String(key)} is not an allowed object key.`);
+        if (String(key).length > MOTIF_MCP_LIMITS.maxShortTextLength) {
+          throw new Error(`${path} contains an oversized object key.`);
+        }
+        budget.bytes += utf8Bytes(JSON.stringify(String(key))) + 1;
+      }
+      if (entryCount > 0) budget.bytes += 1;
+      entryCount += 1;
+      validateMetadataJsonValue(entry, `${path}.${String(key)}`, seen, depth + 1, budget);
+    }
+    seen.delete(value);
+  }
+  if (budget.bytes > MOTIF_MCP_LIMITS.maxMetadataJsonBytes) {
+    throw new Error(`${path} exceeds the maximum serialized size of 1 MiB.`);
+  }
+}
+
+function normalizedRecordIdText(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = Array.from(value).filter((character) => {
+    const code = character.charCodeAt(0);
+    return code === 9 || code === 10 || code === 13 || (code >= 32 && code !== 127);
+  }).join('').trim();
+  return normalized || null;
+}
+
+function uniqueRuntimeRecordId(base: string, usedIds: Set<string>): string {
+  if (!usedIds.has(base)) {
+    usedIds.add(base);
+    return base;
+  }
+  for (let suffix = 2; suffix < 100_000; suffix += 1) {
+    const candidate = `${base}-${suffix}`;
+    if (!usedIds.has(candidate)) {
+      usedIds.add(candidate);
+      return candidate;
+    }
+  }
+  throw new Error(`Payload record id ${base} has too many collisions.`);
+}
+
 function cleanSequence(value: unknown, molecule: unknown, path: string): string {
   if (typeof value !== 'string') throw new Error(`${path} must be a sequence string.`);
   if (value.length > 1_000_000) throw new Error(`${path} cannot exceed 1,000,000 formatted characters.`);
-  const sequence = value.toUpperCase().replace(/[\s\d]+/gu, '');
-  if (!sequence) throw new Error(`${path} must contain at least one residue.`);
+  const normalized = value.toUpperCase().replace(/[^A-Z*]/gu, '');
+  const withoutStops = normalized.replace(/\*/gu, '');
+  const looksLikeImplicitProtein = !/[a-z]/u.test(value.trim()) && !/[A-Z*][\t ]+[A-Z*]/u.test(value.trim());
+  const sequence = molecule === 'dna'
+    ? (DNA_ALPHABET.test(withoutStops) ? withoutStops : '')
+    : molecule === 'rna'
+      ? (RNA_ALPHABET.test(withoutStops) ? withoutStops : '')
+      : molecule === 'protein'
+        ? (PROTEIN_ALPHABET.test(normalized) ? normalized : '')
+        : normalized.includes('*')
+          ? (PROTEIN_ALPHABET.test(normalized) ? normalized : '')
+          : NUCLEOTIDE_ALPHABET.test(withoutStops)
+            ? withoutStops
+            : PROTEIN_ALPHABET.test(withoutStops) && looksLikeImplicitProtein
+              ? withoutStops
+              : '';
+  if (!sequence) throw new Error(`${path} must contain at least one valid residue.`);
   if (sequence.length > MOTIF_MCP_LIMITS.maxRecordResidues) {
     throw new Error(`${path} cannot exceed ${MOTIF_MCP_LIMITS.maxRecordResidues.toLocaleString()} residues.`);
   }
@@ -124,6 +233,50 @@ function cleanSequence(value: unknown, molecule: unknown, path: string): string 
         : NUCLEOTIDE_ALPHABET.test(sequence) || PROTEIN_ALPHABET.test(sequence);
   if (!valid) throw new Error(`${path} contains residues outside its declared molecule alphabet.`);
   return sequence;
+}
+
+function normalizedRecordType(value: unknown, sequence: string): SequenceType {
+  if (SEQUENCE_TYPES.has(value as SequenceType)) return value as SequenceType;
+  if (sequence.includes('*')) return 'protein';
+  if (NUCLEOTIDE_ALPHABET.test(sequence)) return sequence.includes('U') && !sequence.includes('T') ? 'rna' : 'dna';
+  return 'protein';
+}
+
+function validateRecordOverhangs(record: RecordLike, path: string, recordType: SequenceType): void {
+  for (const field of ['overhang5', 'overhang3'] as const) {
+    const value = record[field];
+    if (value === undefined) continue;
+    if (typeof value !== 'string') throw new Error(`${path}.${field} must be a DNA string when provided.`);
+    if (value.length > MOTIF_MCP_LIMITS.maxOverhangLength) {
+      throw new Error(`${path}.${field} cannot exceed ${MOTIF_MCP_LIMITS.maxOverhangLength} bases.`);
+    }
+    if (!/^[ACGTRYSWKMBDHVN]*$/u.test(value.toUpperCase().replace(/\s+/gu, ''))) {
+      throw new Error(`${path}.${field} must contain DNA IUPAC bases only.`);
+    }
+    if (recordType !== 'dna') throw new Error(`${path}.${field} is valid on DNA records only.`);
+  }
+  for (const [sequenceField, typeField] of [
+    ['overhang5', 'overhang5Type'],
+    ['overhang3', 'overhang3Type'],
+  ] as const) {
+    const type = record[typeField];
+    if (type === undefined) continue;
+    if (type !== 'blunt' && type !== '5prime' && type !== '3prime') {
+      throw new Error(`${path}.${typeField} must be blunt, 5prime, or 3prime.`);
+    }
+    if (recordType !== 'dna') throw new Error(`${path}.${typeField} is valid on DNA records only.`);
+    const sequence = record[sequenceField];
+    if (typeof sequence !== 'string') {
+      throw new Error(`${path}.${typeField} requires a matching ${sequenceField} string.`);
+    }
+    const compact = sequence.replace(/\s+/gu, '');
+    if (type === 'blunt' && compact.length > 0) {
+      throw new Error(`${path}.${typeField} cannot be blunt when ${sequenceField} contains a sticky sequence.`);
+    }
+    if (type !== 'blunt' && compact.length === 0) {
+      throw new Error(`${path}.${typeField} must be blunt when ${sequenceField} is empty.`);
+    }
+  }
 }
 
 function recordArray(payload: RecordLike): unknown[] {
@@ -145,8 +298,10 @@ function validatePayloadEnvelope(payload: RecordLike): void {
   }
   const recordContainers = ['records', 'entries', 'vectors', 'record']
     .filter(field => payload[field] !== undefined);
-  if (recordContainers.length === 0) {
-    throw new Error('Motif payload must explicitly contain records, entries, vectors, or record.');
+  const hasWorkspaceSidecar = ['alignment', 'alignments', 'notes', 'workflowResults', 'analysisResults', 'analysisAssets', 'artifactState']
+    .some(field => payload[field] !== undefined);
+  if (recordContainers.length === 0 && !hasWorkspaceSidecar) {
+    throw new Error('Motif payload must contain records or a supported workspace sidecar.');
   }
   if (recordContainers.length > 1) {
     throw new Error(`Motif payload has ambiguous record containers: ${recordContainers.join(', ')}.`);
@@ -175,6 +330,10 @@ function validateFeature(feature: unknown, path: string, sequenceLength: number)
   for (const field of ['id', 'name', 'type', 'color'] as const) {
     boundedOptionalText(feature[field], `${path}.${field}`, MOTIF_MCP_LIMITS.maxShortTextLength);
   }
+  if (typeof feature.color === 'string'
+    && (feature.color.length > 80 || !SAFE_FEATURE_COLOR.test(feature.color.trim()))) {
+    throw new Error(`${path}.color must be a simple CSS color value no longer than 80 characters.`);
+  }
   if (!Number.isFinite(feature.start) || !Number.isFinite(feature.end)) {
     throw new Error(`${path} must have finite start and end coordinates.`);
   }
@@ -183,16 +342,21 @@ function validateFeature(feature: unknown, path: string, sequenceLength: number)
   if (start < 0 || end <= start || end > sequenceLength) {
     throw new Error(`${path} coordinates must satisfy 0 <= start < end <= ${sequenceLength}.`);
   }
-  if (feature.strand !== undefined && ![-1, 0, 1].includes(Number(feature.strand))) {
+  if (feature.strand !== undefined && ![-1, 0, 1].includes(feature.strand as number)) {
     throw new Error(`${path}.strand must be -1, 0, or 1.`);
   }
   if (feature.direction !== undefined
     && !['forward', 'reverse', 'none', -1, 0, 1].includes(feature.direction as string | number)) {
     throw new Error(`${path}.direction is not supported.`);
   }
+  if (feature.metadata !== undefined) {
+    if (!isPlainObject(feature.metadata)) throw new Error(`${path}.metadata must be a plain JSON object.`);
+    validateMetadataJsonValue(feature.metadata, `${path}.metadata`);
+  }
   if (feature.subRanges !== undefined) {
-    if (!Array.isArray(feature.subRanges) || feature.subRanges.length > 2_000) {
-      throw new Error(`${path}.subRanges must be an array with at most 2,000 entries.`);
+    if (!Array.isArray(feature.subRanges)
+      || feature.subRanges.length > MOTIF_MCP_LIMITS.maxSubRangesPerFeature) {
+      throw new Error(`${path}.subRanges must be an array with at most ${MOTIF_MCP_LIMITS.maxSubRangesPerFeature.toLocaleString()} entries.`);
     }
     feature.subRanges.forEach((range, index) => validateFeatureRange(range, `${path}.subRanges[${index}]`, sequenceLength));
   }
@@ -207,14 +371,68 @@ function validateFeatureRange(range: unknown, path: string, sequenceLength: numb
   if (start < 0 || end <= start || end > sequenceLength) {
     throw new Error(`${path} coordinates must satisfy 0 <= start < end <= ${sequenceLength}.`);
   }
+  if (range.strand !== undefined && ![-1, 0, 1].includes(range.strand as number)) {
+    throw new Error(`${path}.strand must be -1, 0, or 1.`);
+  }
 }
 
-function validateRecord(record: unknown, index: number): number {
+function validateSites(sites: unknown, path: string): void {
+  if (!Array.isArray(sites)) throw new Error(`${path} must be an array of site objects.`);
+  if (sites.length > MOTIF_MCP_LIMITS.maxSitesPerRecord) {
+    throw new Error(`${path} cannot contain more than ${MOTIF_MCP_LIMITS.maxSitesPerRecord.toLocaleString()} entries.`);
+  }
+  let totalHits = 0;
+  sites.forEach((site, siteIndex) => {
+    const sitePath = `${path}[${siteIndex}]`;
+    if (!isPlainObject(site)) throw new Error(`${sitePath} must be a plain object.`);
+    for (const field of ['enzyme', 'motif'] as const) {
+      boundedOptionalText(site[field], `${sitePath}.${field}`, MOTIF_MCP_LIMITS.maxShortTextLength);
+    }
+    if (site.count !== undefined && (!Number.isInteger(site.count) || Number(site.count) < 0)) {
+      throw new Error(`${sitePath}.count must be a non-negative integer.`);
+    }
+    if (site.indexBase !== undefined && site.indexBase !== 0 && site.indexBase !== 1) {
+      throw new Error(`${sitePath}.indexBase must be 0 or 1.`);
+    }
+    if (site.overhang !== undefined && site.overhang !== 'blunt' && site.overhang !== '5prime' && site.overhang !== '3prime') {
+      throw new Error(`${sitePath}.overhang must be blunt, 5prime, or 3prime.`);
+    }
+    if (site.hits === undefined) return;
+    if (!Array.isArray(site.hits)) throw new Error(`${sitePath}.hits must be an array.`);
+    if (site.hits.length > MOTIF_MCP_LIMITS.maxHitsPerSite) {
+      throw new Error(`${sitePath}.hits cannot contain more than ${MOTIF_MCP_LIMITS.maxHitsPerSite.toLocaleString()} entries.`);
+    }
+    totalHits += site.hits.length;
+    site.hits.forEach((hit, hitIndex) => {
+      const hitPath = `${sitePath}.hits[${hitIndex}]`;
+      if (!isPlainObject(hit)) throw new Error(`${hitPath} must be a plain object.`);
+      if (!Number.isFinite(hit.position) || Number(hit.position) < 0) {
+        throw new Error(`${hitPath}.position must be a non-negative finite number.`);
+      }
+      if (hit.cutPosition !== undefined && (!Number.isFinite(hit.cutPosition) || Number(hit.cutPosition) < 0)) {
+        throw new Error(`${hitPath}.cutPosition must be a non-negative finite number.`);
+      }
+      if (hit.strand !== undefined && hit.strand !== -1 && hit.strand !== 1) {
+        throw new Error(`${hitPath}.strand must be -1 or 1.`);
+      }
+      if (hit.indexBase !== undefined && hit.indexBase !== 0 && hit.indexBase !== 1) {
+        throw new Error(`${hitPath}.indexBase must be 0 or 1.`);
+      }
+    });
+  });
+  if (totalHits > MOTIF_MCP_LIMITS.maxTotalHitsPerRecord) {
+    throw new Error(`${path} cannot contain more than ${MOTIF_MCP_LIMITS.maxTotalHitsPerRecord.toLocaleString()} hits in total.`);
+  }
+}
+
+function validateRecord(record: unknown, index: number): { length: number; sangerTraceSamples: number } {
   const path = `payload.records[${index}]`;
   if (!isPlainObject(record)) throw new Error(`${path} must be a plain object.`);
   const molecule = record.molecule ?? record.type;
-  if (molecule !== undefined && (!SEQUENCE_TYPES.has(molecule as SequenceType))) {
-    throw new Error(`${path}.molecule must be dna, rna, protein, misc, unknown, or mixed.`);
+  for (const field of ['molecule', 'type'] as const) {
+    if (record[field] !== undefined && !SEQUENCE_TYPES.has(record[field] as SequenceType)) {
+      throw new Error(`${path}.${field} must be dna, rna, protein, misc, unknown, or mixed.`);
+    }
   }
   if (record.topology !== undefined && record.topology !== 'linear' && record.topology !== 'circular') {
     throw new Error(`${path}.topology must be linear or circular.`);
@@ -224,6 +442,9 @@ function validateRecord(record: unknown, index: number): number {
       throw new Error(`${path}.${field} must be a boolean when provided.`);
     }
   }
+  if (record.truncated === true) {
+    throw new Error(`${path} is marked as truncated; provide the complete record.`);
+  }
   if (record.tags !== undefined) {
     if (!Array.isArray(record.tags) || record.tags.length > 100) {
       throw new Error(`${path}.tags must be an array with at most 100 entries.`);
@@ -232,11 +453,13 @@ function validateRecord(record: unknown, index: number): number {
       boundedOptionalText(tag, `${path}.tags[${tagIndex}]`, 256);
     });
   }
-  for (const field of ['id', 'name', 'organism', 'source', 'group', 'project', 'folder', 'collection'] as const) {
+  for (const field of ['id', 'name', 'organism', 'source', 'group', 'project', 'folder', 'collection', 'dateAdded'] as const) {
     boundedOptionalText(record[field], `${path}.${field}`, MOTIF_MCP_LIMITS.maxShortTextLength);
   }
   boundedOptionalText(record.description, `${path}.description`, MOTIF_MCP_LIMITS.maxTextLength);
-  const sequence = cleanSequence(record.sequence ?? record.seq, molecule, `${path}.sequence`);
+  const sequence = cleanSequence(record.seq ?? record.sequence, molecule, `${path}.sequence`);
+  const recordType = normalizedRecordType(molecule, sequence);
+  validateRecordOverhangs(record, path, recordType);
   const features = [
     ...(Array.isArray(record.features) ? record.features : []),
     ...(Array.isArray(record.annotations) ? record.annotations : []),
@@ -247,13 +470,41 @@ function validateRecord(record: unknown, index: number): number {
     throw new Error(`${path} cannot contain more than ${MOTIF_MCP_LIMITS.maxFeaturesPerRecord.toLocaleString()} features.`);
   }
   features.forEach((feature, featureIndex) => validateFeature(feature, `${path}.features[${featureIndex}]`, sequence.length));
-  return sequence.length;
+  if (record.sites !== undefined) validateSites(record.sites, `${path}.sites`);
+  if (record.provenance !== undefined) {
+    if (!isPlainObject(record.provenance)) throw new Error(`${path}.provenance must be a plain JSON object.`);
+    validateMetadataJsonValue(record.provenance, `${path}.provenance`);
+  }
+  let sangerTraceSamples = 0;
+  if (record.sangerTrace !== undefined) {
+    if (recordType !== 'dna') throw new Error(`${path}.sangerTrace is only valid on DNA records.`);
+    try {
+      sangerTraceSamples = artifactSangerTraceSampleEntries(
+        normalizeArtifactSangerTrace(record.sangerTrace, sequence),
+      );
+    } catch (error) {
+      throw new Error(`${path}.sangerTrace is invalid: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  return { length: sequence.length, sangerTraceSamples };
 }
 
 function coercePayload(value: unknown): MotifWorkbenchPayload {
   if (Array.isArray(value)) return { records: value };
   if (!isPlainObject(value)) throw new Error('Motif payload must be a JSON object or an array of records.');
-  if (typeof value.sequence === 'string' || typeof value.seq === 'string') return { records: [value] };
+  if (['records', 'entries', 'vectors', 'record'].some((field) => (
+    Object.prototype.hasOwnProperty.call(value, field)
+  ))) {
+    return value;
+  }
+  if (typeof value.sequence === 'string' || typeof value.seq === 'string') {
+    const payload: RecordLike = { ...value, records: [value] };
+    // The nested record is authoritative after coercion. Keeping a second
+    // top-level trace would make the browser count the same large arrays as
+    // arbitrary payload metadata even though the typed record trace is valid.
+    delete payload.sangerTrace;
+    return payload;
+  }
   return value;
 }
 
@@ -261,13 +512,49 @@ function cloneJsonObject(value: MotifWorkbenchPayload): MotifWorkbenchPayload {
   return JSON.parse(JSON.stringify(value)) as MotifWorkbenchPayload;
 }
 
+function omitTraceArraysForGenericJsonValidation(
+  payload: MotifWorkbenchPayload,
+  stripTopLevelBareTrace: boolean,
+): MotifWorkbenchPayload {
+  const stripRecord = (record: unknown): unknown => {
+    if (!isPlainObject(record) || record.sangerTrace === undefined) return record;
+    return {
+      ...record,
+      sangerTrace: isPlainObject(record.sangerTrace)
+        ? { schema: record.sangerTrace.schema, version: record.sangerTrace.version }
+        : record.sangerTrace,
+    };
+  };
+  const projected: MotifWorkbenchPayload = { ...payload };
+  for (const field of ['records', 'entries', 'vectors'] as const) {
+    if (Array.isArray(projected[field])) projected[field] = projected[field].map(stripRecord);
+  }
+  if (projected.record !== undefined) projected.record = stripRecord(projected.record);
+  if (stripTopLevelBareTrace && projected.sangerTrace !== undefined) {
+    projected.sangerTrace = isPlainObject(projected.sangerTrace)
+      ? { schema: projected.sangerTrace.schema, version: projected.sangerTrace.version }
+      : projected.sangerTrace;
+  }
+  return projected;
+}
+
 export function validateMotifPayload(value: unknown): {
   payload: MotifWorkbenchPayload;
   recordCount: number;
   residueCount: number;
 } {
+  const isBareRecord = isPlainObject(value)
+    && !['records', 'entries', 'vectors', 'record'].some((field) => (
+      Object.prototype.hasOwnProperty.call(value, field)
+    ))
+    && (typeof value.seq === 'string' || typeof value.sequence === 'string');
   const payload = coercePayload(value);
-  validateJsonValue(payload, 'payload', { nodes: 0 }, new WeakSet());
+  validateJsonValue(
+    omitTraceArraysForGenericJsonValidation(payload, isBareRecord),
+    'payload',
+    { nodes: 0 },
+    new WeakSet(),
+  );
   validatePayloadEnvelope(payload);
   const serialized = JSON.stringify(payload);
   if (utf8Bytes(serialized) > MOTIF_MCP_LIMITS.maxPayloadBytes) {
@@ -283,23 +570,55 @@ export function validateMotifPayload(value: unknown): {
     throw new Error(`Payload cannot contain more than ${MOTIF_MCP_LIMITS.maxRecords} records.`);
   }
   const explicitIds = new Set<string>();
+  const usedIds = new Set<string>();
+  const recordLengths = new Map<string, number>();
   let activeRecords = 0;
+  let totalSangerTraceSamples = 0;
   const residueCount = records.reduce<number>((total, record, index) => {
+    const validatedRecord = validateRecord(record, index);
+    const { length } = validatedRecord;
+    totalSangerTraceSamples += validatedRecord.sangerTraceSamples;
+    if (totalSangerTraceSamples > ARTIFACT_SANGER_MAX_WORKSPACE_SAMPLE_ENTRIES) {
+      throw new Error(
+        `Payload chromatograms cannot contain more than ${ARTIFACT_SANGER_MAX_WORKSPACE_SAMPLE_ENTRIES.toLocaleString()} channel sample entries in total.`,
+      );
+    }
     if (isPlainObject(record)) {
       if (record.active !== false) activeRecords += 1;
-      if (typeof record.id === 'string' && record.id.trim()) {
-        const id = record.id.trim();
-        if (explicitIds.has(id)) throw new Error(`Payload records contain duplicate id ${id}.`);
-        explicitIds.add(id);
-      }
+      const explicitId = normalizedRecordIdText(record.id);
+      if (explicitId && explicitIds.has(explicitId)) throw new Error(`Payload records contain duplicate id ${explicitId}.`);
+      if (explicitId) explicitIds.add(explicitId);
+      const id = uniqueRuntimeRecordId(
+        explicitId ?? normalizedRecordIdText(record.name) ?? `record-${index + 1}`,
+        usedIds,
+      );
+      if (record.active !== false) recordLengths.set(id, length);
     }
-    return total + validateRecord(record, index);
+    return total + length;
   }, 0);
   if (records.length > 0 && activeRecords === 0) {
     throw new Error('A non-empty Motif payload must contain at least one active record.');
   }
   if (residueCount > MOTIF_MCP_LIMITS.maxTotalResidues) {
     throw new Error(`Payload cannot contain more than ${MOTIF_MCP_LIMITS.maxTotalResidues.toLocaleString()} residues in total.`);
+  }
+  try {
+    normalizeArtifactAlignments(payload.alignments ?? payload.alignment);
+  } catch (error) {
+    throw new Error(`Payload alignment workspace is invalid: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  try {
+    normalizeArtifactWorkspaceEnvelope(payload, recordLengths);
+  } catch (error) {
+    throw new Error(`Payload workspace is invalid: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  try {
+    normalizeArtifactAnalysisWorkspace({
+      analysisResults: payload.analysisResults,
+      analysisAssets: payload.analysisAssets,
+    }, { recordLengths });
+  } catch (error) {
+    throw new Error(`Payload analysis workspace is invalid: ${error instanceof Error ? error.message : String(error)}`);
   }
   return { payload: cloneJsonObject(payload), recordCount: records.length, residueCount };
 }

--- a/scripts/build-claude-science-artifact.mjs
+++ b/scripts/build-claude-science-artifact.mjs
@@ -13,6 +13,7 @@ import {
 } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { buildSync } from 'esbuild';
 import { validatePayload as validateArtifactPayload } from '../src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/create-artifact.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -307,6 +308,36 @@ export function validatePluginSource(pluginPath = pluginSourcePath) {
   }
   if (!existsSync(join(skillDirectory, 'scripts/run-msa.mjs'))) {
     throw new Error('Plugin is missing its external MSA runner');
+  }
+  const generatedValidators = [
+    {
+      filename: 'analysis-validator.mjs',
+      source: 'src/artifacts/claude-science-analysis-results.ts',
+    },
+    {
+      filename: 'workspace-validator.mjs',
+      source: 'src/artifacts/claude-science-workspace-envelope.ts',
+    },
+  ];
+  for (const validator of generatedValidators) {
+    const generatedPath = join(skillDirectory, 'scripts', validator.filename);
+    if (!existsSync(generatedPath)) {
+      throw new Error(`Plugin is missing its generated ${validator.filename}`);
+    }
+    const regenerated = buildSync({
+      entryPoints: [join(root, validator.source)],
+      bundle: true,
+      platform: 'node',
+      format: 'esm',
+      target: 'node20',
+      write: false,
+      banner: {
+        js: `// Generated from ${validator.source}. Regenerate with the documented esbuild command; do not edit by hand.`,
+      },
+    }).outputFiles[0].text;
+    if (readFileSync(generatedPath, 'utf8') !== regenerated) {
+      throw new Error(`Plugin generated validator ${validator.filename} is stale; regenerate it from ${validator.source}`);
+    }
   }
   const mcpConfig = JSON.parse(readFileSync(join(pluginPath, '.mcp.json'), 'utf8'));
   if (mcpConfig?.motif?.command !== 'node') {

--- a/scripts/test-claude-science-plugin-packaging.mjs
+++ b/scripts/test-claude-science-plugin-packaging.mjs
@@ -164,6 +164,7 @@ check('plugin source has a matching, bounded manifest and skill', () => {
   assert.match(changelog, new RegExp(`^## ${manifest.version.replace(/\./g, '\\.')}(?:\\s|$)`, 'm'));
   assert.ok(existsSync(join(pluginSource, runnerRelativePath)));
   assert.ok(existsSync(join(pluginSource, 'skills/motif-for-claude-science/scripts/analysis-validator.mjs')));
+  assert.ok(existsSync(join(pluginSource, 'skills/motif-for-claude-science/scripts/workspace-validator.mjs')));
 });
 
 check('release versions stay aligned across package, runtime, bridge, and plugin', () => {
@@ -258,6 +259,95 @@ check('bundled analysis validator is generated from the canonical artifact norma
     },
   }).outputFiles[0].text;
   assert.equal(readFileSync(generatedPath, 'utf8'), regenerated);
+});
+
+check('bundled workspace validator is generated from the canonical artifact normalizer', () => {
+  const generatedPath = join(pluginSource, 'skills/motif-for-claude-science/scripts/workspace-validator.mjs');
+  const regenerated = buildSync({
+    entryPoints: [join(root, 'src/artifacts/claude-science-workspace-envelope.ts')],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    target: 'node20',
+    write: false,
+    banner: {
+      js: '// Generated from src/artifacts/claude-science-workspace-envelope.ts. Regenerate with the documented esbuild command; do not edit by hand.',
+    },
+  }).outputFiles[0].text;
+  assert.equal(readFileSync(generatedPath, 'utf8'), regenerated);
+});
+
+check('payload helper applies canonical notes and durable-state validation', () => {
+  const createdAt = '2026-07-12T12:00:00.000Z';
+  const base = { records: [{ id: 'record-a', type: 'dna', sequence: 'ATGGAATTCTAA' }] };
+  const valid = {
+    ...base,
+    notes: [{
+      id: 'note-a', body: 'Review A.', format: 'plain', scope: 'record', recordId: 'record-a', createdAt, updatedAt: createdAt,
+    }],
+    artifactState: {
+      customEnzymes: [{
+        name: 'HelperI', recognitionSequence: 'GAATTC', cutOffset: 1, complementCutOffset: 5, overhang: '5prime',
+      }],
+      translationLayersByRecord: {
+        'record-a': [{ id: 'layer-a', label: 'Layer A', start: 0, end: 6, strand: 1, frame: 0 }],
+      },
+      enzymeSourcesByRecord: { 'record-a': ['common'] },
+    },
+  };
+  assert.equal(validatePayload(valid), valid);
+  const sidecarOnly = { name: 'Workspace label', notes: [] };
+  assert.equal(validatePayload(sidecarOnly), sidecarOnly);
+
+  const malformed = [
+    { notes: { malformed: true } },
+    { notes: [{ id: 'bad', body: 'Bad', format: 'plain', scope: 'elsewhere', createdAt, updatedAt: createdAt }] },
+    { artifactState: null },
+    { artifactState: { customEnzymes: { malformed: true } } },
+    { artifactState: { translationLayersByRecord: {
+      'record-a': [{ id: 'bad', label: 'Bad', start: 0, end: 99, strand: 1, frame: 0 }],
+    } } },
+    { alignments: [{
+      id: 'orphaned', molecule: 'dna', rows: [
+        { id: 'a', name: 'A', aligned: 'ATGC', sourceRecordId: 'missing' },
+        { id: 'b', name: 'B', aligned: 'AT-C' },
+      ],
+    }] },
+  ];
+  for (const patch of malformed) {
+    assert.throws(() => validatePayload({ ...base, ...patch }), /Payload workspace is invalid/i);
+  }
+  assert.throws(() => validatePayload({
+    records: [
+      { id: 'record-a', type: 'dna', sequence: 'ATGC', active: false },
+      { id: 'record-a', type: 'dna', sequence: 'ATGC', active: true },
+    ],
+    notes: [{
+      id: 'note-a', body: 'Ambiguous record link.', format: 'plain', scope: 'record', recordId: 'record-a', createdAt, updatedAt: createdAt,
+    }],
+  }), /duplicate id record-a/i);
+  assert.throws(() => validatePayload({
+    records: [
+      { name: 'record-a', type: 'dna', sequence: 'ATGC', active: false },
+      { id: 'record-a', type: 'dna', sequence: 'ATGC', active: true },
+    ],
+    notes: [{
+      id: 'note-a', body: 'Must not relink after id allocation.', format: 'plain', scope: 'record', recordId: 'record-a', createdAt, updatedAt: createdAt,
+    }],
+  }), /Payload workspace is invalid/i);
+  assert.throws(() => validatePayload({
+    records: [{ id: 'record-a', type: 'dna', sequence: 'AT*GC' }],
+    notes: [{
+      id: 'note-a', body: 'Range uses normalized DNA length.', format: 'plain', scope: 'range', recordId: 'record-a', range: { start: 0, end: 5 }, createdAt, updatedAt: createdAt,
+    }],
+  }), /Payload workspace is invalid/i);
+  assert.throws(() => validatePayload({
+    records: [{ id: 'inactive-only', type: 'dna', sequence: 'ATGC', active: false }],
+  }), /at least one active record/i);
+  assert.throws(() => validatePayload({
+    schema: 'motif.claude-science.inventory.v99',
+    records: [{ id: 'future', type: 'dna', sequence: 'ATGC' }],
+  }), /unsupported Motif inventory schema/i);
 });
 
 check('payload helper bounds typed analysis results and forbids executable assets', () => {
@@ -492,6 +582,13 @@ check('bundled helper safely injects payloads and refuses accidental overwrite',
 
 check('bundled helper rejects malformed nested shapes and oversized records', () => {
   const base = { id: 'safe', type: 'dna', sequence: 'GAATTCAAAAAA' };
+  assert.doesNotThrow(() => validatePayload({ records: [{
+    ...base,
+    overhang5: 'AATT',
+    overhang5Type: '5prime',
+    overhang3: '',
+    overhang3Type: 'blunt',
+  }] }));
   for (const record of [
     { ...base, tags: 42 },
     { ...base, features: { start: 0, end: 3 } },
@@ -500,6 +597,10 @@ check('bundled helper rejects malformed nested shapes and oversized records', ()
     { ...base, sites: { enzyme: 'EcoRI' } },
     { ...base, sites: [{ enzyme: 'EcoRI', hits: [null] }] },
     { ...base, features: [{ start: 0, end: 3, type: '<script>alert(1)</script>' }] },
+    { ...base, overhang5: 'AATT', overhang5Type: 'blunt' },
+    { ...base, overhang5Type: '5prime' },
+    { ...base, overhang3: 'AX' },
+    { ...base, type: 'protein', sequence: 'MPEPTIDE', overhang5: 'AATT', overhang5Type: '5prime' },
   ]) {
     assert.throws(() => validatePayload({ records: [record] }), /Payload record 1/);
   }
@@ -590,8 +691,22 @@ check('bundled helper accepts linked Sanger traces and rejects detached or malfo
     () => validatePayload({ records: [{ id: 'read-01', type: 'dna', sequence: 'ACGT', sangerTrace: { ...sangerTrace, channels: { ...sangerTrace.channels, C: 'not-an-array' } } }] }),
     /channels\.C must be an array/,
   );
+  assert.throws(
+    () => validatePayload({ records: [{
+      id: 'protein-like-trace',
+      sequence: 'ATG*',
+      sangerTrace: {
+        ...sangerTrace,
+        baseCalls: 'ATG',
+        sequence: 'ATG',
+        qualityScores: [12, 24, 36],
+        peakPositions: [1, 3, 5],
+      },
+    }] }),
+    /can only belong to a DNA record/,
+  );
   const channel = Array(63_000).fill(0);
-  assert.doesNotThrow(() => validatePayload({ records: [{
+  const boundedLargeTraceRecord = {
     id: 'bounded-large-trace',
     type: 'dna',
     sequence: 'A',
@@ -604,7 +719,9 @@ check('bundled helper accepts linked Sanger traces and rejects detached or malfo
       channels: { A: channel, C: channel, G: channel, T: channel },
       sampleCount: channel.length,
     },
-  }] }));
+  };
+  assert.doesNotThrow(() => validatePayload({ records: [boundedLargeTraceRecord] }));
+  assert.doesNotThrow(() => validatePayload(boundedLargeTraceRecord));
 });
 
 check('external MSA runner validates CLI bounds and unique FASTA headers', () => {

--- a/src/artifacts/ClaudeScienceAgentResultsPanel.tsx
+++ b/src/artifacts/ClaudeScienceAgentResultsPanel.tsx
@@ -4,12 +4,17 @@ import type {
   ArtifactAnalysisKind,
   ArtifactAnalysisResult,
 } from './claude-science-analysis-results';
+import {
+  ClaudeScienceFreshnessBadge,
+  type ScientificFreshnessDisplayEvaluation,
+} from './ClaudeScienceFreshnessBadge';
 import './claude-science-agent-results.css';
 
 export type ClaudeScienceAgentResultsPanelProps = {
   results: readonly ArtifactAnalysisResult[];
   assets: readonly ArtifactAnalysisAsset[];
   recordNames: Readonly<Record<string, string>>;
+  freshnessByResultId?: ReadonlyMap<string, ScientificFreshnessDisplayEvaluation>;
   onRevealRecord: (recordId: string) => void;
   onRemove: (resultId: string) => boolean | void;
 };
@@ -18,6 +23,7 @@ const KIND_LABELS: Record<ArtifactAnalysisKind, string> = {
   primer_design: 'Primer Design',
   pcr: 'PCR',
   assembly_plan: 'Assembly Plan',
+  construct_verification: 'Construct Verification',
   blast_search: 'BLAST Search',
   structure_model: 'Structure Model',
   report: 'Report',
@@ -28,7 +34,7 @@ type ResultFilter = 'all' | 'design' | 'sequence' | 'evidence';
 
 const FILTER_KINDS: Record<Exclude<ResultFilter, 'all'>, ReadonlySet<ArtifactAnalysisKind>> = {
   design: new Set(['primer_design', 'pcr', 'assembly_plan']),
-  sequence: new Set(['blast_search', 'structure_model']),
+  sequence: new Set(['construct_verification', 'blast_search', 'structure_model']),
   evidence: new Set(['report', 'table']),
 };
 
@@ -61,6 +67,13 @@ function resultFacts(result: ArtifactAnalysisResult): Array<{ label: string; val
         { label: 'Method', value: result.data.method.replaceAll('_', ' ') },
         { label: 'Parts', value: result.data.orderedPartRecordIds.length.toLocaleString() },
         ...(result.data.standard ? [{ label: 'Standard', value: result.data.standard }] : []),
+      ];
+    case 'construct_verification':
+      return [
+        { label: 'Verdict', value: result.data.state.replaceAll('_', ' ') },
+        { label: 'Coverage', value: `${(result.data.coverageFraction * 100).toFixed(1)}%` },
+        { label: 'Mapped Reads', value: `${result.data.mappedReadCount}/${result.data.readRecordIds.length}` },
+        { label: 'Unexpected', value: result.data.unexpectedVariantCount.toLocaleString() },
       ];
     case 'blast_search':
       return [
@@ -96,6 +109,11 @@ function safePreview(result: ArtifactAnalysisResult): string | null {
     const rows = result.data.rows.slice(0, 8).map((row) => row.map((cell) => String(cell ?? '')).join('\t'));
     return [header, ...rows].join('\n');
   }
+  if (result.kind === 'construct_verification') {
+    return result.data.reasonCodes.length
+      ? result.data.reasonCodes.map((code) => code.replaceAll('_', ' ')).join('\n')
+      : 'No verification issues recorded.';
+  }
   return null;
 }
 
@@ -103,6 +121,7 @@ export function ClaudeScienceAgentResultsPanel({
   results,
   assets,
   recordNames,
+  freshnessByResultId,
   onRevealRecord,
   onRemove,
 }: ClaudeScienceAgentResultsPanelProps) {
@@ -156,7 +175,7 @@ export function ClaudeScienceAgentResultsPanel({
       {results.length === 0 ? (
         <div className="motif-cs-agent-results-empty">
           <strong>No analysis results yet</strong>
-          <span>Primer designs, assembly plans, BLAST hits, structures, reports, and tables will appear here with their provenance.</span>
+          <span>Primer designs, assembly plans, construct checks, BLAST hits, structures, reports, and tables will appear here with their provenance.</span>
         </div>
       ) : ordered.length === 0 ? (
         <div className="motif-cs-agent-results-empty">
@@ -172,6 +191,7 @@ export function ClaudeScienceAgentResultsPanel({
             const engine = result.provenance.engine
               ? `${result.provenance.engine}${result.provenance.engineVersion ? ` ${result.provenance.engineVersion}` : ''}`
               : result.provenance.source;
+            const freshness = freshnessByResultId?.get(result.id);
             return (
               <article className="motif-cs-agent-result-row" key={result.id} data-testid={`analysis-result-${result.id}`}>
                 <div className="motif-cs-agent-result-heading">
@@ -180,7 +200,10 @@ export function ClaudeScienceAgentResultsPanel({
                     <strong>{result.name}</strong>
                     <small>{recordList(result.inputRecordIds, recordNames)}</small>
                   </div>
-                  <span className="motif-cs-agent-result-status" data-status={result.status}>{result.status}</span>
+                  <span className="motif-cs-agent-result-state">
+                    <span className="motif-cs-agent-result-status" data-status={result.status}>{result.status}</span>
+                    {freshness ? <ClaudeScienceFreshnessBadge evaluation={freshness} recordNames={recordNames} /> : null}
+                  </span>
                 </div>
 
                 {result.summary ? <p>{result.summary}</p> : null}
@@ -202,6 +225,12 @@ export function ClaudeScienceAgentResultsPanel({
                       <div><dt>Inputs</dt><dd>{recordList(result.inputRecordIds, recordNames)}</dd></div>
                       {result.inputSha256s?.length ? (
                         <div><dt>Hashes</dt><dd>{result.inputSha256s.map((hash) => hash.slice(0, 12)).join(', ')}…</dd></div>
+                      ) : null}
+                      {freshness ? (
+                        <div>
+                          <dt>Freshness</dt>
+                          <dd><ClaudeScienceFreshnessBadge evaluation={freshness} recordNames={recordNames} showReason /></dd>
+                        </div>
                       ) : null}
                       {linkedAssets.length ? (
                         <div><dt>Assets</dt><dd>{linkedAssets.map((asset) => `${asset.name} (${asset.mediaType})`).join(', ')}</dd></div>

--- a/src/artifacts/ClaudeScienceCloningDesignWorkspace.tsx
+++ b/src/artifacts/ClaudeScienceCloningDesignWorkspace.tsx
@@ -1,7 +1,9 @@
 import {
+  forwardRef,
   useCallback,
   useEffect,
   useId,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -72,6 +74,21 @@ export type ClaudeScienceCloningDesignWorkspaceProps = {
   initialMethod?: ClaudeScienceCloningDesignMethod;
   initialRecordIds?: readonly string[];
   embedded?: boolean;
+};
+
+export type ClaudeSciencePreparedPartReplacement = {
+  /** The reviewed plan identity captured when primer preparation opened. */
+  expectedRequestSha256: string;
+  /** The exact reviewed preparation action being satisfied. */
+  actionId: string;
+  sourceRecordId: string;
+  productRecordId: string;
+  productRecordName: string;
+};
+
+export type ClaudeScienceCloningDesignWorkspaceHandle = {
+  /** Replaces a reviewed source part while retaining all other live draft choices. */
+  replacePreparedPart: (replacement: ClaudeSciencePreparedPartReplacement) => boolean;
 };
 
 type PartOrientation = NonNullable<ArtifactCloningInput['orientation']>;
@@ -228,7 +245,10 @@ function excerpt(sequence: string): string {
   return `${sequence.slice(0, 36)}…${sequence.slice(-36)}`;
 }
 
-export function ClaudeScienceCloningDesignWorkspace({
+export const ClaudeScienceCloningDesignWorkspace = forwardRef<
+  ClaudeScienceCloningDesignWorkspaceHandle,
+  ClaudeScienceCloningDesignWorkspaceProps
+>(function ClaudeScienceCloningDesignWorkspace({
   records,
   onClose,
   onDesignPrimers,
@@ -236,7 +256,7 @@ export function ClaudeScienceCloningDesignWorkspace({
   initialMethod = 'golden_gate',
   initialRecordIds,
   embedded = false,
-}: ClaudeScienceCloningDesignWorkspaceProps) {
+}, forwardedRef) {
   const titleId = useId();
   const tabPanelId = useId();
   const partHelpId = useId();
@@ -387,6 +407,33 @@ export function ClaudeScienceCloningDesignWorkspace({
   const primerActions = plan.preparation.filter(isPrimerPreparation);
   const readyPrimerActions = primerActions.filter((action) => primerPreparationBlocker(plan, action) === null);
   const goldenGateNeedsAnotherInput = plan.kind === 'golden_gate_design' && plan.inputs.length < 2;
+
+  useImperativeHandle(forwardedRef, () => ({
+    replacePreparedPart(replacement) {
+      const action = plan.preparation.find((item) => item.id === replacement.actionId);
+      const requestMatches = plan.provenance?.requestSha256 === replacement.expectedRequestSha256;
+      const actionMatches = action?.recordIds.includes(replacement.sourceRecordId) === true;
+      const sourcePartExists = parts.some((part) => part.recordId === replacement.sourceRecordId);
+      const sourceIsDestination = destinationRecordId === replacement.sourceRecordId;
+      if (!requestMatches || !actionMatches || (!sourcePartExists && !sourceIsDestination)) {
+        setError('The cloning draft changed after primer preparation opened. The amplicon was not inserted into this draft.');
+        setStatus('');
+        return false;
+      }
+      if (sourcePartExists) {
+        setParts((current) => current.map((part) => (
+          part.recordId === replacement.sourceRecordId
+            ? { ...part, recordId: replacement.productRecordId }
+            : part
+        )));
+      }
+      if (sourceIsDestination) setDestinationRecordId(replacement.productRecordId);
+      setSavedSignatures({ plan: '', product: '' });
+      setError('');
+      setStatus(`${replacement.productRecordName} replaced the prepared source; the cloning draft was rechecked.`);
+      return true;
+    },
+  }), [destinationRecordId, parts, plan]);
 
   const movePart = useCallback((index: number, destination: number) => {
     if (destination < 0 || destination >= parts.length || destination === index) return;
@@ -1250,4 +1297,4 @@ export function ClaudeScienceCloningDesignWorkspace({
       </section>
     </div>
   );
-}
+});

--- a/src/artifacts/ClaudeScienceConstructVerificationPanel.tsx
+++ b/src/artifacts/ClaudeScienceConstructVerificationPanel.tsx
@@ -1,0 +1,525 @@
+import { useId, useMemo, useState } from 'react';
+import './claude-science-construct-verification.css';
+
+type ArtifactConstructVerificationState = 'consistent' | 'needs_review' | 'inconsistent';
+
+type ArtifactConstructVerificationReasonPresentation = {
+  code: string;
+  severity: string;
+  message: string;
+  readId?: string;
+  regionId?: string;
+  variantId?: string;
+};
+
+type ArtifactConstructVerificationVariantPresentation = {
+  id?: string;
+  position?: number;
+  referencePosition?: number;
+  referenceStart?: number;
+  referenceEnd?: number;
+  type?: string;
+  reference?: string;
+  ref?: string;
+  observed?: string;
+  alternate?: string;
+  alt?: string;
+  supportingReadIds?: readonly string[];
+  supportingReads?: number;
+  support?: number;
+  quality?: number;
+  meanQuality?: number | null;
+  confidence?: 'high' | 'low';
+  depth?: number;
+  status?: 'observed' | 'low_confidence' | 'not_observed' | 'not_covered';
+  observedVariantId?: string;
+};
+
+type ArtifactConstructVerificationRegionPresentation = {
+  id?: string;
+  name?: string;
+  label?: string;
+  start?: number;
+  end?: number;
+  wraps?: boolean;
+  length?: number;
+  minDepth?: number;
+  requireBothStrands?: boolean;
+  coveredBases?: number;
+  basesMeetingMinDepth?: number;
+  coveredFraction?: number;
+  minimumDepth?: number;
+  maximumDepth?: number;
+  meanDepth?: number;
+  forwardCoveredBases?: number;
+  reverseCoveredBases?: number;
+  bothStrandsCoveredBases?: number;
+  status?: string;
+};
+
+type ArtifactConstructVerificationReadPresentation = {
+  id: string;
+  name?: string;
+  rawLength: number;
+  meanQuality: number | null;
+  status: string;
+  trim?: {
+    rawStart?: number;
+    rawEnd?: number;
+    trimmedLength?: number;
+    removedFromStart?: number;
+    removedFromEnd?: number;
+  };
+  mapping: {
+    orientation: 'forward' | 'reverse';
+    referenceStart?: number;
+    referenceEnd?: number;
+    alignedBases?: number;
+    alignedLength?: number;
+    identity?: number;
+    insertions?: number;
+    deletions?: number;
+  } | null;
+};
+
+/**
+ * Narrow structural view of the frozen construct-verification result. Keeping
+ * the presentation boundary independent lets this branch remain UI-only while
+ * the engine result remains directly assignable. No sequence evaluation lives
+ * in this component.
+ */
+export type ArtifactConstructVerificationPresentationResult = {
+  schema: string;
+  version: number;
+  state: ArtifactConstructVerificationState;
+  reasons: readonly ArtifactConstructVerificationReasonPresentation[];
+  reference: {
+    id?: string;
+    recordId?: string;
+    name?: string;
+    length?: number;
+    topology?: string;
+  };
+  reads: readonly ArtifactConstructVerificationReadPresentation[];
+  coverage: {
+    depth?: readonly number[];
+    forward?: readonly number[];
+    reverse?: readonly number[];
+    coveredBases: number;
+    basesMeetingMinDepth?: number;
+    coveredFraction: number;
+    meanDepth?: number;
+    requiredRegions: readonly ArtifactConstructVerificationRegionPresentation[];
+  };
+  consensus: {
+    calls: readonly { status: string }[];
+  };
+  variants: {
+    observed: readonly ArtifactConstructVerificationVariantPresentation[];
+    expected: readonly ArtifactConstructVerificationVariantPresentation[];
+    unexpected: readonly ArtifactConstructVerificationVariantPresentation[];
+    missingExpected: readonly ArtifactConstructVerificationVariantPresentation[];
+  };
+  provenance?: {
+    engine?: string;
+    engineVersion?: string;
+    workUnits?: number;
+  };
+};
+
+export type ClaudeScienceConstructVerificationPanelProps = {
+  result: ArtifactConstructVerificationPresentationResult;
+  referenceName?: string;
+  readNames?: Readonly<Record<string, string>>;
+};
+
+type VariantClassification = 'expected' | 'unexpected' | 'missing_expected' | 'uncertain';
+type VariantFilter = 'all' | VariantClassification;
+
+type ClassifiedVariant = {
+  classification: VariantClassification;
+  variant: ArtifactConstructVerificationVariantPresentation;
+  key: string;
+};
+
+const VERDICT_COPY: Record<ArtifactConstructVerificationState, { label: string; summary: string }> = {
+  consistent: {
+    label: 'Consistent',
+    summary: 'Observed read evidence is consistent with the predicted construct within the recorded thresholds.',
+  },
+  needs_review: {
+    label: 'Needs review',
+    summary: 'The evidence is incomplete or contains findings that need scientific review before acceptance.',
+  },
+  inconsistent: {
+    label: 'Inconsistent',
+    summary: 'Observed read evidence conflicts with the predicted construct or a required expectation is missing.',
+  },
+};
+
+const CLASSIFICATION_LABELS: Record<VariantClassification, string> = {
+  expected: 'Expected',
+  unexpected: 'Unexpected',
+  missing_expected: 'Missing expected',
+  uncertain: 'Low confidence',
+};
+
+const PRIMARY_REASON_LIMIT = 4;
+const TOTAL_REASON_LIMIT = 24;
+const VARIANT_LIMIT = 100;
+const READ_LIMIT = 48;
+const REGION_LIMIT = 48;
+
+function boundedPercent(fraction: number | undefined): number | null {
+  if (!Number.isFinite(fraction)) return null;
+  return Math.min(100, Math.max(0, (fraction ?? 0) * 100));
+}
+
+function formatPercent(fraction: number | undefined, digits = 1): string {
+  const percent = boundedPercent(fraction);
+  return percent === null ? '—' : `${percent.toFixed(digits)}%`;
+}
+
+function formatNumber(value: number | undefined, suffix = ''): string {
+  return Number.isFinite(value) ? `${(value ?? 0).toLocaleString()}${suffix}` : '—';
+}
+
+function formatQuality(value: number | null | undefined): string {
+  return Number.isFinite(value) ? `Q${(value ?? 0).toFixed(1)}` : '—';
+}
+
+function readableToken(value: string | undefined): string {
+  if (!value) return '—';
+  return value.replaceAll('_', ' ').replaceAll('-', ' ');
+}
+
+function variantPosition(variant: ArtifactConstructVerificationVariantPresentation): string {
+  const position = variant.position ?? variant.referencePosition ?? variant.referenceStart;
+  return Number.isFinite(position) ? (position ?? 0).toLocaleString() : '—';
+}
+
+function variantAlleles(variant: ArtifactConstructVerificationVariantPresentation): string {
+  const reference = variant.reference ?? variant.ref ?? '—';
+  const observed = variant.observed ?? variant.alternate ?? variant.alt ?? '—';
+  return `${reference} → ${observed}`;
+}
+
+function variantSupport(variant: ArtifactConstructVerificationVariantPresentation): string {
+  const count = variant.supportingReadIds?.length ?? variant.supportingReads ?? variant.support;
+  if (Number.isFinite(count)) return formatNumber(count, count === 1 ? ' read' : ' reads');
+  return Number.isFinite(variant.depth) ? formatNumber(variant.depth, '× depth') : '—';
+}
+
+function variantQuality(variant: ArtifactConstructVerificationVariantPresentation): string {
+  const quality = variant.quality ?? variant.meanQuality;
+  return Number.isFinite(quality) ? `Q${(quality ?? 0).toFixed(1)}` : '—';
+}
+
+function variantKey(variant: ArtifactConstructVerificationVariantPresentation, index: number): string {
+  if (variant.id) return variant.id;
+  const position = variant.position ?? variant.referencePosition ?? variant.referenceStart;
+  const reference = variant.reference ?? variant.ref;
+  const observed = variant.observed ?? variant.alternate ?? variant.alt;
+  if (position === undefined && reference === undefined && observed === undefined) return `anonymous:${index}`;
+  return `${position ?? ''}:${reference ?? ''}:${observed ?? ''}`;
+}
+
+function classifiedVariants(
+  result: ArtifactConstructVerificationPresentationResult,
+): ClassifiedVariant[] {
+  const output: ClassifiedVariant[] = [];
+  const seen = new Set<string>();
+  result.variants.unexpected.forEach((variant, index) => {
+    const classification: VariantClassification = variant.confidence === 'low' ? 'uncertain' : 'unexpected';
+    const baseKey = variantKey(variant, index);
+    if (seen.has(baseKey)) return;
+    seen.add(baseKey);
+    output.push({ classification, variant, key: `${classification}:${baseKey}` });
+  });
+  const observedById = new Map(result.variants.observed.map((variant) => [variant.id, variant]));
+  result.variants.expected.forEach((expected, index) => {
+    const observed = expected.observedVariantId ? observedById.get(expected.observedVariantId) : undefined;
+    const displayVariant = observed
+      ? { ...expected, support: observed.support, supportingReadIds: observed.supportingReadIds, meanQuality: observed.meanQuality }
+      : expected;
+    const classification: VariantClassification = expected.status === 'observed'
+      ? 'expected'
+      : expected.status === 'low_confidence'
+        ? 'uncertain'
+        : 'missing_expected';
+    const baseKey = variantKey(displayVariant, index);
+    if (seen.has(baseKey)) return;
+    seen.add(baseKey);
+    output.push({ classification, variant: displayVariant, key: `${classification}:${baseKey}` });
+  });
+  return output;
+}
+
+function meanDepth(depth: readonly number[] | undefined): number | null {
+  if (!depth?.length) return null;
+  let total = 0;
+  for (const value of depth) total += value;
+  return total / depth.length;
+}
+
+function regionName(region: ArtifactConstructVerificationRegionPresentation, index: number): string {
+  return region.name ?? region.label ?? region.id ?? `Required region ${index + 1}`;
+}
+
+function regionRange(region: ArtifactConstructVerificationRegionPresentation): string {
+  if (!Number.isFinite(region.start) || !Number.isFinite(region.end)) return '—';
+  return `${(region.start ?? 0).toLocaleString()}–${(region.end ?? 0).toLocaleString()}`;
+}
+
+function regionStrands(region: ArtifactConstructVerificationRegionPresentation): string {
+  const forward = (region.forwardCoveredBases ?? 0) > 0;
+  const reverse = (region.reverseCoveredBases ?? 0) > 0;
+  if (forward && reverse) return 'Forward + reverse';
+  if (forward) return 'Forward only';
+  if (reverse) return 'Reverse only';
+  return 'No strand support';
+}
+
+function readRange(read: ArtifactConstructVerificationReadPresentation): string {
+  const start = read.mapping?.referenceStart;
+  const end = read.mapping?.referenceEnd;
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return 'No mapped range';
+  return `ref ${(start ?? 0).toLocaleString()}–${(end ?? 0).toLocaleString()} (0-based, end exclusive)`;
+}
+
+export function ClaudeScienceConstructVerificationPanel({
+  result,
+  referenceName,
+  readNames = {},
+}: ClaudeScienceConstructVerificationPanelProps) {
+  const sectionId = useId();
+  const [variantFilter, setVariantFilter] = useState<VariantFilter>('all');
+  const verdict = VERDICT_COPY[result.state];
+  const allVariants = useMemo(() => classifiedVariants(result), [result]);
+  const matchingVariants = useMemo(() => allVariants.filter((entry) => (
+    variantFilter === 'all' || entry.classification === variantFilter
+  )), [allVariants, variantFilter]);
+  const filteredVariants = matchingVariants.slice(0, VARIANT_LIMIT);
+  const filteredVariantCount = matchingVariants.length;
+  const forwardReads = result.reads.filter((read) => read.status === 'mapped' && read.mapping?.orientation === 'forward').length;
+  const reverseReads = result.reads.filter((read) => read.status === 'mapped' && read.mapping?.orientation === 'reverse').length;
+  const mappedReads = result.reads.filter((read) => read.status === 'mapped').length;
+  const readQualities = result.reads.flatMap((read) => read.meanQuality === null ? [] : [read.meanQuality]);
+  const meanReadQuality = readQualities.length
+    ? readQualities.reduce((total, value) => total + value, 0) / readQualities.length
+    : undefined;
+  const variantsByReadId = useMemo(() => {
+    const counts = new Map<string, number>();
+    result.variants.observed.forEach((variant) => {
+      variant.supportingReadIds?.forEach((readId) => counts.set(readId, (counts.get(readId) ?? 0) + 1));
+    });
+    return counts;
+  }, [result.variants.observed]);
+  const averageDepth = result.coverage.meanDepth ?? meanDepth(result.coverage.depth);
+  const coveragePercent = boundedPercent(result.coverage.coveredFraction);
+  const primaryReasons = result.reasons.slice(0, PRIMARY_REASON_LIMIT);
+  const additionalReasons = result.reasons.slice(PRIMARY_REASON_LIMIT, TOTAL_REASON_LIMIT);
+  const omittedReasons = Math.max(0, result.reasons.length - TOTAL_REASON_LIMIT);
+  const referenceLabel = referenceName
+    ?? result.reference.name
+    ?? result.reference.recordId
+      ?? result.reference.id
+      ?? 'Predicted construct';
+  const expectedVariantCount = result.variants.expected.length;
+  const unexpectedVariantCount = result.variants.unexpected.filter((variant) => variant.confidence !== 'low').length;
+  const missingExpectedCount = result.variants.missingExpected.length;
+  const acceptedCoveredBases = result.coverage.basesMeetingMinDepth ?? result.coverage.coveredBases;
+
+  return (
+    <section
+      className="motif-cs-construct-verification"
+      aria-label={`Construct verification: ${verdict.label}`}
+      data-testid="construct-verification-panel"
+    >
+      <header className="motif-cs-construct-verification-verdict" data-verdict={result.state}>
+        <span className="motif-cs-construct-verification-rail" aria-hidden="true" />
+        <div className="motif-cs-construct-verification-heading">
+          <span className="motif-cs-construct-verification-eyebrow">Construct verification</span>
+          <strong>{verdict.label}</strong>
+          <p>{verdict.summary}</p>
+        </div>
+        <div className="motif-cs-construct-verification-reference">
+          <span>Predicted reference</span>
+          <strong title={referenceLabel}>{referenceLabel}</strong>
+          <span>{formatNumber(result.reference.length, ' bp')} · {readableToken(result.reference.topology)}</span>
+        </div>
+      </header>
+
+      <dl className="motif-cs-construct-verification-facts" aria-label="Verification summary facts">
+        <div><dt>Reference coverage</dt><dd>{formatPercent(result.coverage.coveredFraction)}</dd></div>
+        <div><dt>Mapped reads</dt><dd>{mappedReads.toLocaleString()} / {result.reads.length.toLocaleString()}</dd></div>
+        <div><dt>Strand support</dt><dd>{forwardReads.toLocaleString()} F · {reverseReads.toLocaleString()} R</dd></div>
+        <div><dt>Mean depth</dt><dd>{averageDepth === null ? '—' : `${averageDepth.toFixed(1)}×`}</dd></div>
+        <div><dt>Unexpected</dt><dd>{unexpectedVariantCount.toLocaleString()}</dd></div>
+        <div><dt>Mean read quality</dt><dd>{formatQuality(meanReadQuality)}</dd></div>
+      </dl>
+
+      <div className="motif-cs-construct-verification-coverage">
+        <div className="motif-cs-construct-verification-coverage-label">
+          <span>Reference bases with accepted read coverage</span>
+          <strong>{acceptedCoveredBases.toLocaleString()} bp · {formatPercent(result.coverage.coveredFraction)}</strong>
+        </div>
+        <progress
+          aria-label={`Reference coverage ${formatPercent(result.coverage.coveredFraction)}`}
+          max={100}
+          value={coveragePercent ?? 0}
+        />
+      </div>
+
+      <section className="motif-cs-construct-verification-section" aria-labelledby={`${sectionId}-findings`}>
+        <div className="motif-cs-construct-verification-section-heading">
+          <span id={`${sectionId}-findings`}>Review findings</span>
+          <small>{result.reasons.length.toLocaleString()} reason{result.reasons.length === 1 ? '' : 's'}</small>
+        </div>
+        {primaryReasons.length ? (
+          <>
+            <ul className="motif-cs-construct-verification-reasons">
+              {primaryReasons.map((reason, index) => (
+                <li className="motif-cs-construct-verification-reason" key={`${reason.code}:${reason.readId ?? reason.regionId ?? reason.variantId ?? index}`}>
+                  <span className="motif-cs-construct-verification-reason-code">{readableToken(reason.severity)} · {readableToken(reason.code)}</span>
+                  <span>{reason.message}</span>
+                </li>
+              ))}
+            </ul>
+            {additionalReasons.length ? (
+              <details className="motif-cs-construct-verification-disclosure">
+                <summary>Show {additionalReasons.length.toLocaleString()} more finding{additionalReasons.length === 1 ? '' : 's'}</summary>
+                <ul className="motif-cs-construct-verification-reasons">
+                  {additionalReasons.map((reason, index) => (
+                    <li className="motif-cs-construct-verification-reason" key={`${reason.code}:${reason.readId ?? reason.regionId ?? reason.variantId ?? index}`}>
+                      <span className="motif-cs-construct-verification-reason-code">{readableToken(reason.severity)} · {readableToken(reason.code)}</span>
+                      <span>{reason.message}</span>
+                    </li>
+                  ))}
+                </ul>
+                {omittedReasons ? <p className="motif-cs-construct-verification-empty">{omittedReasons.toLocaleString()} additional findings are outside this bounded preview.</p> : null}
+              </details>
+            ) : null}
+          </>
+        ) : (
+          <p className="motif-cs-construct-verification-empty">No review findings were recorded for this result.</p>
+        )}
+      </section>
+
+      <section className="motif-cs-construct-verification-section" aria-labelledby={`${sectionId}-variants`}>
+        <div className="motif-cs-construct-verification-section-heading">
+          <span id={`${sectionId}-variants`}>Variant evidence</span>
+          <label className="motif-cs-construct-verification-filter">
+            <span>Show</span>
+            <select value={variantFilter} onChange={(event) => setVariantFilter(event.target.value as VariantFilter)}>
+              <option value="all">All evidence ({allVariants.length.toLocaleString()})</option>
+              <option value="unexpected">Unexpected ({unexpectedVariantCount.toLocaleString()})</option>
+              <option value="expected">Expected ({expectedVariantCount.toLocaleString()})</option>
+              <option value="missing_expected">Missing expected ({missingExpectedCount.toLocaleString()})</option>
+              <option value="uncertain">Low confidence</option>
+            </select>
+          </label>
+        </div>
+        {filteredVariants.length ? (
+          <div
+            className="motif-cs-construct-verification-table-scroll"
+            tabIndex={0}
+            aria-label="Scrollable variant evidence table"
+            data-testid="construct-verification-variant-table"
+          >
+            <table className="motif-cs-construct-verification-table">
+              <thead>
+                <tr><th>Position (0-based)</th><th>Change</th><th>Type</th><th>Assessment</th><th>Support</th><th>Quality</th></tr>
+              </thead>
+              <tbody>
+                {filteredVariants.map(({ classification, variant, key }) => (
+                  <tr key={key}>
+                    <td data-numeric>{variantPosition(variant)}</td>
+                    <td data-sequence>{variantAlleles(variant)}</td>
+                    <td>{readableToken(variant.type)}</td>
+                    <td><span className="motif-cs-construct-verification-tag" data-classification={classification}>{CLASSIFICATION_LABELS[classification]}</span></td>
+                    <td data-numeric>{variantSupport(variant)}</td>
+                    <td data-numeric>{variantQuality(variant)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {filteredVariantCount > VARIANT_LIMIT ? (
+              <p className="motif-cs-construct-verification-empty">Showing the first {VARIANT_LIMIT.toLocaleString()} of {filteredVariantCount.toLocaleString()} matching variants.</p>
+            ) : null}
+          </div>
+        ) : (
+          <p className="motif-cs-construct-verification-empty">No variant evidence matches this view.</p>
+        )}
+      </section>
+
+      {result.coverage.requiredRegions.length ? (
+        <section className="motif-cs-construct-verification-section" aria-labelledby={`${sectionId}-regions`}>
+          <div className="motif-cs-construct-verification-section-heading">
+            <span id={`${sectionId}-regions`}>Required &amp; junction coverage</span>
+            <small>{result.coverage.requiredRegions.length.toLocaleString()} region{result.coverage.requiredRegions.length === 1 ? '' : 's'}</small>
+          </div>
+          <div className="motif-cs-construct-verification-table-scroll" tabIndex={0} aria-label="Scrollable required region coverage table">
+            <table className="motif-cs-construct-verification-table">
+              <thead><tr><th>Region</th><th>Reference range (0-based, end exclusive)</th><th>Coverage</th><th>Strands</th><th>Status</th></tr></thead>
+              <tbody>
+                {result.coverage.requiredRegions.slice(0, REGION_LIMIT).map((region, index) => (
+                  <tr key={region.id ?? `${regionName(region, index)}:${index}`}>
+                    <td>{regionName(region, index)}</td>
+                    <td data-numeric>{regionRange(region)}</td>
+                    <td data-numeric>{formatPercent(region.coveredFraction)}</td>
+                    <td>{regionStrands(region)}</td>
+                    <td>{readableToken(region.status)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {result.coverage.requiredRegions.length > REGION_LIMIT ? (
+              <p className="motif-cs-construct-verification-empty">Showing the first {REGION_LIMIT.toLocaleString()} required regions.</p>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="motif-cs-construct-verification-section" aria-labelledby={`${sectionId}-reads`}>
+        <div className="motif-cs-construct-verification-section-heading">
+          <span id={`${sectionId}-reads`}>Read evidence</span>
+          <small>{result.reads.length.toLocaleString()} read{result.reads.length === 1 ? '' : 's'}</small>
+        </div>
+        {result.reads.length ? (
+          <details className="motif-cs-construct-verification-disclosure">
+            <summary>Inspect mapped reads and quality</summary>
+            <div className="motif-cs-construct-verification-read-grid">
+              {result.reads.slice(0, READ_LIMIT).map((read) => {
+                const label = readNames[read.id] ?? read.name ?? read.id;
+                const orientation = read.mapping?.orientation;
+                const variantCount = variantsByReadId.get(read.id) ?? 0;
+                return (
+                  <article className="motif-cs-construct-verification-read" key={read.id}>
+                    <strong>{label}</strong>
+                    <span>{readableToken(orientation)} · {readableToken(read.status)} · {readRange(read)}</span>
+                    <span>{read.rawLength.toLocaleString()} calls · {formatQuality(read.meanQuality)} · {variantCount.toLocaleString()} variant{variantCount === 1 ? '' : 's'}</span>
+                  </article>
+                );
+              })}
+            </div>
+            {result.reads.length > READ_LIMIT ? (
+              <p className="motif-cs-construct-verification-empty">Showing the first {READ_LIMIT.toLocaleString()} reads.</p>
+            ) : null}
+          </details>
+        ) : (
+          <p className="motif-cs-construct-verification-empty">No read evidence was recorded.</p>
+        )}
+      </section>
+
+      <footer className="motif-cs-construct-verification-provenance">
+        <span>{result.schema} · v{result.version.toLocaleString()}</span>
+        {result.provenance?.engine ? (
+          <span>{result.provenance.engine}{result.provenance.engineVersion ? ` ${result.provenance.engineVersion}` : ''}</span>
+        ) : null}
+      </footer>
+    </section>
+  );
+}
+
+export default ClaudeScienceConstructVerificationPanel;

--- a/src/artifacts/ClaudeScienceConstructVerificationWorkspace.tsx
+++ b/src/artifacts/ClaudeScienceConstructVerificationWorkspace.tsx
@@ -1,0 +1,682 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from 'react';
+import {
+  ClaudeScienceConstructVerificationPanel,
+} from './ClaudeScienceConstructVerificationPanel';
+import {
+  ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS,
+  type ArtifactConstructVerificationResult,
+} from './claude-science-construct-verification';
+import './claude-science-construct-verification-workspace.css';
+
+const MIN_DEPTH = 1;
+const MAX_DEPTH = 96;
+const MAX_SELECTED_READS = ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReads;
+const FOCUSABLE = [
+  'button:not([disabled])',
+  'select:not([disabled])',
+  'input:not([disabled])',
+  'summary',
+  '[href]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export type ClaudeScienceConstructVerificationSangerTrace = {
+  baseCalls: string;
+  qualityScores?: readonly number[];
+};
+
+export type ClaudeScienceConstructVerificationRecord = {
+  id: string;
+  name: string;
+  sequence: string;
+  topology: 'linear' | 'circular';
+  /** SHA-256 of the current normalized record sequence. */
+  sha256: string;
+  sangerTrace?: ClaudeScienceConstructVerificationSangerTrace;
+  /** SHA-256 of the imported Sanger evidence, distinct from the record sequence hash. */
+  sangerEvidenceSha256?: string;
+};
+
+export type ClaudeScienceConstructVerificationReadRecord = ClaudeScienceConstructVerificationRecord & {
+  sangerTrace: ClaudeScienceConstructVerificationSangerTrace;
+};
+
+export type ClaudeScienceConstructVerificationRequest = {
+  reference: ClaudeScienceConstructVerificationRecord;
+  reads: readonly ClaudeScienceConstructVerificationReadRecord[];
+  minDepth: number;
+  requireBothStrands: boolean;
+};
+
+export type ClaudeScienceConstructVerificationThresholds = {
+  trimQuality: number;
+  trimWindow: number;
+  minTrimmedReadLength: number;
+  minMappingIdentity: number;
+  minMappingMargin: number;
+  maxIndelFraction: number;
+  minCoverageFraction: number;
+  minDepth: number;
+  requireBothStrands: boolean;
+  minConsensusFraction: number;
+  minVariantQuality: number;
+  minVariantFraction: number;
+};
+
+/**
+ * Structural extension of the evidence panel's presentation boundary. The
+ * construct-verification engine result is directly assignable without making
+ * this workspace own or persist its large coordinate and depth arrays.
+ */
+export type ClaudeScienceConstructVerificationResult = ArtifactConstructVerificationResult;
+
+export type ClaudeScienceConstructVerificationSnapshot = Readonly<{
+  reference: Readonly<{
+    id: string;
+    sequenceSha256: string;
+    topology: 'linear' | 'circular';
+  }>;
+  reads: readonly Readonly<{
+    id: string;
+    sequenceSha256: string;
+    sangerEvidenceSha256: string | null;
+  }>[];
+  minDepth: number;
+  requireBothStrands: boolean;
+}>;
+
+export type ClaudeScienceConstructVerificationSavePayload = Readonly<{
+  result: ClaudeScienceConstructVerificationResult;
+  snapshot: ClaudeScienceConstructVerificationSnapshot;
+}>;
+
+export type ClaudeScienceConstructVerificationWorkspaceProps = {
+  records: readonly ClaudeScienceConstructVerificationRecord[];
+  initialReferenceId?: string;
+  /** Runs synchronously against bounded inputs; the large result stays local until Save. */
+  onVerify: (request: ClaudeScienceConstructVerificationRequest) => ClaudeScienceConstructVerificationResult;
+  onSave: (payload: ClaudeScienceConstructVerificationSavePayload) => void;
+  onClose?: () => void;
+  embedded?: boolean;
+};
+
+type VerificationFormState = {
+  referenceId: string;
+  selectedReadIds: string[];
+  minDepth: number;
+  requireBothStrands: boolean;
+};
+
+type CompletedRun = {
+  result: ClaudeScienceConstructVerificationResult;
+  snapshot: ClaudeScienceConstructVerificationSnapshot;
+};
+
+function isTraceBacked(
+  record: ClaudeScienceConstructVerificationRecord,
+): record is ClaudeScienceConstructVerificationReadRecord {
+  return Boolean(record.sangerTrace && record.sangerTrace.baseCalls.trim().length > 0);
+}
+
+function eligibleReferenceRecords(
+  records: readonly ClaudeScienceConstructVerificationRecord[],
+): ClaudeScienceConstructVerificationRecord[] {
+  return records.filter((record) => !isTraceBacked(record));
+}
+
+function preferredReferenceId(
+  records: readonly ClaudeScienceConstructVerificationRecord[],
+  initialReferenceId: string | undefined,
+): string {
+  const references = eligibleReferenceRecords(records);
+  const requested = initialReferenceId
+    ? references.find((record) => record.id === initialReferenceId)
+    : undefined;
+  return requested?.id ?? references[0]?.id ?? '';
+}
+
+function eligibleReadRecords(
+  records: readonly ClaudeScienceConstructVerificationRecord[],
+  referenceId: string,
+): ClaudeScienceConstructVerificationReadRecord[] {
+  return records.filter((record): record is ClaudeScienceConstructVerificationReadRecord => (
+    record.id !== referenceId && isTraceBacked(record)
+  ));
+}
+
+function initialFormState(
+  records: readonly ClaudeScienceConstructVerificationRecord[],
+  initialReferenceId: string | undefined,
+): VerificationFormState {
+  const referenceId = preferredReferenceId(records, initialReferenceId);
+  return {
+    referenceId,
+    selectedReadIds: eligibleReadRecords(records, referenceId)
+      .slice(0, MAX_SELECTED_READS)
+      .map((record) => record.id),
+    minDepth: MIN_DEPTH,
+    requireBothStrands: false,
+  };
+}
+
+function recordsSignature(records: readonly ClaudeScienceConstructVerificationRecord[]): string {
+  return JSON.stringify(records.map((record) => {
+    const trace = record.sangerTrace;
+    const fallbackEvidence = trace ? [trace.baseCalls, trace.qualityScores ?? null] : null;
+    return [
+      record.id,
+      record.sha256,
+      record.topology,
+      record.sangerEvidenceSha256 ?? fallbackEvidence,
+    ];
+  }));
+}
+
+function clampDepth(value: number): number {
+  if (!Number.isFinite(value)) return MIN_DEPTH;
+  return Math.max(MIN_DEPTH, Math.min(MAX_DEPTH, Math.round(value)));
+}
+
+function boundedErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.trim() || 'Construct verification could not be completed.';
+  return normalized.length <= 320 ? normalized : `${normalized.slice(0, 319)}…`;
+}
+
+function freezeSnapshot(
+  reference: ClaudeScienceConstructVerificationRecord,
+  reads: readonly ClaudeScienceConstructVerificationReadRecord[],
+  minDepth: number,
+  requireBothStrands: boolean,
+): ClaudeScienceConstructVerificationSnapshot {
+  const frozenReads = Object.freeze(reads.map((read) => Object.freeze({
+    id: read.id,
+    sequenceSha256: read.sha256,
+    sangerEvidenceSha256: read.sangerEvidenceSha256 ?? null,
+  })));
+  return Object.freeze({
+    reference: Object.freeze({
+      id: reference.id,
+      sequenceSha256: reference.sha256,
+      topology: reference.topology,
+    }),
+    reads: frozenReads,
+    minDepth,
+    requireBothStrands,
+  });
+}
+
+export function ClaudeScienceConstructVerificationWorkspace({
+  records,
+  initialReferenceId,
+  onVerify,
+  onSave,
+  onClose,
+  embedded = false,
+}: ClaudeScienceConstructVerificationWorkspaceProps) {
+  const titleId = useId();
+  const criteriaId = useId();
+  const workspaceRef = useRef<HTMLElement>(null);
+  const initialFocusRef = useRef<HTMLSelectElement>(null);
+  const recordsRef = useRef(records);
+  recordsRef.current = records;
+  const recordSignature = useMemo(() => recordsSignature(records), [records]);
+  const [form, setForm] = useState<VerificationFormState>(() => (
+    initialFormState(records, initialReferenceId)
+  ));
+  const [completedRun, setCompletedRun] = useState<CompletedRun | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [statusMessage, setStatusMessage] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const recordById = useMemo(
+    () => new Map(records.map((record) => [record.id, record])),
+    [records],
+  );
+  const referenceRecords = useMemo(
+    () => eligibleReferenceRecords(records),
+    [records],
+  );
+  const eligibleReads = useMemo(
+    () => eligibleReadRecords(records, form.referenceId),
+    [form.referenceId, records],
+  );
+  const eligibleReadIdSet = useMemo(
+    () => new Set(eligibleReads.map((record) => record.id)),
+    [eligibleReads],
+  );
+  const selectedReadIdSet = useMemo(
+    () => new Set(form.selectedReadIds),
+    [form.selectedReadIds],
+  );
+  const selectedReads = useMemo(
+    () => eligibleReads.filter((record) => selectedReadIdSet.has(record.id)),
+    [eligibleReads, selectedReadIdSet],
+  );
+
+  const clearCompletedRun = useCallback(() => {
+    setCompletedRun(null);
+    setSaved(false);
+    setStatusMessage('');
+    setErrorMessage('');
+  }, []);
+
+  useEffect(() => {
+    const currentRecords = recordsRef.current;
+    setForm((current) => {
+      const referenceStillExists = currentRecords.some((record) => (
+        record.id === current.referenceId && !isTraceBacked(record)
+      ));
+      const referenceId = referenceStillExists
+        ? current.referenceId
+        : preferredReferenceId(currentRecords, undefined);
+      const nextEligibleReads = eligibleReadRecords(currentRecords, referenceId);
+      const validReadIds = new Set(nextEligibleReads.map((record) => record.id));
+      const selectedReadIds = referenceStillExists
+        ? current.selectedReadIds.filter((id) => validReadIds.has(id)).slice(0, MAX_SELECTED_READS)
+        : nextEligibleReads.slice(0, MAX_SELECTED_READS).map((record) => record.id);
+      if (
+        referenceId === current.referenceId
+        && selectedReadIds.length === current.selectedReadIds.length
+        && selectedReadIds.every((id, index) => id === current.selectedReadIds[index])
+      ) return current;
+      return { ...current, referenceId, selectedReadIds };
+    });
+    clearCompletedRun();
+  }, [clearCompletedRun, recordSignature]);
+
+  useEffect(() => {
+    if (embedded) return undefined;
+    const previouslyFocused = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    initialFocusRef.current?.focus();
+    return () => previouslyFocused?.focus();
+  }, [embedded]);
+
+  useEffect(() => {
+    if (embedded || !onClose) return undefined;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !event.defaultPrevented) {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const focusable = Array.from(
+        workspaceRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? [],
+      ).filter((element) => element.offsetParent !== null || element === document.activeElement);
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [embedded, onClose]);
+
+  const updateReference = (referenceId: string) => {
+    if (!referenceRecords.some((record) => record.id === referenceId)) return;
+    setForm((current) => ({
+      ...current,
+      referenceId,
+      selectedReadIds: eligibleReadRecords(records, referenceId)
+        .slice(0, MAX_SELECTED_READS)
+        .map((record) => record.id),
+    }));
+    clearCompletedRun();
+  };
+
+  const updateReadSelection = (readId: string, checked: boolean) => {
+    if (checked && !selectedReadIdSet.has(readId) && selectedReads.length >= MAX_SELECTED_READS) return;
+    setForm((current) => {
+      const selected = new Set(current.selectedReadIds);
+      if (checked) selected.add(readId);
+      else selected.delete(readId);
+      return {
+        ...current,
+        selectedReadIds: eligibleReads
+          .filter((record) => selected.has(record.id))
+          .map((record) => record.id),
+      };
+    });
+    clearCompletedRun();
+  };
+
+  const selectAllReads = () => {
+    setForm((current) => ({
+      ...current,
+      selectedReadIds: eligibleReads.slice(0, MAX_SELECTED_READS).map((record) => record.id),
+    }));
+    clearCompletedRun();
+  };
+
+  const clearReads = () => {
+    setForm((current) => ({ ...current, selectedReadIds: [] }));
+    clearCompletedRun();
+  };
+
+  const updateMinimumDepth = (value: number) => {
+    setForm((current) => ({ ...current, minDepth: clampDepth(value) }));
+    clearCompletedRun();
+  };
+
+  const updateStrandRequirement = (requireBothStrands: boolean) => {
+    setForm((current) => ({ ...current, requireBothStrands }));
+    clearCompletedRun();
+  };
+
+  const runVerification = (event: FormEvent) => {
+    event.preventDefault();
+    setCompletedRun(null);
+    setSaved(false);
+    setErrorMessage('');
+    setStatusMessage('');
+
+    const reference = recordById.get(form.referenceId);
+    if (!reference || isTraceBacked(reference)) {
+      setErrorMessage('Choose a predicted DNA reference before verification.');
+      return;
+    }
+    if (!selectedReads.length) {
+      setErrorMessage('Select at least one imported Sanger read before verification.');
+      return;
+    }
+    if (selectedReads.length > MAX_SELECTED_READS) {
+      setErrorMessage(`Select no more than ${MAX_SELECTED_READS.toLocaleString()} Sanger reads per verification run.`);
+      return;
+    }
+
+    const snapshot = freezeSnapshot(
+      reference,
+      selectedReads,
+      form.minDepth,
+      form.requireBothStrands,
+    );
+    const request = Object.freeze({
+      reference,
+      reads: Object.freeze([...selectedReads]),
+      minDepth: form.minDepth,
+      requireBothStrands: form.requireBothStrands,
+    });
+
+    try {
+      const result = onVerify(request);
+      setCompletedRun({ result, snapshot });
+      setStatusMessage('Verification complete. Review the evidence before saving.');
+    } catch (error) {
+      setErrorMessage(boundedErrorMessage(error));
+    }
+  };
+
+  const saveVerification = () => {
+    if (!completedRun || saved) return;
+    setErrorMessage('');
+    try {
+      onSave(Object.freeze({
+        result: completedRun.result,
+        snapshot: completedRun.snapshot,
+      }));
+      setSaved(true);
+      setStatusMessage('Verification saved to Results with its frozen evidence snapshot.');
+    } catch (error) {
+      setErrorMessage(boundedErrorMessage(error));
+    }
+  };
+
+  const reference = recordById.get(form.referenceId);
+  const selectedCount = selectedReads.length;
+  const defaultSelectedReadIds = eligibleReads.slice(0, MAX_SELECTED_READS).map((record) => record.id);
+  const allReadsSelected = defaultSelectedReadIds.length > 0
+    && defaultSelectedReadIds.length === selectedCount
+    && defaultSelectedReadIds.every((id) => selectedReadIdSet.has(id));
+  const readSelectionAtLimit = selectedCount >= MAX_SELECTED_READS;
+  const runDisabled = !reference || isTraceBacked(reference) || eligibleReads.length === 0 || selectedCount === 0;
+  const resultReadNames = useMemo(
+    () => Object.fromEntries(records.map((record) => [record.id, record.name])),
+    [records],
+  );
+
+  const workspace = (
+    <section
+      ref={workspaceRef}
+      className="motif-cs-verification-workspace"
+      data-embedded={embedded || undefined}
+      role={embedded ? 'region' : 'dialog'}
+      aria-modal={embedded ? undefined : true}
+      aria-label={embedded ? 'Construct verification' : undefined}
+      aria-labelledby={embedded ? undefined : titleId}
+      data-testid="construct-verification-workspace"
+    >
+      {embedded ? null : (
+        <header className="motif-cs-verification-workspace-header">
+          <div>
+            <span>Evidence workspace</span>
+            <h2 id={titleId}>Construct verification</h2>
+            <p>Compare imported Sanger base calls with the predicted DNA record.</p>
+          </div>
+          {onClose ? (
+            <button
+              className="motif-cs-verification-icon-button"
+              type="button"
+              onClick={onClose}
+              aria-label="Close construct verification workspace"
+            >×</button>
+          ) : null}
+        </header>
+      )}
+
+      <div className="motif-cs-verification-workspace-body">
+        <form className="motif-cs-verification-setup" onSubmit={runVerification}>
+          <div className="motif-cs-verification-intro">
+            <span>Predicted vs observed</span>
+            <strong>Define the acceptance evidence</strong>
+            <p>Motif uses the entire predicted construct as the required region. Adjustments invalidate the prior run until you verify again.</p>
+          </div>
+
+          <section className="motif-cs-verification-form-section" aria-labelledby={`${criteriaId}-reference`}>
+            <div className="motif-cs-verification-section-index" aria-hidden="true">01</div>
+            <div className="motif-cs-verification-section-content">
+              <label className="motif-cs-verification-field" htmlFor={`${criteriaId}-reference-select`}>
+                <span id={`${criteriaId}-reference`}>Predicted reference</span>
+                <select
+                  ref={initialFocusRef}
+                  id={`${criteriaId}-reference-select`}
+                  data-testid="construct-verification-reference"
+                  value={form.referenceId}
+                  disabled={!referenceRecords.length}
+                  onChange={(event) => updateReference(event.target.value)}
+                >
+                  {!referenceRecords.length ? <option value="">No predicted DNA references</option> : null}
+                  {referenceRecords.map((record) => (
+                    <option key={record.id} value={record.id}>
+                      {record.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {reference ? (
+                <p className="motif-cs-verification-record-detail">
+                  {reference.sequence.length.toLocaleString()} bp · {reference.topology} · sequence hash recorded
+                </p>
+              ) : (
+                <p className="motif-cs-verification-record-detail">Add a DNA record to define the predicted construct.</p>
+              )}
+            </div>
+          </section>
+
+          <fieldset className="motif-cs-verification-form-section motif-cs-verification-read-fieldset">
+            <legend className="motif-cs-verification-sr-only">Imported Sanger evidence</legend>
+            <div className="motif-cs-verification-section-index" aria-hidden="true">02</div>
+            <div className="motif-cs-verification-section-content">
+              <div className="motif-cs-verification-read-heading">
+                <div>
+                  <strong>Imported Sanger evidence</strong>
+                  <span id={`${criteriaId}-read-limit`}>
+                    {selectedCount.toLocaleString()} of {eligibleReads.length.toLocaleString()} reads selected · maximum {MAX_SELECTED_READS.toLocaleString()} per run
+                  </span>
+                </div>
+                <div className="motif-cs-verification-read-actions" aria-label="Sanger read selection actions">
+                  <button type="button" onClick={selectAllReads} disabled={!eligibleReads.length || allReadsSelected}>
+                    {eligibleReads.length > MAX_SELECTED_READS ? `First ${MAX_SELECTED_READS.toLocaleString()}` : 'All'}
+                  </button>
+                  <button type="button" onClick={clearReads} disabled={!selectedCount}>Clear</button>
+                </div>
+              </div>
+
+              {eligibleReads.length ? (
+                <div
+                  className="motif-cs-verification-read-list"
+                  data-testid="construct-verification-read-list"
+                  aria-label="Available imported Sanger reads"
+                >
+                  {eligibleReads.map((read) => {
+                    const checked = eligibleReadIdSet.has(read.id) && selectedReadIdSet.has(read.id);
+                    const disabledByLimit = !checked && readSelectionAtLimit;
+                    return (
+                      <label key={read.id} className="motif-cs-verification-read-option">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          disabled={disabledByLimit}
+                          aria-describedby={`${criteriaId}-read-limit`}
+                          title={disabledByLimit ? 'Deselect another read to include this evidence.' : undefined}
+                          onChange={(event) => updateReadSelection(read.id, event.target.checked)}
+                        />
+                        <span>
+                          <strong>{read.name}</strong>
+                          <small>
+                            {read.sangerTrace.baseCalls.length.toLocaleString()} calls · {read.sangerEvidenceSha256 ? 'evidence hash recorded' : 'evidence hash unavailable'}
+                          </small>
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="motif-cs-verification-empty-evidence" role="note">
+                  No trace-backed DNA records are available besides the selected reference. Import Sanger evidence to run verification.
+                </p>
+              )}
+            </div>
+          </fieldset>
+
+          <section className="motif-cs-verification-form-section" aria-labelledby={`${criteriaId}-acceptance`}>
+            <div className="motif-cs-verification-section-index" aria-hidden="true">03</div>
+            <div className="motif-cs-verification-section-content">
+              <div className="motif-cs-verification-acceptance-heading">
+                <strong id={`${criteriaId}-acceptance`}>Full-reference acceptance</strong>
+                <span>Every reference base is required</span>
+              </div>
+              <div className="motif-cs-verification-criteria-grid">
+                <label className="motif-cs-verification-field">
+                  <span>Minimum read depth</span>
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    min={MIN_DEPTH}
+                    max={MAX_DEPTH}
+                    value={form.minDepth}
+                    onChange={(event) => updateMinimumDepth(Number(event.target.value))}
+                  />
+                </label>
+                <label className="motif-cs-verification-strand-toggle">
+                  <input
+                    type="checkbox"
+                    checked={form.requireBothStrands}
+                    onChange={(event) => updateStrandRequirement(event.target.checked)}
+                  />
+                  <span>
+                    <strong>Require both strands</strong>
+                    <small>Forward and reverse evidence at every required base</small>
+                  </span>
+                </label>
+              </div>
+            </div>
+          </section>
+
+          <div className="motif-cs-verification-action-bar">
+            <div className="motif-cs-verification-messages" aria-live="polite">
+              {errorMessage ? (
+                <p className="motif-cs-verification-error" role="alert" data-testid="construct-verification-error">
+                  {errorMessage}
+                </p>
+              ) : statusMessage ? (
+                <p className="motif-cs-verification-status" role="status" data-testid="construct-verification-status">
+                  {statusMessage}
+                </p>
+              ) : (
+                <p>Run explicitly after reviewing the evidence and criteria.</p>
+              )}
+            </div>
+            <div className="motif-cs-verification-buttons">
+              <button
+                className="motif-cs-verification-secondary-button"
+                type="button"
+                onClick={saveVerification}
+                disabled={!completedRun || saved}
+                data-testid="construct-verification-save"
+              >{saved ? 'Saved' : 'Save verification'}</button>
+              <button
+                className="motif-cs-verification-primary-button"
+                type="submit"
+                disabled={runDisabled}
+                data-testid="construct-verification-run"
+              >Run verification</button>
+            </div>
+          </div>
+        </form>
+
+        <main className="motif-cs-verification-output" aria-label="Construct verification evidence result">
+          {completedRun ? (
+            <ClaudeScienceConstructVerificationPanel
+              result={completedRun.result}
+              referenceName={completedRun.result.reference.name ?? reference?.name}
+              readNames={resultReadNames}
+            />
+          ) : (
+            <div className="motif-cs-verification-awaiting" data-testid="construct-verification-awaiting">
+              <span aria-hidden="true">OBSERVED / PREDICTED</span>
+              <strong>Evidence has not been evaluated</strong>
+              <p>Select trace-backed records and run verification. Motif will retain the complete result locally for review, then save only on explicit confirmation.</p>
+              <dl>
+                <div><dt>Reference</dt><dd>{reference?.name ?? 'Not selected'}</dd></div>
+                <div><dt>Sanger reads</dt><dd>{selectedCount.toLocaleString()}</dd></div>
+                <div><dt>Required depth</dt><dd>{form.minDepth.toLocaleString()}×</dd></div>
+                <div><dt>Strands</dt><dd>{form.requireBothStrands ? 'Forward + reverse' : 'Either accepted'}</dd></div>
+              </dl>
+            </div>
+          )}
+        </main>
+      </div>
+    </section>
+  );
+
+  if (embedded) return workspace;
+  return (
+    <div
+      className="motif-cs-verification-backdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose?.();
+      }}
+    >
+      {workspace}
+    </div>
+  );
+}
+
+export default ClaudeScienceConstructVerificationWorkspace;

--- a/src/artifacts/ClaudeScienceFreshnessBadge.tsx
+++ b/src/artifacts/ClaudeScienceFreshnessBadge.tsx
@@ -1,0 +1,136 @@
+/* eslint-disable react-refresh/only-export-components -- exports inert freshness text formatters for result panels and tests */
+import './claude-science-freshness.css';
+
+export type ScientificFreshnessDisplayReason = {
+  code: string;
+  message?: string;
+  recordId?: string;
+  rowId?: string;
+  field?: string;
+  expected?: string;
+  actual?: string;
+};
+
+export type ScientificFreshnessDisplayEvaluation = {
+  state: 'fresh' | 'stale' | 'unverified';
+  reasons: readonly ScientificFreshnessDisplayReason[];
+};
+
+export type ClaudeScienceFreshnessBadgeProps = {
+  evaluation: ScientificFreshnessDisplayEvaluation;
+  recordNames?: Readonly<Record<string, string>>;
+  showReason?: boolean;
+};
+
+const STATE_LABELS: Record<ScientificFreshnessDisplayEvaluation['state'], string> = {
+  fresh: 'Fresh',
+  stale: 'Stale',
+  unverified: 'Unverified',
+};
+
+function readableCode(code: string): string {
+  const normalized = code.replaceAll('_', ' ').replaceAll('-', ' ').trim();
+  if (!normalized) return 'Saved input identity could not be verified';
+  return `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}`;
+}
+
+function subjectForReason(
+  reason: ScientificFreshnessDisplayReason,
+  recordNames: Readonly<Record<string, string>>,
+): string {
+  const id = reason.recordId ?? reason.rowId;
+  return id ? recordNames[id] ?? id : 'An input';
+}
+
+export function scientificFreshnessReasonText(
+  reason: ScientificFreshnessDisplayReason,
+  recordNames: Readonly<Record<string, string>> = {},
+): string {
+  const subject = subjectForReason(reason, recordNames);
+  switch (reason.code) {
+    case 'record_missing':
+    case 'input_record_missing':
+    case 'missing_input_record':
+    case 'source_record_missing':
+    case 'missing_source_record':
+      return `${subject} is no longer in this workspace.`;
+    case 'sequence_attestation_missing':
+    case 'input_sha256_missing':
+    case 'missing_input_sha256':
+    case 'input_hash_missing':
+    case 'missing_input_hash':
+      return `${subject} was saved without a sequence fingerprint.`;
+    case 'sequence_attestation_invalid':
+      return `${subject}'s saved sequence fingerprint is invalid.`;
+    case 'sequence_hash_mismatch':
+    case 'input_sha256_mismatch':
+    case 'sequence_changed':
+    case 'sequence_mismatch':
+    case 'row_sequence_changed':
+      return `${subject}'s sequence has changed since this was created.`;
+    case 'topology_attestation_missing':
+      return `${subject} was saved without a topology attestation.`;
+    case 'topology_attestation_invalid':
+      return `${subject}'s saved topology attestation is invalid.`;
+    case 'topology_changed':
+    case 'topology_mismatch':
+      return `${subject}'s topology has changed since this was created.`;
+    case 'end_chemistry_attestation_missing':
+      return `${subject} was saved without end-chemistry attestations.`;
+    case 'end_chemistry_attestation_invalid':
+      return `${subject}'s saved end-chemistry attestation is invalid.`;
+    case 'end_chemistry_missing':
+      return `${subject}'s current end chemistry is incomplete.`;
+    case 'end_chemistry_changed':
+    case 'end_chemistry_mismatch':
+    case 'overhang_changed':
+      return `${subject}'s end chemistry has changed since this was created.`;
+    case 'alignment_row_source_unattested':
+      return `${subject} is not linked to an attested source record.`;
+    case 'input_count_mismatch':
+    case 'hash_count_mismatch':
+      return 'Saved input fingerprints do not align with the recorded inputs.';
+    case 'source_identity_unverified':
+    case 'input_identity_unverified':
+      return `${subject}'s saved identity is incomplete.`;
+    default:
+      return reason.message?.trim()
+        || `${readableCode(reason.code)}${reason.field ? ` (${reason.field})` : ''}.`;
+  }
+}
+
+export function scientificFreshnessSummary(
+  evaluation: ScientificFreshnessDisplayEvaluation,
+  recordNames: Readonly<Record<string, string>> = {},
+): string {
+  if (evaluation.state === 'fresh') return 'Saved inputs match the current workspace.';
+  const first = evaluation.reasons[0];
+  const base = first
+    ? scientificFreshnessReasonText(first, recordNames)
+    : evaluation.state === 'stale'
+      ? 'A saved input no longer matches the current workspace.'
+      : 'Saved input identity is incomplete.';
+  const remaining = evaluation.reasons.length - 1;
+  return remaining > 0 ? `${base} ${remaining.toLocaleString()} more issue${remaining === 1 ? '' : 's'}.` : base;
+}
+
+export function ClaudeScienceFreshnessBadge({
+  evaluation,
+  recordNames = {},
+  showReason = false,
+}: ClaudeScienceFreshnessBadgeProps) {
+  const summary = scientificFreshnessSummary(evaluation, recordNames);
+  return (
+    <span className="motif-cs-freshness" data-freshness={evaluation.state}>
+      <span className="motif-cs-freshness-badge" title={summary} aria-label={`${STATE_LABELS[evaluation.state]}: ${summary}`}>
+        <span aria-hidden="true" />
+        {STATE_LABELS[evaluation.state]}
+      </span>
+      {showReason && evaluation.state !== 'fresh' ? (
+        <span className="motif-cs-freshness-reason">{summary}</span>
+      ) : null}
+    </span>
+  );
+}
+
+export default ClaudeScienceFreshnessBadge;

--- a/src/artifacts/ClaudeScienceGelWorkspace.tsx
+++ b/src/artifacts/ClaudeScienceGelWorkspace.tsx
@@ -174,12 +174,14 @@ function digestInputSha256(result: ArtifactWorkflowResult, recordId: string): st
 export function createClaudeScienceGelLaneCandidates(
   records: readonly ClaudeScienceGelRecord[],
   workflowResults: readonly ArtifactWorkflowResult[],
+  freshnessByResultId?: ReadonlyMap<string, { state: 'fresh' | 'stale' | 'unverified' }>,
 ): ClaudeScienceGelLaneCandidate[] {
   const recordById = new Map(records.map((record) => [record.id, record]));
   const candidates: ClaudeScienceGelLaneCandidate[] = [];
 
   for (const result of workflowResults) {
     if (result.kind !== 'digest') continue;
+    if (freshnessByResultId && freshnessByResultId.get(result.id)?.state !== 'fresh') continue;
     const outcome = digestOutcome(result);
     if (outcome === 'uncut') continue;
     const fragmentLengthsBp = digestFragmentLengths(result);

--- a/src/artifacts/ClaudeScienceMsaViewer.tsx
+++ b/src/artifacts/ClaudeScienceMsaViewer.tsx
@@ -8,8 +8,11 @@ import {
   type CSSProperties,
   type DragEvent as ReactDragEvent,
   type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
 } from 'react';
-import { ChevronDown, ChevronLeft, ChevronRight, Play, SlidersHorizontal, Trash2, UploadCloud } from 'lucide-react';
+import './claude-science-msa.css';
+import { ChevronDown, ChevronLeft, ChevronRight, GripVertical, Play, Search, SlidersHorizontal, Trash2, UploadCloud } from 'lucide-react';
 import { MSA_MAX_SEQ_LEN } from '../bio/msa';
 import type { SangerTraceData } from '../bio/abi-import';
 import { reverseComplement } from '../bio/reverse-complement';
@@ -19,16 +22,31 @@ import {
   ARTIFACT_MSA_MAX_IMPORT_BYTES,
   ARTIFACT_MSA_LOCAL_WORK_BUDGET,
   ArtifactAlignmentError,
+  computeMsaColumnStats,
   createLocalArtifactAlignment,
   estimateLocalAlignmentWork,
+  findMsaMotifMatches,
   formatAlignedFasta,
   formatClustal,
   formatConsensusFasta,
+  moveRowId,
+  msaShadeBucket,
   parseAlignmentText,
+  residueColorKey,
   safeAlignmentFilename,
+  selectionToColumnsText,
+  selectionToFasta,
+  selectionToUngappedFasta,
   serializeArtifactAlignment,
+  summarizeSelectionColumns,
+  translateAlignedRow,
   type ArtifactAlignment,
   type ArtifactMsaRecord,
+  type MsaColorScheme,
+  type MsaColumnStats,
+  type MsaMotifMatch,
+  type MsaSelection,
+  type MsaShadeMode,
 } from './claude-science-msa';
 import {
   ClaudeScienceSangerTraceViewer,
@@ -37,6 +55,8 @@ import {
 import { preferredTraceOrientation } from './claude-science-sanger';
 import {
   DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES,
+  MSA_ZOOM_MIN,
+  MSA_ZOOM_MAX,
   normalizeClaudeScienceMsaViewPreferences,
   type ClaudeScienceMsaColorMode,
   type ClaudeScienceMsaEmphasisMode,
@@ -63,7 +83,8 @@ type EmphasisMode = ClaudeScienceMsaEmphasisMode;
 type ColorMode = ClaudeScienceMsaColorMode;
 type RowSortMode = ClaudeScienceMsaRowSortMode;
 type MsaMatrixVisibility = Pick<ClaudeScienceMsaViewPreferences,
-  'showOverview' | 'showAlignmentAxis' | 'showTemplateAxis' | 'showRowStats' | 'showConservation' | 'showConsensus'>;
+  'showOverview' | 'showAlignmentAxis' | 'showTemplateAxis' | 'showRowStats' | 'showConservation'
+  | 'showConservationHistogram' | 'showOccupancy' | 'showConsensus' | 'showTranslation' | 'showAminoAcidIndices'>;
 type CoordinateSystem = 'alignment' | 'template';
 
 const INPUT_FASTA_HEADER_MAX_LENGTH = 1_024;
@@ -387,30 +408,66 @@ function useObservedWidth<T extends HTMLElement>(fallback = 720) {
   return [ref, width] as const;
 }
 
+/** Inclusive rectangular block: column and (ordered-row) index ranges. */
+type MatrixSelection = { colStart: number; colEnd: number; rowStart: number; rowEnd: number };
+/** Cell currently under the pointer, with client coords for the floating readout. */
+type HoverCell = { column: number; rowIndex: number; rowId: string; clientX: number; clientY: number };
+type MatrixContextMenu = { x: number; y: number; column: number; rowId: string | null };
+/** Live state while a row is being drag-reordered by its grip handle. */
+type RowDragState = { id: string; fromIndex: number; overIndex: number; edge: 'before' | 'after' };
+
+// Column density. The font-derived base cell width is scaled by the zoom
+// preference (decoupled from font size); the result is clamped so cells never
+// collapse to nothing or grow unreasonably. Below the legibility floor the
+// viewer drops letters for a birdseye "blocks" rendering.
+const MSA_BASE_CELL_MIN = 8;
+const MSA_BASE_CELL_MAX = 15;
+const MSA_CELL_MIN = 3;
+const MSA_CELL_MAX = 30;
+const MSA_LETTER_MIN = 6.5;
+
 function AlignmentMatrix({
   alignment,
   referenceRowId,
   emphasis,
   colorMode,
+  colorScheme,
+  shadeMode,
   fontSize,
+  zoom,
+  translationFrame,
   jumpColumn,
   jumpToken,
+  jumpRowId,
+  searchMatches,
+  activeSearchMatch,
   sortMode,
   visibility,
   resetToken,
   onTemplateChange,
+  onCopy,
+  onZoomChange,
 }: {
   alignment: ArtifactAlignment;
   referenceRowId: string;
   emphasis: EmphasisMode;
   colorMode: ColorMode;
+  colorScheme: MsaColorScheme;
+  shadeMode: MsaShadeMode;
   fontSize: number;
+  zoom: number;
+  translationFrame: 0 | 1 | 2;
   jumpColumn: number | null;
   jumpToken: number;
+  jumpRowId: string | null;
+  searchMatches: readonly MsaMotifMatch[];
+  activeSearchMatch: MsaMotifMatch | null;
   sortMode: RowSortMode;
   visibility: MsaMatrixVisibility;
   resetToken: number;
   onTemplateChange: (rowId: string) => void;
+  onCopy: (label: string, content: string) => Promise<boolean>;
+  onZoomChange: (zoom: number) => void;
 }) {
   const [viewportRef, viewportWidth] = useObservedWidth<HTMLDivElement>();
   const initialViewport = useMemo(() => msaMatrixViewportSession.get(alignment.id), [alignment.id]);
@@ -420,7 +477,25 @@ function AlignmentMatrix({
   const pendingScrollTopRef = useRef(initialViewport?.top ?? 0);
   const lastResetTokenRef = useRef(resetToken);
   const overviewDraggingRef = useRef(false);
-  const cellWidth = Math.round(Math.max(8, Math.min(15, fontSize * 0.78 + 2)) * 10) / 10;
+  const [selection, setSelection] = useState<MatrixSelection | null>(null);
+  const [hoverCell, setHoverCell] = useState<HoverCell | null>(null);
+  const [contextMenu, setContextMenu] = useState<MatrixContextMenu | null>(null);
+  // Ephemeral, per-alignment manual row order (ids). Null falls back to the
+  // template-pinned sortMode ordering; set once the user drags or key-moves a row.
+  const [manualOrder, setManualOrder] = useState<string[] | null>(null);
+  const [rowDrag, setRowDrag] = useState<RowDragState | null>(null);
+  const rowDragRef = useRef<RowDragState | null>(null);
+  const [reorderStatus, setReorderStatus] = useState('');
+  const selectionAnchorRef = useRef<{ column: number; rowIndex: number } | null>(null);
+  const frameRef = useRef<HTMLDivElement>(null);
+  const baseCellWidth = Math.max(MSA_BASE_CELL_MIN, Math.min(MSA_BASE_CELL_MAX, fontSize * 0.78 + 2));
+  const cellWidth = Math.round(Math.max(MSA_CELL_MIN, Math.min(MSA_CELL_MAX, baseCellWidth * zoom)) * 10) / 10;
+  const blocks = cellWidth < MSA_LETTER_MIN;
+  // Shrink glyphs to fit narrowing cells as the user zooms out, so letters stay
+  // legible (not overlapping) right down to the blocks threshold; never exceed
+  // the chosen font size when zooming in.
+  const renderFontSize = blocks ? fontSize : Math.min(fontSize, Math.max(7, Math.round(cellWidth * 1.32)));
+  const prevCellWidthRef = useRef(cellWidth);
   const labelWidth = Math.max(150, Math.min(260, Math.round(viewportWidth * 0.3)));
   const sequenceViewportWidth = Math.max(120, viewportWidth - labelWidth);
   const overscan = 24;
@@ -444,11 +519,45 @@ function AlignmentMatrix({
     () => templatePositionCoordinates(template?.aligned ?? ''),
     [template],
   );
+  // Amino-acid translation of the reference row (nucleotide alignments only),
+  // codons positioned against alignment columns; empty when the track is off.
+  const translationCodons = useMemo(
+    () => (visibility.showTranslation && alignment.molecule !== 'protein' && template
+      ? translateAlignedRow(template.aligned, translationFrame)
+      : []),
+    [alignment.molecule, template, translationFrame, visibility.showTranslation],
+  );
+  const translationVisible = translationCodons.length > 0;
+
+  // Per-row matched columns for search highlighting, and the active hit.
+  const searchColumnsByRow = useMemo(() => {
+    const map = new Map<string, Set<number>>();
+    for (const match of searchMatches) {
+      let columns = map.get(match.rowId);
+      if (!columns) { columns = new Set<number>(); map.set(match.rowId, columns); }
+      for (const column of match.columns) columns.add(column);
+    }
+    return map;
+  }, [searchMatches]);
+  const activeSearchColumns = useMemo(() => new Set(activeSearchMatch?.columns ?? []), [activeSearchMatch]);
+  const activeSearchRowId = activeSearchMatch?.rowId ?? null;
   const statsByRow = useMemo(() => new Map(alignment.rows.map((row) => [
     row.id,
     pairwiseRowStats(row.aligned, template?.aligned ?? ''),
   ])), [alignment.rows, template]);
   const orderedRows = useMemo(() => {
+    if (manualOrder) {
+      const byId = new Map(alignment.rows.map((row) => [row.id, row] as const));
+      const manual = manualOrder
+        .map((id) => byId.get(id))
+        .filter((row): row is ArtifactAlignment['rows'][number] => row !== undefined);
+      // Only honour a manual order that still covers exactly the current rows;
+      // anything else falls through to the template-pinned sort below. The
+      // reference/template row always stays pinned at the top.
+      if (manual.length === alignment.rows.length) {
+        return template ? [template, ...manual.filter((row) => row.id !== template.id)] : manual;
+      }
+    }
     const originalIndex = new Map(alignment.rows.map((row, index) => [row.id, index]));
     const nonTemplateRows = alignment.rows.filter((row) => row.id !== template?.id);
     nonTemplateRows.sort((left, right) => {
@@ -460,7 +569,7 @@ function AlignmentMatrix({
       return (originalIndex.get(left.id) ?? 0) - (originalIndex.get(right.id) ?? 0);
     });
     return template ? [template, ...nonTemplateRows] : nonTemplateRows;
-  }, [alignment.rows, sortMode, statsByRow, template]);
+  }, [alignment.rows, manualOrder, sortMode, statsByRow, template]);
   const allRowNames = useMemo(() => alignment.rows.map((row) => row.name), [alignment.rows]);
   const rowLabelsById = useMemo(() => new Map(alignment.rows.map((row) => [
     row.id,
@@ -492,15 +601,30 @@ function AlignmentMatrix({
   const tableRowCount = axisRows
     + orderedRows.length
     + Number(visibility.showConservation)
-    + Number(visibility.showConsensus);
+    + Number(visibility.showConservationHistogram)
+    + Number(visibility.showOccupancy)
+    + Number(visibility.showConsensus)
+    + Number(translationVisible);
 
   const scrollToColumn = useCallback((column: number, behavior: ScrollBehavior = 'auto') => {
     const viewport = viewportRef.current;
     if (!viewport) return;
     const boundedColumn = Math.max(0, Math.min(Math.max(0, alignment.alignmentLength - 1), column));
-    const target = Math.max(0, Math.min(maxHorizontalScroll, (boundedColumn * cellWidth) - (sequenceViewportWidth / 2)));
+    // Centre the cell's middle, not its left edge.
+    const target = Math.max(0, Math.min(maxHorizontalScroll, ((boundedColumn + 0.5) * cellWidth) - (sequenceViewportWidth / 2)));
     viewport.scrollTo({ left: target, behavior });
   }, [alignment.alignmentLength, cellWidth, maxHorizontalScroll, sequenceViewportWidth, viewportRef]);
+
+  const setZoom = useCallback((next: number) => {
+    onZoomChange(Math.max(MSA_ZOOM_MIN, Math.min(MSA_ZOOM_MAX, Math.round(next * 100) / 100)));
+  }, [onZoomChange]);
+
+  // Fit the whole alignment across the sequence viewport by solving for the zoom
+  // that makes every column's base-width cell span the available width.
+  const fitZoom = useCallback(() => {
+    if (alignment.alignmentLength === 0) return;
+    setZoom(sequenceViewportWidth / (alignment.alignmentLength * baseCellWidth));
+  }, [alignment.alignmentLength, baseCellWidth, sequenceViewportWidth, setZoom]);
 
   useLayoutEffect(() => {
     const viewport = viewportRef.current;
@@ -513,11 +637,38 @@ function AlignmentMatrix({
     setScrollLeft(viewport.scrollLeft);
   }, [alignment.id, viewportRef]);
 
+  // Keep the same biological column centred when the cell width changes (zoom or
+  // font size), rather than letting the retained pixel scroll shift the view.
+  useLayoutEffect(() => {
+    const viewport = viewportRef.current;
+    const previous = prevCellWidthRef.current;
+    prevCellWidthRef.current = cellWidth;
+    if (!viewport || previous === cellWidth || previous <= 0) return;
+    const centerColumn = (viewport.scrollLeft + sequenceViewportWidth / 2) / previous;
+    const target = Math.max(0, Math.min(maxHorizontalScroll, (centerColumn * cellWidth) - (sequenceViewportWidth / 2)));
+    viewport.scrollLeft = target;
+    pendingScrollLeftRef.current = target;
+    setScrollLeft(target);
+  }, [cellWidth, maxHorizontalScroll, sequenceViewportWidth, viewportRef]);
+
   useEffect(() => {
     if (jumpColumn === null || !viewportRef.current) return;
     const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
     scrollToColumn(jumpColumn, reducedMotion ? 'auto' : 'smooth');
   }, [jumpColumn, jumpToken, scrollToColumn, viewportRef]);
+
+  // Bring a search hit's row into vertical view (horizontal is handled above).
+  useEffect(() => {
+    if (!jumpRowId) return;
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    const rowElement = viewport.querySelector<HTMLElement>(`[data-msa-row-id="${CSS.escape(jumpRowId)}"]`);
+    if (!rowElement) return;
+    const viewportRect = viewport.getBoundingClientRect();
+    const rowRect = rowElement.getBoundingClientRect();
+    const delta = (rowRect.top + rowRect.bottom) / 2 - (viewportRect.top + viewportRect.bottom) / 2;
+    if (Math.abs(delta) > 4) viewport.scrollTop += delta;
+  }, [jumpRowId, jumpToken, viewportRef]);
 
   useEffect(() => {
     if (lastResetTokenRef.current === resetToken) return;
@@ -606,10 +757,324 @@ function AlignmentMatrix({
     setHorizontalScroll(target);
   };
 
+  const columnStats = useMemo<MsaColumnStats[]>(() => computeMsaColumnStats(alignment.rows), [alignment.rows]);
+  const explicitScheme = colorMode === 'residue' && colorScheme !== 'auto';
+  const shadeByColumn = shadeMode === 'identity' || shadeMode === 'conservation';
+  // Colour cells by auto residue tone when the user asked for residue colours,
+  // or whenever letters are hidden in blocks view (so the mosaic stays legible).
+  // An explicit scheme keeps its own data-color-key fills instead.
+  const toneColored = !explicitScheme && (colorMode === 'residue' || blocks);
+
+  const selectingRef = useRef(false);
+  const rulerSelectingRef = useRef(false);
+  const contextMenuRef = useRef<HTMLDivElement>(null);
+
+  // The selected rows' ids in displayed order — always explicit (even for a
+  // whole-height selection) so copy actions follow the visible order.
+  const selectionRowIds = useMemo<string[]>(() => {
+    if (!selection) return [];
+    const ids: string[] = [];
+    for (let index = selection.rowStart; index <= selection.rowEnd; index += 1) {
+      const row = orderedRows[index];
+      if (row) ids.push(row.id);
+    }
+    return ids;
+  }, [orderedRows, selection]);
+
+  const selectionSummary = useMemo(() => {
+    if (!selection) return null;
+    // Stats describe the SELECTED block only — slice each selected row to the
+    // selected columns so unselected rows never skew the readout. Bounded by the
+    // selection size, so it stays cheap even mid-drag on a wide alignment.
+    const selectedRows = orderedRows
+      .slice(selection.rowStart, selection.rowEnd + 1)
+      .map((row) => ({ ...row, aligned: row.aligned.slice(selection.colStart, selection.colEnd + 1) }));
+    const blockStats = computeMsaColumnStats(selectedRows);
+    const stats = summarizeSelectionColumns(blockStats, { start: 0, end: selection.colEnd - selection.colStart });
+    // Template coordinates: first/last non-gap position within the range, so a
+    // gapped endpoint doesn't hide the whole template range.
+    let startPosition: number | null = null;
+    let endPosition: number | null = null;
+    for (let column = selection.colStart; column <= selection.colEnd; column += 1) {
+      if (templateCoordinates[column] != null) { startPosition = templateCoordinates[column]!; break; }
+    }
+    for (let column = selection.colEnd; column >= selection.colStart; column -= 1) {
+      if (templateCoordinates[column] != null) { endPosition = templateCoordinates[column]!; break; }
+    }
+    return { stats, startPosition, endPosition, rows: selectedRows.length };
+  }, [orderedRows, selection, templateCoordinates]);
+
+  const pointToCell = useCallback((clientX: number, clientY: number): HoverCell | null => {
+    const viewport = viewportRef.current;
+    if (!viewport) return null;
+    const rect = viewport.getBoundingClientRect();
+    const localX = clientX - rect.left;
+    // The sticky row-label gutter is not part of the sequence area.
+    if (localX < labelWidth || localX > rect.width) return null;
+    const column = Math.floor((localX - labelWidth + viewport.scrollLeft) / cellWidth);
+    if (column < 0 || column >= alignment.alignmentLength) return null;
+    const target = document.elementFromPoint(clientX, clientY) as HTMLElement | null;
+    const rowElement = target?.closest<HTMLElement>('[data-msa-row-index]');
+    if (!rowElement) return null;
+    const rowIndex = Number(rowElement.dataset.msaRowIndex);
+    if (!Number.isInteger(rowIndex) || rowIndex < 0 || rowIndex >= orderedRows.length) return null;
+    return { column, rowIndex, rowId: rowElement.dataset.msaRowId ?? '', clientX, clientY };
+  }, [alignment.alignmentLength, cellWidth, labelWidth, orderedRows.length, viewportRef]);
+
+  const columnFromClientX = useCallback((clientX: number): number | null => {
+    const viewport = viewportRef.current;
+    if (!viewport) return null;
+    const rect = viewport.getBoundingClientRect();
+    const localX = clientX - rect.left;
+    if (localX < labelWidth || localX > rect.width) return null;
+    const column = Math.floor((localX - labelWidth + viewport.scrollLeft) / cellWidth);
+    return column >= 0 && column < alignment.alignmentLength ? column : null;
+  }, [alignment.alignmentLength, cellWidth, labelWidth, viewportRef]);
+
+  const applySelectionTo = useCallback((cell: { column: number; rowIndex: number }) => {
+    const anchor = selectionAnchorRef.current;
+    if (!anchor) return;
+    setSelection({
+      colStart: Math.min(anchor.column, cell.column),
+      colEnd: Math.max(anchor.column, cell.column),
+      rowStart: Math.min(anchor.rowIndex, cell.rowIndex),
+      rowEnd: Math.max(anchor.rowIndex, cell.rowIndex),
+    });
+  }, []);
+
+  const handleGridPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    const cell = pointToCell(event.clientX, event.clientY);
+    if (!cell) return;
+    event.preventDefault();
+    setContextMenu(null);
+    setHoverCell(null);
+    if (!(event.shiftKey && selectionAnchorRef.current)) {
+      selectionAnchorRef.current = { column: cell.column, rowIndex: cell.rowIndex };
+    }
+    applySelectionTo(cell);
+    selectingRef.current = true;
+    try { event.currentTarget.setPointerCapture(event.pointerId); } catch { /* capture is best-effort */ }
+  };
+
+  const handleGridPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const cell = pointToCell(event.clientX, event.clientY);
+    if (selectingRef.current) {
+      if (cell) applySelectionTo(cell);
+      return;
+    }
+    setHoverCell(cell);
+  };
+
+  const endSelectionDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!selectingRef.current) return;
+    selectingRef.current = false;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const selectWholeColumn = (column: number) => {
+    if (column < 0 || column >= alignment.alignmentLength) return;
+    setContextMenu(null);
+    selectionAnchorRef.current = { column, rowIndex: 0 };
+    setSelection({ colStart: column, colEnd: column, rowStart: 0, rowEnd: Math.max(0, orderedRows.length - 1) });
+  };
+
+  const handleRulerPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    const column = columnFromClientX(event.clientX);
+    if (column == null) return;
+    event.preventDefault();
+    setHoverCell(null);
+    selectWholeColumn(column);
+    rulerSelectingRef.current = true;
+    try { event.currentTarget.setPointerCapture(event.pointerId); } catch { /* capture is best-effort */ }
+  };
+  const handleRulerPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!rulerSelectingRef.current) return;
+    const column = columnFromClientX(event.clientX);
+    const anchor = selectionAnchorRef.current;
+    if (column == null || !anchor) return;
+    setSelection({
+      colStart: Math.min(anchor.column, column),
+      colEnd: Math.max(anchor.column, column),
+      rowStart: 0,
+      rowEnd: Math.max(0, orderedRows.length - 1),
+    });
+  };
+  const handleRulerPointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!rulerSelectingRef.current) return;
+    rulerSelectingRef.current = false;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId);
+  };
+
+  const clearSelection = useCallback(() => {
+    setSelection(null);
+    selectionAnchorRef.current = null;
+    setContextMenu(null);
+  }, []);
+
+  const handleGridContextMenu = (event: ReactMouseEvent<HTMLDivElement>) => {
+    const cell = pointToCell(event.clientX, event.clientY);
+    if (!cell) { setContextMenu(null); return; }
+    event.preventDefault();
+    const insideSelection = selection
+      && cell.column >= selection.colStart && cell.column <= selection.colEnd
+      && cell.rowIndex >= selection.rowStart && cell.rowIndex <= selection.rowEnd;
+    if (!insideSelection) {
+      selectionAnchorRef.current = { column: cell.column, rowIndex: 0 };
+      setSelection({ colStart: cell.column, colEnd: cell.column, rowStart: 0, rowEnd: Math.max(0, orderedRows.length - 1) });
+    }
+    setHoverCell(null);
+    setContextMenu({ x: event.clientX, y: event.clientY, column: cell.column, rowId: cell.rowId });
+  };
+
+  const copySelection = useCallback((mode: 'fasta' | 'ungapped' | 'columns') => {
+    if (!selection) return;
+    const payload: MsaSelection = { columns: { start: selection.colStart, end: selection.colEnd }, rowIds: selectionRowIds };
+    const content = mode === 'fasta'
+      ? selectionToFasta(alignment, payload)
+      : mode === 'ungapped'
+        ? selectionToUngappedFasta(alignment, payload)
+        : selectionToColumnsText(alignment, payload);
+    const label = mode === 'columns' ? 'Selected columns' : mode === 'ungapped' ? 'Selection ungapped FASTA' : 'Selection FASTA';
+    void onCopy(label, content);
+    setContextMenu(null);
+  }, [alignment, onCopy, selection, selectionRowIds]);
+
+  // ===== Row drag-reorder (grip handle) =====
+  // Commit a new manual order and drop any active selection, whose row indices
+  // would otherwise point at the wrong rows after the move.
+  const commitRowOrder = useCallback((nextIds: string[], movedId: string, movedName: string) => {
+    setManualOrder(nextIds);
+    setSelection(null);
+    selectionAnchorRef.current = null;
+    // Announce the DISPLAY position, which keeps the template pinned first.
+    const displayIds = template ? [template.id, ...nextIds.filter((id) => id !== template.id)] : nextIds;
+    setReorderStatus(`Moved ${movedName} to position ${displayIds.indexOf(movedId) + 1} of ${displayIds.length}.`);
+  }, [template]);
+
+  const beginRowDrag = (event: ReactPointerEvent<HTMLButtonElement>, id: string, index: number) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    setContextMenu(null);
+    setHoverCell(null);
+    setSelection(null);
+    selectionAnchorRef.current = null;
+    const state: RowDragState = { id, fromIndex: index, overIndex: index, edge: 'before' };
+    rowDragRef.current = state;
+    setRowDrag(state);
+    try { event.currentTarget.setPointerCapture(event.pointerId); } catch { /* capture is best-effort */ }
+  };
+
+  const updateRowDrag = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (!rowDragRef.current) return;
+    const node = document.elementFromPoint(event.clientX, event.clientY);
+    const rowElement = node instanceof HTMLElement ? node.closest<HTMLElement>('[data-msa-row-index]') : null;
+    if (!rowElement) return;
+    const overIndex = Number(rowElement.dataset.msaRowIndex);
+    if (!Number.isInteger(overIndex)) return;
+    const rect = rowElement.getBoundingClientRect();
+    const edge: 'before' | 'after' = event.clientY < rect.top + rect.height / 2 ? 'before' : 'after';
+    const prev = rowDragRef.current;
+    if (prev.overIndex === overIndex && prev.edge === edge) return;
+    const next = { ...prev, overIndex, edge };
+    rowDragRef.current = next;
+    setRowDrag(next);
+  };
+
+  const endRowDrag = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    const state = rowDragRef.current;
+    rowDragRef.current = null;
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId);
+    setRowDrag(null);
+    if (!state) return;
+    // Convert the (over-row, edge) drop target into an insertion index against
+    // the array with the dragged id removed.
+    let insertion = state.overIndex + (state.edge === 'after' ? 1 : 0);
+    if (state.fromIndex < insertion) insertion -= 1;
+    if (insertion === state.fromIndex) return; // a plain click, or dropped in place
+    const ids = orderedRows.map((row) => row.id);
+    commitRowOrder(moveRowId(ids, state.id, insertion), state.id, orderedRows[state.fromIndex]?.name ?? 'Row');
+  };
+
+  const cancelRowDrag = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    rowDragRef.current = null;
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId);
+    setRowDrag(null);
+  };
+
+  const handleGripKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>, id: string) => {
+    const delta = event.key === 'ArrowUp' ? -1 : event.key === 'ArrowDown' ? 1 : 0;
+    if (delta === 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const ids = orderedRows.map((row) => row.id);
+    const from = ids.indexOf(id);
+    if (from < 0) return;
+    const target = Math.max(0, Math.min(ids.length - 1, from + delta));
+    if (target === from) return;
+    commitRowOrder(moveRowId(ids, id, target), id, orderedRows[from]?.name ?? 'Row');
+  };
+
+  const resetRowOrder = useCallback(() => {
+    setManualOrder(null);
+    setReorderStatus('Row order reset to the current sort.');
+  }, []);
+
+  useEffect(() => {
+    setSelection(null);
+    setHoverCell(null);
+    setContextMenu(null);
+    selectionAnchorRef.current = null;
+    selectingRef.current = false;
+    setManualOrder(null);
+    setRowDrag(null);
+    rowDragRef.current = null;
+    setReorderStatus('');
+  }, [alignment.id, resetToken]);
+
+  // A change to the persisted sort control supersedes any manual drag order.
+  useEffect(() => { setManualOrder(null); }, [sortMode]);
+
+  // A change in display order (sort or the pinned template) invalidates the
+  // index-based selection, which would otherwise silently point at other rows.
+  useEffect(() => {
+    setSelection(null);
+    selectionAnchorRef.current = null;
+    setContextMenu(null);
+  }, [sortMode, referenceRowId]);
+
+  useEffect(() => {
+    if (!contextMenu) return undefined;
+    const onPointerDown = (event: PointerEvent) => {
+      if (contextMenuRef.current?.contains(event.target as Node)) return;
+      setContextMenu(null);
+    };
+    const onKeyDown = (event: KeyboardEvent) => { if (event.key === 'Escape') setContextMenu(null); };
+    window.addEventListener('pointerdown', onPointerDown, true);
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown, true);
+      window.removeEventListener('keydown', onKeyDown, true);
+    };
+  }, [contextMenu]);
+
+  useEffect(() => {
+    if (!selection) return undefined;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !contextMenu) clearSelection();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [clearSelection, contextMenu, selection]);
+
   const frameStyle = {
     '--motif-cs-msa-label-width': `${labelWidth}px`,
     '--motif-cs-msa-cell-width': `${cellWidth}px`,
-    '--motif-cs-msa-font-size': `${fontSize}px`,
+    '--motif-cs-msa-font-size': `${renderFontSize}px`,
   } as CSSProperties;
 
   const matrixStyle = {
@@ -642,11 +1107,18 @@ function AlignmentMatrix({
             key={column}
             className="motif-cs-msa-symbol"
             data-alignment-column={column + 1}
-            data-tone={colorMode === 'residue' ? residueTone(symbol, alignment.molecule) : 'mono'}
+            data-residue={symbol}
+            data-tone={toneColored ? residueTone(symbol, alignment.molecule) : 'mono'}
+            data-color-key={explicitScheme ? residueColorKey(symbol, alignment.molecule, colorScheme) || undefined : undefined}
+            data-shade-bucket={!consensus && shadeByColumn
+              ? msaShadeBucket(shadeMode === 'identity' ? (columnStats[column]?.identity ?? 0) : (columnStats[column]?.conservation ?? 0))
+              : undefined}
             data-difference={!consensus && !matchesTemplate || undefined}
             data-quiet={quietMatch || undefined}
             data-conserved={alignment.conserved[column] || undefined}
             data-jump={jumpColumn === column || undefined}
+            data-search-match={searchColumnsByRow.get(rowId)?.has(column) || undefined}
+            data-search-active={(activeSearchRowId === rowId && activeSearchColumns.has(column)) || undefined}
           >
             {display}
           </span>
@@ -655,8 +1127,66 @@ function AlignmentMatrix({
     </div>
   );
 
+  const renderHistogram = (metric: (stat: MsaColumnStats) => number, kind: 'conservation' | 'occupancy') => (
+    <div className="motif-cs-msa-hist-window" style={{ left: labelWidth + (startColumn * cellWidth) }} aria-hidden="true">
+      {columnStats.slice(startColumn, endColumn).map((stat, offset) => {
+        const column = startColumn + offset;
+        const value = Math.max(0, Math.min(1, metric(stat)));
+        return (
+          <span key={column} className="motif-cs-msa-hist-cell" data-alignment-column={column + 1} data-jump={jumpColumn === column || undefined}>
+            <span
+              className={`motif-cs-msa-hist-bar motif-cs-msa-hist-bar-${kind}`}
+              data-bucket={msaShadeBucket(value)}
+              style={{ height: `${Math.round(value * 100)}%` }}
+            />
+          </span>
+        );
+      })}
+    </div>
+  );
+
+  const renderTranslationTrack = () => (
+    <div className="motif-cs-msa-translation-window" style={{ left: labelWidth, width: sequenceWidth }} aria-hidden="true">
+      {translationCodons
+        .filter((codon) => codon.endColumn >= startColumn && codon.startColumn < endColumn)
+        .map((codon) => {
+          const width = (codon.endColumn - codon.startColumn + 1) * cellWidth;
+          const label = codon.aminoAcid === '*' ? 'Stop' : codon.aminoAcid === 'X' ? 'Unknown' : codon.aminoAcid;
+          const showIndex = visibility.showAminoAcidIndices && (codon.position === 1 || codon.position % 10 === 0);
+          return (
+            <span
+              key={codon.startColumn}
+              className="motif-cs-msa-aa"
+              style={{ left: codon.startColumn * cellWidth, width }}
+              data-aa={codon.aminoAcid}
+              data-color-key={residueColorKey(codon.aminoAcid, 'protein', 'clustal') || undefined}
+              data-stop={codon.aminoAcid === '*' || undefined}
+              data-unknown={codon.aminoAcid === 'X' || undefined}
+              data-gap-spanning={codon.gapSpanning || undefined}
+              data-jump={(jumpColumn !== null && jumpColumn >= codon.startColumn && jumpColumn <= codon.endColumn) || undefined}
+              title={`${label} · residue ${codon.position} · codon ${codon.codon}`}
+            >
+              {showIndex ? <span className="motif-cs-msa-aa-index">{codon.position}</span> : null}
+              <span className="motif-cs-msa-aa-letter">{width >= 7 ? codon.aminoAcid : ''}</span>
+            </span>
+          );
+        })}
+    </div>
+  );
+
+  const selectionColumnLeft = selection ? labelWidth + (selection.colStart * cellWidth) : 0;
+  const selectionColumnWidth = selection ? (selection.colEnd - selection.colStart + 1) * cellWidth : 0;
+  const hoverColumnLeft = hoverCell ? labelWidth + (hoverCell.column * cellWidth) : 0;
+
   return (
-    <div className="motif-cs-msa-matrix-frame" data-testid="msa-alignment-view" style={frameStyle}>
+    <div
+      ref={frameRef}
+      className="motif-cs-msa-matrix-frame"
+      data-testid="msa-alignment-view"
+      style={frameStyle}
+      data-has-selection={selection ? true : undefined}
+      data-motif-cs-escape-scope={selection ? 'true' : undefined}
+    >
       {visibility.showOverview ? <div className="motif-cs-msa-overview-row">
         <span className="motif-cs-msa-overview-label">Overview</span>
         <div
@@ -713,15 +1243,46 @@ function AlignmentMatrix({
         className="motif-cs-msa-matrix-scroll"
         onScroll={(event) => handleScroll(event.currentTarget.scrollLeft, event.currentTarget.scrollTop)}
         onKeyDown={handleMatrixKeyDown}
+        onPointerDown={handleGridPointerDown}
+        onPointerMove={handleGridPointerMove}
+        onPointerUp={endSelectionDrag}
+        onPointerCancel={endSelectionDrag}
+        onPointerLeave={() => setHoverCell(null)}
+        onContextMenu={handleGridContextMenu}
         tabIndex={0}
         role="region"
         aria-label={`Alignment matrix, ${alignment.rows.length} rows by ${alignment.alignmentLength} columns. Scroll horizontally to inspect columns.`}
         aria-describedby="motif-cs-msa-matrix-help"
+        data-selecting={selection ? true : undefined}
       >
-        <div className="motif-cs-msa-matrix" style={matrixStyle} role="table" aria-rowcount={tableRowCount} aria-colcount={alignment.alignmentLength}>
+        <div
+          className="motif-cs-msa-matrix"
+          style={matrixStyle}
+          role="table"
+          aria-rowcount={tableRowCount}
+          aria-colcount={alignment.alignmentLength}
+          data-color-scheme={explicitScheme ? colorScheme : undefined}
+          data-shade={shadeMode !== 'none' ? shadeMode : undefined}
+          data-reordering={rowDrag ? true : undefined}
+          data-blocks={blocks ? true : undefined}
+        >
+          {selection ? (
+            <div className="motif-cs-msa-selection-band" style={{ left: selectionColumnLeft, width: selectionColumnWidth }} aria-hidden="true" />
+          ) : null}
+          {hoverCell ? (
+            <div className="motif-cs-msa-hover-column" style={{ left: hoverColumnLeft, width: cellWidth }} aria-hidden="true" />
+          ) : null}
           {visibility.showAlignmentAxis ? <div className="motif-cs-msa-ruler-row" role="row" aria-rowindex={1}>
             <div className="motif-cs-msa-sticky-label motif-cs-msa-ruler-label" role="columnheader">Alignment position</div>
-            <div className="motif-cs-msa-ruler-window" style={{ left: labelWidth + (startColumn * cellWidth) }} aria-hidden="true">
+            <div
+              className="motif-cs-msa-ruler-window motif-cs-msa-ruler-window-clickable"
+              style={{ left: labelWidth + (startColumn * cellWidth) }}
+              aria-hidden="true"
+              onPointerDown={handleRulerPointerDown}
+              onPointerMove={handleRulerPointerMove}
+              onPointerUp={handleRulerPointerUp}
+              onPointerCancel={handleRulerPointerUp}
+            >
               {Array.from({ length: endColumn - startColumn }, (_, offset) => {
                 const column = startColumn + offset;
                 const position = column + 1;
@@ -781,13 +1342,36 @@ function AlignmentMatrix({
                 key={row.id}
                 className="motif-cs-msa-matrix-row"
                 data-template={isTemplate || undefined}
+                data-msa-row-index={rowIndex}
+                data-msa-row-id={row.id}
+                data-hover={hoverCell?.rowIndex === rowIndex || undefined}
+                data-selected={(selection && rowIndex >= selection.rowStart && rowIndex <= selection.rowEnd) || undefined}
+                data-dragging={rowDrag?.id === row.id || undefined}
+                data-drop-before={(rowDrag && rowDrag.id !== row.id && rowDrag.overIndex === rowIndex && rowDrag.edge === 'before') || undefined}
+                data-drop-after={(rowDrag && rowDrag.id !== row.id && rowDrag.overIndex === rowIndex && rowDrag.edge === 'after') || undefined}
                 role="row"
                 aria-rowindex={firstSequenceRow + rowIndex}
                 aria-label={visibility.showRowStats
                   ? `${row.name}; ${stats.mismatches} mismatches; ${stats.ungappedLength} ungapped ${sequenceUnit(alignment.molecule)}; ${formatIdentity(stats.identity)} percent identity to template; ${isTemplate ? 'template row' : 'alignment row'}`
                   : `${row.name}; ${isTemplate ? 'template row' : 'alignment row'}`}
               >
-                <div className="motif-cs-msa-sticky-label motif-cs-msa-row-label" role="rowheader">
+                <div className="motif-cs-msa-sticky-label motif-cs-msa-row-label motif-cs-msa-row-label-draggable" role="rowheader">
+                  {isTemplate ? null : (
+                    <button
+                      type="button"
+                      className="motif-cs-msa-row-grip"
+                      data-testid="msa-row-grip"
+                      aria-label={`Reorder ${row.name}. Drag, or press Up and Down arrows.`}
+                      title={`Drag to reorder ${row.name}`}
+                      onPointerDown={(event) => beginRowDrag(event, row.id, rowIndex)}
+                      onPointerMove={updateRowDrag}
+                      onPointerUp={endRowDrag}
+                      onPointerCancel={cancelRowDrag}
+                      onKeyDown={(event) => handleGripKeyDown(event, row.id)}
+                    >
+                      <GripVertical size={13} aria-hidden="true" />
+                    </button>
+                  )}
                   <button
                     type="button"
                     className="motif-cs-msa-row-select"
@@ -832,7 +1416,62 @@ function AlignmentMatrix({
             <div className="motif-cs-msa-sticky-label motif-cs-msa-row-label" role="rowheader"><span>Consensus</span></div>
             {renderSymbols(alignment.consensus, '__consensus__', true)}
           </div> : null}
+
+          {visibility.showConservationHistogram ? <div
+            className="motif-cs-msa-hist-row"
+            role="row"
+            aria-rowindex={firstSequenceRow + orderedRows.length + Number(visibility.showConservation) + Number(visibility.showConsensus)}
+            aria-label="Per-column conservation histogram"
+          >
+            <div className="motif-cs-msa-sticky-label motif-cs-msa-row-label motif-cs-msa-hist-label" role="rowheader"><span>Conservation</span></div>
+            {renderHistogram((stat) => stat.conservation, 'conservation')}
+          </div> : null}
+
+          {visibility.showOccupancy ? <div
+            className="motif-cs-msa-hist-row"
+            role="row"
+            aria-rowindex={firstSequenceRow + orderedRows.length + Number(visibility.showConservation) + Number(visibility.showConsensus) + Number(visibility.showConservationHistogram)}
+            aria-label="Per-column occupancy histogram"
+          >
+            <div className="motif-cs-msa-sticky-label motif-cs-msa-row-label motif-cs-msa-hist-label" role="rowheader"><span>Occupancy</span></div>
+            {renderHistogram((stat) => stat.occupancy, 'occupancy')}
+          </div> : null}
+
+          {translationVisible ? <div
+            className="motif-cs-msa-translation-row"
+            role="row"
+            aria-rowindex={firstSequenceRow + orderedRows.length + Number(visibility.showConservation) + Number(visibility.showConsensus) + Number(visibility.showConservationHistogram) + Number(visibility.showOccupancy)}
+            aria-label={`Amino-acid translation of ${template?.name ?? 'reference'}, reading frame ${translationFrame + 1}`}
+          >
+            <div className="motif-cs-msa-sticky-label motif-cs-msa-row-label motif-cs-msa-hist-label motif-cs-msa-translation-label" role="rowheader">
+              <span>Translation</span>
+              <small translate="no">frame +{translationFrame + 1}</small>
+            </div>
+            {renderTranslationTrack()}
+          </div> : null}
         </div>
+      </div>
+      <div className="motif-cs-msa-zoom-row" data-testid="msa-zoom-row">
+        <span className="motif-cs-msa-zoom-label" aria-hidden="true">Zoom</span>
+        <input
+          className="motif-cs-msa-zoom-range"
+          data-testid="msa-zoom-range"
+          type="range"
+          min={Math.round(MSA_ZOOM_MIN * 100)}
+          max={Math.round(MSA_ZOOM_MAX * 100)}
+          step={5}
+          value={Math.round(zoom * 100)}
+          onChange={(event) => setZoom(Number(event.target.value) / 100)}
+          aria-label="Alignment column zoom"
+          aria-valuetext={`${Math.round(zoom * 100)} percent${blocks ? ', blocks view' : ''}`}
+          title="Compress or expand alignment columns"
+        />
+        <span className="motif-cs-msa-zoom-value" data-testid="msa-zoom-value">{Math.round(zoom * 100)}%</span>
+        <button type="button" className="motif-cs-mini-button" data-testid="msa-zoom-fit" onClick={fitZoom} title="Fit the whole alignment to the window width">Fit</button>
+        {Math.round(zoom * 100) !== 100 ? (
+          <button type="button" className="motif-cs-mini-button" data-testid="msa-zoom-reset" onClick={() => setZoom(1)} title="Reset zoom to 100%">100%</button>
+        ) : null}
+        {blocks ? <span className="motif-cs-chip motif-cs-msa-blocks-chip" data-testid="msa-blocks-chip" title="Columns are compressed past letter legibility; residues render as coloured blocks">Blocks</span> : null}
       </div>
       {maxHorizontalScroll > 0 ? (
         <div className="motif-cs-msa-pan-row" data-testid="msa-horizontal-scroll-row">
@@ -857,6 +1496,47 @@ function AlignmentMatrix({
       <div className="motif-cs-msa-window-note" aria-live="polite">
         Alignment columns {visibleStartColumn + 1}–{Math.max(visibleStartColumn + 1, visibleEndColumn)} of {alignment.alignmentLength.toLocaleString()}
       </div>
+      {manualOrder ? (
+        <div className="motif-cs-msa-order-note" data-testid="msa-order-note">
+          <GripVertical size={12} aria-hidden="true" />
+          <span>Custom row order</span>
+          <button type="button" className="motif-cs-mini-button" onClick={resetRowOrder}>Reset order</button>
+        </div>
+      ) : null}
+      <span className="motif-cs-visually-hidden" data-testid="msa-reorder-status" role="status" aria-live="polite">{reorderStatus}</span>
+      {selection && selectionSummary ? (
+        <div className="motif-cs-msa-selection-readout" data-testid="msa-selection-readout" role="status" aria-live="polite">
+          <strong>Selected</strong>
+          <span>cols {selection.colStart + 1}–{selection.colEnd + 1} ({selectionSummary.stats.columns.toLocaleString()})</span>
+          {selectionSummary.startPosition != null && selectionSummary.endPosition != null
+            ? <span>· template {selectionSummary.startPosition}–{selectionSummary.endPosition}</span>
+            : null}
+          <span>· {selectionSummary.rows} row{selectionSummary.rows === 1 ? '' : 's'}</span>
+          <span>· {selectionSummary.stats.variableColumns.toLocaleString()} variable</span>
+          <span>· {Math.round(selectionSummary.stats.meanIdentity * 100)}% mean id</span>
+          <button type="button" className="motif-cs-mini-button" onClick={clearSelection}>Clear</button>
+        </div>
+      ) : null}
+      {hoverCell ? (
+        <div className="motif-cs-msa-hover-readout" style={{ left: hoverCell.clientX + 14, top: hoverCell.clientY + 16 }} aria-hidden="true">
+          <b>{orderedRows[hoverCell.rowIndex]?.aligned[hoverCell.column] ?? '-'}</b>
+          <span>col {hoverCell.column + 1}</span>
+          <span>· {templateCoordinates[hoverCell.column] != null ? `tpl ${templateCoordinates[hoverCell.column]}` : 'tpl gap'}</span>
+          <span className="motif-cs-msa-hover-readout-name">{orderedRows[hoverCell.rowIndex]?.name}</span>
+        </div>
+      ) : null}
+      {contextMenu ? (
+        <div ref={contextMenuRef} className="motif-cs-msa-context-menu" style={{ left: contextMenu.x, top: contextMenu.y }} role="menu" aria-label="Alignment selection actions">
+          <button type="button" role="menuitem" onClick={() => copySelection('fasta')}>Copy selection (FASTA)</button>
+          <button type="button" role="menuitem" onClick={() => copySelection('ungapped')}>Copy without gaps</button>
+          <button type="button" role="menuitem" onClick={() => copySelection('columns')}>Copy columns</button>
+          {contextMenu.rowId ? (
+            <button type="button" role="menuitem" onClick={() => { onTemplateChange(contextMenu.rowId!); setContextMenu(null); }}>Set row as reference</button>
+          ) : null}
+          <button type="button" role="menuitem" onClick={() => { scrollToColumn(contextMenu.column); setContextMenu(null); }}>Center this column</button>
+          <button type="button" role="menuitem" onClick={clearSelection}>Clear selection</button>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -894,11 +1574,14 @@ export function ClaudeScienceMsaViewer({
   const [importMolecule, setImportMolecule] = useState<SequenceType>('dna');
   const [error, setError] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
-  const { displayMode, emphasis, colorMode, sortMode, fontSize, textFormat } = viewPreferences;
+  const { displayMode, emphasis, colorMode, colorScheme, shadeMode, sortMode, fontSize, zoom, translationFrame, textFormat } = viewPreferences;
   const [referenceRowId, setReferenceRowId] = useState(activeAlignment?.referenceRowId ?? '');
   const [differenceIndex, setDifferenceIndex] = useState(-1);
   const [jumpColumn, setJumpColumn] = useState<number | null>(null);
   const [jumpToken, setJumpToken] = useState(0);
+  const [jumpRowId, setJumpRowId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchIndex, setSearchIndex] = useState(-1);
   const [viewResetToken, setViewResetToken] = useState(0);
   const [coordinateSystem, setCoordinateSystem] = useState<CoordinateSystem>('alignment');
   const [columnDraft, setColumnDraft] = useState('');
@@ -936,11 +1619,20 @@ export function ClaudeScienceMsaViewer({
     setReferenceRowId(activeAlignment?.referenceRowId ?? activeAlignment?.rows[0]?.id ?? '');
     setDifferenceIndex(-1);
     setJumpColumn(null);
+    setJumpRowId(null);
     setColumnDraft('');
     setColumnError(null);
     setColumnStatus('');
     setPendingDeleteId(null);
   }, [activeAlignment]);
+
+  // Reset the sequence search only when switching to a different alignment, not
+  // when the same alignment yields a new object (e.g. a template change), so a
+  // template switch keeps the active search.
+  useEffect(() => {
+    setSearchQuery('');
+    setSearchIndex(-1);
+  }, [activeAlignment?.id]);
 
   const traceAvailable = activeAlignment ? hasLinkedSangerTrace(activeAlignment, records) : false;
 
@@ -998,6 +1690,19 @@ export function ClaudeScienceMsaViewer({
     () => activeAlignment ? differenceColumns(activeAlignment, referenceRowId) : [],
     [activeAlignment, referenceRowId],
   );
+  const searchResult = useMemo(
+    () => (activeAlignment && searchQuery.trim()
+      ? findMsaMotifMatches(activeAlignment.rows, searchQuery, { molecule: activeAlignment.molecule })
+      : { matches: [], truncated: false }),
+    [activeAlignment, searchQuery],
+  );
+  const searchMatches = searchResult.matches;
+  const activeSearchMatch = searchIndex >= 0 && searchMatches.length > 0
+    ? searchMatches[Math.min(searchIndex, searchMatches.length - 1)] ?? null
+    : null;
+  // A new query starts unnavigated: matches highlight, but nothing is focused
+  // until the user steps with Enter or the prev/next controls.
+  useEffect(() => { setSearchIndex(-1); }, [searchQuery]);
   const conservedCount = activeAlignment?.conserved.filter(Boolean).length ?? 0;
   const conservedPct = activeAlignment && activeAlignment.alignmentLength > 0
     ? Math.round((conservedCount / activeAlignment.alignmentLength) * 100)
@@ -1017,14 +1722,22 @@ export function ClaudeScienceMsaViewer({
     showTemplateAxis: viewPreferences.showTemplateAxis,
     showRowStats: viewPreferences.showRowStats,
     showConservation: viewPreferences.showConservation,
+    showConservationHistogram: viewPreferences.showConservationHistogram,
+    showOccupancy: viewPreferences.showOccupancy,
     showConsensus: viewPreferences.showConsensus,
+    showTranslation: viewPreferences.showTranslation,
+    showAminoAcidIndices: viewPreferences.showAminoAcidIndices,
   }), [
     viewPreferences.showAlignmentAxis,
+    viewPreferences.showAminoAcidIndices,
     viewPreferences.showConsensus,
     viewPreferences.showConservation,
+    viewPreferences.showConservationHistogram,
+    viewPreferences.showOccupancy,
     viewPreferences.showOverview,
     viewPreferences.showRowStats,
     viewPreferences.showTemplateAxis,
+    viewPreferences.showTranslation,
   ]);
 
   const copyFromViewer = useCallback(async (label: string, content: string) => {
@@ -1350,8 +2063,29 @@ export function ClaudeScienceMsaViewer({
       : (differenceIndex + direction + differences.length) % differences.length;
     setDifferenceIndex(nextIndex);
     setJumpColumn(differences[nextIndex]);
+    setJumpRowId(null);
     setJumpToken((token) => token + 1);
   };
+
+  const goToSearchMatch = useCallback((index: number) => {
+    const count = searchMatches.length;
+    if (count === 0) return;
+    const next = ((index % count) + count) % count;
+    const match = searchMatches[next];
+    setSearchIndex(next);
+    setDifferenceIndex(-1);
+    // Centre on an actual matched residue column, not the midpoint between the
+    // endpoints — a gap-spanning match's midpoint can be an unrelated column.
+    setJumpColumn(match.columns[Math.floor(match.columns.length / 2)] ?? match.startColumn);
+    setJumpRowId(match.rowId);
+    setJumpToken((token) => token + 1);
+  }, [searchMatches]);
+
+  const stepSearch = useCallback((direction: 1 | -1) => {
+    if (searchMatches.length === 0) return;
+    if (searchIndex < 0) goToSearchMatch(direction === 1 ? 0 : searchMatches.length - 1);
+    else goToSearchMatch(searchIndex + direction);
+  }, [goToSearchMatch, searchIndex, searchMatches.length]);
 
   const goToCoordinate = () => {
     if (!activeAlignment) return;
@@ -1377,6 +2111,7 @@ export function ClaudeScienceMsaViewer({
     setColumnError(null);
     setDifferenceIndex(-1);
     setJumpColumn(column);
+    setJumpRowId(null);
     setJumpToken((token) => token + 1);
     setColumnStatus(coordinateSystem === 'alignment'
       ? `Alignment column ${requested.toLocaleString()} shown.`
@@ -1742,7 +2477,9 @@ export function ClaudeScienceMsaViewer({
                   ['showAlignmentAxis', 'Alignment axis'],
                   ['showTemplateAxis', 'Template axis'],
                   ['showRowStats', 'Row statistics'],
-                  ['showConservation', 'Conservation'],
+                  ['showConservation', 'Conservation marks'],
+                  ['showConservationHistogram', 'Conservation histogram'],
+                  ['showOccupancy', 'Occupancy'],
                   ['showConsensus', 'Consensus'],
                 ] as const).map(([key, label]) => (
                   <label key={key}>
@@ -1754,6 +2491,42 @@ export function ClaudeScienceMsaViewer({
                     <span>{label}</span>
                   </label>
                 ))}
+                {activeAlignment.molecule !== 'protein' ? (
+                  <>
+                    <label>
+                      <input
+                        type="checkbox"
+                        checked={viewPreferences.showTranslation}
+                        onChange={(event) => updateViewPreferences({ showTranslation: event.target.checked })}
+                      />
+                      <span>Translation (amino acids)</span>
+                    </label>
+                    {viewPreferences.showTranslation ? (
+                      <>
+                        <label>
+                          <input
+                            type="checkbox"
+                            checked={viewPreferences.showAminoAcidIndices}
+                            onChange={(event) => updateViewPreferences({ showAminoAcidIndices: event.target.checked })}
+                          />
+                          <span>Amino-acid indices</span>
+                        </label>
+                        <label className="motif-cs-msa-view-select">
+                          <span>Reading frame</span>
+                          <select
+                            value={translationFrame}
+                            aria-label="Translation reading frame"
+                            onChange={(event) => updateViewPreferences({ translationFrame: Number(event.target.value) as 0 | 1 | 2 })}
+                          >
+                            <option value={0}>+1</option>
+                            <option value={1}>+2</option>
+                            <option value={2}>+3</option>
+                          </select>
+                        </label>
+                      </>
+                    ) : null}
+                  </>
+                ) : null}
                 <label>
                   <input
                     type="checkbox"
@@ -1761,6 +2534,32 @@ export function ClaudeScienceMsaViewer({
                     onChange={(event) => updateViewPreferences({ colorMode: event.target.checked ? 'residue' : 'mono' })}
                   />
                   <span>Residue colors</span>
+                </label>
+                <label className="motif-cs-msa-view-select">
+                  <span>Colour scheme</span>
+                  <select
+                    value={colorScheme}
+                    disabled={colorMode !== 'residue'}
+                    onChange={(event) => updateViewPreferences({ colorScheme: event.target.value as MsaColorScheme })}
+                  >
+                    <option value="auto">Auto (by molecule)</option>
+                    <option value="nucleotide">Nucleotide</option>
+                    <option value="clustal">Clustal (protein)</option>
+                    <option value="hydrophobicity">Hydrophobicity</option>
+                    <option value="taylor">Taylor</option>
+                  </select>
+                </label>
+                <label className="motif-cs-msa-view-select">
+                  <span>Shade columns</span>
+                  <select
+                    value={shadeMode}
+                    onChange={(event) => updateViewPreferences({ shadeMode: event.target.value as MsaShadeMode })}
+                  >
+                    <option value="none">None</option>
+                    <option value="mismatch">Mismatches</option>
+                    <option value="identity">By identity</option>
+                    <option value="conservation">By conservation</option>
+                  </select>
                 </label>
                 <div className="motif-cs-msa-view-font-row">
                   <span>Aa {fontSize} px</span>
@@ -1854,6 +2653,40 @@ export function ClaudeScienceMsaViewer({
                   <button className="motif-cs-mini-button" type="button" disabled={differences.length === 0} onClick={() => jumpDifference(1)} aria-label="Next variable column"><ChevronRight size={13} /></button>
                 </div>
                 <form
+                  className="motif-cs-msa-search"
+                  data-testid="msa-search"
+                  role="search"
+                  data-motif-cs-escape-scope={searchQuery ? 'true' : undefined}
+                  onSubmit={(event) => { event.preventDefault(); stepSearch(1); }}
+                >
+                  <Search size={13} aria-hidden="true" className="motif-cs-msa-search-icon" />
+                  <input
+                    className="motif-cs-input motif-cs-msa-search-input"
+                    data-testid="msa-search-input"
+                    type="search"
+                    name="alignment-search"
+                    autoComplete="off"
+                    spellCheck={false}
+                    value={searchQuery}
+                    placeholder="Find sequence…"
+                    aria-label="Find a sequence motif in the alignment"
+                    onChange={(event) => setSearchQuery(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') { event.preventDefault(); stepSearch(event.shiftKey ? -1 : 1); }
+                      else if (event.key === 'Escape' && searchQuery) { event.preventDefault(); event.stopPropagation(); setSearchQuery(''); }
+                    }}
+                  />
+                  <span className="motif-cs-msa-search-count" data-testid="msa-search-count" role="status" aria-live="polite">
+                    {searchQuery.trim()
+                      ? searchMatches.length === 0
+                        ? 'No matches'
+                        : `${searchIndex >= 0 ? `${Math.min(searchIndex, searchMatches.length - 1) + 1} of ` : ''}${searchMatches.length.toLocaleString()}${searchResult.truncated ? '+' : ''}`
+                      : ''}
+                  </span>
+                  <button type="button" className="motif-cs-mini-button" data-testid="msa-search-prev" disabled={searchMatches.length === 0} onClick={() => stepSearch(-1)} aria-label="Previous match"><ChevronLeft size={13} /></button>
+                  <button type="submit" className="motif-cs-mini-button" data-testid="msa-search-next" disabled={searchMatches.length === 0} aria-label="Next match"><ChevronRight size={13} /></button>
+                </form>
+                <form
                   className="motif-cs-msa-column-jump"
                   data-invalid={columnError ? true : undefined}
                   noValidate
@@ -1913,13 +2746,22 @@ export function ClaudeScienceMsaViewer({
                 referenceRowId={referenceRowId}
                 emphasis={emphasis}
                 colorMode={colorMode}
+                colorScheme={colorScheme}
+                shadeMode={shadeMode}
                 fontSize={fontSize}
+                zoom={zoom}
+                translationFrame={translationFrame}
                 jumpColumn={jumpColumn}
                 jumpToken={jumpToken}
+                jumpRowId={jumpRowId}
+                searchMatches={searchMatches}
+                activeSearchMatch={activeSearchMatch}
                 sortMode={sortMode}
                 visibility={matrixVisibility}
                 resetToken={viewResetToken}
                 onTemplateChange={selectTemplate}
+                onCopy={copyFromViewer}
+                onZoomChange={(next) => updateViewPreferences({ zoom: next })}
               />
             </>
           ) : displayMode === 'trace' ? (

--- a/src/artifacts/ClaudeSciencePrimerWorkspace.tsx
+++ b/src/artifacts/ClaudeSciencePrimerWorkspace.tsx
@@ -83,6 +83,8 @@ export type ClaudeSciencePrimerWorkspaceProps = {
   onSaveDesign?: (handoff: ClaudeSciencePrimerHandoff) => void | Promise<void>;
   onAddAnnotations?: (features: readonly Feature[], handoff: ClaudeSciencePrimerHandoff) => void | Promise<void>;
   onSimulatePcr?: (handoff: ClaudeSciencePrimerHandoff) => void | Promise<void>;
+  /** Creates an exact linear amplicon record; distinct from result-only simulation. */
+  onCreateAmplicon?: (handoff: ClaudeSciencePrimerHandoff) => void | Promise<void>;
   onUseForCloning?: (handoff: ClaudeSciencePrimerHandoff) => void | Promise<void>;
   initialIntent?: ClaudeSciencePrimerIntent;
   /** Verified preparation context supplied by the owning cloning workflow. */
@@ -270,6 +272,7 @@ export function ClaudeSciencePrimerWorkspace({
   onSaveDesign,
   onAddAnnotations,
   onSimulatePcr,
+  onCreateAmplicon,
   onUseForCloning,
   initialIntent = 'pcr',
   preparationContext = null,
@@ -565,7 +568,7 @@ export function ClaudeSciencePrimerWorkspace({
               {preparationContext.method === 'gibson' && !initialForwardTail && !initialReverseTail ? (
                 <small>No homology tail was inferred. Enter the intended 5′ tail in Advanced constraints before saving.</small>
               ) : null}
-              <small>Saving returns this primer plan to the cloning draft. It does not create an amplicon or modify the source record; add or import the prepared DNA record, replace the source part, then recheck the assembly.</small>
+              <small>Simulate PCR saves a result only. Create &amp; use amplicon creates the exact linear PCR product, keeps the source record unchanged, replaces this prepared part, and rechecks the live cloning draft. Save primer plan only records the oligos without creating DNA.</small>
               {preparationProgress ? (
                 <div className="motif-cs-primer-preparation-navigation" aria-label="Primer preparation worklist">
                   <span>
@@ -775,17 +778,36 @@ export function ClaudeSciencePrimerWorkspace({
           <button type="button" disabled={!handoff || !onSaveDesign || !!busyAction} onClick={() => { if (handoff) void runAction('Save design', () => onSaveDesign?.(handoff)); }}>Save design</button>
           <button type="button" disabled={!handoff || !onAddAnnotations || !!busyAction} onClick={addAnnotations}>Add annotations</button>
           <button type="button" disabled={!handoff || !onSimulatePcr || !!busyAction} onClick={() => { if (handoff) void runAction('PCR simulation', () => onSimulatePcr?.(handoff)); }}>Simulate PCR</button>
+          {preparationContext ? (
+            <button
+              type="button"
+              disabled={!handoff || !onUseForCloning || !!busyAction}
+              onClick={() => {
+                if (handoff) void runAction('Save primer plan only', () => onUseForCloning?.(handoff));
+              }}
+            >Save primer plan only</button>
+          ) : (
+            <button
+              type="button"
+              disabled={!handoff || !onCreateAmplicon || !!busyAction}
+              onClick={() => {
+                if (handoff) void runAction('Create amplicon record', () => onCreateAmplicon?.(handoff));
+              }}
+            >Create amplicon record</button>
+          )}
           <button
             className="motif-cs-primer-primary-action"
             type="button"
-            disabled={!handoff || !onUseForCloning || !!busyAction}
+            disabled={!handoff || !(preparationContext ? onCreateAmplicon : onUseForCloning) || !!busyAction}
             onClick={() => {
-              if (handoff) void runAction(
-                preparationContext ? 'Save primer plan' : 'Cloning handoff',
-                () => onUseForCloning?.(handoff),
-              );
+              if (!handoff) return;
+              if (preparationContext) {
+                void runAction('Create & use amplicon', () => onCreateAmplicon?.(handoff));
+              } else {
+                void runAction('Cloning handoff', () => onUseForCloning?.(handoff));
+              }
             }}
-          >{preparationContext ? 'Save primer plan' : 'Use in cloning'}</button>
+          >{preparationContext ? 'Create & use amplicon' : 'Use in cloning'}</button>
         </div>
       </footer>
     </section>

--- a/src/artifacts/ClaudeScienceWorkflowHistoryPanel.tsx
+++ b/src/artifacts/ClaudeScienceWorkflowHistoryPanel.tsx
@@ -1,9 +1,14 @@
 import { useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 import type { ArtifactWorkflowResult } from './claude-science-workspace-collections';
+import {
+  ClaudeScienceFreshnessBadge,
+  type ScientificFreshnessDisplayEvaluation,
+} from './ClaudeScienceFreshnessBadge';
 
 export type ClaudeScienceWorkflowHistoryPanelProps = {
   results: readonly ArtifactWorkflowResult[];
   recordNames: Readonly<Record<string, string>>;
+  freshnessByResultId?: ReadonlyMap<string, ScientificFreshnessDisplayEvaluation>;
   onRevealRecord: (recordId: string) => void;
   onRemove: (resultId: string) => boolean | void;
 };
@@ -122,6 +127,7 @@ function provenanceText(result: ArtifactWorkflowResult, names: Readonly<Record<s
 export function ClaudeScienceWorkflowHistoryPanel({
   results,
   recordNames,
+  freshnessByResultId,
   onRevealRecord,
   onRemove,
 }: ClaudeScienceWorkflowHistoryPanelProps) {
@@ -175,6 +181,7 @@ export function ClaudeScienceWorkflowHistoryPanel({
               : result.provenance.source;
             const parametersPreview = structuredPreview(result.parameters);
             const resultPreview = result.result ? structuredPreview(result.result) : null;
+            const freshness = freshnessByResultId?.get(result.id);
             return (
               <article className="motif-cs-workflow-row" key={result.id} data-testid={`workflow-result-${result.id}`}>
                 <div className="motif-cs-workflow-row-copy">
@@ -184,7 +191,10 @@ export function ClaudeScienceWorkflowHistoryPanel({
                   {result.outputRecordIds.length > 0 ? (
                     <span><span className="motif-cs-workflow-record-label">Outputs:</span> {recordList(result.outputRecordIds, recordNames)}</span>
                   ) : null}
-                  <small><time dateTime={result.createdAt}>{resultTimestamp(result.createdAt)}</time> · {engine}</small>
+                  <span className="motif-cs-workflow-meta">
+                    <small><time dateTime={result.createdAt}>{resultTimestamp(result.createdAt)}</time> · {engine}</small>
+                    {freshness ? <ClaudeScienceFreshnessBadge evaluation={freshness} recordNames={recordNames} /> : null}
+                  </span>
                   <details className="motif-cs-workflow-details">
                     <summary>Details</summary>
                     <div className="motif-cs-workflow-details-body">
@@ -205,6 +215,12 @@ export function ClaudeScienceWorkflowHistoryPanel({
                                 <code key={`${hash}-${index}`} title={hash}>{hash.slice(0, 12)}…</code>
                               ))}
                             </dd>
+                          </div>
+                        ) : null}
+                        {freshness ? (
+                          <div>
+                            <dt>Freshness</dt>
+                            <dd><ClaudeScienceFreshnessBadge evaluation={freshness} recordNames={recordNames} showReason /></dd>
                           </div>
                         ) : null}
                         <div>

--- a/src/artifacts/__tests__/ClaudeScienceAgentResultsPanel.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceAgentResultsPanel.jsdom.test.tsx
@@ -102,6 +102,26 @@ describe('ClaudeScienceAgentResultsPanel', () => {
     expect(screen.getByText('1 shown')).toBeTruthy();
   });
 
+  it('shows saved-input freshness and its reason without changing the result status', () => {
+    render(
+      <ClaudeScienceAgentResultsPanel
+        results={[primerResult]}
+        assets={[]}
+        recordNames={{ puc19: 'pUC19' }}
+        freshnessByResultId={new Map([[
+          'primer-1',
+          { state: 'stale', reasons: [{ code: 'sequence_changed', recordId: 'puc19' }] },
+        ]])}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('complete')).toBeTruthy();
+    expect(screen.getAllByText('Stale')).toHaveLength(2);
+    fireEvent.click(screen.getByText('Provenance & Data'));
+    expect(screen.getByText(/pUC19's sequence has changed/)).toBeTruthy();
+  });
+
   it('reveals linked records and confirms removal with focus restoration', async () => {
     const onRevealRecord = vi.fn();
     const onRemove = vi.fn(() => true);

--- a/src/artifacts/__tests__/ClaudeScienceCloningDesignWorkspace.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceCloningDesignWorkspace.jsdom.test.tsx
@@ -1,11 +1,13 @@
 /** @vitest-environment jsdom */
 
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { createRef } from 'react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ClaudeScienceCloningDesignWorkspace,
   type ClaudeScienceCloningDesignRecord,
+  type ClaudeScienceCloningDesignWorkspaceHandle,
   type ClaudeScienceCloningDesignWorkspaceProps,
 } from '../ClaudeScienceCloningDesignWorkspace';
 
@@ -257,6 +259,73 @@ describe('ClaudeScienceCloningDesignWorkspace', () => {
       },
     });
     expect(screen.getByRole('status').textContent).toContain('Primer workspace opened');
+  });
+
+  it('replaces only the verified prepared part, preserves live draft choices, and replans against the amplicon', async () => {
+    const user = userEvent.setup();
+    const workspaceRef = createRef<ClaudeScienceCloningDesignWorkspaceHandle>();
+    const onDesignPrimers = vi.fn().mockResolvedValue(undefined);
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const view = render(<ClaudeScienceCloningDesignWorkspace
+      ref={workspaceRef}
+      {...props({ onDesignPrimers, onSave })}
+    />);
+
+    await user.click(screen.getByRole('button', { name: 'Use Destination vector in reverse complement orientation' }));
+    await user.click(screen.getAllByText('Set primer fusion sites')[0]);
+    await user.type(screen.getByLabelText('Left fusion site for Destination vector'), 'GGAG');
+    await user.type(screen.getByLabelText('Right fusion site for Destination vector'), 'GCTT');
+    await user.click(screen.getByRole('button', { name: 'Open primer workspace' }));
+    await waitFor(() => expect(onDesignPrimers).toHaveBeenCalledTimes(1));
+    const request = onDesignPrimers.mock.calls[0][0];
+    const actionId = request.actionIds[0] as string;
+    const expectedRequestSha256 = request.plan.provenance.requestSha256 as string;
+    const amplicon = bsaIPart('amplicon', 'GGAG', plainRecords[0].sequence, 'GCTT');
+    amplicon.name = 'Destination vector · PCR amplicon';
+
+    let replaced = false;
+    act(() => {
+      replaced = workspaceRef.current?.replacePreparedPart({
+        expectedRequestSha256,
+        actionId,
+        sourceRecordId: 'vector',
+        productRecordId: 'amplicon',
+        productRecordName: amplicon.name,
+      }) ?? false;
+      view.rerender(<ClaudeScienceCloningDesignWorkspace
+        ref={workspaceRef}
+        {...props({ records: [...plainRecords, amplicon], onDesignPrimers, onSave })}
+      />);
+    });
+
+    expect(replaced).toBe(true);
+    expect(partNames()).toEqual(['Destination vector · PCR amplicon', 'Reporter insert']);
+    expect(screen.getByRole('button', { name: 'Use Destination vector · PCR amplicon in reverse complement orientation' }).getAttribute('aria-pressed')).toBe('true');
+    expect((screen.getByLabelText('Left fusion site for Destination vector · PCR amplicon') as HTMLInputElement).value).toBe('GGAG');
+    expect((screen.getByLabelText('Right fusion site for Destination vector · PCR amplicon') as HTMLInputElement).value).toBe('GCTT');
+    expect(screen.getByRole('status').textContent).toContain('rechecked');
+
+    await user.click(screen.getByRole('button', { name: 'Save Plan' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave.mock.calls[0][0]).toMatchObject({
+      requestedRecordIds: ['amplicon', 'insert'],
+      requestedOrientations: ['reverse', 'forward'],
+      provenance: { inputRecordIds: ['amplicon', 'insert'] },
+    });
+
+    let staleReplacement = true;
+    act(() => {
+      staleReplacement = workspaceRef.current?.replacePreparedPart({
+        expectedRequestSha256,
+        actionId,
+        sourceRecordId: 'vector',
+        productRecordId: 'another-product',
+        productRecordName: 'Another product',
+      }) ?? false;
+    });
+    expect(staleReplacement).toBe(false);
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('draft changed'));
+    expect(partNames()[0]).toBe('Destination vector · PCR amplicon');
   });
 
   it('previews and saves a provenance-linked Gibson plan and product', async () => {

--- a/src/artifacts/__tests__/ClaudeScienceConstructVerificationPanel.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceConstructVerificationPanel.jsdom.test.tsx
@@ -1,0 +1,207 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  ClaudeScienceConstructVerificationPanel,
+  type ArtifactConstructVerificationPresentationResult,
+} from '../ClaudeScienceConstructVerificationPanel';
+
+function resultFixture(
+  override: Partial<ArtifactConstructVerificationPresentationResult> = {},
+): ArtifactConstructVerificationPresentationResult {
+  return {
+    schema: 'motif.construct-verification.v1',
+    version: 1,
+    state: 'consistent',
+    reasons: [],
+    reference: {
+      id: 'predicted-plasmid',
+      name: 'pTarget predicted construct',
+      length: 4_812,
+      topology: 'circular',
+    },
+    reads: [{
+      id: 'read-forward-1',
+      name: 'Forward read 1',
+      rawLength: 720,
+      meanQuality: 34.2,
+      status: 'mapped',
+      trim: { rawStart: 16, rawEnd: 688, trimmedLength: 672, removedFromStart: 16, removedFromEnd: 32 },
+      mapping: { orientation: 'forward', referenceStart: 1, referenceEnd: 672, alignedLength: 672, identity: 1 },
+    }, {
+      id: 'read-forward-2',
+      name: 'Forward read 2',
+      rawLength: 705,
+      meanQuality: 31.8,
+      status: 'mapped',
+      mapping: { orientation: 'forward', referenceStart: 650, referenceEnd: 1_304, alignedLength: 655, identity: 1 },
+    }, {
+      id: 'read-reverse-1',
+      name: 'Reverse read 1',
+      rawLength: 698,
+      meanQuality: 33.5,
+      status: 'mapped',
+      mapping: { orientation: 'reverse', referenceStart: 1_270, referenceEnd: 1_910, alignedLength: 641, identity: 1 },
+    }],
+    coverage: {
+      depth: [1, 2, 3, 2],
+      forward: [1, 1, 2, 1],
+      reverse: [0, 1, 1, 1],
+      coveredBases: 4_812,
+      basesMeetingMinDepth: 4_812,
+      coveredFraction: 1,
+      meanDepth: 2,
+      requiredRegions: [],
+    },
+    consensus: { calls: [] },
+    variants: { observed: [], expected: [], unexpected: [], missingExpected: [] },
+    provenance: { engine: 'motif-construct-verification', engineVersion: '1' },
+    ...override,
+  };
+}
+
+afterEach(cleanup);
+
+describe('ClaudeScienceConstructVerificationPanel', () => {
+  it('states a consistent verdict and presents compact coverage, strand, and read facts', () => {
+    render(<ClaudeScienceConstructVerificationPanel result={resultFixture()} />);
+
+    expect(screen.getByLabelText('Construct verification: Consistent')).toBeTruthy();
+    expect(screen.getByText('Consistent')).toBeTruthy();
+    expect(screen.getByText('pTarget predicted construct')).toBeTruthy();
+    expect(screen.getByText('3 / 3')).toBeTruthy();
+    expect(screen.getByText('2 F · 1 R')).toBeTruthy();
+    expect(screen.getByText('2.0×')).toBeTruthy();
+    expect(screen.getByRole('progressbar', { name: 'Reference coverage 100.0%' }).getAttribute('value')).toBe('100');
+    expect(screen.getByText('No review findings were recorded for this result.')).toBeTruthy();
+  });
+
+  it('keeps findings inert, bounds their initial presentation, and filters variant evidence accessibly', async () => {
+    const user = userEvent.setup();
+    const malicious = '<img src=x onerror=alert(1)> needs manual review';
+    const reasons = Array.from({ length: 7 }, (_, index) => ({
+      code: `reason_${index + 1}`,
+      severity: 'warning',
+      message: index === 0 ? malicious : `Secondary reason ${index + 1}`,
+      readId: `read-${index + 1}`,
+    }));
+    const expected = { id: 'expected-1', referenceStart: 170, type: 'substitution', reference: 'A', alternate: 'G', status: 'observed' as const, depth: 2, observedVariantId: 'observed-expected-1' };
+    const observedExpected = { id: 'observed-expected-1', referenceStart: 170, type: 'substitution', reference: 'A', alternate: 'G', supportingReadIds: ['read-forward-1', 'read-forward-2'], support: 2, meanQuality: 38 };
+    const unexpected = { id: 'unexpected-1', referenceStart: 420, type: 'deletion', reference: 'AT', alternate: 'A', supportingReadIds: ['read-forward-1'], support: 1, meanQuality: 31 };
+
+    const view = render(
+      <ClaudeScienceConstructVerificationPanel
+        result={resultFixture({
+          state: 'needs_review',
+          reasons,
+          variants: {
+            observed: [observedExpected, unexpected],
+            expected: [expected],
+            unexpected: [unexpected],
+            missingExpected: [],
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Needs review')).toBeTruthy();
+    expect(screen.getByText(malicious)).toBeTruthy();
+    expect(view.container.querySelector('img')).toBeNull();
+    expect(screen.getByText('Secondary reason 7').closest('details')?.open).toBe(false);
+    await user.click(screen.getByText('Show 3 more findings'));
+    expect(screen.getByText('Secondary reason 7').closest('details')?.open).toBe(true);
+
+    await user.selectOptions(screen.getByLabelText('Show'), 'unexpected');
+    const variantTable = screen.getByLabelText('Scrollable variant evidence table');
+    expect(within(variantTable).getByText('Unexpected')).toBeTruthy();
+    expect(within(variantTable).getByText('420')).toBeTruthy();
+    expect(within(variantTable).queryByText('170')).toBeNull();
+  });
+
+  it('separates low-confidence unexpected evidence from supported contradictions', async () => {
+    const user = userEvent.setup();
+    const uncertain = {
+      id: 'unexpected-low',
+      referenceStart: 42,
+      type: 'substitution',
+      reference: 'A',
+      alternate: 'G',
+      confidence: 'low' as const,
+      support: 1,
+      meanQuality: 12,
+    };
+    render(
+      <ClaudeScienceConstructVerificationPanel
+        result={resultFixture({
+          state: 'needs_review',
+          variants: { observed: [uncertain], expected: [], unexpected: [uncertain], missingExpected: [] },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Unexpected').nextElementSibling?.textContent).toBe('0');
+    await user.selectOptions(screen.getByLabelText('Show'), 'uncertain');
+    expect(within(screen.getByLabelText('Scrollable variant evidence table')).getByText('Low confidence')).toBeTruthy();
+  });
+
+  it('discloses required-region and per-read evidence without exposing mutations', async () => {
+    const user = userEvent.setup();
+    const frozen = Object.freeze(resultFixture({
+      state: 'inconsistent',
+      reference: Object.freeze({ id: 'reference-1', length: 5_000, topology: 'linear' }),
+      coverage: Object.freeze({
+        coveredBases: 4_100,
+        coveredFraction: 0.82,
+        requiredRegions: Object.freeze([{
+          id: 'junction-a',
+          name: 'Insert–backbone junction',
+          start: 1_990,
+          end: 2_030,
+          coveredFraction: 0.5,
+          forwardCoveredBases: 20,
+          reverseCoveredBases: 0,
+          status: 'insufficient',
+        }]),
+      }),
+    }));
+
+    const view = render(
+      <ClaudeScienceConstructVerificationPanel
+        result={frozen}
+        referenceName="Expected pTarget"
+        readNames={{ 'read-forward-1': '<script>bad()</script>' }}
+      />,
+    );
+
+    expect(screen.getByText('Inconsistent')).toBeTruthy();
+    expect(screen.getByText('Insert–backbone junction')).toBeTruthy();
+    expect(screen.getByText('Forward only')).toBeTruthy();
+    expect(screen.getByRole('progressbar', { name: 'Reference coverage 82.0%' })).toBeTruthy();
+
+    await user.click(screen.getByText('Inspect mapped reads and quality'));
+    expect(screen.getByText('<script>bad()</script>')).toBeTruthy();
+    expect(view.container.querySelector('script')).toBeNull();
+    expect(frozen.coverage.coveredFraction).toBe(0.82);
+  });
+
+  it('caps large variant previews while preserving the matching count', () => {
+    const observed = Array.from({ length: 105 }, (_, index) => ({
+      id: `variant-${index}`,
+      referenceStart: index + 1,
+      type: 'substitution',
+      reference: 'A',
+      alternate: 'C',
+    }));
+    render(
+      <ClaudeScienceConstructVerificationPanel
+        result={resultFixture({ variants: { observed, expected: [], unexpected: observed, missingExpected: [] } })}
+      />,
+    );
+
+    const table = screen.getByLabelText('Scrollable variant evidence table');
+    expect(within(table).getAllByRole('row')).toHaveLength(101);
+    expect(screen.getByText('Showing the first 100 of 105 matching variants.')).toBeTruthy();
+  });
+});

--- a/src/artifacts/__tests__/ClaudeScienceConstructVerificationWorkspace.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceConstructVerificationWorkspace.jsdom.test.tsx
@@ -1,0 +1,475 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  ClaudeScienceConstructVerificationWorkspace,
+  type ClaudeScienceConstructVerificationRecord,
+  type ClaudeScienceConstructVerificationRequest,
+  type ClaudeScienceConstructVerificationResult,
+} from '../ClaudeScienceConstructVerificationWorkspace';
+import { ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS } from '../claude-science-construct-verification';
+
+const DEFAULT_THRESHOLDS = {
+  trimQuality: 20,
+  trimWindow: 12,
+  minTrimmedReadLength: 40,
+  minMappingIdentity: 0.82,
+  minMappingMargin: 0.03,
+  maxIndelFraction: 0.12,
+  minCoverageFraction: 1,
+  minDepth: 1,
+  requireBothStrands: false,
+  minConsensusFraction: 0.7,
+  minVariantQuality: 20,
+  minVariantFraction: 0.6,
+} as const;
+
+function referenceRecord(
+  override: Partial<ClaudeScienceConstructVerificationRecord> = {},
+): ClaudeScienceConstructVerificationRecord {
+  return {
+    id: 'predicted-reference',
+    name: 'Predicted pTarget',
+    sequence: 'ACGT'.repeat(300),
+    topology: 'circular',
+    sha256: 'a'.repeat(64),
+    ...override,
+  };
+}
+
+function traceRecord(
+  id: string,
+  override: Partial<ClaudeScienceConstructVerificationRecord> = {},
+): ClaudeScienceConstructVerificationRecord {
+  return {
+    id,
+    name: `Sanger ${id}`,
+    sequence: 'ACGT'.repeat(120),
+    topology: 'linear',
+    sha256: id === 'read-a' ? 'b'.repeat(64) : 'c'.repeat(64),
+    sangerTrace: {
+      baseCalls: 'ACGT'.repeat(120),
+      qualityScores: Array.from({ length: 480 }, () => 36),
+    },
+    sangerEvidenceSha256: id === 'read-a' ? 'd'.repeat(64) : 'e'.repeat(64),
+    ...override,
+  };
+}
+
+function verificationResult(
+  request?: ClaudeScienceConstructVerificationRequest,
+): ClaudeScienceConstructVerificationResult {
+  const reference = request?.reference ?? referenceRecord();
+  const reads = request?.reads ?? [traceRecord('read-a') as ClaudeScienceConstructVerificationRecord & { sangerTrace: { baseCalls: string; qualityScores?: readonly number[] } }];
+  return {
+    schema: 'motif.construct-verification.v1',
+    version: 1,
+    state: 'consistent',
+    reasons: [],
+    reference: {
+      id: reference.id,
+      name: reference.name,
+      sequence: reference.sequence,
+      length: reference.sequence.length,
+      topology: reference.topology,
+      sha256: reference.sha256,
+    },
+    thresholds: {
+      ...DEFAULT_THRESHOLDS,
+      minDepth: request?.minDepth ?? DEFAULT_THRESHOLDS.minDepth,
+      requireBothStrands: request?.requireBothStrands ?? DEFAULT_THRESHOLDS.requireBothStrands,
+    },
+    reads: reads.map((read) => ({
+      id: read.id,
+      name: read.name,
+      sha256: read.sha256,
+      rawLength: read.sangerTrace.baseCalls.length,
+      qualityProvided: true,
+      meanQuality: 36,
+      status: 'mapped',
+      trim: {
+        method: 'quality_window',
+        rawStart: 0,
+        rawEnd: read.sangerTrace.baseCalls.length,
+        trimmedLength: read.sangerTrace.baseCalls.length,
+        removedFromStart: 0,
+        removedFromEnd: 0,
+      },
+      mapping: {
+        orientation: read.id === 'read-b' ? 'reverse' : 'forward',
+        referenceStart: 0,
+        referenceEnd: read.sangerTrace.baseCalls.length,
+        wraps: false,
+        referenceSpan: read.sangerTrace.baseCalls.length,
+        score: read.sangerTrace.baseCalls.length * 2,
+        secondBestScore: null,
+        mappingMargin: null,
+        alignedLength: read.sangerTrace.baseCalls.length,
+        identity: 1,
+        matches: read.sangerTrace.baseCalls.length,
+        substitutions: 0,
+        insertions: 0,
+        deletions: 0,
+        indelFraction: 0,
+        coordinateMap: {
+          columns: [],
+          referencePositions: [],
+          rawCallIndices: [],
+        },
+      },
+    })),
+    coverage: {
+      depth: Array.from({ length: reference.sequence.length }, () => 1),
+      forward: Array.from({ length: reference.sequence.length }, () => 1),
+      reverse: Array.from({ length: reference.sequence.length }, () => 0),
+      coveredBases: reference.sequence.length,
+      basesMeetingMinDepth: reference.sequence.length,
+      coveredFraction: 1,
+      minimumDepth: 1,
+      maximumDepth: 1,
+      meanDepth: 1,
+      requiredRegions: [{
+        id: 'full-reference',
+        name: 'Full predicted construct',
+        start: 0,
+        end: reference.sequence.length,
+        wraps: false,
+        length: reference.sequence.length,
+        minDepth: request?.minDepth ?? 1,
+        requireBothStrands: request?.requireBothStrands ?? false,
+        coveredBases: reference.sequence.length,
+        basesMeetingMinDepth: reference.sequence.length,
+        coveredFraction: 1,
+        minimumDepth: 1,
+        maximumDepth: 1,
+        meanDepth: 1,
+        forwardCoveredBases: reference.sequence.length,
+        reverseCoveredBases: 0,
+        bothStrandsCoveredBases: 0,
+        status: 'covered',
+      }],
+    },
+    consensus: { sequence: reference.sequence, calls: [], variants: [] },
+    variants: { observed: [], expected: [], unexpected: [], missingExpected: [] },
+    provenance: {
+      engine: 'motif-construct-verification',
+      engineVersion: '1',
+      referenceSha256: reference.sha256,
+      readSha256s: reads.map((read) => read.sha256),
+      requestSha256: 'f'.repeat(64),
+      workUnits: 1_200,
+      limits: ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS,
+    },
+  };
+}
+
+afterEach(cleanup);
+
+describe('ClaudeScienceConstructVerificationWorkspace', () => {
+  it('explains missing evidence and cannot run without an eligible trace-backed read', () => {
+    const onVerify = vi.fn(verificationResult);
+    render(
+      <ClaudeScienceConstructVerificationWorkspace
+        records={[referenceRecord()]}
+        onVerify={onVerify}
+        onSave={vi.fn()}
+        embedded
+      />,
+    );
+
+    expect(screen.getByText(/No trace-backed DNA records are available/)).toBeTruthy();
+    expect((screen.getByTestId('construct-verification-run') as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId('construct-verification-save') as HTMLButtonElement).disabled).toBe(true);
+    expect(onVerify).not.toHaveBeenCalled();
+  });
+
+  it('never offers or accepts trace-backed records as predicted references', async () => {
+    const user = userEvent.setup();
+    const reference = referenceRecord();
+    const readA = traceRecord('read-a');
+    const readB = traceRecord('read-b');
+    const onVerify = vi.fn((request: ClaudeScienceConstructVerificationRequest) => verificationResult(request));
+    render(
+      <ClaudeScienceConstructVerificationWorkspace
+        records={[readA, reference, readB]}
+        initialReferenceId={readA.id}
+        onVerify={onVerify}
+        onSave={vi.fn()}
+        embedded
+      />,
+    );
+
+    const referenceSelect = screen.getByTestId('construct-verification-reference') as HTMLSelectElement;
+    expect(referenceSelect.value).toBe(reference.id);
+    expect(Array.from(referenceSelect.options).map((option) => option.value)).toEqual([reference.id]);
+
+    fireEvent.change(referenceSelect, { target: { value: readB.id } });
+    expect(referenceSelect.value).toBe(reference.id);
+    await user.click(screen.getByTestId('construct-verification-run'));
+    expect(onVerify).toHaveBeenCalledTimes(1);
+    expect(onVerify.mock.calls[0][0].reference).toBe(reference);
+    expect(onVerify.mock.calls[0][0].reads.map((read) => read.id)).toEqual([readA.id, readB.id]);
+  });
+
+  it('does not treat trace-only evidence as a predicted-reference candidate', () => {
+    render(
+      <ClaudeScienceConstructVerificationWorkspace
+        records={[traceRecord('read-a'), traceRecord('read-b')]}
+        initialReferenceId="read-a"
+        onVerify={vi.fn(verificationResult)}
+        onSave={vi.fn()}
+        embedded
+      />,
+    );
+
+    const referenceSelect = screen.getByTestId('construct-verification-reference') as HTMLSelectElement;
+    expect(referenceSelect.disabled).toBe(true);
+    expect(Array.from(referenceSelect.options).map((option) => option.textContent)).toEqual([
+      'No predicted DNA references',
+    ]);
+    expect((screen.getByTestId('construct-verification-run') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('shows every eligible read while letting any read replace a default selection at the run cap', async () => {
+    const user = userEvent.setup();
+    const reads = Array.from(
+      { length: ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReads + 1 },
+      (_, index) => traceRecord(`read-${String(index + 1).padStart(3, '0')}`),
+    );
+    let capturedRequest: ClaudeScienceConstructVerificationRequest | undefined;
+    render(
+      <ClaudeScienceConstructVerificationWorkspace
+        records={[referenceRecord(), ...reads]}
+        onVerify={(request) => {
+          capturedRequest = request;
+          return verificationResult(request);
+        }}
+        onSave={vi.fn()}
+        embedded
+      />,
+    );
+
+    const readList = screen.getByTestId('construct-verification-read-list');
+    const checkboxes = within(readList).getAllByRole('checkbox') as HTMLInputElement[];
+    expect(checkboxes).toHaveLength(ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReads + 1);
+    expect(checkboxes.filter((checkbox) => checkbox.checked)).toHaveLength(
+      ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReads,
+    );
+    expect(screen.getByText(/96 of 97 reads selected · maximum 96 per run/)).toBeTruthy();
+    expect((screen.getByRole('button', { name: 'First 96' }) as HTMLButtonElement).disabled).toBe(true);
+
+    const firstRead = within(readList).getByLabelText(/Sanger read-001/) as HTMLInputElement;
+    const alternativeRead = within(readList).getByLabelText(/Sanger read-097/) as HTMLInputElement;
+    expect(alternativeRead.checked).toBe(false);
+    expect(alternativeRead.disabled).toBe(true);
+    expect(alternativeRead.title).toMatch(/Deselect another read/);
+
+    await user.click(firstRead);
+    expect(alternativeRead.disabled).toBe(false);
+    await user.click(alternativeRead);
+    expect(firstRead.checked).toBe(false);
+    expect(firstRead.disabled).toBe(true);
+    expect(alternativeRead.checked).toBe(true);
+
+    await user.click(screen.getByTestId('construct-verification-run'));
+    expect(capturedRequest?.reads).toHaveLength(ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReads);
+    expect(capturedRequest?.reads.some((read) => read.id === 'read-001')).toBe(false);
+    expect(capturedRequest?.reads.some((read) => read.id === 'read-097')).toBe(true);
+  });
+
+  it('passes the exact ordered request and a deeply frozen evidence snapshot', async () => {
+    const user = userEvent.setup();
+    const reference = referenceRecord();
+    const readB = traceRecord('read-b');
+    const readA = traceRecord('read-a');
+    let capturedRequest: ClaudeScienceConstructVerificationRequest | undefined;
+    const onVerify = vi.fn((request: ClaudeScienceConstructVerificationRequest) => {
+      capturedRequest = request;
+      return verificationResult(request);
+    });
+    const onSave = vi.fn();
+
+    render(
+      <ClaudeScienceConstructVerificationWorkspace
+        records={[readB, reference, readA]}
+        initialReferenceId={reference.id}
+        onVerify={onVerify}
+        onSave={onSave}
+        embedded
+      />,
+    );
+
+    expect((screen.getByTestId('construct-verification-reference') as HTMLSelectElement).value).toBe(reference.id);
+    await user.tripleClick(screen.getByLabelText('Minimum read depth'));
+    await user.keyboard('3');
+    await user.click(screen.getByLabelText(/Require both strands/));
+    await user.click(screen.getByTestId('construct-verification-run'));
+
+    expect(onVerify).toHaveBeenCalledTimes(1);
+    expect(capturedRequest).toEqual({
+      reference,
+      reads: [readB, readA],
+      minDepth: 3,
+      requireBothStrands: true,
+    });
+    expect(capturedRequest?.reference).toBe(reference);
+    expect(capturedRequest?.reads[0]).toBe(readB);
+    expect(capturedRequest?.reads[1]).toBe(readA);
+    expect(Object.isFrozen(capturedRequest)).toBe(true);
+    expect(Object.isFrozen(capturedRequest?.reads)).toBe(true);
+
+    await user.click(screen.getByTestId('construct-verification-save'));
+    const payload = onSave.mock.calls[0][0];
+    expect(payload.snapshot).toEqual({
+      reference: {
+        id: reference.id,
+        sequenceSha256: reference.sha256,
+        topology: reference.topology,
+      },
+      reads: [{
+        id: readB.id,
+        sequenceSha256: readB.sha256,
+        sangerEvidenceSha256: readB.sangerEvidenceSha256,
+      }, {
+        id: readA.id,
+        sequenceSha256: readA.sha256,
+        sangerEvidenceSha256: readA.sangerEvidenceSha256,
+      }],
+      minDepth: 3,
+      requireBothStrands: true,
+    });
+    expect(Object.isFrozen(payload)).toBe(true);
+    expect(Object.isFrozen(payload.snapshot)).toBe(true);
+    expect(Object.isFrozen(payload.snapshot.reference)).toBe(true);
+    expect(Object.isFrozen(payload.snapshot.reads)).toBe(true);
+    expect(Object.isFrozen(payload.snapshot.reads[0])).toBe(true);
+  });
+
+  it('clears a live result and disables Save when any acceptance control changes', async () => {
+    const user = userEvent.setup();
+    render(
+      <ClaudeScienceConstructVerificationWorkspace
+        records={[referenceRecord(), traceRecord('read-a'), traceRecord('read-b')]}
+        onVerify={(request) => verificationResult(request)}
+        onSave={vi.fn()}
+        embedded
+      />,
+    );
+
+    await user.click(screen.getByTestId('construct-verification-run'));
+    expect(screen.getByTestId('construct-verification-panel')).toBeTruthy();
+    expect((screen.getByTestId('construct-verification-save') as HTMLButtonElement).disabled).toBe(false);
+
+    await user.click(screen.getByLabelText(/Sanger read-a/));
+    expect(screen.queryByTestId('construct-verification-panel')).toBeNull();
+    expect(screen.getByTestId('construct-verification-awaiting')).toBeTruthy();
+    expect((screen.getByTestId('construct-verification-save') as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.queryByTestId('construct-verification-status')).toBeNull();
+  });
+
+  it('saves the exact local result and the snapshot from that run', async () => {
+    const user = userEvent.setup();
+    const result = verificationResult();
+    const onSave = vi.fn();
+    render(
+      <ClaudeScienceConstructVerificationWorkspace
+        records={[referenceRecord(), traceRecord('read-a')]}
+        onVerify={() => result}
+        onSave={onSave}
+        embedded
+      />,
+    );
+
+    expect((screen.getByTestId('construct-verification-save') as HTMLButtonElement).disabled).toBe(true);
+    await user.click(screen.getByTestId('construct-verification-run'));
+    await user.click(screen.getByTestId('construct-verification-save'));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0][0].result).toBe(result);
+    expect(onSave.mock.calls[0][0].snapshot.reads.map((read: { id: string }) => read.id)).toEqual(['read-a']);
+    expect((screen.getByTestId('construct-verification-save') as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText(/Verification saved to Results/)).toBeTruthy();
+  });
+
+  it('renders callback failures as inert bounded text', async () => {
+    const user = userEvent.setup();
+    const malicious = '<img src=x onerror=alert(1)> evidence engine failed';
+    const view = render(
+      <ClaudeScienceConstructVerificationWorkspace
+        records={[referenceRecord(), traceRecord('read-a')]}
+        onVerify={() => { throw new Error(malicious); }}
+        onSave={vi.fn()}
+        embedded
+      />,
+    );
+
+    await user.click(screen.getByTestId('construct-verification-run'));
+    expect(screen.getByRole('alert').textContent).toContain(malicious);
+    expect(view.container.querySelector('img')).toBeNull();
+    expect(screen.queryByTestId('construct-verification-panel')).toBeNull();
+  });
+
+  it('reconciles removed evidence and clears stale results when record props change', async () => {
+    const user = userEvent.setup();
+    const reference = referenceRecord();
+    const readA = traceRecord('read-a');
+    const readB = traceRecord('read-b');
+    const view = render(
+      <ClaudeScienceConstructVerificationWorkspace
+        records={[reference, readA, readB]}
+        onVerify={(request) => verificationResult(request)}
+        onSave={vi.fn()}
+        embedded
+      />,
+    );
+
+    await user.click(screen.getByTestId('construct-verification-run'));
+    expect(screen.getByTestId('construct-verification-panel')).toBeTruthy();
+
+    view.rerender(
+      <ClaudeScienceConstructVerificationWorkspace
+        records={[reference, { ...readB, sha256: '9'.repeat(64) }]}
+        onVerify={(request) => verificationResult(request)}
+        onSave={vi.fn()}
+        embedded
+      />,
+    );
+
+    await waitFor(() => expect(screen.queryByTestId('construct-verification-panel')).toBeNull());
+    const readList = screen.getByTestId('construct-verification-read-list');
+    expect(within(readList).queryByLabelText(/Sanger read-a/)).toBeNull();
+    expect((within(readList).getByLabelText(/Sanger read-b/) as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByTestId('construct-verification-save') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('never mutates frozen record, trace, or quality-score inputs', async () => {
+    const user = userEvent.setup();
+    const qualityScores = Object.freeze(Array.from({ length: 480 }, () => 35));
+    const reference = Object.freeze(referenceRecord());
+    const read = Object.freeze(traceRecord('read-a', {
+      sangerTrace: Object.freeze({
+        baseCalls: 'ACGT'.repeat(120),
+        qualityScores,
+      }),
+    }));
+    const records = Object.freeze([reference, read]);
+    const before = JSON.stringify(records);
+
+    render(
+      <ClaudeScienceConstructVerificationWorkspace
+        records={records}
+        onVerify={(request) => verificationResult(request)}
+        onSave={vi.fn()}
+        embedded
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+    await user.click(screen.getByRole('button', { name: 'All' }));
+    await user.click(screen.getByTestId('construct-verification-run'));
+    expect(JSON.stringify(records)).toBe(before);
+    expect(Object.isFrozen(qualityScores)).toBe(true);
+  });
+});

--- a/src/artifacts/__tests__/ClaudeScienceFreshnessBadge.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceFreshnessBadge.jsdom.test.tsx
@@ -1,0 +1,43 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  ClaudeScienceFreshnessBadge,
+  scientificFreshnessReasonText,
+  scientificFreshnessSummary,
+} from '../ClaudeScienceFreshnessBadge';
+
+afterEach(cleanup);
+
+describe('ClaudeScienceFreshnessBadge', () => {
+  it('states freshness in text instead of relying on color', () => {
+    render(<ClaudeScienceFreshnessBadge evaluation={{ state: 'fresh', reasons: [] }} />);
+    const badge = screen.getByText('Fresh');
+    expect(badge.getAttribute('aria-label')).toContain('Saved inputs match');
+    expect(badge.closest('[data-freshness]')?.getAttribute('data-freshness')).toBe('fresh');
+  });
+
+  it('names the affected record and summarizes additional reasons', () => {
+    render(
+      <ClaudeScienceFreshnessBadge
+        evaluation={{
+          state: 'stale',
+          reasons: [
+            { code: 'sequence_changed', recordId: 'vector' },
+            { code: 'topology_changed', recordId: 'vector' },
+          ],
+        }}
+        recordNames={{ vector: 'pUC19' }}
+        showReason
+      />,
+    );
+    expect(screen.getByText('Stale')).toBeTruthy();
+    expect(screen.getByText(/pUC19's sequence has changed/).textContent).toContain('1 more issue');
+  });
+
+  it('provides stable fallbacks for unverified and future reason codes', () => {
+    expect(scientificFreshnessSummary({ state: 'unverified', reasons: [] })).toContain('identity is incomplete');
+    expect(scientificFreshnessReasonText({ code: 'future_reason', field: 'source' })).toBe('Future reason (source).');
+  });
+});

--- a/src/artifacts/__tests__/ClaudeScienceGelWorkspace.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceGelWorkspace.jsdom.test.tsx
@@ -164,6 +164,26 @@ describe('createClaudeScienceGelLaneCandidates', () => {
     expect(digestCandidate?.lane).not.toHaveProperty('recordSha256');
   });
 
+  it('omits stale and unverified workflow history when a scientific freshness map is supplied', () => {
+    const source = record('source-plasmid', { topology: 'linear', sequence: 'ACGT' });
+    const fresh = digestResult('fresh', {
+      inputSha256s: [sha256HexSync(source.sequence)],
+      parameters: { topology: 'linear', outcome: 'fragmented' },
+      result: { outcome: 'fragmented', fragments: [{ length: 2 }, { length: 2 }] },
+    });
+    const stale = { ...fresh, id: 'stale' };
+    const unverified = { ...fresh, id: 'unverified', inputSha256s: undefined };
+    const freshness = new Map([
+      ['fresh', { state: 'fresh' as const }],
+      ['stale', { state: 'stale' as const }],
+      ['unverified', { state: 'unverified' as const }],
+    ]);
+
+    expect(createClaudeScienceGelLaneCandidates([source], [fresh, stale, unverified], freshness)
+      .filter((candidate) => candidate.sourceKind === 'digest')
+      .map((candidate) => candidate.id)).toEqual(['digest:fresh']);
+  });
+
   it('omits records whose declared digest is malformed or does not match their current sequence', () => {
     const mismatched = record('mismatched', {
       sequence: 'AAAA',

--- a/src/artifacts/__tests__/ClaudeSciencePrimerWorkspace.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeSciencePrimerWorkspace.jsdom.test.tsx
@@ -23,6 +23,7 @@ function props(overrides: Partial<ClaudeSciencePrimerWorkspaceProps> = {}): Clau
     onSaveDesign: vi.fn(),
     onAddAnnotations: vi.fn(),
     onSimulatePcr: vi.fn(),
+    onCreateAmplicon: vi.fn(),
     onUseForCloning: vi.fn(),
     ...overrides,
   };
@@ -172,6 +173,7 @@ describe('ClaudeSciencePrimerWorkspace', () => {
       onSaveDesign: vi.fn(),
       onAddAnnotations: vi.fn(),
       onSimulatePcr: vi.fn(),
+      onCreateAmplicon: vi.fn(),
       onUseForCloning: vi.fn(),
     };
     render(<ClaudeSciencePrimerWorkspace {...props(callbacks)} />);
@@ -186,6 +188,8 @@ describe('ClaudeSciencePrimerWorkspace', () => {
     await waitFor(() => expect(callbacks.onAddAnnotations).toHaveBeenCalledTimes(1));
     await user.click(screen.getByRole('button', { name: 'Simulate PCR' }));
     await waitFor(() => expect(callbacks.onSimulatePcr).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole('button', { name: 'Create amplicon record' }));
+    await waitFor(() => expect(callbacks.onCreateAmplicon).toHaveBeenCalledTimes(1));
     await user.click(screen.getByRole('button', { name: 'Use in cloning' }));
 
     await waitFor(() => expect(callbacks.onUseForCloning).toHaveBeenCalledTimes(1));
@@ -200,19 +204,22 @@ describe('ClaudeSciencePrimerWorkspace', () => {
     expect(callbacks.onUseForCloning.mock.calls[0][0].recordName).toBe('Example insert');
   });
 
-  it('retains cloning action provenance in the handoff and labels save without claiming an amplicon', async () => {
+  it('retains cloning provenance and keeps plan-only, simulation, and create-and-use actions explicit', async () => {
     const user = userEvent.setup();
     const onUseForCloning = vi.fn();
+    const onCreateAmplicon = vi.fn();
     render(<ClaudeSciencePrimerWorkspace {...props({
       record: { id: 'record-1', name: 'Example insert', molecule: 'dna', sequence: sequence.slice(150, 550) },
       initialIntent: 'cloning',
       preparationContext: preparationContext(),
       onUseForCloning,
+      onCreateAmplicon,
     })} />);
 
-    expect(screen.getByRole('note', { name: 'Cloning preparation context' }).textContent).toContain('does not create an amplicon');
-    expect(screen.getByRole('note', { name: 'Cloning preparation context' }).textContent).toContain('add or import the prepared DNA record');
-    await user.click(screen.getByRole('button', { name: 'Save primer plan' }));
+    const context = screen.getByRole('note', { name: 'Cloning preparation context' });
+    expect(context.textContent).toContain('Simulate PCR saves a result only');
+    expect(context.textContent).toContain('keeps the source record unchanged');
+    await user.click(screen.getByRole('button', { name: 'Save primer plan only' }));
     await waitFor(() => expect(onUseForCloning).toHaveBeenCalledTimes(1));
     expect(onUseForCloning.mock.calls[0][0]).toMatchObject({
       target: { start: 0, end: 400 },
@@ -226,6 +233,9 @@ describe('ClaudeSciencePrimerWorkspace', () => {
         fusionSites: { left: 'AATG', right: 'GCTT' },
       },
     });
+    await user.click(screen.getByRole('button', { name: 'Create & use amplicon' }));
+    await waitFor(() => expect(onCreateAmplicon).toHaveBeenCalledTimes(1));
+    expect(onCreateAmplicon.mock.calls[0][0].preparationContext.actionId).toBe('flanks:record-1');
   });
 
   it('explains the manual 5′-tail step when a Gibson overlap cannot be inferred', () => {
@@ -247,7 +257,8 @@ describe('ClaudeSciencePrimerWorkspace', () => {
     const context = screen.getByRole('note', { name: 'Cloning preparation context' });
     expect(context.textContent).toContain('No homology tail was inferred');
     expect(context.textContent).toContain('Advanced constraints');
-    expect(screen.getByRole('button', { name: 'Save primer plan' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Save primer plan only' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Create & use amplicon' })).toBeTruthy();
   });
 
   it('uses an existing selection and reports invalid targets accessibly', async () => {

--- a/src/artifacts/__tests__/ClaudeScienceWorkflowHistoryPanel.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceWorkflowHistoryPanel.jsdom.test.tsx
@@ -49,6 +49,25 @@ describe('ClaudeScienceWorkflowHistoryPanel', () => {
     expect(onRevealRecord).toHaveBeenLastCalledWith('source');
   });
 
+  it('surfaces unverified lineage in both the row and workflow details', async () => {
+    const user = userEvent.setup();
+    render(
+      <ClaudeScienceWorkflowHistoryPanel
+        results={[result]}
+        recordNames={{ source: 'Source', fragment: 'Fragment 1' }}
+        freshnessByResultId={new Map([[
+          result.id,
+          { state: 'unverified', reasons: [{ code: 'missing_input_hash', recordId: 'source' }] },
+        ]])}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByText('Unverified')).toHaveLength(2);
+    await user.click(screen.getByText('Details'));
+    expect(screen.getByText(/Source was saved without a sequence fingerprint/)).toBeTruthy();
+  });
+
   it('summarizes large record sets and exposes bounded, inert workflow details', async () => {
     const user = userEvent.setup();
     const outputRecordIds = Array.from({ length: 18 }, (_, index) => `output-${index + 1}`);

--- a/src/artifacts/__tests__/claude-science-analysis-results.test.ts
+++ b/src/artifacts/__tests__/claude-science-analysis-results.test.ts
@@ -18,9 +18,27 @@ import {
   removeArtifactAnalysisResultsForRecord,
   serializeArtifactAnalysisWorkspace,
 } from '../claude-science-analysis-results';
+import { sha256HexSync } from '../claude-science-sha256';
 
 const CREATED_AT = '2026-07-12T16:30:00.000Z';
 const SHA256 = 'A'.repeat(64);
+const NORMALIZED_SHA256 = SHA256.toLowerCase();
+const REQUEST_SHA256 = sha256HexSync('construct-verification-request');
+const READ_EVIDENCE_SHA256 = sha256HexSync('construct-read-evidence');
+const VERIFICATION_THRESHOLDS = {
+  trimQuality: 20,
+  trimWindow: 12,
+  minTrimmedReadLength: 40,
+  minMappingIdentity: 0.82,
+  minMappingMargin: 0.03,
+  maxIndelFraction: 0.12,
+  minCoverageFraction: 1,
+  minDepth: 1,
+  requireBothStrands: false,
+  minConsensusFraction: 0.7,
+  minVariantQuality: 20,
+  minVariantFraction: 0.6,
+};
 
 function provenance() {
   return {
@@ -33,16 +51,245 @@ function provenance() {
 }
 
 function asset(overrides: Record<string, unknown> = {}) {
+  const content = typeof overrides.content === 'string' ? overrides.content : 'Inert analysis text';
   return {
     id: 'asset-1',
     name: 'analysis.txt',
     mediaType: 'text/plain',
-    content: 'Inert analysis text',
-    sha256: SHA256,
+    content,
+    sha256: sha256HexSync(content),
     createdAt: CREATED_AT,
     provenance: provenance(),
     ...overrides,
   };
+}
+
+function constructVerificationProvenance() {
+  return {
+    source: 'motif-for-claude-science-artifact',
+    operation: 'construct_verification',
+    actor: 'user',
+    engine: 'motif-construct-verification',
+    engineVersion: '1',
+    parentIds: ['record-a', 'record-b'],
+    metadata: { requestSha256: REQUEST_SHA256, workUnits: 128 },
+  };
+}
+
+function constructVerificationReport() {
+  return {
+    schema: 'motif.construct-verification-report.v1',
+    version: 1,
+    state: 'needs_review',
+    reasons: [{
+      code: 'partial_reference_coverage',
+      severity: 'review',
+      message: 'Only part of the reference met the requested depth.',
+    }, {
+      code: 'required_region_uncovered',
+      severity: 'review',
+      message: 'A required region is not fully covered.',
+      regionId: 'region-review',
+    }, {
+      code: 'low_confidence_variant',
+      severity: 'review',
+      message: 'A low-confidence unexpected variant requires review.',
+    }],
+    reference: {
+      id: 'record-a',
+      name: 'Predicted construct',
+      length: 2_000,
+      topology: 'linear',
+      sha256: NORMALIZED_SHA256,
+    },
+    thresholds: { ...VERIFICATION_THRESHOLDS },
+    reads: [{
+      id: 'record-b',
+      sha256: NORMALIZED_SHA256,
+      rawLength: 1_000,
+      qualityProvided: true,
+      meanQuality: 30,
+      status: 'mapped',
+      trim: {
+        method: 'quality_window',
+        rawStart: 0,
+        rawEnd: 1_000,
+        trimmedLength: 1_000,
+        removedFromStart: 0,
+        removedFromEnd: 0,
+      },
+      mapping: {
+        orientation: 'forward',
+        referenceStart: 0,
+        referenceEnd: 1_000,
+        wraps: false,
+        referenceSpan: 1_000,
+        score: 3_000,
+        secondBestScore: null,
+        mappingMargin: null,
+        identity: 1,
+        alignedLength: 1_000,
+        matches: 1_000,
+        substitutions: 0,
+        insertions: 0,
+        deletions: 0,
+        indelFraction: 0,
+      },
+    }],
+    coverage: {
+      coveredBasesAtAnyDepth: 1_500,
+      basesMeetingMinDepth: 1_500,
+      coverageFraction: 0.75,
+      minimumDepth: 0,
+      maximumDepth: 1,
+      meanDepth: 0.75,
+      requiredRegions: [{
+        id: 'region-pass',
+        start: 0,
+        end: 100,
+        wraps: false,
+        length: 100,
+        minDepth: 1,
+        requireBothStrands: false,
+        coveredBases: 100,
+        basesMeetingMinDepth: 100,
+        coveredFraction: 1,
+        minimumDepth: 1,
+        maximumDepth: 1,
+        meanDepth: 1,
+        forwardCoveredBases: 100,
+        reverseCoveredBases: 0,
+        bothStrandsCoveredBases: 0,
+        status: 'covered',
+      }, {
+        id: 'region-review',
+        start: 100,
+        end: 200,
+        wraps: false,
+        length: 100,
+        minDepth: 1,
+        requireBothStrands: false,
+        coveredBases: 0,
+        basesMeetingMinDepth: 0,
+        coveredFraction: 0,
+        minimumDepth: 0,
+        maximumDepth: 0,
+        meanDepth: 0,
+        forwardCoveredBases: 0,
+        reverseCoveredBases: 0,
+        bothStrandsCoveredBases: 0,
+        status: 'uncovered',
+      }],
+    },
+    consensus: { sequence: 'N' },
+    variants: {
+      observed: [{
+        id: 'observed-1',
+        type: 'substitution',
+        referenceStart: 10,
+        referenceEnd: 11,
+        reference: 'A',
+        alternate: 'C',
+        depth: 1,
+        support: 1,
+        supportWeight: 31,
+        fraction: 1,
+        meanQuality: 30,
+        confidence: 'high',
+        supportingReadIds: ['record-b'],
+        expectedVariantId: 'expected-1',
+        omittedSupportingReadIds: 0,
+      }, {
+        id: 'observed-2',
+        type: 'substitution',
+        referenceStart: 20,
+        referenceEnd: 21,
+        reference: 'A',
+        alternate: 'G',
+        depth: 1,
+        support: 1,
+        supportWeight: 1,
+        fraction: 1,
+        meanQuality: null,
+        confidence: 'low',
+        supportingReadIds: ['record-b'],
+        omittedSupportingReadIds: 0,
+      }],
+      expected: [{
+        id: 'expected-1',
+        type: 'substitution',
+        referenceStart: 10,
+        referenceEnd: 11,
+        reference: 'A',
+        alternate: 'C',
+        status: 'observed',
+        depth: 1,
+        observedVariantId: 'observed-1',
+      }],
+      unexpected: [{
+        id: 'observed-2',
+        type: 'substitution',
+        referenceStart: 20,
+        referenceEnd: 21,
+        reference: 'A',
+        alternate: 'G',
+        depth: 1,
+        support: 1,
+        supportWeight: 1,
+        fraction: 1,
+        meanQuality: null,
+        confidence: 'low',
+        supportingReadIds: ['record-b'],
+        omittedSupportingReadIds: 0,
+      }],
+      missingExpected: [],
+    },
+    provenance: {
+      engine: 'motif-construct-verification',
+      engineVersion: '1',
+      referenceSha256: NORMALIZED_SHA256,
+      readSha256s: [NORMALIZED_SHA256],
+      requestSha256: REQUEST_SHA256,
+      workUnits: 128,
+      limits: {
+        maxReferenceLength: 50_000,
+        maxReads: 96,
+        maxReadLength: 5_000,
+        maxRequiredRegions: 128,
+        maxRequiredRegionBases: 500_000,
+        maxExpectedVariants: 256,
+        maxObservedVariants: 2_000,
+        maxIndelLength: 24,
+        maxWorkUnits: 25_000_000,
+      },
+    },
+    omitted: {
+      reasons: 0,
+      reads: 0,
+      requiredRegions: 0,
+      observedVariants: 0,
+      expectedVariants: 0,
+      unexpectedVariants: 0,
+      missingExpectedVariants: 0,
+      supportingReadIds: 0,
+    },
+  };
+}
+
+function constructVerificationReportAsset(
+  mutate?: (report: ReturnType<typeof constructVerificationReport>) => void,
+) {
+  const report = constructVerificationReport();
+  mutate?.(report);
+  const content = `${JSON.stringify(report, null, 2)}\n`;
+  return asset({
+    id: 'verification-report',
+    name: 'construct-verification-report.json',
+    mediaType: 'application/json',
+    content,
+    sha256: sha256HexSync(content),
+    provenance: constructVerificationProvenance(),
+  });
 }
 
 function baseResult(kind: string, data: Record<string, unknown>, overrides: Record<string, unknown> = {}) {
@@ -91,6 +338,37 @@ const resultFixtures = [
     enzyme: 'BsaI',
     junctions: [{ leftRecordId: 'record-a', rightRecordId: 'record-b', compatible: true, overhang: 'AATG' }],
   }, { inputRecordIds: ['record-a', 'record-b', 'record-c', 'record-d'], inputSha256s: [SHA256, SHA256, SHA256, SHA256] }),
+  baseResult('construct_verification', {
+    referenceRecordId: 'record-a',
+    readRecordIds: ['record-b'],
+    state: 'needs_review',
+    referenceLength: 2_000,
+    coveredBases: 1_500,
+    coverageFraction: 0.75,
+    mappedReadCount: 1,
+    requiredRegionCount: 2,
+    passingRegionCount: 1,
+    observedVariantCount: 2,
+    expectedVariantCount: 1,
+    unexpectedVariantCount: 1,
+    missingExpectedVariantCount: 0,
+    reasonCodes: ['partial_reference_coverage', 'required_region_uncovered', 'low_confidence_variant'],
+    verificationReportAssetId: 'verification-report',
+  }, {
+    inputRecordIds: ['record-a', 'record-b'],
+    inputSha256s: [SHA256, SHA256],
+    assetIds: ['verification-report'],
+    parameters: {
+      topology: 'linear',
+      requestSha256: REQUEST_SHA256,
+      thresholds: { ...VERIFICATION_THRESHOLDS },
+      readEvidence: {
+        schema: 'motif.construct-read-evidence.v1',
+        sha256s: [READ_EVIDENCE_SHA256],
+      },
+    },
+    provenance: constructVerificationProvenance(),
+  }),
   baseResult('blast_search', {
     program: 'blastn',
     database: 'nt',
@@ -139,11 +417,12 @@ const recordLengths = new Map([
 ]);
 
 describe('Claude Science typed analysis results', () => {
-  it('normalizes all seven discriminated result kinds with record, hash, and asset references', () => {
+  it('normalizes all eight discriminated result kinds with record, hash, and asset references', () => {
     const workspace = normalizeArtifactAnalysisWorkspace({
       analysisResults: resultFixtures,
       analysisAssets: [
         asset(),
+        constructVerificationReportAsset(),
         asset({ id: 'structure-asset', name: 'model.pdb', mediaType: 'chemical/x-pdb', content: 'ATOM      1  N   MET A   1' }),
       ],
     }, { recordLengths });
@@ -152,6 +431,7 @@ describe('Claude Science typed analysis results', () => {
       'primer_design',
       'pcr',
       'assembly_plan',
+      'construct_verification',
       'blast_search',
       'structure_model',
       'report',
@@ -160,7 +440,7 @@ describe('Claude Science typed analysis results', () => {
     expect(workspace.analysisResults[0].inputSha256s).toEqual(['a'.repeat(64)]);
     expect(workspace.analysisResults[0].kind === 'primer_design' && workspace.analysisResults[0].data.pairs[0].forward.sequence)
       .toBe('ACGTACGTACGTACGTACGT');
-    expect(workspace.analysisAssets[0].sha256).toBe('a'.repeat(64));
+    expect(workspace.analysisAssets[0].sha256).toBe(sha256HexSync('Inert analysis text'));
   });
 
   it('keeps absent collections backward-compatible and omits empty serialized fields', () => {
@@ -203,9 +483,136 @@ describe('Claude Science typed analysis results', () => {
       analysisAssets: [asset({ content: 'é'.repeat(Math.floor(MAX_ARTIFACT_ANALYSIS_ASSET_BYTES / 2) + 1) })],
     })).toThrow(/UTF-8 bytes/i);
     expect(() => normalizeArtifactAnalysisWorkspace({
-      analysisResults: [resultFixtures[4]],
+      analysisResults: [resultFixtures[5]],
       analysisAssets: [asset({ id: 'structure-asset', mediaType: 'text/csv' })],
     })).toThrow(/mediaType does not match pdb/i);
+  });
+
+  it('recomputes supplied asset digests and rejects content tampering with a retained SHA-256', () => {
+    const originalContent = 'Signed inert analysis text';
+    const signed = asset({
+      content: originalContent,
+      sha256: sha256HexSync(originalContent),
+    });
+    expect(normalizeArtifactAnalysisWorkspace({ analysisResults: [], analysisAssets: [signed] }).analysisAssets[0].sha256)
+      .toBe(sha256HexSync(originalContent));
+
+    expect(() => normalizeArtifactAnalysisWorkspace({
+      analysisResults: [],
+      analysisAssets: [{ ...signed, content: 'Tampered inert analysis text' }],
+    })).toThrow(/sha256 must match the exact UTF-8 content/i);
+
+    expect(normalizeArtifactAnalysisWorkspace({
+      analysisResults: [],
+      analysisAssets: [asset({ sha256: undefined })],
+    }).analysisAssets[0].sha256).toBeUndefined();
+  });
+
+  it('rejects imported compact construct reports whose identity no longer matches the saved result', () => {
+    const normalizeReport = (reportAsset: ReturnType<typeof constructVerificationReportAsset>) => (
+      normalizeArtifactAnalysisWorkspace({
+        analysisResults: [resultFixtures[3]],
+        analysisAssets: [reportAsset],
+      }, { recordLengths })
+    );
+    expect(() => normalizeReport(constructVerificationReportAsset())).not.toThrow();
+
+    expect(() => normalizeReport(constructVerificationReportAsset((report) => {
+      report.state = 'inconsistent';
+    }))).toThrow(/verification report state must match the saved result/i);
+
+    expect(() => normalizeReport(constructVerificationReportAsset((report) => {
+      report.provenance.requestSha256 = sha256HexSync('different-request');
+    }))).toThrow(/provenance\.requestSha256 must match the saved result/i);
+
+    expect(() => normalizeReport(constructVerificationReportAsset((report) => {
+      report.reference.sha256 = sha256HexSync('different-reference');
+    }))).toThrow(/reference\.sha256 must match the saved result/i);
+
+    expect(() => normalizeReport(constructVerificationReportAsset((report) => {
+      report.reads[0].sha256 = sha256HexSync('different-read');
+    }))).toThrow(/reads\[\]\.sha256 must match the saved result/i);
+  });
+
+  it('rejects rehashed compact reports with impossible or incomplete nested scientific evidence', () => {
+    type ConstructReport = ReturnType<typeof constructVerificationReport>;
+    const normalizeReport = (reportAsset: ReturnType<typeof constructVerificationReportAsset>) => (
+      normalizeArtifactAnalysisWorkspace({
+        analysisResults: [resultFixtures[3]],
+        analysisAssets: [reportAsset],
+      }, { recordLengths })
+    );
+    const cases: Array<[string, (report: ConstructReport) => void]> = [
+      ['mapped read without a mapping', (report) => {
+        (report.reads[0] as { mapping: unknown }).mapping = null;
+      }],
+      ['nonmapped read with a mapping', (report) => {
+        report.reads[0].status = 'unmapped';
+      }],
+      ['inconsistent trim arithmetic', (report) => {
+        report.reads[0].trim.trimmedLength -= 1;
+      }],
+      ['inconsistent alignment counts', (report) => {
+        report.reads[0].mapping.matches -= 1;
+      }],
+      ['linear mapping marked as wrapping', (report) => {
+        report.reads[0].mapping.wraps = true;
+      }],
+      ['mapped status below the saved identity threshold', (report) => {
+        report.reads[0].mapping.matches = 800;
+        report.reads[0].mapping.substitutions = 200;
+        report.reads[0].mapping.identity = 0.8;
+      }],
+      ['invalid consensus alphabet', (report) => {
+        report.consensus.sequence = '<script>';
+      }],
+      ['coverage meeting more bases than are covered', (report) => {
+        report.coverage.coveredBasesAtAnyDepth = 1_000;
+      }],
+      ['global depth extrema below the saved threshold with passing bases', (report) => {
+        report.coverage.maximumDepth = 0;
+        report.coverage.meanDepth = 0;
+      }],
+      ['region status contradicting its depth evidence', (report) => {
+        report.coverage.requiredRegions[1].status = 'covered';
+      }],
+      ['region passing a depth threshold above its maximum depth', (report) => {
+        report.coverage.requiredRegions[0].minDepth = 2;
+      }],
+      ['substitution with identical alleles', (report) => {
+        report.variants.observed[0].alternate = report.variants.observed[0].reference;
+      }],
+      ['unknown supporting read', (report) => {
+        report.variants.observed[0].supportingReadIds[0] = 'forged-read';
+      }],
+      ['unexpected variant differing from observed evidence', (report) => {
+        report.variants.unexpected[0].alternate = 'T';
+      }],
+      ['broken expected-observed cross-link', (report) => {
+        report.variants.expected[0].observedVariantId = 'observed-2';
+      }],
+      ['cross-linked expected and observed variants with different alleles', (report) => {
+        report.variants.expected[0].alternate = 'T';
+      }],
+      ['below-cap variants hidden through an omission count', (report) => {
+        report.variants.observed.pop();
+        report.omitted.observedVariants = 1;
+      }],
+      ['partial provenance limits', (report) => {
+        delete (report.provenance.limits as Record<string, number>).maxWorkUnits;
+      }],
+      ['unknown nested mapping field', (report) => {
+        Object.assign(report.reads[0].mapping, { executableHint: 'ignored?' });
+      }],
+    ];
+
+    cases.forEach(([label, mutate]) => {
+      expect(() => normalizeReport(constructVerificationReportAsset(mutate)), label).toThrow();
+    });
+
+    const unsigned = constructVerificationReportAsset();
+    (unsigned as { sha256: string | undefined }).sha256 = undefined;
+    expect(() => normalizeReport(unsigned)).toThrow(/requires a content SHA-256/i);
   });
 
   it('rejects dangling, self-referential, and cyclic dependencies as atomic batches', () => {
@@ -238,7 +645,7 @@ describe('Claude Science typed analysis results', () => {
       analysisResults: [{ ...resultFixtures[0], inputRecordIds: ['missing'], inputSha256s: [SHA256] }],
       analysisAssets: [],
     }, { recordLengths })).toThrow(/does not match a workspace record/i);
-    expect(() => normalizeArtifactAnalysisWorkspace({ analysisResults: [resultFixtures[4]], analysisAssets: [] }))
+    expect(() => normalizeArtifactAnalysisWorkspace({ analysisResults: [resultFixtures[5]], analysisAssets: [] }))
       .toThrow(/references missing asset/i);
     expect(() => normalizeArtifactAnalysisWorkspace({ analysisResults: [resultFixtures[0], resultFixtures[0]], analysisAssets: [] }))
       .toThrow(/duplicate id/i);
@@ -278,6 +685,16 @@ describe('Claude Science typed analysis results', () => {
       })],
       analysisAssets: [],
     })).toThrow(/no greater than 100/i);
+    const verification = resultFixtures[3] as Record<string, unknown>;
+    const verificationData = verification.data as Record<string, unknown>;
+    expect(() => normalizeArtifactAnalysisWorkspace({
+      analysisResults: [{ ...verification, data: { ...verificationData, coverageFraction: 0.5 } }],
+      analysisAssets: [asset({ id: 'verification-report', name: 'verification.json', mediaType: 'application/json', content: '{}' })],
+    })).toThrow(/must agree with coveredBases/i);
+    expect(() => normalizeArtifactAnalysisWorkspace({
+      analysisResults: [{ ...verification, inputRecordIds: ['record-b', 'record-a'] }],
+      analysisAssets: [asset({ id: 'verification-report', name: 'verification.json', mediaType: 'application/json', content: '{}' })],
+    })).toThrow(/reference first/i);
   });
 
   it('defensively clones nested data and provides familiar result collection helpers', () => {
@@ -305,10 +722,10 @@ describe('Claude Science typed analysis results', () => {
       mediaType: 'chemical/x-pdb',
       content: 'ATOM      1  N   MET A   1',
     }));
-    const withResult = appendArtifactAnalysisWorkspaceResult(withAsset, resultFixtures[4]);
+    const withResult = appendArtifactAnalysisWorkspaceResult(withAsset, resultFixtures[5]);
     expect(withResult.analysisAssets).toHaveLength(1);
     expect(withResult.analysisResults).toHaveLength(1);
-    expect(() => appendArtifactAnalysisWorkspaceResult(withResult, resultFixtures[4])).toThrow(/duplicate id/i);
+    expect(() => appendArtifactAnalysisWorkspaceResult(withResult, resultFixtures[5])).toThrow(/duplicate id/i);
     expect(withAsset.analysisResults).toEqual([]);
   });
 
@@ -320,7 +737,7 @@ describe('Claude Science typed analysis results', () => {
       products: [],
     }, { id: 'pcr-dependent', dependsOnResultIds: ['primer_design-1'] });
     const workspace = normalizeArtifactAnalysisWorkspace({
-      analysisResults: [primer, pcr, resultFixtures[4]],
+      analysisResults: [primer, pcr, resultFixtures[5]],
       analysisAssets: [asset({ id: 'structure-asset', name: 'model.pdb', mediaType: 'chemical/x-pdb' })],
     });
 

--- a/src/artifacts/__tests__/claude-science-construct-verification-artifacts.test.ts
+++ b/src/artifacts/__tests__/claude-science-construct-verification-artifacts.test.ts
@@ -1,0 +1,877 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendArtifactAnalysisAsset,
+  appendArtifactAnalysisWorkspaceResult,
+  MAX_ARTIFACT_ANALYSIS_ASSET_BYTES,
+} from '../claude-science-analysis-results';
+import {
+  ARTIFACT_CONSTRUCT_READ_EVIDENCE_SCHEMA,
+  ARTIFACT_CONSTRUCT_VERIFICATION_REPORT_LIMITS,
+  artifactConstructReadEvidenceSha256,
+  buildArtifactConstructVerificationArtifacts,
+  canonicalizeArtifactConstructReadEvidence,
+  findDuplicateArtifactConstructVerificationResult,
+  type ArtifactConstructVerificationPersistenceSource,
+} from '../claude-science-construct-verification-artifacts';
+import { verifyArtifactConstruct } from '../claude-science-construct-verification';
+import { sha256HexSync } from '../claude-science-sha256';
+
+const CREATED_AT = '2026-07-17T20:00:00.000Z';
+const REFERENCE_SEQUENCE = 'ACGT';
+const READ_SEQUENCES = ['ACGT', 'TGCA'] as const;
+const REFERENCE_SHA256 = sha256HexSync(REFERENCE_SEQUENCE);
+const READ_SHA256S = READ_SEQUENCES.map((sequence) => sha256HexSync(sequence));
+const REQUEST_SHA256 = sha256HexSync('construct-verification-request');
+const ENGINE_REFERENCE_SEQUENCE = 'TCCGGGTCCACTCAATAGGGCCTATGGTGTTAAATATGTGTCTCTTGTTCGCTAGGGTGATAGCAAAAAATATAGTGCCTGCTTTTGTGGATGTAAATAATAACTCGCCCCCCTCCCTCACGAGAGCGCTACGCAAACGTATTTGCCGCCCGCCCTTGGTCAGACATTAGCAGTCGTTTGCTAGATATCCCCTGAAGACTAATGCCCACATTGCGCGCCGATACCCCAGCGTAGGACGAA';
+
+function mutateBuiltReport(
+  built: ReturnType<typeof buildArtifactConstructVerificationArtifacts>,
+  mutate: (report: Record<string, unknown>) => void,
+) {
+  const report = JSON.parse(built.asset.content) as Record<string, unknown>;
+  mutate(report);
+  const content = `${JSON.stringify(report, null, 2)}\n`;
+  return {
+    ...built,
+    asset: {
+      ...built.asset,
+      content,
+      sha256: sha256HexSync(content),
+    },
+  };
+}
+
+function removeBuiltReason(
+  built: ReturnType<typeof buildArtifactConstructVerificationArtifacts>,
+  code: string,
+) {
+  const result = structuredClone(built.result);
+  result.data.reasonCodes = result.data.reasonCodes.filter((candidate) => candidate !== code);
+  const mutated = mutateBuiltReport(built, (report) => {
+    const reasons = report.reasons as Array<{ code: string }>;
+    report.reasons = reasons.filter((reason) => reason.code !== code);
+  });
+  return { asset: mutated.asset, result };
+}
+
+function observedVariant(index = 0) {
+  const reference = REFERENCE_SEQUENCE[index % REFERENCE_SEQUENCE.length];
+  return {
+    id: `observed-${index}`,
+    type: 'substitution' as const,
+    referenceStart: index % REFERENCE_SEQUENCE.length,
+    referenceEnd: (index % REFERENCE_SEQUENCE.length) + 1,
+    reference,
+    alternate: reference === 'A' ? 'C' : 'A',
+    depth: 2,
+    support: 2,
+    supportWeight: 64,
+    fraction: 1,
+    meanQuality: 31,
+    confidence: 'high' as const,
+    supportingReadIds: ['read-1', 'read-2'],
+  };
+}
+
+function expectedVariant(index = 0) {
+  const reference = REFERENCE_SEQUENCE[index % REFERENCE_SEQUENCE.length];
+  return {
+    id: `expected-${index}`,
+    type: 'substitution' as const,
+    referenceStart: index % REFERENCE_SEQUENCE.length,
+    referenceEnd: (index % REFERENCE_SEQUENCE.length) + 1,
+    reference,
+    alternate: reference === 'A' ? 'C' : 'A',
+    status: 'observed' as const,
+    depth: 2,
+    observedVariantId: `observed-${index}`,
+  };
+}
+
+function verificationSource(): ArtifactConstructVerificationPersistenceSource {
+  const mappingWithHeavyEvidence = {
+    orientation: 'forward' as const,
+    referenceStart: 0,
+    referenceEnd: 4,
+    wraps: false,
+    referenceSpan: 4,
+    score: 12,
+    secondBestScore: 6,
+    mappingMargin: 0.5,
+    identity: 1,
+    alignedLength: 4,
+    matches: 4,
+    substitutions: 0,
+    insertions: 0,
+    deletions: 0,
+    indelFraction: 0,
+    coordinateMap: {
+      columns: [{ rawCallIndex: 0, qualityScore: 30 }],
+      referencePositions: [0],
+      rawCallIndices: [0],
+    },
+  };
+  const coverageWithPerBaseArrays = {
+    depth: [2, 2, 1, 1],
+    forward: [1, 1, 1, 1],
+    reverse: [1, 1, 0, 0],
+    coveredBases: 4,
+    basesMeetingMinDepth: 2,
+    coveredFraction: 0.5,
+    minimumDepth: 1,
+    maximumDepth: 2,
+    meanDepth: 1.5,
+    requiredRegions: [{
+      id: 'full-construct',
+      name: 'Full construct',
+      start: 0,
+      end: 4,
+      wraps: false,
+      length: 4,
+      minDepth: 2,
+      requireBothStrands: false,
+      coveredBases: 4,
+      basesMeetingMinDepth: 2,
+      coveredFraction: 0.5,
+      minimumDepth: 1,
+      maximumDepth: 2,
+      meanDepth: 1.5,
+      forwardCoveredBases: 4,
+      reverseCoveredBases: 2,
+      bothStrandsCoveredBases: 2,
+      status: 'low_depth' as const,
+    }],
+  };
+  const consensusWithHeavyEvidence = {
+    sequence: 'ACGT',
+    calls: [{
+      referencePosition: 0,
+      call: 'A',
+      depth: 2,
+      alleles: [{ allele: 'A', count: 2 }],
+    }],
+    variants: [observedVariant()],
+  };
+  return {
+    schema: 'motif.construct-verification.v1',
+    version: 1,
+    state: 'needs_review',
+    reasons: [{
+      code: 'partial_reference_coverage',
+      severity: 'review',
+      message: 'Only half of the reference meets the requested two-read depth.',
+      regionId: 'full-construct',
+    }, {
+      code: 'required_region_low_depth',
+      severity: 'review',
+      message: 'The full construct is below its required depth at one or more bases.',
+      regionId: 'full-construct',
+    }],
+    reference: {
+      id: 'reference',
+      name: 'Expected construct',
+      sequence: REFERENCE_SEQUENCE,
+      length: REFERENCE_SEQUENCE.length,
+      topology: 'linear',
+      sha256: REFERENCE_SHA256,
+    },
+    thresholds: {
+      trimQuality: 20,
+      trimWindow: 2,
+      minTrimmedReadLength: 2,
+      minMappingIdentity: 0.82,
+      minMappingMargin: 0.03,
+      maxIndelFraction: 0.12,
+      minCoverageFraction: 1,
+      minDepth: 2,
+      requireBothStrands: false,
+      minConsensusFraction: 0.7,
+      minVariantQuality: 20,
+      minVariantFraction: 0.6,
+    },
+    reads: READ_SEQUENCES.map((sequence, index) => ({
+      id: `read-${index + 1}`,
+      name: `Read ${index + 1}`,
+      sha256: READ_SHA256S[index],
+      rawLength: sequence.length,
+      qualityProvided: true,
+      meanQuality: 30 + index,
+      status: 'mapped' as const,
+      trim: {
+        method: 'quality_window' as const,
+        rawStart: 0,
+        rawEnd: sequence.length,
+        trimmedLength: sequence.length,
+        removedFromStart: 0,
+        removedFromEnd: 0,
+      },
+      mapping: mappingWithHeavyEvidence,
+    })),
+    coverage: coverageWithPerBaseArrays,
+    consensus: consensusWithHeavyEvidence,
+    variants: {
+      observed: [{ ...observedVariant(), expectedVariantId: 'expected-0' }],
+      expected: [expectedVariant()],
+      unexpected: [],
+      missingExpected: [],
+    },
+    provenance: {
+      engine: 'motif-construct-verification',
+      engineVersion: '1',
+      referenceSha256: REFERENCE_SHA256,
+      readSha256s: READ_SHA256S,
+      requestSha256: REQUEST_SHA256,
+      workUnits: 128,
+      limits: {
+        maxReferenceLength: 50_000,
+        maxReads: 96,
+        maxReadLength: 5_000,
+        maxRequiredRegions: 128,
+        maxRequiredRegionBases: 500_000,
+        maxExpectedVariants: 256,
+        maxObservedVariants: 2_000,
+        maxIndelLength: 24,
+        maxWorkUnits: 25_000_000,
+      },
+    },
+  };
+}
+
+function evidenceSha256s(): string[] {
+  return READ_SEQUENCES.map((baseCalls) => artifactConstructReadEvidenceSha256({
+    baseCalls,
+    qualityScores: Array.from({ length: baseCalls.length }, () => 30),
+  }));
+}
+
+function build(source = verificationSource()) {
+  return buildArtifactConstructVerificationArtifacts(source, evidenceSha256s(), {
+    resultId: 'verification-result',
+    assetId: 'verification-report',
+    createdAt: CREATED_AT,
+  });
+}
+
+function collectObjectKeys(value: unknown, keys = new Set<string>()): Set<string> {
+  if (!value || typeof value !== 'object') return keys;
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectObjectKeys(item, keys));
+    return keys;
+  }
+  Object.entries(value).forEach(([key, item]) => {
+    keys.add(key);
+    collectObjectKeys(item, keys);
+  });
+  return keys;
+}
+
+describe('construct verification evidence and persistence artifacts', () => {
+  it('hashes only canonical uppercase calls and a copied nonempty quality array', () => {
+    const qualityScores = [12, 24, 36, 48];
+    const noisyInput = {
+      id: 'ignored-read-id',
+      name: 'Ignored name',
+      baseCalls: 'acgt',
+      qualityScores,
+      channels: { A: [1, 2, 3] },
+      peakPositions: [4, 8, 12, 16],
+      metadata: { instrument: 'ignored' },
+    };
+    const canonical = canonicalizeArtifactConstructReadEvidence(noisyInput);
+    expect(canonical).toEqual({
+      schema: ARTIFACT_CONSTRUCT_READ_EVIDENCE_SCHEMA,
+      baseCalls: 'ACGT',
+      qualityScores: [12, 24, 36, 48],
+    });
+    qualityScores[0] = 255;
+    expect(canonical.qualityScores).toEqual([12, 24, 36, 48]);
+    expect(artifactConstructReadEvidenceSha256(noisyInput)).toBe(sha256HexSync(JSON.stringify({
+      schema: 'motif.construct-read-evidence.v1',
+      baseCalls: 'ACGT',
+      qualityScores: [255, 24, 36, 48],
+    })));
+    expect(canonicalizeArtifactConstructReadEvidence({ baseCalls: 'ACGT', qualityScores: [] }).qualityScores)
+      .toBeNull();
+    expect(canonicalizeArtifactConstructReadEvidence({ baseCalls: 'ACGT' }).qualityScores).toBeNull();
+
+    expect(() => canonicalizeArtifactConstructReadEvidence({ baseCalls: 'AC GT' })).toThrow(/unspaced/i);
+    expect(() => canonicalizeArtifactConstructReadEvidence({ baseCalls: 'ACGU' })).toThrow(/IUPAC/i);
+    expect(() => canonicalizeArtifactConstructReadEvidence({ baseCalls: 'ACGT', qualityScores: [30] }))
+      .toThrow(/one score per base/i);
+    expect(() => canonicalizeArtifactConstructReadEvidence({ baseCalls: 'ACGT', qualityScores: [1, 2, 3, 256] }))
+      .toThrow(/0 through 255/i);
+  });
+
+  it('builds deterministically without mutating verification or evidence inputs', () => {
+    const source = verificationSource();
+    const evidence = evidenceSha256s();
+    const sourceBefore = JSON.stringify(source);
+    const evidenceBefore = [...evidence];
+    const first = buildArtifactConstructVerificationArtifacts(source, evidence, {
+      resultId: 'verification-result',
+      assetId: 'verification-report',
+      createdAt: CREATED_AT,
+    });
+    const second = buildArtifactConstructVerificationArtifacts(source, evidence, {
+      resultId: 'verification-result',
+      assetId: 'verification-report',
+      createdAt: CREATED_AT,
+    });
+
+    expect(second).toEqual(first);
+    expect(JSON.stringify(source)).toBe(sourceBefore);
+    expect(evidence).toEqual(evidenceBefore);
+    expect(first.asset.sha256).toBe(sha256HexSync(first.asset.content));
+    expect(first.result.provenance).toMatchObject({
+      engine: 'motif-construct-verification',
+      engineVersion: '1',
+    });
+  });
+
+  it('keeps the inert report compact and recursively excludes raw/per-base evidence', () => {
+    const built = build();
+    const report = JSON.parse(built.asset.content) as Record<string, unknown>;
+    const reference = report.reference as Record<string, unknown>;
+    const coverage = report.coverage as Record<string, unknown>;
+    const consensus = report.consensus as Record<string, unknown>;
+    const reads = report.reads as Array<Record<string, unknown>>;
+
+    expect(built.asset.mediaType).toBe('application/json');
+    expect(reference).not.toHaveProperty('sequence');
+    expect(coverage).not.toHaveProperty('depth');
+    expect(coverage).not.toHaveProperty('forward');
+    expect(coverage).not.toHaveProperty('reverse');
+    expect(consensus).toEqual({ sequence: 'ACGT' });
+    expect(reads[0].mapping).not.toHaveProperty('coordinateMap');
+    const keys = collectObjectKeys(report);
+    for (const excluded of [
+      'baseCalls',
+      'qualityScores',
+      'channels',
+      'peakPositions',
+      'chromatograms',
+      'coordinateMap',
+      'calls',
+    ]) {
+      expect(keys.has(excluded), excluded).toBe(false);
+    }
+    expect(new TextEncoder().encode(built.asset.content).byteLength)
+      .toBeLessThan(MAX_ARTIFACT_ANALYSIS_ASSET_BYTES);
+  });
+
+  it('caps large evidence collections and records every omitted count', () => {
+    const source = verificationSource();
+    source.reasons = Array.from({ length: 600 }, (_, index) => ({
+      code: `reason_${index}`,
+      severity: 'review' as const,
+      message: `${index}:${'x'.repeat(1_000)}`,
+    }));
+    const readIds = Array.from({ length: 20 }, (_, index) => `supporting-read-${index}`);
+    source.variants.observed = Array.from({ length: 250 }, (_, index) => ({
+      ...observedVariant(index),
+      supportingReadIds: readIds,
+    }));
+    source.variants.unexpected = Array.from({ length: 250 }, (_, index) => ({
+      ...observedVariant(index + 250),
+      supportingReadIds: readIds,
+    }));
+    source.variants.expected = Array.from({ length: 300 }, (_, index) => expectedVariant(index));
+    source.variants.missingExpected = Array.from({ length: 300 }, (_, index) => ({
+      ...expectedVariant(index),
+      status: 'not_observed' as const,
+    }));
+
+    const built = build(source);
+    const report = JSON.parse(built.asset.content) as {
+      reasons: Array<{ message: string }>;
+      variants: {
+        observed: Array<{ supportingReadIds: string[]; omittedSupportingReadIds: number }>;
+        expected: unknown[];
+        unexpected: unknown[];
+        missingExpected: unknown[];
+      };
+      omitted: Record<string, number>;
+    };
+    const limits = ARTIFACT_CONSTRUCT_VERIFICATION_REPORT_LIMITS;
+    expect(report.reasons).toHaveLength(limits.maxReasons);
+    expect(report.reasons[0].message.length).toBeLessThanOrEqual(limits.maxReasonMessageLength);
+    expect(report.variants.observed).toHaveLength(limits.maxObservedVariants);
+    expect(report.variants.expected).toHaveLength(limits.maxExpectedVariants);
+    expect(report.variants.unexpected).toHaveLength(limits.maxUnexpectedVariants);
+    expect(report.variants.missingExpected).toHaveLength(limits.maxMissingExpectedVariants);
+    expect(report.variants.observed[0]).toMatchObject({
+      supportingReadIds: readIds.slice(0, limits.maxSupportingReadIds),
+      omittedSupportingReadIds: readIds.length - limits.maxSupportingReadIds,
+    });
+    expect(report.omitted).toMatchObject({
+      reasons: 600 - limits.maxReasons,
+      observedVariants: 250 - limits.maxObservedVariants,
+      expectedVariants: 300 - limits.maxExpectedVariants,
+      unexpectedVariants: 250 - limits.maxUnexpectedVariants,
+      missingExpectedVariants: 300 - limits.maxMissingExpectedVariants,
+      supportingReadIds: 500 * (readIds.length - limits.maxSupportingReadIds),
+    });
+    expect(built.result.data.reasonCodes).toHaveLength(500);
+    expect(new Set(built.result.data.reasonCodes).size).toBe(500);
+    expect(new TextEncoder().encode(built.asset.content).byteLength)
+      .toBeLessThan(MAX_ARTIFACT_ANALYSIS_ASSET_BYTES);
+  });
+
+  it('passes strict asset/result appenders with reference-first records and JSON-only report linkage', () => {
+    const built = build();
+    const recordLengths = new Map([
+      ['reference', REFERENCE_SEQUENCE.length],
+      ['read-1', READ_SEQUENCES[0].length],
+      ['read-2', READ_SEQUENCES[1].length],
+    ]);
+    const withAsset = appendArtifactAnalysisAsset(undefined, built.asset, { recordLengths });
+    const workspace = appendArtifactAnalysisWorkspaceResult(withAsset, built.result, { recordLengths });
+
+    expect(workspace.analysisAssets).toHaveLength(1);
+    expect(workspace.analysisAssets[0].mediaType).toBe('application/json');
+    expect(workspace.analysisResults).toHaveLength(1);
+    expect(workspace.analysisResults[0]).toMatchObject({
+      kind: 'construct_verification',
+      status: 'complete',
+      inputRecordIds: ['reference', 'read-1', 'read-2'],
+      inputSha256s: [REFERENCE_SHA256, ...READ_SHA256S],
+      assetIds: ['verification-report'],
+      data: {
+        verificationReportAssetId: 'verification-report',
+      },
+      provenance: {
+        engine: 'motif-construct-verification',
+        engineVersion: '1',
+      },
+    });
+  });
+
+  it('round-trips a real engine variant report through the strict durable boundary', () => {
+    const reference = ENGINE_REFERENCE_SEQUENCE;
+    const changed = `${reference.slice(0, 120)}${reference[120] === 'A' ? 'C' : 'A'}${reference.slice(121)}`;
+    const qualityScores = Array.from({ length: changed.length }, () => 40);
+    const verification = verifyArtifactConstruct({
+      reference: {
+        id: 'engine-reference',
+        sequence: reference,
+        topology: 'linear',
+        sha256: sha256HexSync(reference),
+      },
+      reads: [{
+        id: 'engine-read',
+        baseCalls: changed,
+        qualityScores,
+        sha256: sha256HexSync(changed),
+      }],
+      thresholds: { minCoverageFraction: 0 },
+    });
+    expect(verification.state).toBe('inconsistent');
+    expect(verification.variants.unexpected).toHaveLength(1);
+
+    const built = buildArtifactConstructVerificationArtifacts(
+      verification,
+      [artifactConstructReadEvidenceSha256({ baseCalls: changed, qualityScores })],
+      {
+        resultId: 'engine-verification-result',
+        assetId: 'engine-verification-report',
+        createdAt: CREATED_AT,
+      },
+    );
+    const withAsset = appendArtifactAnalysisAsset(undefined, built.asset);
+    expect(() => appendArtifactAnalysisWorkspaceResult(withAsset, built.result)).not.toThrow();
+  });
+
+  it('rejects zero-depth not-observed expected variants in a rehashed real-engine report', () => {
+    const qualityScores = Array.from({ length: ENGINE_REFERENCE_SEQUENCE.length }, () => 40);
+    const position = 120;
+    const referenceBase = ENGINE_REFERENCE_SEQUENCE[position];
+    const verification = verifyArtifactConstruct({
+      reference: {
+        id: 'expected-reference',
+        sequence: ENGINE_REFERENCE_SEQUENCE,
+        topology: 'linear',
+        sha256: sha256HexSync(ENGINE_REFERENCE_SEQUENCE),
+      },
+      reads: [{
+        id: 'reference-read',
+        baseCalls: ENGINE_REFERENCE_SEQUENCE,
+        qualityScores,
+        sha256: sha256HexSync(ENGINE_REFERENCE_SEQUENCE),
+      }],
+      expectedVariants: [{
+        id: 'expected-change',
+        type: 'substitution',
+        referenceStart: position,
+        referenceEnd: position + 1,
+        reference: referenceBase,
+        alternate: referenceBase === 'A' ? 'C' : 'A',
+      }],
+    });
+    expect(verification.variants.expected[0]).toMatchObject({ status: 'not_observed', depth: 1 });
+
+    const built = buildArtifactConstructVerificationArtifacts(
+      verification,
+      [artifactConstructReadEvidenceSha256({
+        baseCalls: ENGINE_REFERENCE_SEQUENCE,
+        qualityScores,
+      })],
+      {
+        resultId: 'expected-status-result',
+        assetId: 'expected-status-report',
+        createdAt: CREATED_AT,
+      },
+    );
+    const mutated = mutateBuiltReport(built, (report) => {
+      const variants = report.variants as {
+        expected: Array<{ depth: number }>;
+        missingExpected: Array<{ depth: number }>;
+      };
+      variants.expected[0].depth = 0;
+      variants.missingExpected[0].depth = 0;
+    });
+    const withAsset = appendArtifactAnalysisAsset(undefined, mutated.asset);
+    expect(() => appendArtifactAnalysisWorkspaceResult(withAsset, mutated.result))
+      .toThrow(/depth is inconsistent with status not_observed/i);
+  });
+
+  it('rejects high-confidence variants whose rehashed support has no possible quality-bearing read', () => {
+    const changed = `${ENGINE_REFERENCE_SEQUENCE.slice(0, 120)}${ENGINE_REFERENCE_SEQUENCE[120] === 'A' ? 'C' : 'A'}${ENGINE_REFERENCE_SEQUENCE.slice(121)}`;
+    const qualityScores = Array.from({ length: changed.length }, () => 40);
+    const verification = verifyArtifactConstruct({
+      reference: {
+        id: 'quality-reference',
+        sequence: ENGINE_REFERENCE_SEQUENCE,
+        topology: 'linear',
+        sha256: sha256HexSync(ENGINE_REFERENCE_SEQUENCE),
+      },
+      reads: [{
+        id: 'quality-read',
+        baseCalls: changed,
+        qualityScores,
+        sha256: sha256HexSync(changed),
+      }],
+      thresholds: { minCoverageFraction: 0 },
+    });
+    expect(verification.variants.unexpected[0]).toMatchObject({ confidence: 'high' });
+    const built = buildArtifactConstructVerificationArtifacts(
+      verification,
+      [artifactConstructReadEvidenceSha256({ baseCalls: changed, qualityScores })],
+      {
+        resultId: 'quality-result',
+        assetId: 'quality-report',
+        createdAt: CREATED_AT,
+      },
+    );
+    const mutated = mutateBuiltReport(built, (report) => {
+      const reads = report.reads as Array<{
+        qualityProvided: boolean;
+        meanQuality: number | null;
+        trim: { method: string };
+      }>;
+      reads[0].qualityProvided = false;
+      reads[0].meanQuality = null;
+      reads[0].trim.method = 'none_missing_quality';
+      const reasons = report.reasons as Array<Record<string, unknown>>;
+      reasons.unshift({
+        code: 'missing_quality',
+        severity: 'review',
+        message: 'The forged read has no quality evidence.',
+        readId: 'quality-read',
+      });
+    });
+    const result = structuredClone(mutated.result);
+    result.data.reasonCodes = ['missing_quality', ...result.data.reasonCodes];
+    const withAsset = appendArtifactAnalysisAsset(undefined, mutated.asset);
+    expect(() => appendArtifactAnalysisWorkspaceResult(withAsset, result))
+      .toThrow(/confidence high requires possible quality-bearing mapped-read support/i);
+  });
+
+  it('accepts compact high-confidence support when its quality-bearing read is honestly omitted', () => {
+    const source = verificationSource();
+    const mappedTemplate = source.reads[0];
+    const readIds = [
+      ...Array.from({ length: 12 }, (_, index) => `a-qualityless-${String(index).padStart(2, '0')}`),
+      'z-quality-bearing',
+    ];
+    source.reads = readIds.map((id, index) => ({
+      ...mappedTemplate,
+      id,
+      name: id,
+      sha256: sha256HexSync(id),
+      qualityProvided: index === readIds.length - 1,
+      meanQuality: index === readIds.length - 1 ? 40 : null,
+      trim: {
+        ...mappedTemplate.trim,
+        method: index === readIds.length - 1 ? 'quality_window' : 'none_missing_quality',
+      },
+    }));
+    source.reasons = [{
+      code: 'missing_quality',
+      severity: 'review',
+      message: 'Some supporting reads lack quality evidence.',
+    }, ...source.reasons];
+    source.variants.observed = [{
+      ...observedVariant(),
+      depth: readIds.length,
+      support: readIds.length,
+      supportWeight: 52,
+      fraction: 1,
+      meanQuality: 40,
+      supportingReadIds: readIds,
+      expectedVariantId: 'expected-0',
+    }];
+    source.variants.expected = [{ ...expectedVariant(), depth: 1 }];
+    source.provenance.readSha256s = source.reads.map((read) => read.sha256);
+    const qualityScores = Array.from({ length: REFERENCE_SEQUENCE.length }, () => 40);
+    const built = buildArtifactConstructVerificationArtifacts(
+      source,
+      readIds.map((_, index) => artifactConstructReadEvidenceSha256({
+        baseCalls: REFERENCE_SEQUENCE,
+        qualityScores: index === readIds.length - 1 ? qualityScores : null,
+      })),
+      {
+        resultId: 'compact-quality-result',
+        assetId: 'compact-quality-report',
+        createdAt: CREATED_AT,
+      },
+    );
+    const report = JSON.parse(built.asset.content) as {
+      variants: { observed: Array<{ supportingReadIds: string[]; omittedSupportingReadIds: number }> };
+    };
+    expect(report.variants.observed[0]).toMatchObject({
+      supportingReadIds: expect.not.arrayContaining(['z-quality-bearing']),
+      omittedSupportingReadIds:
+        readIds.length - ARTIFACT_CONSTRUCT_VERIFICATION_REPORT_LIMITS.maxSupportingReadIds,
+    });
+    const withAsset = appendArtifactAnalysisAsset(undefined, built.asset);
+    expect(() => appendArtifactAnalysisWorkspaceResult(withAsset, built.result)).not.toThrow();
+
+    const impossibleDepth = mutateBuiltReport(built, (forgedReport) => {
+      const variants = forgedReport.variants as { expected: Array<{ depth: number }> };
+      variants.expected[0].depth = 2;
+    });
+    const withForgedAsset = appendArtifactAnalysisAsset(undefined, impossibleDepth.asset);
+    expect(() => appendArtifactAnalysisWorkspaceResult(withForgedAsset, impossibleDepth.result))
+      .toThrow(/expected\[0\]\.depth must be an integer from 0 through 1/i);
+  });
+
+  it('rejects linked expected quality depth above the observed variant span', () => {
+    const built = build();
+    const mutated = mutateBuiltReport(built, (report) => {
+      const variants = report.variants as {
+        observed: Array<{
+          depth: number;
+          support: number;
+          supportWeight: number;
+          supportingReadIds: string[];
+          omittedSupportingReadIds: number;
+        }>;
+      };
+      Object.assign(variants.observed[0], {
+        depth: 1,
+        support: 1,
+        supportWeight: 32,
+        supportingReadIds: ['read-1'],
+        omittedSupportingReadIds: 0,
+      });
+    });
+    const withAsset = appendArtifactAnalysisAsset(undefined, mutated.asset);
+    expect(() => appendArtifactAnalysisWorkspaceResult(withAsset, mutated.result))
+      .toThrow(/cross-links are inconsistent/i);
+  });
+
+  it('rejects rehashed variant support reassigned to a known but nonmapped read', () => {
+    const changed = `${ENGINE_REFERENCE_SEQUENCE.slice(0, 120)}${ENGINE_REFERENCE_SEQUENCE[120] === 'A' ? 'C' : 'A'}${ENGINE_REFERENCE_SEQUENCE.slice(121)}`;
+    const mappedQuality = Array.from({ length: changed.length }, () => 40);
+    const nonmapped = 'A'.repeat(ENGINE_REFERENCE_SEQUENCE.length);
+    const nonmappedQuality = Array.from({ length: nonmapped.length }, () => 40);
+    const verification = verifyArtifactConstruct({
+      reference: {
+        id: 'support-reference',
+        sequence: ENGINE_REFERENCE_SEQUENCE,
+        topology: 'linear',
+        sha256: sha256HexSync(ENGINE_REFERENCE_SEQUENCE),
+      },
+      reads: [{
+        id: 'mapped-read',
+        baseCalls: changed,
+        qualityScores: mappedQuality,
+        sha256: sha256HexSync(changed),
+      }, {
+        id: 'known-nonmapped-read',
+        baseCalls: nonmapped,
+        qualityScores: nonmappedQuality,
+        sha256: sha256HexSync(nonmapped),
+      }],
+      thresholds: { minCoverageFraction: 0 },
+    });
+    expect(verification.reads.find((read) => read.id === 'mapped-read')?.status).toBe('mapped');
+    expect(verification.reads.find((read) => read.id === 'known-nonmapped-read')?.status).not.toBe('mapped');
+    expect(verification.variants.unexpected).toHaveLength(1);
+
+    const built = buildArtifactConstructVerificationArtifacts(
+      verification,
+      [
+        artifactConstructReadEvidenceSha256({ baseCalls: changed, qualityScores: mappedQuality }),
+        artifactConstructReadEvidenceSha256({ baseCalls: nonmapped, qualityScores: nonmappedQuality }),
+      ],
+      {
+        resultId: 'support-verification-result',
+        assetId: 'support-verification-report',
+        createdAt: CREATED_AT,
+      },
+    );
+    const mutated = mutateBuiltReport(built, (report) => {
+      const variants = report.variants as {
+        observed: Array<{ supportingReadIds: string[] }>;
+        unexpected: Array<{ supportingReadIds: string[] }>;
+      };
+      variants.observed[0].supportingReadIds[0] = 'known-nonmapped-read';
+      variants.unexpected[0].supportingReadIds[0] = 'known-nonmapped-read';
+    });
+    const withAsset = appendArtifactAnalysisAsset(undefined, mutated.asset);
+    expect(() => appendArtifactAnalysisWorkspaceResult(withAsset, mutated.result))
+      .toThrow(/supportingReadIds must be unique mapped reads/i);
+  });
+
+  it('requires the no-usable-reads finding even when a report and summary are rehashed together', () => {
+    const nonmapped = 'A'.repeat(ENGINE_REFERENCE_SEQUENCE.length);
+    const qualityScores = Array.from({ length: nonmapped.length }, () => 40);
+    const verification = verifyArtifactConstruct({
+      reference: {
+        id: 'no-usable-reference',
+        sequence: ENGINE_REFERENCE_SEQUENCE,
+        topology: 'linear',
+        sha256: sha256HexSync(ENGINE_REFERENCE_SEQUENCE),
+      },
+      reads: [{
+        id: 'no-usable-read',
+        baseCalls: nonmapped,
+        qualityScores,
+        sha256: sha256HexSync(nonmapped),
+      }],
+      thresholds: { minCoverageFraction: 0 },
+    });
+    expect(verification.reads[0].status).not.toBe('mapped');
+    expect(verification.reasons.map((reason) => reason.code)).toContain('no_usable_reads');
+
+    const built = buildArtifactConstructVerificationArtifacts(
+      verification,
+      [artifactConstructReadEvidenceSha256({ baseCalls: nonmapped, qualityScores })],
+      {
+        resultId: 'no-usable-result',
+        assetId: 'no-usable-report',
+        createdAt: CREATED_AT,
+      },
+    );
+    const mutated = removeBuiltReason(built, 'no_usable_reads');
+    const withAsset = appendArtifactAnalysisAsset(undefined, mutated.asset);
+    expect(() => appendArtifactAnalysisWorkspaceResult(withAsset, mutated.result))
+      .toThrow(/missing required reason code no_usable_reads/i);
+  });
+
+  it('retains both low-depth and missing-strand findings for the same required region', () => {
+    const qualityScores = Array.from({ length: ENGINE_REFERENCE_SEQUENCE.length }, () => 40);
+    const verification = verifyArtifactConstruct({
+      reference: {
+        id: 'strand-reference',
+        sequence: ENGINE_REFERENCE_SEQUENCE,
+        topology: 'linear',
+        sha256: sha256HexSync(ENGINE_REFERENCE_SEQUENCE),
+      },
+      reads: [{
+        id: 'forward-read',
+        baseCalls: ENGINE_REFERENCE_SEQUENCE,
+        qualityScores,
+        sha256: sha256HexSync(ENGINE_REFERENCE_SEQUENCE),
+      }],
+      thresholds: { minCoverageFraction: 0, minTrimmedReadLength: 20 },
+      requiredRegions: [{
+        id: 'bidirectional-region',
+        start: 0,
+        end: ENGINE_REFERENCE_SEQUENCE.length,
+        minDepth: 2,
+        requireBothStrands: true,
+      }],
+    });
+    expect(verification.coverage.requiredRegions[0]).toMatchObject({
+      status: 'low_depth',
+      coveredBases: ENGINE_REFERENCE_SEQUENCE.length,
+      basesMeetingMinDepth: 0,
+      forwardCoveredBases: ENGINE_REFERENCE_SEQUENCE.length,
+      reverseCoveredBases: 0,
+      bothStrandsCoveredBases: 0,
+    });
+    expect(verification.reasons.map((reason) => reason.code)).toEqual(expect.arrayContaining([
+      'required_region_low_depth',
+      'required_region_missing_strand',
+    ]));
+
+    const built = buildArtifactConstructVerificationArtifacts(
+      verification,
+      [artifactConstructReadEvidenceSha256({ baseCalls: ENGINE_REFERENCE_SEQUENCE, qualityScores })],
+      {
+        resultId: 'strand-result',
+        assetId: 'strand-report',
+        createdAt: CREATED_AT,
+      },
+    );
+    const pristineWorkspace = appendArtifactAnalysisAsset(undefined, built.asset);
+    expect(() => appendArtifactAnalysisWorkspaceResult(pristineWorkspace, built.result)).not.toThrow();
+
+    for (const code of ['required_region_low_depth', 'required_region_missing_strand']) {
+      const mutated = removeBuiltReason(built, code);
+      const withAsset = appendArtifactAnalysisAsset(undefined, mutated.asset);
+      expect(() => appendArtifactAnalysisWorkspaceResult(withAsset, mutated.result), code)
+        .toThrow(new RegExp(`missing required reason code ${code}`, 'i'));
+    }
+  });
+
+  it('uses bases meeting min depth for the durable coverage invariant and only covered regions pass', () => {
+    const built = build();
+    expect(built.result.parameters.thresholds).toMatchObject({ minDepth: 2 });
+    expect(built.result.data).toMatchObject({
+      referenceLength: 4,
+      coveredBases: 2,
+      coverageFraction: 0.5,
+      requiredRegionCount: 1,
+      passingRegionCount: 0,
+    });
+    const withAsset = appendArtifactAnalysisAsset(undefined, built.asset);
+    expect(() => appendArtifactAnalysisWorkspaceResult(withAsset, built.result)).not.toThrow();
+  });
+
+  it('finds duplicates only by the exact engine, engineVersion, requestSha256 tuple', () => {
+    const built = build();
+    const exact = {
+      engine: 'motif-construct-verification',
+      engineVersion: '1',
+      requestSha256: REQUEST_SHA256,
+    };
+    expect(findDuplicateArtifactConstructVerificationResult([built.result], exact)).toBe(built.result);
+    expect(findDuplicateArtifactConstructVerificationResult([built.result], { ...exact, engine: 'other' }))
+      .toBeUndefined();
+    expect(findDuplicateArtifactConstructVerificationResult([built.result], { ...exact, engineVersion: '2' }))
+      .toBeUndefined();
+    expect(findDuplicateArtifactConstructVerificationResult([built.result], {
+      ...exact,
+      requestSha256: sha256HexSync('different-request'),
+    })).toBeUndefined();
+  });
+
+  it('rejects inconsistent structural hashes and misaligned evidence attestations', () => {
+    const badReference = verificationSource();
+    badReference.reference.sha256 = sha256HexSync('AAAA');
+    expect(() => build(badReference)).toThrow(/reference\.sha256 must match/i);
+
+    const badProvenance = verificationSource();
+    badProvenance.provenance.readSha256s = [...READ_SHA256S].reverse();
+    expect(() => build(badProvenance)).toThrow(/must match reads\[\]\.sha256 in input order/i);
+
+    expect(() => buildArtifactConstructVerificationArtifacts(
+      verificationSource(),
+      evidenceSha256s().slice(0, 1),
+      { resultId: 'result', assetId: 'asset', createdAt: CREATED_AT },
+    )).toThrow(/one-to-one/i);
+  });
+});

--- a/src/artifacts/__tests__/claude-science-construct-verification.test.ts
+++ b/src/artifacts/__tests__/claude-science-construct-verification.test.ts
@@ -1,0 +1,662 @@
+import { describe, expect, it } from 'vitest';
+import { reverseComplement } from '../../bio/reverse-complement';
+import {
+  ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS,
+  ArtifactConstructVerificationError,
+  verifyArtifactConstruct,
+  type ArtifactConstructExpectedVariantInput,
+  type ArtifactConstructReadInput,
+  type ArtifactConstructVerificationInput,
+} from '../claude-science-construct-verification';
+import { sha256HexSync } from '../claude-science-sha256';
+
+function deterministicDna(length: number, seed = 0x5eed1234): string {
+  const bases = ['A', 'C', 'G', 'T'] as const;
+  let state = seed >>> 0;
+  let sequence = '';
+  for (let index = 0; index < length; index += 1) {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    sequence += bases[(state >>> 28) & 3];
+  }
+  return sequence;
+}
+
+function read(
+  id: string,
+  baseCalls: string,
+  qualityScores: readonly number[] | null = new Array(baseCalls.length).fill(40),
+  name?: string,
+): ArtifactConstructReadInput {
+  return {
+    id,
+    ...(name === undefined ? {} : { name }),
+    baseCalls,
+    ...(qualityScores === null ? {} : { qualityScores }),
+    sha256: sha256HexSync(baseCalls.toUpperCase()),
+  };
+}
+
+function verificationInput(
+  sequence: string,
+  reads: ArtifactConstructReadInput[],
+  overrides: Partial<Omit<ArtifactConstructVerificationInput, 'reference' | 'reads'>> = {},
+  topology: 'linear' | 'circular' = 'linear',
+): ArtifactConstructVerificationInput {
+  return {
+    reference: {
+      id: 'reference',
+      name: 'Reference display name',
+      sequence,
+      topology,
+      sha256: sha256HexSync(sequence),
+    },
+    reads,
+    ...overrides,
+  };
+}
+
+function substitute(sequence: string, position: number): { sequence: string; alternate: string } {
+  const referenceBase = sequence[position];
+  const alternate = referenceBase === 'A' ? 'C' : 'A';
+  return {
+    sequence: `${sequence.slice(0, position)}${alternate}${sequence.slice(position + 1)}`,
+    alternate,
+  };
+}
+
+function expectedSubstitution(
+  reference: string,
+  position: number,
+  alternate: string,
+): ArtifactConstructExpectedVariantInput {
+  return {
+    id: `expected-${position}`,
+    type: 'substitution',
+    referenceStart: position,
+    referenceEnd: position + 1,
+    reference: reference[position],
+    alternate,
+  };
+}
+
+describe('verifyArtifactConstruct', () => {
+  it('maps exact full-reference reads in both orientations and proves bidirectional depth', () => {
+    const reference = deterministicDna(160);
+    const result = verifyArtifactConstruct(verificationInput(reference, [
+      read('forward', reference),
+      read('reverse', reverseComplement(reference)),
+    ], {
+      requiredRegions: [{
+        id: 'whole-reference',
+        start: 0,
+        end: reference.length,
+        minDepth: 2,
+        requireBothStrands: true,
+      }],
+    }));
+
+    expect(result.state).toBe('consistent');
+    expect(result.reasons).toEqual([]);
+    expect(result.reads.map((entry) => entry.mapping?.orientation)).toEqual(['forward', 'reverse']);
+    expect(result.coverage.depth).toEqual(new Array(reference.length).fill(2));
+    expect(result.coverage.forward).toEqual(new Array(reference.length).fill(1));
+    expect(result.coverage.reverse).toEqual(new Array(reference.length).fill(1));
+    expect(result.coverage.requiredRegions[0]).toMatchObject({
+      status: 'covered',
+      bothStrandsCoveredBases: reference.length,
+    });
+    expect(result.consensus.sequence).toBe(reference);
+
+    const reverseRawIndices = result.reads[1].mapping?.coordinateMap.rawCallIndices
+      .filter((index): index is number => index !== null);
+    expect(reverseRawIndices?.[0]).toBe(reference.length - 1);
+    expect(reverseRawIndices?.at(-1)).toBe(0);
+  });
+
+  it('maps a circular read across the origin with wrapped coordinates', () => {
+    const reference = deterministicDna(160, 0xabc123);
+    const baseCalls = reference.slice(125) + reference.slice(0, 45);
+    const result = verifyArtifactConstruct(verificationInput(reference, [read('origin-read', baseCalls)], {
+      requiredRegions: [{ id: 'origin', start: 125, end: 45 }],
+      thresholds: { minCoverageFraction: 0 },
+    }, 'circular'));
+
+    expect(result.state).toBe('consistent');
+    expect(result.reads[0]).toMatchObject({
+      status: 'mapped',
+      mapping: { orientation: 'forward', referenceStart: 125, referenceEnd: 45, wraps: true },
+    });
+    expect(result.coverage.requiredRegions[0]).toMatchObject({ wraps: true, status: 'covered' });
+  });
+
+  it('proves a unique exact global maximum without exhaustively scanning a large reference', () => {
+    const reference = deterministicDna(5_000, 0x101010);
+    const baseCalls = reference.slice(2_100, 2_900);
+    const result = verifyArtifactConstruct(verificationInput(reference, [
+      read('large-exact-read', baseCalls),
+    ], { thresholds: { minCoverageFraction: 0, minMappingMargin: 0 } }));
+
+    expect(result.reads[0]).toMatchObject({
+      status: 'mapped',
+      mapping: {
+        orientation: 'forward',
+        referenceStart: 2_100,
+        score: baseCalls.length * 3,
+        secondBestScore: null,
+      },
+    });
+    expect(result.state).toBe('consistent');
+  });
+
+  it('enforces mapping margin against a near-exact runner-up even with one exact locus', () => {
+    const baseCalls = deterministicDna(100, 0x303030);
+    const nearCopy = substitute(baseCalls, 50).sequence;
+    const reference = [
+      deterministicDna(20, 0x303031),
+      baseCalls,
+      deterministicDna(20, 0x303032),
+      nearCopy,
+      deterministicDna(20, 0x303033),
+    ].join('');
+    const result = verifyArtifactConstruct(verificationInput(reference, [
+      read('exact-with-near-copy', baseCalls),
+    ], { thresholds: { minCoverageFraction: 0 } }));
+
+    expect(result.reads[0]).toMatchObject({
+      status: 'ambiguous_mapping',
+      mapping: {
+        referenceStart: 20,
+        score: baseCalls.length * 3,
+        secondBestScore: (baseCalls.length * 3) - 6,
+        mappingMargin: 0.02,
+      },
+    });
+    expect(result.state).toBe('needs_review');
+    expect(result.reasons).toContainEqual(expect.objectContaining({
+      code: 'ambiguous_mapping',
+      readId: 'exact-with-near-copy',
+    }));
+  });
+
+  it('proves the default runner-up margin for two exact full-length reads within the shared budget', () => {
+    const reference = deterministicDna(240, 0x404040);
+    const result = verifyArtifactConstruct(verificationInput(reference, [
+      read('full-forward', reference),
+      read('full-reverse', reverseComplement(reference)),
+    ], { thresholds: { minCoverageFraction: 0, requireBothStrands: true } }));
+
+    expect(result.reads).toEqual([
+      expect.objectContaining({ status: 'mapped', mapping: expect.objectContaining({ orientation: 'forward' }) }),
+      expect.objectContaining({ status: 'mapped', mapping: expect.objectContaining({ orientation: 'reverse' }) }),
+    ]);
+    expect(result.state).toBe('consistent');
+    expect(result.provenance.workUnits).toBeLessThan(ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxWorkUnits);
+  });
+
+  it('keeps non-exhaustive seeded mappings review-only in either orientation', () => {
+    const reference = deterministicDna(5_000, 0x202020);
+    const source = reference.slice(2_400, 2_600);
+    const changed = substitute(source, 100).sequence;
+    const result = verifyArtifactConstruct(verificationInput(reference, [
+      read('large-forward-noisy', changed),
+      read('large-reverse-noisy', reverseComplement(changed)),
+    ], { thresholds: { minCoverageFraction: 0 } }));
+
+    expect(result.reads).toEqual([
+      expect.objectContaining({
+        status: 'ambiguous_mapping',
+        mapping: expect.objectContaining({ orientation: 'forward', referenceStart: 2_400 }),
+      }),
+      expect.objectContaining({
+        status: 'ambiguous_mapping',
+        mapping: expect.objectContaining({ orientation: 'reverse', referenceStart: 2_400 }),
+      }),
+    ]);
+    expect(result.state).toBe('needs_review');
+    expect(result.reasons.filter((entry) => entry.code === 'ambiguous_mapping')).toHaveLength(2);
+  });
+
+  it('makes an unexpected high-confidence SNV inconsistent and accepts it when expected', () => {
+    const reference = deterministicDna(150, 0x1234567);
+    const changed = substitute(reference, 73);
+    const unexpected = verifyArtifactConstruct(verificationInput(reference, [read('variant-read', changed.sequence)]));
+
+    expect(unexpected.state).toBe('inconsistent');
+    expect(unexpected.reasons).toContainEqual(expect.objectContaining({ code: 'unexpected_variant' }));
+    expect(unexpected.variants.observed).toContainEqual(expect.objectContaining({
+      type: 'substitution',
+      referenceStart: 73,
+      reference: reference[73],
+      alternate: changed.alternate,
+      confidence: 'high',
+    }));
+
+    const expected = verifyArtifactConstruct(verificationInput(reference, [read('variant-read', changed.sequence)], {
+      expectedVariants: [expectedSubstitution(reference, 73, changed.alternate)],
+    }));
+    expect(expected.state).toBe('consistent');
+    expect(expected.variants.expected[0]).toMatchObject({ status: 'observed' });
+    expect(expected.variants.unexpected).toEqual([]);
+  });
+
+  it('distinguishes a covered missing expected variant from inconclusive coverage', () => {
+    const reference = deterministicDna(150, 0x9911);
+    const alternate = reference[100] === 'A' ? 'C' : 'A';
+    const expected = expectedSubstitution(reference, 100, alternate);
+    const absent = verifyArtifactConstruct(verificationInput(reference, [read('reference-read', reference)], {
+      expectedVariants: [expected],
+    }));
+    expect(absent.state).toBe('inconsistent');
+    expect(absent.variants.expected[0]).toMatchObject({ status: 'not_observed', depth: 1 });
+    expect(absent.reasons).toContainEqual(expect.objectContaining({ code: 'expected_variant_not_observed' }));
+
+    const partial = verifyArtifactConstruct(verificationInput(reference, [
+      read('left-read', reference.slice(0, 70)),
+    ], {
+      expectedVariants: [expected],
+      thresholds: { minCoverageFraction: 0 },
+    }));
+    expect(partial.state).toBe('needs_review');
+    expect(partial.variants.expected[0]).toMatchObject({ status: 'not_covered', depth: 0 });
+    expect(partial.reasons).toContainEqual(expect.objectContaining({
+      code: 'expected_variant_not_covered',
+      severity: 'review',
+    }));
+
+    const missingQuality = verifyArtifactConstruct(verificationInput(reference, [
+      read('qualityless-reference', reference, null),
+    ], { expectedVariants: [expected] }));
+    expect(missingQuality.state).toBe('needs_review');
+    expect(missingQuality.variants.expected[0]).toMatchObject({ status: 'not_covered', depth: 0 });
+    expect(missingQuality.reasons.map((entry) => entry.code)).toEqual(expect.arrayContaining([
+      'missing_quality',
+      'expected_variant_not_covered',
+    ]));
+
+    const internalLowQuality = new Array(reference.length).fill(40);
+    internalLowQuality[100] = 5;
+    const lowQuality = verifyArtifactConstruct(verificationInput(reference, [
+      read('low-quality-reference', reference, internalLowQuality),
+    ], { expectedVariants: [expected] }));
+    expect(lowQuality.state).toBe('needs_review');
+    expect(lowQuality.variants.expected[0]).toMatchObject({ status: 'not_covered', depth: 0 });
+  });
+
+  it('treats missing quality and low-confidence edits as review-only and gates consensus edits', () => {
+    const reference = deterministicDna(140, 0x445566);
+    const changed = substitute(reference, 64);
+    const result = verifyArtifactConstruct(verificationInput(reference, [
+      read('qualityless', changed.sequence, null),
+    ]));
+
+    expect(result.state).toBe('needs_review');
+    expect(result.reasons.map((entry) => entry.code)).toEqual(expect.arrayContaining([
+      'missing_quality',
+      'low_confidence_variant',
+    ]));
+    expect(result.variants.observed[0]).toMatchObject({ confidence: 'low' });
+    expect(result.consensus.calls[64]).toMatchObject({ call: 'N', status: 'conflict' });
+    expect(result.consensus.sequence[64]).toBe('N');
+    expect(result.consensus.variants).toEqual([]);
+    expect(result.reasons.some((entry) => entry.code === 'conflicting_consensus')).toBe(false);
+  });
+
+  it('quality-trims ends without changing calls and reports resulting partial coverage', () => {
+    const reference = deterministicDna(140, 0x998877);
+    const qualities = [
+      ...new Array(15).fill(5),
+      ...new Array(110).fill(40),
+      ...new Array(15).fill(5),
+    ];
+    const result = verifyArtifactConstruct(verificationInput(reference, [
+      read('trimmed', reference, qualities),
+    ], { thresholds: { trimWindow: 5 } }));
+
+    expect(result.state).toBe('needs_review');
+    expect(result.reads[0]).toMatchObject({
+      status: 'mapped',
+      trim: { rawStart: 13, rawEnd: 127, trimmedLength: 114 },
+    });
+    expect(result.reasons).toContainEqual(expect.objectContaining({ code: 'partial_reference_coverage' }));
+  });
+
+  it('does not turn an IUPAC no-call into identity, depth, conflict, or supported absence', () => {
+    const reference = deterministicDna(140, 0x2020);
+    const noCallPosition = 71;
+    const withNoCall = `${reference.slice(0, noCallPosition)}N${reference.slice(noCallPosition + 1)}`;
+    const alternate = reference[noCallPosition] === 'A' ? 'C' : 'A';
+    const result = verifyArtifactConstruct(verificationInput(reference, [read('n-call', withNoCall)], {
+      expectedVariants: [expectedSubstitution(reference, noCallPosition, alternate)],
+    }));
+
+    expect(result.state).toBe('needs_review');
+    expect(result.reads[0].mapping?.matches).toBe(reference.length - 1);
+    expect(result.coverage.depth[noCallPosition]).toBe(0);
+    expect(result.consensus.calls[noCallPosition]).toMatchObject({ status: 'uncovered', call: 'N' });
+    expect(result.variants.expected[0]).toMatchObject({ status: 'not_covered', depth: 0 });
+    expect(result.reasons.some((entry) => entry.code === 'conflicting_consensus')).toBe(false);
+  });
+
+  it('requires one read to span both insertion flanks before declaring expected absence', () => {
+    const reference = deterministicDna(160, 0x8181);
+    const expected: ArtifactConstructExpectedVariantInput = {
+      id: 'expected-insertion',
+      type: 'insertion',
+      referenceStart: 80,
+      referenceEnd: 80,
+      reference: '',
+      alternate: 'GG',
+    };
+    const result = verifyArtifactConstruct(verificationInput(reference, [
+      read('left-only', reference.slice(25, 80)),
+      read('right-only', reference.slice(80, 135)),
+    ], {
+      expectedVariants: [expected],
+      thresholds: { minCoverageFraction: 0 },
+    }));
+
+    expect(result.state).toBe('needs_review');
+    expect(result.coverage.depth[79]).toBe(1);
+    expect(result.coverage.depth[80]).toBe(1);
+    expect(result.variants.expected[0]).toMatchObject({ status: 'not_covered', depth: 0 });
+  });
+
+  it('requires one read to span an entire deletion event before declaring expected absence', () => {
+    const reference = deterministicDna(160, 0x9191);
+    const deletionStart = Array.from({ length: 41 }, (_, offset) => 60 + offset)
+      .find((position) => reference[position - 1] !== reference[position + 2]) as number;
+    const result = verifyArtifactConstruct(verificationInput(reference, [
+      read('deletion-left', reference.slice(deletionStart - 55, deletionStart + 2)),
+      read('deletion-right', reference.slice(deletionStart + 2, deletionStart + 57)),
+    ], {
+      expectedVariants: [{
+        id: 'expected-deletion',
+        type: 'deletion',
+        referenceStart: deletionStart,
+        referenceEnd: deletionStart + 3,
+        reference: reference.slice(deletionStart, deletionStart + 3),
+        alternate: '',
+      }],
+      thresholds: { minCoverageFraction: 0 },
+    }));
+
+    expect(result.coverage.depth.slice(deletionStart, deletionStart + 3)).toEqual([1, 1, 1]);
+    expect(result.variants.expected[0]).toMatchObject({ status: 'not_covered', depth: 0 });
+    expect(result.state).toBe('needs_review');
+  });
+
+  it('calls bounded insertions and applies the same high-confidence consensus gate', () => {
+    const reference = deterministicDna(150, 0x31337);
+    const position = 70;
+    const insertedBase = reference[position - 1] === 'A' ? 'C' : 'A';
+    const alternate = insertedBase.repeat(3);
+    const insertedRead = `${reference.slice(0, position)}${alternate}${reference.slice(position)}`;
+    const result = verifyArtifactConstruct(verificationInput(reference, [read('insertion-read', insertedRead)], {
+      expectedVariants: [{
+        id: 'expected-insertion',
+        type: 'insertion',
+        referenceStart: position,
+        referenceEnd: position,
+        reference: '',
+        alternate,
+      }],
+    }));
+
+    expect(result.state).toBe('consistent');
+    expect(result.variants.expected[0]).toMatchObject({ status: 'observed' });
+    expect(result.consensus.variants).toContainEqual(expect.objectContaining({
+      type: 'insertion',
+      alternate,
+    }));
+    expect(result.consensus.sequence).toBe(insertedRead);
+  });
+
+  it('uses quality weights, not a raw read majority, for consensus and variant fraction', () => {
+    const reference = deterministicDna(140, 0x5151);
+    const position = 67;
+    const changed = substitute(reference, position);
+    const lowReferenceQuality = new Array(reference.length).fill(40);
+    lowReferenceQuality[position] = 5;
+    const result = verifyArtifactConstruct(verificationInput(reference, [
+      read('low-reference', reference, lowReferenceQuality),
+      read('high-alternate', changed.sequence),
+    ]));
+
+    expect(result.state).toBe('inconsistent');
+    expect(result.consensus.calls[position]).toMatchObject({ call: changed.alternate, status: 'variant' });
+    expect(result.variants.observed[0].fraction).toBeGreaterThan(0.8);
+    expect(result.variants.observed[0]).toMatchObject({ confidence: 'high', support: 1, depth: 2 });
+  });
+
+  it('left-normalizes repeat-context indels before matching expected variants', () => {
+    const reference = `${deterministicDna(69, 0x111)}CAAAAAA${deterministicDna(70, 0x222)}`;
+    const deletedRead = `${reference.slice(0, 73)}${reference.slice(74)}`;
+    const result = verifyArtifactConstruct(verificationInput(reference, [read('deletion-read', deletedRead)], {
+      expectedVariants: [{
+        id: 'expected-repeat-deletion',
+        type: 'deletion',
+        referenceStart: 73,
+        referenceEnd: 74,
+        reference: 'A',
+        alternate: '',
+      }],
+    }));
+
+    expect(result.variants.expected[0]).toMatchObject({
+      status: 'observed',
+      referenceStart: 70,
+      referenceEnd: 71,
+    });
+    expect(result.variants.observed[0]).toMatchObject({
+      type: 'deletion',
+      referenceStart: 70,
+      referenceEnd: 71,
+      expectedVariantId: 'expected-repeat-deletion',
+    });
+    expect(result.state).toBe('consistent');
+    expect(result.consensus.variants).toContainEqual(expect.objectContaining({
+      type: 'deletion',
+      referenceStart: 70,
+    }));
+    expect(result.consensus.sequence).toBe(`${reference.slice(0, 70)}${reference.slice(71)}`);
+  });
+
+  it('keeps repeated loci ambiguous and multi-lap circular mappings review-only', () => {
+    const repeatedReference = 'ACGT'.repeat(40);
+    const repeated = verifyArtifactConstruct(verificationInput(repeatedReference, [
+      read('repeat', 'ACGT'.repeat(15)),
+    ], { thresholds: { minCoverageFraction: 0 } }));
+    expect(repeated.state).toBe('needs_review');
+    expect(repeated.reads[0].status).toBe('ambiguous_mapping');
+
+    const circularReference = deterministicDna(60, 0x9090);
+    const multiLap = circularReference + circularReference.slice(0, 45);
+    const circular = verifyArtifactConstruct(verificationInput(circularReference, [
+      read('multi-lap', multiLap),
+    ], { thresholds: { minCoverageFraction: 0 } }, 'circular'));
+    expect(circular.state).toBe('needs_review');
+    expect(circular.reads[0].status).toBe('ambiguous_mapping');
+    expect(circular.coverage.coveredBases).toBe(0);
+  });
+
+  it('recovers a noisy true locus when exhaustive scoring fits the work budget', () => {
+    const uniqueLocus = `AAAAAAAAAAA${deterministicDna(109, 0x424242)}`;
+    const reference = `${'A'.repeat(700)}${uniqueLocus}${deterministicDna(80, 0x1212)}`;
+    let noisyRead = uniqueLocus;
+    const expectedVariants: ArtifactConstructExpectedVariantInput[] = [];
+    for (let offset = 20; offset < uniqueLocus.length; offset += 10) {
+      const absolute = 700 + offset;
+      const changed = substitute(noisyRead, offset);
+      noisyRead = changed.sequence;
+      expectedVariants.push(expectedSubstitution(reference, absolute, changed.alternate));
+    }
+    const result = verifyArtifactConstruct(verificationInput(reference, [read('late-locus', noisyRead)], {
+      expectedVariants,
+      thresholds: { minCoverageFraction: 0 },
+    }));
+
+    expect(result.reads[0]).toMatchObject({
+      status: 'mapped',
+      mapping: { referenceStart: 700, orientation: 'forward' },
+    });
+    expect(result.state).toBe('consistent');
+  });
+
+  it('cannot promote an omitted equal-scoring locus to a unique mapping', () => {
+    const bases = ['A', 'C', 'G', 'T'] as const;
+    let readState = 777;
+    let baseCalls = '';
+    for (let index = 0; index < 100; index += 1) {
+      readState = (Math.imul(readState, 1_664_525) + 1_013_904_223) >>> 0;
+      baseCalls += bases[Math.floor((readState / (2 ** 32)) * 4)];
+    }
+    const mutateAt = (positions: readonly number[]) => {
+      const calls = [...baseCalls];
+      for (const position of positions) calls[position] = calls[position] === 'A' ? 'C' : 'A';
+      return calls.join('');
+    };
+    const mutationSets = [
+      [57, 64, 66, 90, 94, 95],
+      [22, 28, 29, 31, 32, 41, 43, 46],
+      [39, 40, 43, 44, 74, 81, 87, 88, 94],
+      [5, 33, 34, 35, 38, 39, 40, 71, 79],
+      [39, 40, 44, 46, 63, 67, 69, 80],
+      [5, 10, 17, 21, 27, 28, 34, 35, 46],
+      [5, 6, 11, 22, 25, 30, 33, 68, 70],
+      [4, 21, 24, 26, 38, 69, 74, 77],
+      [13, 15, 19, 62, 64, 79, 80, 81, 83, 86],
+      [54, 63, 65, 67, 73, 83, 88, 89],
+      [15, 20, 29, 77, 80, 82, 84, 85, 93],
+      [26, 46, 55, 58, 60, 61, 90, 91, 92],
+      [6, 18, 20, 72, 78, 82, 89, 91],
+      [34, 39, 43, 50, 55, 73, 74, 75, 78],
+      [12, 24, 25, 28, 29, 34, 44, 45, 50, 52],
+      [16, 19, 21, 26, 48, 53, 55, 91],
+      [18, 41, 57, 70, 75, 89],
+    ] as const;
+    let spacerState = 991;
+    const nextSpacer = () => {
+      let spacer = '';
+      for (let index = 0; index < 80; index += 1) {
+        spacerState = (Math.imul(spacerState, 1_664_525) + 1_013_904_223) >>> 0;
+        spacer += bases[(spacerState >>> 28) & 3];
+      }
+      return spacer;
+    };
+    const reference = `${mutationSets.map((positions) => (
+      `${nextSpacer()}${mutateAt(positions)}`
+    )).join('')}${nextSpacer()}`;
+
+    const result = verifyArtifactConstruct(verificationInput(reference, [
+      read('candidate-cap-read', baseCalls),
+    ], { thresholds: { minCoverageFraction: 0 } }));
+
+    expect(result.reads[0]).toMatchObject({
+      status: 'ambiguous_mapping',
+      mapping: { referenceStart: 80, score: 264 },
+    });
+    expect(result.reads[0].mapping?.secondBestScore).toBeNull();
+    expect(result.reads[0].mapping?.mappingMargin).toBeNull();
+    expect(result.state).toBe('needs_review');
+    expect(result.reasons).toContainEqual(expect.objectContaining({
+      code: 'ambiguous_mapping',
+      readId: 'candidate-cap-read',
+    }));
+  });
+
+  it('scores equal loci hidden inside one seed-vote neighborhood', () => {
+    const baseCalls = 'GAGCTCAACCGTACTGGATTCACGTCGATTCCAGCCGGGC';
+    const reference = [
+      'ATAGCATTTCCAATCTCAAGGCGAAGATGT',
+      'GAGCTAACCCATAATAGCTTCACGTCGATTCCAGCCGAGC',
+      'AACTCTCC',
+      'GAACTAACCCGTACTGGATTCAAGTCGCTTACAGCAGGGC',
+      'CCACGCAGGGCTGGTAGGTGAAGAGAGATA',
+    ].join('');
+    const result = verifyArtifactConstruct(verificationInput(reference, [
+      read('clustered-equal-score-read', baseCalls),
+    ], { thresholds: { minCoverageFraction: 0 } }));
+
+    expect(result.reads[0]).toMatchObject({
+      status: 'ambiguous_mapping',
+      mapping: { referenceStart: 30, score: 79, secondBestScore: 79, mappingMargin: 0 },
+    });
+    expect(result.state).toBe('needs_review');
+    expect(result.reasons).toContainEqual(expect.objectContaining({
+      code: 'ambiguous_mapping',
+      readId: 'clustered-equal-score-read',
+    }));
+  });
+
+  it('is deterministic, does not mutate input, and hashes scientific identity rather than names/order', () => {
+    const reference = deterministicDna(130, 0x777);
+    const original = verificationInput(reference, [
+      read('b-read', reference, null, 'Second display name'),
+      read('a-read', reverseComplement(reference), new Array(reference.length).fill(40), 'First display name'),
+    ]);
+    const snapshot = structuredClone(original);
+    const first = verifyArtifactConstruct(original);
+    const second = verifyArtifactConstruct(original);
+    expect(second).toEqual(first);
+    expect(original).toEqual(snapshot);
+
+    const renamedAndReordered = structuredClone(original);
+    renamedAndReordered.reference.name = 'Renamed reference';
+    renamedAndReordered.reads = [...renamedAndReordered.reads].reverse().map((entry) => ({
+      ...entry,
+      name: `Renamed ${entry.id}`,
+    }));
+    const renamed = verifyArtifactConstruct(renamedAndReordered);
+    expect(renamed.provenance.requestSha256).toBe(first.provenance.requestSha256);
+    expect(first.provenance.engine).toBe('motif-construct-verification');
+    expect(first.provenance.engineVersion).toBe('1');
+  });
+
+  it('rejects malformed hashes, quality arrays, and oversized inputs with typed codes', () => {
+    const reference = deterministicDna(80);
+    const badHash = verificationInput(reference, [read('read', reference)]);
+    badHash.reference.sha256 = '0'.repeat(64);
+    expect(() => verifyArtifactConstruct(badHash)).toThrowError(expect.objectContaining({
+      name: 'ArtifactConstructVerificationError',
+      code: 'invalid_input',
+    }));
+
+    const badQuality = verificationInput(reference, [{
+      ...read('read', reference),
+      qualityScores: [40],
+    }]);
+    expect(() => verifyArtifactConstruct(badQuality)).toThrowError(ArtifactConstructVerificationError);
+    try {
+      verifyArtifactConstruct(badQuality);
+    } catch (error) {
+      expect(error).toMatchObject({ code: 'invalid_input' });
+    }
+
+    const oversizedReference = 'A'.repeat(
+      ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReferenceLength + 1,
+    );
+    expect(() => verifyArtifactConstruct({
+      reference: {
+        id: 'too-large',
+        sequence: oversizedReference,
+        topology: 'linear',
+        sha256: sha256HexSync(oversizedReference),
+      },
+      reads: [],
+    })).toThrowError(expect.objectContaining({ code: 'too_large' }));
+  });
+
+  it('fails closed when repetitive alignment work exceeds the explicit budget', { timeout: 20_000 }, () => {
+    const reference = 'A'.repeat(ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReferenceLength);
+    const baseCalls = `${'A'.repeat(ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReadLength - 1)}C`;
+    const input = verificationInput(reference, [
+      read('repeat-1', baseCalls),
+      read('repeat-2', baseCalls),
+      read('repeat-3', baseCalls),
+      read('repeat-4', baseCalls),
+    ]);
+    expect(() => verifyArtifactConstruct(input)).toThrowError(expect.objectContaining({
+      code: 'work_budget',
+    }));
+  });
+});

--- a/src/artifacts/__tests__/claude-science-error-boundary.jsdom.test.tsx
+++ b/src/artifacts/__tests__/claude-science-error-boundary.jsdom.test.tsx
@@ -3,10 +3,18 @@
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ArtifactRuntimeErrorBoundary } from '../motif-artifact';
+import { ArtifactRuntimeErrorBoundary, MotifArtifactRuntimeError } from '../motif-artifact';
 
 function Crash(): never {
   throw new Error('render exploded');
+}
+
+function PreloadCrash(): never {
+  throw new MotifArtifactRuntimeError(
+    'MOTIF_INVALID_PRELOAD',
+    'Preloaded workspace could not be opened: malformed state.',
+    { operation: 'initialHydration', mutated: false },
+  );
 }
 
 describe('ArtifactRuntimeErrorBoundary', () => {
@@ -34,6 +42,33 @@ describe('ArtifactRuntimeErrorBoundary', () => {
     expect(shell?.textContent).toContain('last accepted inventory');
     expect(shell?.textContent).toContain('render exploded');
     expect(shell?.querySelector('button')?.textContent).toContain('Copy recovery JSON');
+
+    act(() => root.unmount());
+  });
+
+  it('reports preload rejection without claiming samples or recovery data were loaded', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <ArtifactRuntimeErrorBoundary>
+          <PreloadCrash />
+        </ArtifactRuntimeErrorBoundary>,
+      );
+    });
+
+    const shell = container.querySelector<HTMLElement>('[data-testid="artifact-runtime-error-shell"]');
+    expect(shell?.textContent).toContain('Preloaded workspace could not be opened');
+    expect(shell?.textContent).toContain('No bundled sample data was substituted');
+    expect(shell?.textContent).toContain('No workspace was accepted');
+    expect(shell?.textContent).not.toContain('last accepted inventory');
+    expect(shell?.textContent).not.toContain('bundled starting inventory');
+    expect(Array.from(shell?.querySelectorAll('button') ?? []).map((button) => button.textContent)).toEqual([
+      'Reload artifact',
+    ]);
 
     act(() => root.unmount());
   });

--- a/src/artifacts/__tests__/claude-science-freshness.test.ts
+++ b/src/artifacts/__tests__/claude-science-freshness.test.ts
@@ -1,0 +1,557 @@
+import { describe, expect, it } from 'vitest';
+import type { ArtifactAnalysisResult } from '../claude-science-analysis-results';
+import {
+  createScientificFreshnessRecordIndex,
+  evaluateAlignmentFreshness,
+  evaluateAlignmentsFreshness,
+  evaluateAnalysisResultFreshness,
+  evaluateAnalysisResultsFreshness,
+  evaluateWorkflowResultFreshness,
+  evaluateWorkflowResultsFreshness,
+  type ScientificFreshnessRecord,
+} from '../claude-science-freshness';
+import type { ArtifactAlignment } from '../claude-science-msa';
+import { sha256HexSync } from '../claude-science-sha256';
+import type { ArtifactWorkflowResult } from '../claude-science-workspace-collections';
+
+const CREATED_AT = '2026-07-17T12:00:00.000Z';
+
+function record(
+  id: string,
+  sequence: string,
+  patch: Partial<ScientificFreshnessRecord> = {},
+): ScientificFreshnessRecord {
+  return {
+    id,
+    sequence,
+    topology: 'linear',
+    ...patch,
+  };
+}
+
+function workflow(
+  patch: Partial<ArtifactWorkflowResult> = {},
+): ArtifactWorkflowResult {
+  return {
+    id: 'workflow-1',
+    kind: 'gel',
+    name: 'Saved workflow',
+    inputRecordIds: ['record-a'],
+    inputSha256s: [sha256HexSync('ACGT')],
+    parameters: {},
+    outputRecordIds: [],
+    createdAt: CREATED_AT,
+    provenance: { source: 'test' },
+    ...patch,
+  };
+}
+
+function analysis(
+  patch: Partial<Extract<ArtifactAnalysisResult, { kind: 'report' }>> = {},
+): Extract<ArtifactAnalysisResult, { kind: 'report' }> {
+  return {
+    id: 'analysis-1',
+    kind: 'report',
+    name: 'Saved analysis',
+    status: 'complete',
+    inputRecordIds: ['record-a'],
+    inputSha256s: [sha256HexSync('ACGT')],
+    dependsOnResultIds: [],
+    assetIds: [],
+    parameters: {},
+    data: { format: 'plain', body: 'Review' },
+    createdAt: CREATED_AT,
+    provenance: { source: 'test' },
+    ...patch,
+  };
+}
+
+type ConstructVerificationResult = Extract<ArtifactAnalysisResult, { kind: 'construct_verification' }>;
+
+const CONSTRUCT_SEQUENCES: Readonly<Record<string, string>> = {
+  reference: 'ACGT',
+  'read-1': 'ACG',
+  'read-2': 'CGT',
+};
+
+function constructVerification(
+  readRecordIds: string[] = ['read-1'],
+  parameters: ConstructVerificationResult['parameters'] = { topology: 'linear' },
+  id = 'verification-1',
+): ConstructVerificationResult {
+  return {
+    id,
+    kind: 'construct_verification',
+    name: 'Construct verification',
+    status: 'complete',
+    inputRecordIds: ['reference', ...readRecordIds],
+    inputSha256s: ['reference', ...readRecordIds].map((recordId) => sha256HexSync(CONSTRUCT_SEQUENCES[recordId])),
+    dependsOnResultIds: [],
+    assetIds: [],
+    parameters,
+    data: {
+      referenceRecordId: 'reference',
+      readRecordIds,
+      state: 'consistent',
+      referenceLength: 4,
+      coveredBases: 4,
+      coverageFraction: 1,
+      mappedReadCount: readRecordIds.length,
+      requiredRegionCount: 1,
+      passingRegionCount: 1,
+      observedVariantCount: 0,
+      expectedVariantCount: 0,
+      unexpectedVariantCount: 0,
+      missingExpectedVariantCount: 0,
+      reasonCodes: [],
+    },
+    createdAt: CREATED_AT,
+    provenance: { source: 'test' },
+  };
+}
+
+function alignment(
+  rows: ArtifactAlignment['rows'],
+  id = 'alignment-1',
+): ArtifactAlignment {
+  return {
+    id,
+    name: 'Saved alignment',
+    molecule: 'dna',
+    referenceRowId: rows[0]?.id ?? '',
+    rows,
+    engine: { id: 'imported', label: 'Imported', mode: 'imported' },
+    consensus: 'ACGT',
+    conserved: [true, true, true, true],
+    gapOnly: [false, false, false, false],
+    alignmentLength: 4,
+    centerIdx: 2,
+  };
+}
+
+describe('scientific freshness sequence attestations', () => {
+  it('moves from fresh to stale after an edit and back to fresh after undo-equivalent restoration', () => {
+    const saved = analysis({ inputSha256s: [sha256HexSync('ACGT').toUpperCase()] });
+    const original = createScientificFreshnessRecordIndex([record('record-a', 'ACGT')]);
+    const edited = createScientificFreshnessRecordIndex([record('record-a', 'ACGA')]);
+    const restored = createScientificFreshnessRecordIndex([record('record-a', 'ACGT')]);
+
+    expect(evaluateAnalysisResultFreshness(saved, original)).toEqual({
+      state: 'fresh',
+      reasons: [],
+      affectedRecordIds: [],
+    });
+    expect(evaluateAnalysisResultFreshness(saved, edited)).toMatchObject({
+      state: 'stale',
+      reasons: [{ code: 'sequence_hash_mismatch', state: 'stale', recordId: 'record-a', field: 'sequence' }],
+      affectedRecordIds: ['record-a'],
+    });
+    expect(evaluateAnalysisResultFreshness(saved, restored).state).toBe('fresh');
+  });
+
+  it('treats a missing input record as stale even when its saved hash is well formed', () => {
+    const evaluation = evaluateWorkflowResultFreshness(workflow(), createScientificFreshnessRecordIndex([]));
+
+    expect(evaluation.state).toBe('stale');
+    expect(evaluation.reasons).toEqual([
+      expect.objectContaining({ code: 'record_missing', state: 'stale', recordId: 'record-a' }),
+    ]);
+    expect(evaluation.affectedRecordIds).toEqual(['record-a']);
+  });
+
+  it('treats absent hashes as unverified rather than inventing provenance', () => {
+    const evaluation = evaluateAnalysisResultFreshness(
+      analysis({ inputSha256s: undefined }),
+      createScientificFreshnessRecordIndex([record('record-a', 'ACGT')]),
+    );
+
+    expect(evaluation).toMatchObject({
+      state: 'unverified',
+      reasons: [{ code: 'sequence_attestation_missing', state: 'unverified', recordId: 'record-a' }],
+      affectedRecordIds: ['record-a'],
+    });
+  });
+
+  it('uses stale dominance while retaining mixed stale and unverified reasons', () => {
+    const saved = workflow({
+      inputRecordIds: ['record-a', 'record-b'],
+      inputSha256s: [sha256HexSync('TTTT')],
+    });
+    const records = createScientificFreshnessRecordIndex([
+      record('record-a', 'ACGT'),
+      record('record-b', 'CCCC'),
+    ]);
+
+    const evaluation = evaluateWorkflowResultFreshness(saved, records);
+
+    expect(evaluation.state).toBe('stale');
+    expect(evaluation.reasons.map((entry) => [entry.code, entry.recordId])).toEqual([
+      ['sequence_hash_mismatch', 'record-a'],
+      ['sequence_attestation_missing', 'record-b'],
+    ]);
+    expect(evaluation.affectedRecordIds).toEqual(['record-a', 'record-b']);
+  });
+});
+
+describe('scientific freshness context attestations', () => {
+  it('detects a topology-only digest change with an unchanged sequence hash', () => {
+    const saved = workflow({
+      id: 'digest-1',
+      kind: 'digest',
+      parameters: { topology: 'circular', enzymes: ['EcoRI'] },
+    });
+    const circular = createScientificFreshnessRecordIndex([
+      record('record-a', 'ACGT', { topology: 'circular' }),
+    ]);
+    const linear = createScientificFreshnessRecordIndex([
+      record('record-a', 'ACGT', { topology: 'linear' }),
+    ]);
+
+    expect(evaluateWorkflowResultFreshness(saved, circular).state).toBe('fresh');
+    expect(evaluateWorkflowResultFreshness(saved, linear)).toMatchObject({
+      state: 'stale',
+      reasons: [expect.objectContaining({
+        code: 'topology_mismatch',
+        recordId: 'record-a',
+        expected: 'circular',
+        actual: 'linear',
+      })],
+    });
+  });
+
+  it('leaves a legacy digest without topology provenance unverified', () => {
+    const evaluation = evaluateWorkflowResultFreshness(
+      workflow({ kind: 'digest', parameters: { enzymes: ['EcoRI'] } }),
+      createScientificFreshnessRecordIndex([record('record-a', 'ACGT')]),
+    );
+
+    expect(evaluation).toMatchObject({
+      state: 'unverified',
+      reasons: [{ code: 'topology_attestation_missing', recordId: 'record-a' }],
+    });
+  });
+
+  it('detects a construct-verification reference topology change without treating read topology as evidence', () => {
+    const saved = constructVerification(['read-1'], {
+      topology: 'circular',
+      readEvidence: {
+        schema: 'motif.construct-read-evidence.v1',
+        sha256s: [sha256HexSync('trace-evidence-1')],
+      },
+    });
+    const exact = createScientificFreshnessRecordIndex([
+      record('reference', 'ACGT', { topology: 'circular' }),
+      record('read-1', 'ACG', {
+        topology: 'linear',
+        sangerEvidenceSha256: sha256HexSync('trace-evidence-1'),
+      }),
+    ]);
+    const changed = createScientificFreshnessRecordIndex([
+      record('reference', 'ACGT', { topology: 'linear' }),
+      record('read-1', 'ACG', {
+        topology: 'circular',
+        sangerEvidenceSha256: sha256HexSync('trace-evidence-1'),
+      }),
+    ]);
+
+    expect(evaluateAnalysisResultFreshness(saved, exact).state).toBe('fresh');
+    expect(evaluateAnalysisResultFreshness(saved, changed)).toMatchObject({
+      state: 'stale',
+      reasons: [expect.objectContaining({
+        code: 'topology_mismatch',
+        recordId: 'reference',
+        expected: 'circular',
+        actual: 'linear',
+      })],
+    });
+  });
+
+  it('leaves legacy construct verification without Sanger-evidence attestations unverified', () => {
+    const saved = constructVerification(['read-1', 'read-2'], { topology: 'linear' }, 'verification-legacy');
+    const records = createScientificFreshnessRecordIndex([
+      record('reference', 'ACGT'),
+      record('read-1', 'ACG', { sangerEvidenceSha256: sha256HexSync('trace-1') }),
+      record('read-2', 'CGT', { sangerEvidenceSha256: sha256HexSync('trace-2') }),
+    ]);
+
+    expect(evaluateAnalysisResultFreshness(saved, records)).toMatchObject({
+      state: 'unverified',
+      reasons: [
+        { code: 'sanger_evidence_attestation_missing', state: 'unverified', recordId: 'read-1', field: 'sanger_evidence' },
+        { code: 'sanger_evidence_attestation_missing', state: 'unverified', recordId: 'read-2', field: 'sanger_evidence' },
+      ],
+      affectedRecordIds: ['read-1', 'read-2'],
+    });
+  });
+
+  it('distinguishes malformed and count-misaligned saved Sanger-evidence attestations', () => {
+    const base = constructVerification(
+      ['read-1', 'read-2'],
+      { topology: 'linear' },
+      'verification-invalid-evidence',
+    );
+    const records = createScientificFreshnessRecordIndex([
+      record('reference', 'ACGT'),
+      record('read-1', 'ACG', { sangerEvidenceSha256: sha256HexSync('trace-1') }),
+      record('read-2', 'CGT', { sangerEvidenceSha256: sha256HexSync('trace-2') }),
+    ]);
+
+    const malformed = evaluateAnalysisResultFreshness({
+      ...base,
+      parameters: {
+        topology: 'linear',
+        readEvidence: {
+          schema: 'motif.construct-read-evidence.v1',
+          sha256s: [sha256HexSync('trace-1'), 'not-a-sha'],
+        },
+      },
+    }, records);
+    expect(malformed).toMatchObject({
+      state: 'unverified',
+      reasons: [{ code: 'sanger_evidence_attestation_invalid', recordId: 'read-2' }],
+      affectedRecordIds: ['read-2'],
+    });
+
+    const wrongSchema = evaluateAnalysisResultFreshness({
+      ...base,
+      parameters: {
+        topology: 'linear',
+        readEvidence: {
+          schema: 'motif.construct-read-evidence.v0',
+          sha256s: [sha256HexSync('trace-1'), sha256HexSync('trace-2')],
+        },
+      },
+    }, records);
+    expect(wrongSchema).toMatchObject({
+      state: 'unverified',
+      reasons: [
+        { code: 'sanger_evidence_attestation_invalid', recordId: 'read-1' },
+        { code: 'sanger_evidence_attestation_invalid', recordId: 'read-2' },
+      ],
+      affectedRecordIds: ['read-1', 'read-2'],
+    });
+
+    const misaligned = evaluateAnalysisResultFreshness({
+      ...base,
+      parameters: {
+        topology: 'linear',
+        readEvidence: {
+          schema: 'motif.construct-read-evidence.v1',
+          sha256s: [sha256HexSync('trace-1')],
+        },
+      },
+    }, records);
+    expect(misaligned).toMatchObject({
+      state: 'unverified',
+      reasons: [
+        { code: 'sanger_evidence_attestation_misaligned', recordId: 'read-1' },
+        { code: 'sanger_evidence_attestation_misaligned', recordId: 'read-2' },
+      ],
+      affectedRecordIds: ['read-1', 'read-2'],
+    });
+  });
+
+  it('marks lost or changed current Sanger evidence stale with read-level attribution', () => {
+    const evidenceSha256 = sha256HexSync('trace-evidence');
+    const saved = constructVerification(['read-1'], {
+      topology: 'linear',
+      readEvidence: {
+        schema: 'motif.construct-read-evidence.v1',
+        sha256s: [evidenceSha256.toUpperCase()],
+      },
+    }, 'verification-stale-evidence');
+
+    const missing = createScientificFreshnessRecordIndex([
+      record('reference', 'ACGT'),
+      record('read-1', 'ACG'),
+    ]);
+    expect(evaluateAnalysisResultFreshness(saved, missing)).toMatchObject({
+      state: 'stale',
+      reasons: [{ code: 'sanger_evidence_missing', state: 'stale', recordId: 'read-1' }],
+      affectedRecordIds: ['read-1'],
+    });
+
+    const changed = createScientificFreshnessRecordIndex([
+      record('reference', 'ACGT'),
+      record('read-1', 'ACG', { sangerEvidenceSha256: sha256HexSync('changed-trace') }),
+    ]);
+    expect(evaluateAnalysisResultFreshness(saved, changed)).toMatchObject({
+      state: 'stale',
+      reasons: [{
+        code: 'sanger_evidence_hash_mismatch',
+        state: 'stale',
+        recordId: 'read-1',
+        expected: evidenceSha256,
+        actual: sha256HexSync('changed-trace'),
+      }],
+      affectedRecordIds: ['read-1'],
+    });
+
+    const exact = createScientificFreshnessRecordIndex([
+      record('reference', 'ACGT'),
+      record('read-1', 'ACG', { sangerEvidenceSha256: evidenceSha256.toUpperCase() }),
+    ]);
+    expect(evaluateAnalysisResultFreshness(saved, exact).state).toBe('fresh');
+  });
+
+  it('keeps stale evidence loss dominant over another read\'s unverified attestation', () => {
+    const saved = constructVerification(['read-1', 'read-2'], {
+      topology: 'linear',
+      readEvidence: {
+        schema: 'motif.construct-read-evidence.v1',
+        sha256s: [sha256HexSync('trace-1'), 'malformed'],
+      },
+    }, 'verification-mixed-evidence');
+    const records = createScientificFreshnessRecordIndex([
+      record('reference', 'ACGT'),
+      record('read-1', 'ACG'),
+      record('read-2', 'CGT', { sangerEvidenceSha256: sha256HexSync('trace-2') }),
+    ]);
+
+    expect(evaluateAnalysisResultFreshness(saved, records)).toMatchObject({
+      state: 'stale',
+      reasons: [
+        { code: 'sanger_evidence_missing', state: 'stale', recordId: 'read-1' },
+        { code: 'sanger_evidence_attestation_invalid', state: 'unverified', recordId: 'read-2' },
+      ],
+      affectedRecordIds: ['read-1', 'read-2'],
+    });
+  });
+
+  it('checks saved ligation end chemistry independently of the sequence hash', () => {
+    const saved = workflow({
+      id: 'ligation-1',
+      kind: 'ligation',
+      inputRecordIds: ['left', 'right'],
+      inputSha256s: [sha256HexSync('AAAA'), sha256HexSync('CCCC')],
+      parameters: {
+        topology: 'linear',
+        orderedInputRecordIds: ['left', 'right'],
+        terminalEnds: {
+          left: { type: 'blunt', sequence: '' },
+          right: { type: 'blunt', sequence: '' },
+        },
+        junctions: [{
+          leftRecordId: 'left',
+          rightRecordId: 'right',
+          closing: false,
+          leftEnd: { type: '5prime', sequence: 'CAGT' },
+          rightEnd: { type: '5prime', sequence: 'ACTG' },
+        }],
+      },
+    });
+    const exactRecords = [
+      record('left', 'AAAA', {
+        overhang5: '',
+        overhang5Type: 'blunt',
+        overhang3: 'CAGT',
+        overhang3Type: '5prime',
+      }),
+      record('right', 'CCCC', {
+        overhang5: 'ACTG',
+        overhang5Type: '5prime',
+        overhang3: '',
+        overhang3Type: 'blunt',
+      }),
+    ];
+
+    expect(evaluateWorkflowResultFreshness(
+      saved,
+      createScientificFreshnessRecordIndex(exactRecords),
+    ).state).toBe('fresh');
+
+    const changedRecords = exactRecords.map((entry) => entry.id === 'right'
+      ? { ...entry, overhang5Type: '3prime' as const }
+      : entry);
+    expect(evaluateWorkflowResultFreshness(
+      saved,
+      createScientificFreshnessRecordIndex(changedRecords),
+    )).toMatchObject({
+      state: 'stale',
+      reasons: [expect.objectContaining({
+        code: 'end_chemistry_mismatch',
+        recordId: 'right',
+        field: 'left_end',
+      })],
+    });
+
+    const removedRecords = exactRecords.map((entry) => entry.id === 'right'
+      ? { ...entry, overhang5: undefined, overhang5Type: undefined }
+      : entry);
+    expect(evaluateWorkflowResultFreshness(
+      saved,
+      createScientificFreshnessRecordIndex(removedRecords),
+    )).toMatchObject({
+      state: 'stale',
+      reasons: [expect.objectContaining({
+        code: 'end_chemistry_missing',
+        state: 'stale',
+        recordId: 'right',
+        field: 'left_end',
+        expected: '5prime:ACTG',
+      })],
+    });
+  });
+});
+
+describe('alignment freshness', () => {
+  it('evaluates every linked row and identifies the row carrying a stale source', () => {
+    const saved = alignment([
+      { id: 'row-a', name: 'Alpha', aligned: 'ACGT', identity: 1, sourceRecordId: 'record-a', inputSha256: sha256HexSync('ACGT') },
+      { id: 'row-b', name: 'Beta', aligned: 'ACGA', identity: 0.75, sourceRecordId: 'record-b', inputSha256: sha256HexSync('ACGA') },
+    ]);
+    const exact = createScientificFreshnessRecordIndex([
+      record('record-a', 'ACGT'),
+      record('record-b', 'ACGA'),
+    ]);
+    const edited = createScientificFreshnessRecordIndex([
+      record('record-a', 'ACGT'),
+      record('record-b', 'ACGG'),
+    ]);
+
+    expect(evaluateAlignmentFreshness(saved, exact).state).toBe('fresh');
+    expect(evaluateAlignmentFreshness(saved, edited)).toMatchObject({
+      state: 'stale',
+      reasons: [{ code: 'sequence_hash_mismatch', recordId: 'record-b', rowId: 'row-b' }],
+      affectedRecordIds: ['record-b'],
+    });
+  });
+
+  it('marks an imported row without a source id unverified and lets stale linked rows dominate', () => {
+    const saved = alignment([
+      { id: 'external', name: 'External', aligned: 'ACGT', identity: 1 },
+      { id: 'linked', name: 'Linked', aligned: 'ACGT', identity: 1, sourceRecordId: 'missing', inputSha256: sha256HexSync('ACGT') },
+    ]);
+
+    const evaluation = evaluateAlignmentFreshness(saved, createScientificFreshnessRecordIndex([]));
+
+    expect(evaluation.state).toBe('stale');
+    expect(evaluation.reasons.map((entry) => [entry.code, entry.rowId])).toEqual([
+      ['alignment_row_source_unattested', 'external'],
+      ['record_missing', 'linked'],
+    ]);
+    expect(evaluation.affectedRecordIds).toEqual(['missing']);
+  });
+});
+
+describe('freshness batches', () => {
+  it('returns Maps keyed by result/alignment id while reusing one record index', () => {
+    const records = createScientificFreshnessRecordIndex([record('record-a', 'ACGT')]);
+    const savedWorkflow = workflow({ id: 'workflow-batch' });
+    const savedAnalysis = analysis({ id: 'analysis-batch' });
+    const savedAlignment = alignment([
+      { id: 'row-a', name: 'Alpha', aligned: 'ACGT', identity: 1, sourceRecordId: 'record-a', inputSha256: sha256HexSync('ACGT') },
+    ], 'alignment-batch');
+
+    const workflows = evaluateWorkflowResultsFreshness([savedWorkflow], records);
+    const analyses = evaluateAnalysisResultsFreshness([savedAnalysis], records);
+    const alignments = evaluateAlignmentsFreshness([savedAlignment], records);
+
+    expect(workflows).toBeInstanceOf(Map);
+    expect(analyses).toBeInstanceOf(Map);
+    expect(alignments).toBeInstanceOf(Map);
+    expect(workflows.get('workflow-batch')?.state).toBe('fresh');
+    expect(analyses.get('analysis-batch')?.state).toBe('fresh');
+    expect(alignments.get('alignment-batch')?.state).toBe('fresh');
+  });
+});

--- a/src/artifacts/__tests__/claude-science-msa-analytics.test.ts
+++ b/src/artifacts/__tests__/claude-science-msa-analytics.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeMsaColumnStats,
+  msaShadeBucket,
+  residueColorKey,
+  sliceSelectionRows,
+  selectionToFasta,
+  selectionToUngappedFasta,
+  selectionToColumnsText,
+  summarizeSelectionColumns,
+  moveRowId,
+  translateAlignedRow,
+  findMsaMotifMatches,
+  normalizeArtifactAlignment,
+  type ArtifactAlignment,
+} from '../claude-science-msa';
+
+function dnaAlignment(): ArtifactAlignment {
+  return normalizeArtifactAlignment({
+    id: 'aln',
+    name: 'Demo',
+    molecule: 'dna',
+    rows: [
+      { id: 'a', name: 'Alpha', aligned: 'ACGT' },
+      { id: 'b', name: 'Beta', aligned: 'ACGA' },
+      { id: 'c', name: 'Gamma', aligned: 'AC-T' },
+    ],
+  });
+}
+
+describe('computeMsaColumnStats', () => {
+  const stats = computeMsaColumnStats(dnaAlignment().rows);
+
+  it('reports fully conserved columns', () => {
+    expect(stats[0]).toMatchObject({ occupancy: 1, consensusResidue: 'A', fullyConserved: true, conservation: 1, entropy: 0 });
+    expect(stats[1].fullyConserved).toBe(true);
+  });
+
+  it('gates identity/conservation by occupancy when a row is gapped', () => {
+    // col 2: G,G,- -> present rows agree but only 2/3 rows are occupied.
+    expect(stats[2].occupancy).toBeCloseTo(2 / 3, 6);
+    expect(stats[2].consensusFraction).toBe(1);
+    expect(stats[2].identity).toBeCloseTo(2 / 3, 6);
+    expect(stats[2].conservation).toBeCloseTo(2 / 3, 6);
+    expect(stats[2].fullyConserved).toBe(false);
+    expect(stats[2].entropy).toBe(0);
+  });
+
+  it('computes Shannon entropy for a variable column', () => {
+    // col 3: T,A,T -> winner T (2/3), entropy = -(2/3 log2 2/3 + 1/3 log2 1/3).
+    expect(stats[3].consensusResidue).toBe('T');
+    expect(stats[3].identity).toBeCloseTo(2 / 3, 6);
+    expect(stats[3].entropy).toBeCloseTo(0.9182958, 5);
+    expect(stats[3].fullyConserved).toBe(false);
+  });
+
+  it('handles all-gap columns without dividing by zero', () => {
+    const gapped = computeMsaColumnStats([{ aligned: 'A-' }, { aligned: 'A-' }]);
+    expect(gapped[1]).toMatchObject({ occupancy: 0, consensusResidue: '-', conservation: 0, entropy: 0, fullyConserved: false });
+  });
+});
+
+describe('msaShadeBucket', () => {
+  it('buckets a 0..1 score into 0..4', () => {
+    expect(msaShadeBucket(1)).toBe(4);
+    expect(msaShadeBucket(0.85)).toBe(3);
+    expect(msaShadeBucket(0.7)).toBe(2);
+    expect(msaShadeBucket(0.5)).toBe(1);
+    expect(msaShadeBucket(0.3)).toBe(0);
+    expect(msaShadeBucket(0)).toBe(0);
+    expect(msaShadeBucket(-1)).toBe(0);
+  });
+});
+
+describe('residueColorKey', () => {
+  it('colours nucleotides for nucleotide and auto-DNA schemes', () => {
+    expect(residueColorKey('A', 'dna', 'nucleotide')).toBe('nt-a');
+    expect(residueColorKey('T', 'dna', 'auto')).toBe('nt-t');
+    expect(residueColorKey('U', 'rna', 'nucleotide')).toBe('nt-t');
+    expect(residueColorKey('N', 'dna', 'nucleotide')).toBe('nt-other');
+  });
+
+  it('returns no colour for gaps and unknowns', () => {
+    expect(residueColorKey('-', 'dna', 'nucleotide')).toBe('');
+    expect(residueColorKey('.', 'protein', 'clustal')).toBe('');
+    expect(residueColorKey('?', 'protein', 'clustal')).toBe('');
+  });
+
+  it('groups amino acids by ClustalX chemistry (and for auto-protein)', () => {
+    expect(residueColorKey('K', 'protein', 'clustal')).toBe('cl-positive');
+    expect(residueColorKey('L', 'protein', 'clustal')).toBe('cl-hydrophobic');
+    expect(residueColorKey('D', 'protein', 'clustal')).toBe('cl-negative');
+    expect(residueColorKey('A', 'protein', 'auto')).toBe('cl-hydrophobic');
+  });
+
+  it('buckets hydrophobicity and passes taylor through', () => {
+    expect(residueColorKey('L', 'protein', 'hydrophobicity')).toBe('hyd-4');
+    expect(residueColorKey('R', 'protein', 'hydrophobicity')).toBe('hyd-0');
+    expect(residueColorKey('W', 'protein', 'taylor')).toBe('taylor');
+  });
+});
+
+describe('selection helpers', () => {
+  const alignment = dnaAlignment();
+
+  it('slices an inclusive column range across all rows', () => {
+    expect(sliceSelectionRows(alignment, { columns: { start: 1, end: 2 } })).toEqual([
+      { id: 'a', name: 'Alpha', aligned: 'CG' },
+      { id: 'b', name: 'Beta', aligned: 'CG' },
+      { id: 'c', name: 'Gamma', aligned: 'C-' },
+    ]);
+  });
+
+  it('restricts to a row subset when rowIds are given', () => {
+    expect(sliceSelectionRows(alignment, { columns: { start: 0, end: 0 }, rowIds: ['c'] })).toEqual([
+      { id: 'c', name: 'Gamma', aligned: 'A' },
+    ]);
+  });
+
+  it('formats gapped and ungapped FASTA plus a plain column block', () => {
+    const selection = { columns: { start: 2, end: 3 } };
+    expect(selectionToFasta(alignment, selection)).toBe('>Alpha\nGT\n>Beta\nGA\n>Gamma\n-T\n');
+    expect(selectionToUngappedFasta(alignment, selection)).toBe('>Alpha\nGT\n>Beta\nGA\n>Gamma\nT\n');
+    expect(selectionToColumnsText(alignment, selection)).toBe('GT\nGA\n-T');
+  });
+
+  it('normalizes reversed/overflowing ranges', () => {
+    expect(sliceSelectionRows(alignment, { columns: { start: 9, end: -3 } }).map((row) => row.aligned)).toEqual(['ACGT', 'ACGA', 'AC-T']);
+  });
+});
+
+describe('summarizeSelectionColumns', () => {
+  it('aggregates conserved, variable, and gap columns over a range', () => {
+    const stats = computeMsaColumnStats(dnaAlignment().rows);
+    const summary = summarizeSelectionColumns(stats, { start: 0, end: 3 });
+    expect(summary.columns).toBe(4);
+    expect(summary.fullyConserved).toBe(2);
+    expect(summary.variableColumns).toBe(1);
+    expect(summary.gapColumns).toBe(0);
+    expect(summary.meanIdentity).toBeCloseTo((1 + 1 + 2 / 3 + 2 / 3) / 4, 6);
+  });
+
+  it('counts an all-gap column as a gap only, not a variable column', () => {
+    const aln = normalizeArtifactAlignment({
+      id: 'g', name: 'g', molecule: 'dna',
+      rows: [{ id: 'a', name: 'a', aligned: 'A-' }, { id: 'b', name: 'b', aligned: 'T-' }],
+    });
+    const summary = summarizeSelectionColumns(computeMsaColumnStats(aln.rows), { start: 1, end: 1 });
+    expect(summary.gapColumns).toBe(1);
+    expect(summary.variableColumns).toBe(0);
+  });
+});
+
+describe('selection row order', () => {
+  it('slices selected rows in the supplied (displayed) order, not alignment order', () => {
+    const aln = dnaAlignment(); // rows a=Alpha, b=Beta, c=Gamma
+    const rows = sliceSelectionRows(aln, { columns: { start: 0, end: 3 }, rowIds: ['c', 'a'] });
+    expect(rows.map((row) => row.id)).toEqual(['c', 'a']);
+    const fasta = selectionToColumnsText(aln, { columns: { start: 0, end: 1 }, rowIds: ['c', 'a'] });
+    expect(fasta.split('\n')).toEqual(['AC', 'AC']); // Gamma then Alpha, both 'AC' at cols 0-1
+  });
+});
+
+describe('moveRowId', () => {
+  const base = ['a', 'b', 'c', 'd'];
+
+  it('moves an item down to an explicit index without mutating the input', () => {
+    const next = moveRowId(base, 'a', 2);
+    expect(next).toEqual(['b', 'c', 'a', 'd']);
+    expect(base).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('moves an item up toward the front', () => {
+    expect(moveRowId(base, 'd', 1)).toEqual(['a', 'd', 'b', 'c']);
+  });
+
+  it('moves an item to the very front and the very end', () => {
+    expect(moveRowId(base, 'c', 0)).toEqual(['c', 'a', 'b', 'd']);
+    expect(moveRowId(base, 'b', 3)).toEqual(['a', 'c', 'd', 'b']);
+  });
+
+  it('clamps out-of-range target indices to the array bounds', () => {
+    expect(moveRowId(base, 'a', 99)).toEqual(['b', 'c', 'd', 'a']);
+    expect(moveRowId(base, 'd', -5)).toEqual(['d', 'a', 'b', 'c']);
+  });
+
+  it('returns an equivalent order when the id is unknown or already in place', () => {
+    expect(moveRowId(base, 'z', 1)).toEqual(base);
+    expect(moveRowId(base, 'z', 1)).not.toBe(base);
+    // targetIndex equal to the current slot leaves the order unchanged.
+    expect(moveRowId(base, 'b', 1)).toEqual(base);
+  });
+});
+
+describe('translateAlignedRow', () => {
+  it('translates an ungapped row into positioned amino-acid cells', () => {
+    const codons = translateAlignedRow('ATGTGGTAA');
+    expect(codons.map((c) => c.aminoAcid)).toEqual(['M', 'W', '*']);
+    expect(codons.map((c) => c.position)).toEqual([1, 2, 3]);
+    expect(codons[0]).toMatchObject({ startColumn: 0, endColumn: 2, codon: 'ATG', gapSpanning: false });
+    expect(codons[2]).toMatchObject({ startColumn: 6, endColumn: 8 });
+  });
+
+  it('reads U as T so RNA rows translate', () => {
+    expect(translateAlignedRow('AUGUGG').map((c) => c.aminoAcid)).toEqual(['M', 'W']);
+  });
+
+  it('honours the reading-frame offset without consuming gaps', () => {
+    // frame 1 skips the leading A, then ATG=M, TGG=W.
+    const codons = translateAlignedRow('AATGTGG', 1);
+    expect(codons.map((c) => c.aminoAcid)).toEqual(['M', 'W']);
+    expect(codons[0].startColumn).toBe(1);
+  });
+
+  it('spans alignment gaps within a codon and flags it', () => {
+    const codons = translateAlignedRow('AT-GTGG');
+    expect(codons[0]).toMatchObject({ aminoAcid: 'M', startColumn: 0, endColumn: 3, gapSpanning: true });
+    expect(codons[1]).toMatchObject({ aminoAcid: 'W', gapSpanning: false });
+  });
+
+  it('drops a trailing 1-2 nucleotide remainder and marks unknown codons X', () => {
+    expect(translateAlignedRow('ATGTG').map((c) => c.aminoAcid)).toEqual(['M']);
+    expect(translateAlignedRow('ATGNNN').map((c) => c.aminoAcid)).toEqual(['M', 'X']);
+  });
+});
+
+describe('findMsaMotifMatches', () => {
+  const dnaRows = [
+    { id: 'a', name: 'Alpha', aligned: 'ACGTACGT' },
+    { id: 'b', name: 'Beta', aligned: 'AC-GTACG' },
+  ];
+
+  it('finds a motif and reports its alignment columns per row', () => {
+    const { matches, truncated } = findMsaMotifMatches(dnaRows, 'CGT', { molecule: 'dna' });
+    expect(truncated).toBe(false);
+    // Row a: CGT at ungapped 1-3 → columns 1,2,3; and again at 5-7.
+    const alpha = matches.filter((m) => m.rowId === 'a');
+    expect(alpha.map((m) => [m.startColumn, m.endColumn])).toEqual([[1, 3], [5, 7]]);
+    // Row b: C(col1) G(col3) T(col4) — the gap at col2 is skipped, not part of the motif.
+    const beta = matches.find((m) => m.rowId === 'b');
+    expect(beta).toMatchObject({ startColumn: 1, endColumn: 4, columns: [1, 3, 4] });
+  });
+
+  it('is case-insensitive and treats U as T', () => {
+    const rows = [{ id: 'r', name: 'RNA', aligned: 'acguACGU' }];
+    expect(findMsaMotifMatches(rows, 'cgt', { molecule: 'rna' }).matches).toHaveLength(2);
+  });
+
+  it('honours IUPAC ambiguity in the query', () => {
+    const rows = [{ id: 'r', name: 'r', aligned: 'AAGAAT' }];
+    // R = A or G, so "AAR" matches AAG (0-2) and AAT? no — AAT third is T not A/G. Only AAG.
+    expect(findMsaMotifMatches(rows, 'AAR', { molecule: 'dna' }).matches.map((m) => m.startColumn)).toEqual([0]);
+    // N matches anything.
+    expect(findMsaMotifMatches(rows, 'NNN', { molecule: 'dna' }).matches.length).toBe(4);
+  });
+
+  it('returns overlapping matches and rejects gap or empty queries', () => {
+    const rows = [{ id: 'r', name: 'r', aligned: 'AAAA' }];
+    expect(findMsaMotifMatches(rows, 'AA', { molecule: 'dna' }).matches).toHaveLength(3);
+    expect(findMsaMotifMatches(rows, 'A-C', { molecule: 'dna' }).matches).toHaveLength(0);
+    expect(findMsaMotifMatches(rows, '   ', { molecule: 'dna' }).matches).toHaveLength(0);
+  });
+
+  it('caps matches and flags truncation', () => {
+    const rows = [{ id: 'r', name: 'r', aligned: 'AAAAAAAAAA' }];
+    const { matches, truncated } = findMsaMotifMatches(rows, 'A', { molecule: 'dna', maxMatches: 4 });
+    expect(matches).toHaveLength(4);
+    expect(truncated).toBe(true);
+    // A zero/negative cap stores nothing (does not leak one match).
+    expect(findMsaMotifMatches(rows, 'A', { molecule: 'dna', maxMatches: 0 }).matches).toHaveLength(0);
+  });
+});

--- a/src/artifacts/__tests__/claude-science-msa-view-preferences.test.ts
+++ b/src/artifacts/__tests__/claude-science-msa-view-preferences.test.ts
@@ -10,46 +10,99 @@ describe('Claude Science MSA view preferences', () => {
     expect(normalizeClaudeScienceMsaViewPreferences('broken')).toEqual(DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES);
   });
 
-  it('preserves valid presentation and track choices', () => {
+  it('preserves valid presentation, colour, and track choices', () => {
     expect(normalizeClaudeScienceMsaViewPreferences({
       displayMode: 'text',
       emphasis: 'letters',
       colorMode: 'residue',
+      colorScheme: 'clustal',
+      shadeMode: 'conservation',
       sortMode: 'mismatches',
       fontSize: 14,
+      zoom: 1.5,
+      translationFrame: 2,
       textFormat: 'json',
       showOverview: false,
       showAlignmentAxis: false,
       showTemplateAxis: true,
       showRowStats: false,
       showConservation: true,
+      showConservationHistogram: false,
+      showOccupancy: true,
       showConsensus: false,
+      showTranslation: true,
+      showAminoAcidIndices: false,
     })).toEqual({
       displayMode: 'text',
       emphasis: 'letters',
       colorMode: 'residue',
+      colorScheme: 'clustal',
+      shadeMode: 'conservation',
       sortMode: 'mismatches',
       fontSize: 14,
+      zoom: 1.5,
+      translationFrame: 2,
       textFormat: 'json',
       showOverview: false,
       showAlignmentAxis: false,
       showTemplateAxis: true,
       showRowStats: false,
       showConservation: true,
+      showConservationHistogram: false,
+      showOccupancy: true,
       showConsensus: false,
+      showTranslation: true,
+      showAminoAcidIndices: false,
     });
   });
 
-  it('clamps font size and defaults invalid values without hiding tracks', () => {
+  it('clamps font size and defaults invalid values without hiding default-on tracks', () => {
     const normalized = normalizeClaudeScienceMsaViewPreferences({
       displayMode: 'unknown',
       fontSize: 400,
       showOverview: 'false',
       showConsensus: 0,
+      showConservationHistogram: 'nope',
     });
     expect(normalized.displayMode).toBe('viewer');
     expect(normalized.fontSize).toBe(16);
     expect(normalized.showOverview).toBe(true);
     expect(normalized.showConsensus).toBe(true);
+    expect(normalized.showConservationHistogram).toBe(true);
+  });
+
+  it('defaults and clamps the column zoom preference', () => {
+    expect(normalizeClaudeScienceMsaViewPreferences({}).zoom).toBe(1);
+    expect(normalizeClaudeScienceMsaViewPreferences({ zoom: 'big' }).zoom).toBe(1);
+    expect(normalizeClaudeScienceMsaViewPreferences({ zoom: 9 }).zoom).toBe(2);
+    expect(normalizeClaudeScienceMsaViewPreferences({ zoom: 0 }).zoom).toBe(0.2);
+    expect(normalizeClaudeScienceMsaViewPreferences({ zoom: 0.5 }).zoom).toBe(0.5);
+  });
+
+  it('keeps the translation track opt-in, indices default-on, and frame strict', () => {
+    const defaults = normalizeClaudeScienceMsaViewPreferences({});
+    expect(defaults.showTranslation).toBe(false);
+    expect(defaults.showAminoAcidIndices).toBe(true);
+    expect(defaults.translationFrame).toBe(0);
+    expect(normalizeClaudeScienceMsaViewPreferences({ showTranslation: 'yes' }).showTranslation).toBe(false);
+    expect(normalizeClaudeScienceMsaViewPreferences({ showTranslation: true }).showTranslation).toBe(true);
+    expect(normalizeClaudeScienceMsaViewPreferences({ showAminoAcidIndices: false }).showAminoAcidIndices).toBe(false);
+    expect(normalizeClaudeScienceMsaViewPreferences({ translationFrame: 2 }).translationFrame).toBe(2);
+    expect(normalizeClaudeScienceMsaViewPreferences({ translationFrame: 5 }).translationFrame).toBe(0);
+  });
+
+  it('falls back to safe colour/shade defaults and keeps occupancy opt-in', () => {
+    const normalized = normalizeClaudeScienceMsaViewPreferences({
+      colorScheme: 'rainbow',
+      shadeMode: 'sparkles',
+      showOccupancy: 'yes',
+    });
+    expect(normalized.colorScheme).toBe('auto');
+    expect(normalized.shadeMode).toBe('none');
+    // showOccupancy only turns on for a literal true, so a truthy string stays off.
+    expect(normalized.showOccupancy).toBe(false);
+    expect(normalizeClaudeScienceMsaViewPreferences({ showOccupancy: true }).showOccupancy).toBe(true);
+    expect(normalizeClaudeScienceMsaViewPreferences({ colorScheme: 'hydrophobicity' }).colorScheme).toBe('hydrophobicity');
+    expect(normalizeClaudeScienceMsaViewPreferences({ shadeMode: 'mismatch' }).shadeMode).toBe('mismatch');
   });
 });

--- a/src/artifacts/__tests__/claude-science-pcr-materialization.test.ts
+++ b/src/artifacts/__tests__/claude-science-pcr-materialization.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it } from 'vitest';
+import type { PrimerCandidate, PrimerPair } from '../../bio/primer-design';
+import { simulatePCR } from '../../bio/pcr';
+import { reverseComplement } from '../../bio/reverse-complement';
+import type { Feature } from '../../bio/types';
+import {
+  normalizeArtifactAnalysisWorkspace,
+  type ArtifactAnalysisResult,
+} from '../claude-science-analysis-results';
+import {
+  findPcrMaterializationDuplicate,
+  materializePcrAmplicon,
+  PcrMaterializationError,
+  type PcrMaterializationSelection,
+  type PcrMaterializationSourceRecord,
+} from '../claude-science-pcr-materialization';
+import { sha256HexSync } from '../claude-science-sha256';
+
+function candidate(
+  direction: 'forward' | 'reverse',
+  sequence: string,
+  start: number,
+  end: number,
+  tail = '',
+): PrimerCandidate {
+  return {
+    direction,
+    sequence,
+    fullSequence: tail + sequence,
+    tail,
+    start,
+    end,
+    length: sequence.length,
+    fullLength: sequence.length + tail.length,
+    tm: 60,
+    gcPercent: 50,
+    anchorDistance: 0,
+  };
+}
+
+function pairFor(
+  template: string,
+  forwardStart: number,
+  forwardEnd: number,
+  reverseStart: number,
+  reverseEnd: number,
+  forwardTail = '',
+  reverseTail = '',
+): PrimerPair {
+  return {
+    forward: candidate(
+      'forward',
+      template.slice(forwardStart, forwardEnd),
+      forwardStart,
+      forwardEnd,
+      forwardTail,
+    ),
+    reverse: candidate(
+      'reverse',
+      reverseComplement(template.slice(reverseStart, reverseEnd)),
+      reverseStart,
+      reverseEnd,
+      reverseTail,
+    ),
+    productLength: reverseEnd - forwardStart,
+    tmDifference: 0,
+  };
+}
+
+function selection(pair: PrimerPair): PcrMaterializationSelection {
+  return {
+    pair,
+    pairNumber: 1,
+    target: { start: pair.forward.start, end: pair.reverse.end },
+  };
+}
+
+function source(
+  sequence: string,
+  topology: 'linear' | 'circular' = 'linear',
+  features: readonly Feature[] = [],
+): PcrMaterializationSourceRecord {
+  return {
+    id: 'template-1',
+    name: 'Template DNA',
+    sequence,
+    type: 'dna',
+    topology,
+    active: true,
+    features,
+    group: 'Cloning',
+    tags: ['source'],
+  };
+}
+
+describe('PCR engine selected-pair semantics', () => {
+  it('uses the selected repeat occurrence and incorporates both 5′ tails with correct reverse-primer semantics', () => {
+    const template = 'AACCGGTTAA' + 'GGGGGGGGGG' + 'AACCGGTTAA' + 'CCCCCCCCCC' + 'TTGCAACGTA' + 'AAAAAAAAAA';
+    const pair = pairFor(template, 20, 30, 40, 50, 'GGATCC', 'CATATG');
+    const result = simulatePCR(
+      template,
+      pair.forward.fullSequence,
+      pair.reverse.fullSequence,
+      [],
+      'linear',
+      {
+        forward: { start: pair.forward.start, end: pair.forward.end },
+        reverse: { start: pair.reverse.start, end: pair.reverse.end },
+      },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.forward.bindStart).toBe(20);
+    expect(result?.product).toBe(`GGATCC${template.slice(20, 50)}${reverseComplement('CATATG')}`);
+    expect(result?.product.startsWith(pair.forward.fullSequence)).toBe(true);
+    expect(result?.product.endsWith(reverseComplement(pair.reverse.fullSequence))).toBe(true);
+  });
+
+  it('propagates in-range feature subranges and source identity into product coordinates', () => {
+    const template = 'AAAACCCCGGGGTTTTAAAACCCCGGGGTTTT';
+    const pair = pairFor(template, 4, 14, 20, 30, 'GGATCC', 'AAGCTT');
+    const feature: Feature = {
+      id: 'source-feature',
+      name: 'coding segment',
+      type: 'cds',
+      start: 10,
+      end: 16,
+      strand: 1,
+      subRanges: [{ start: 11, end: 14, strand: 1 }],
+      color: '#000000',
+      metadata: { note: 'retain' },
+    };
+    const result = simulatePCR(
+      template,
+      pair.forward.fullSequence,
+      pair.reverse.fullSequence,
+      [feature],
+      'linear',
+      {
+        forward: { start: 4, end: 14 },
+        reverse: { start: 20, end: 30 },
+      },
+    );
+
+    expect(result?.features).toHaveLength(1);
+    expect(result?.features[0]).toMatchObject({
+      start: 12,
+      end: 18,
+      subRanges: [{ start: 13, end: 16, strand: 1 }],
+      metadata: {
+        note: 'retain',
+        pcrSourceFeatureId: 'source-feature',
+        pcrSourceStart: 10,
+        pcrSourceEnd: 16,
+      },
+    });
+  });
+
+  it('creates the exact origin-crossing product for a selected circular pair', () => {
+    const template = 'AAAACCCCGGGGTTTTAAAACCCCGGGGTTTTAAAACCCC';
+    const pair = pairFor(template, 30, 40, 2, 12);
+    const result = simulatePCR(
+      template,
+      pair.forward.fullSequence,
+      pair.reverse.fullSequence,
+      [],
+      'circular',
+      {
+        forward: { start: 30, end: 40 },
+        reverse: { start: 2, end: 12 },
+      },
+    );
+
+    expect(result?.wrapsOrigin).toBe(true);
+    expect(result?.product).toBe(template.slice(30) + template.slice(0, 12));
+  });
+});
+
+describe('PCR amplicon materialization', () => {
+  it('rejects noncanonical or internally inconsistent selected primer sequences', () => {
+    const template = 'AAAACCCCGGGGTTTTAAAACCCCGGGGTTTT';
+    const baseSelection = selection(pairFor(template, 4, 14, 20, 30));
+    const materialize = (selected: PcrMaterializationSelection) => materializePcrAmplicon({
+      sourceRecord: source(template),
+      selection: selected,
+      identity: {
+        recordId: 'guarded-amplicon',
+        resultId: 'guarded-result',
+        productId: 'guarded-product',
+        createdAt: '2026-07-17T12:00:00.000Z',
+      },
+      primerDesignResultId: 'primer-result',
+    });
+
+    const noncanonical = structuredClone(baseSelection);
+    noncanonical.pair.forward.tail = 'NNNN';
+    noncanonical.pair.forward.fullSequence = `NNNN${noncanonical.pair.forward.sequence}`;
+    noncanonical.pair.forward.fullLength = noncanonical.pair.forward.fullSequence.length;
+    expect(() => materialize(noncanonical)).toThrowError(new PcrMaterializationError(
+      'Forward primer materialization requires unambiguous A/C/G/T binding and full sequences.',
+    ));
+
+    const inconsistent = structuredClone(baseSelection);
+    inconsistent.pair.reverse.fullSequence = `A${inconsistent.pair.reverse.fullSequence}`;
+    inconsistent.pair.reverse.fullLength = inconsistent.pair.reverse.fullSequence.length;
+    expect(() => materialize(inconsistent)).toThrowError(new PcrMaterializationError(
+      'Reverse primer fullSequence must equal its 5′ tail followed by its binding sequence.',
+    ));
+  });
+
+  it('creates one exact linear record with primer annotations, hashes, and a linked PCR result', () => {
+    const template = 'AAAACCCCGGGGTTTTAAAACCCCGGGGTTTT';
+    const feature: Feature = {
+      id: 'gene-1',
+      name: 'payload',
+      type: 'gene',
+      start: 10,
+      end: 16,
+      strand: 1,
+      color: '#000000',
+      metadata: {},
+    };
+    const selected = selection(pairFor(template, 4, 14, 20, 30, 'GGATCC', 'CATATG'));
+    const templateRecord = source(template, 'linear', [feature]);
+    const sourceSnapshot = structuredClone(templateRecord);
+    const result = materializePcrAmplicon({
+      sourceRecord: templateRecord,
+      selection: selected,
+      identity: {
+        recordId: 'amplicon-record',
+        resultId: 'pcr-result',
+        productId: 'pcr-product',
+        createdAt: '2026-07-17T12:00:00.000Z',
+      },
+      primerDesignResultId: 'primer-result',
+      preparation: {
+        requestSha256: 'a'.repeat(64),
+        actionId: 'prep-action',
+        actionKind: 'add_homology',
+        method: 'gibson',
+        orientation: 'forward',
+      },
+    });
+
+    expect(result.record).toMatchObject({
+      id: 'amplicon-record',
+      molecule: 'dna',
+      topology: 'linear',
+      length: result.record.seq.length,
+      active: true,
+      group: 'Cloning',
+      tags: ['source', 'PCR amplicon'],
+      provenance: {
+        operation: 'pcr_materialization',
+        parentRecordId: 'template-1',
+        primerDesignResultId: 'primer-result',
+        productSha256: sha256HexSync(result.record.seq),
+        cloningPreparation: {
+          requestSha256: 'a'.repeat(64),
+          actionId: 'prep-action',
+        },
+      },
+    });
+    expect(templateRecord).toEqual(sourceSnapshot);
+    expect(result.record.seq.startsWith(selected.pair.forward.fullSequence)).toBe(true);
+    expect(result.record.seq.endsWith(reverseComplement(selected.pair.reverse.fullSequence))).toBe(true);
+    expect(result.record.annotations.filter((item) => item.type === 'primer_bind')).toEqual([
+      expect.objectContaining({ start: 0, strand: 1 }),
+      expect.objectContaining({ end: result.record.seq.length, strand: -1 }),
+    ]);
+    expect(result.record.annotations.find((item) => item.name === 'payload')?.metadata).toMatchObject({
+      pcrSourceFeatureId: 'gene-1',
+    });
+    expect(result.analysisResult).toMatchObject({
+      id: 'pcr-result',
+      kind: 'pcr',
+      inputRecordIds: ['template-1'],
+      dependsOnResultIds: ['primer-result'],
+      parameters: { topology: 'linear' },
+      data: {
+        templateRecordId: 'template-1',
+        primerDesignResultId: 'primer-result',
+        products: [{
+          id: 'pcr-product',
+          recordId: 'amplicon-record',
+          lengthBp: result.record.seq.length,
+          templateRange: { start: 4, end: 30 },
+        }],
+      },
+    });
+    expect(result.materializationKey).toMatch(/^[0-9a-f]{64}$/);
+    const primerResult: ArtifactAnalysisResult = {
+      id: 'primer-result',
+      kind: 'primer_design',
+      name: 'Primer design',
+      status: 'complete',
+      inputRecordIds: ['template-1'],
+      inputSha256s: [sha256HexSync(template)],
+      dependsOnResultIds: [],
+      assetIds: [],
+      parameters: {},
+      data: {
+        targetRecordId: 'template-1',
+        pairs: [{
+          id: 'pair-1',
+          forward: { sequence: selected.pair.forward.fullSequence, tmC: 60, gcPercent: 50 },
+          reverse: { sequence: selected.pair.reverse.fullSequence, tmC: 60, gcPercent: 50 },
+          productLengthBp: selected.pair.productLength,
+        }],
+        selectedPairId: 'pair-1',
+      },
+      createdAt: '2026-07-17T12:00:00.000Z',
+      provenance: { source: 'motif-for-claude-science-artifact' },
+    };
+    const normalizedWorkspace = normalizeArtifactAnalysisWorkspace({
+      analysisResults: [primerResult, result.analysisResult],
+      analysisAssets: [],
+    }, {
+      recordLengths: new Map([
+        ['template-1', template.length],
+        ['amplicon-record', result.record.length],
+      ]),
+    });
+    expect(normalizedWorkspace.analysisResults[1]).toMatchObject({
+      dependsOnResultIds: ['primer-result'],
+      data: { products: [{ recordId: 'amplicon-record' }] },
+    });
+    expect(findPcrMaterializationDuplicate([
+      {
+        id: result.record.id,
+        name: result.record.name,
+        sequence: result.record.seq,
+        provenance: result.record.provenance,
+      },
+    ], result.materializationKey)?.id).toBe('amplicon-record');
+    expect(findPcrMaterializationDuplicate([{
+      id: result.record.id,
+      name: result.record.name,
+      sequence: `${result.record.seq}A`,
+      provenance: result.record.provenance,
+    }], result.materializationKey)).toBeNull();
+    expect(findPcrMaterializationDuplicate([], result.materializationKey)).toBeNull();
+  });
+
+  it('omits an invalid linear template range for an origin-crossing product', () => {
+    const template = 'AAAACCCCGGGGTTTTAAAACCCCGGGGTTTTAAAACCCC';
+    const result = materializePcrAmplicon({
+      sourceRecord: source(template, 'circular'),
+      selection: selection(pairFor(template, 30, 40, 2, 12)),
+      identity: {
+        recordId: 'wrapped-record',
+        resultId: 'wrapped-result',
+        productId: 'wrapped-product',
+        createdAt: '2026-07-17T12:00:00.000Z',
+      },
+      primerDesignResultId: 'primer-result',
+    });
+
+    expect(result.simulation.wrapsOrigin).toBe(true);
+    expect(result.analysisResult.parameters.topology).toBe('circular');
+    expect(result.analysisResult.data.products[0]).not.toHaveProperty('templateRange');
+  });
+});

--- a/src/artifacts/__tests__/claude-science-preload-integrity.jsdom.test.ts
+++ b/src/artifacts/__tests__/claude-science-preload-integrity.jsdom.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  loadInitialArtifactWorkspace,
+  prepareInitialArtifactWorkspace,
+  readInitialArtifactSourceFromDom,
+} from '../motif-artifact';
+
+function embed(value: string): void {
+  document.body.innerHTML = `<script type="application/json" id="motif-artifact-data">${value}</script>`;
+}
+
+const validWorkspace = {
+  schema: 'motif.claude-science.inventory.v2',
+  inventory: { id: 'preload-integrity', title: 'Preload integrity' },
+  records: [{ id: 'record-a', name: '__SEQUENCE_INVENTORY__ is data', type: 'dna', sequence: 'ATGGAATTCTAA' }],
+  selectedRecordId: 'record-a',
+  artifactState: {
+    customEnzymes: [{
+      name: 'PreloadI', recognitionSequence: 'GAATTC', cutOffset: 1, complementCutOffset: 5, overhang: '5prime',
+    }],
+    translationLayersByRecord: {
+      'record-a': [{ id: 'layer-a', label: 'Layer A', start: 0, end: 6, strand: 1, frame: 0 }],
+    },
+    enzymeSourcesByRecord: { 'record-a': ['common'] },
+    hiddenEnzymesByRecord: { 'record-a': ['EcoRI'] },
+    hiddenFeatureTranslationsByRecord: { 'record-a': ['feat:a'] },
+    restrictionLabelsByRecord: { 'record-a': true },
+    motifsByRecord: { 'record-a': 'GAATTC' },
+  },
+} satisfies NonNullable<typeof window.MOTIF_ARTIFACT_DATA>;
+
+describe('Claude Science initial workspace integrity', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    delete window.MOTIF_ARTIFACT_DATA;
+  });
+
+  it('uses samples only for an absent payload or an exact build placeholder', () => {
+    embed('__SEQUENCE_INVENTORY__');
+    expect(readInitialArtifactSourceFromDom()).toEqual({ kind: 'sample' });
+    const sample = loadInitialArtifactWorkspace();
+    expect(sample.payload.inventory.id).toBe('motif-built-in-vectors');
+    expect(sample.artifactState.customEnzymes).toEqual([]);
+
+    window.MOTIF_ARTIFACT_DATA = validWorkspace;
+    expect(readInitialArtifactSourceFromDom()).toMatchObject({
+      kind: 'payload',
+      origin: 'window',
+      value: validWorkspace,
+    });
+    delete window.MOTIF_ARTIFACT_DATA;
+
+    embed(JSON.stringify(validWorkspace));
+    expect(readInitialArtifactSourceFromDom()).toMatchObject({ kind: 'payload', origin: 'script' });
+  });
+
+  it('hydrates payload and durable state as one validated initial workspace', () => {
+    const prepared = prepareInitialArtifactWorkspace(validWorkspace);
+    expect(prepared.payload.inventory.id).toBe('preload-integrity');
+    expect(prepared.payload.records.map((record) => record.id)).toEqual(['record-a']);
+    expect(prepared.artifactState.customEnzymes[0]?.name).toBe('PreloadI');
+    expect(prepared.artifactState.translationLayersByRecord['record-a'][0]).toMatchObject({
+      id: 'layer-a', start: 0, end: 6, source: 'layer',
+    });
+
+    embed(JSON.stringify(validWorkspace));
+    expect(loadInitialArtifactWorkspace()).toEqual(prepared);
+  });
+
+  it('opens an alignment-only workspace with an empty inventory instead of sample records', () => {
+    const prepared = prepareInitialArtifactWorkspace({
+      alignments: [{
+        id: 'alignment-only',
+        molecule: 'dna',
+        rows: [
+          { id: 'a', name: 'A', aligned: 'ATGC' },
+          { id: 'b', name: 'B', aligned: 'AT-C' },
+        ],
+      }],
+    });
+    expect(prepared.payload.inventory.id).toBe('motif-sequence-inventory');
+    expect(prepared.payload.records).toEqual([]);
+    expect(prepared.payload.alignments).toHaveLength(1);
+  });
+
+  it('rejects malformed explicit preload data without substituting built-in records', () => {
+    embed('{"records": [}');
+    expect(() => loadInitialArtifactWorkspace()).toThrowError(expect.objectContaining({
+      code: 'MOTIF_INVALID_PRELOAD',
+      details: expect.objectContaining({ operation: 'initialHydration', origin: 'script', mutated: false }),
+    }));
+
+    const invalidState = {
+      records: [{ id: 'record-a', type: 'dna', sequence: 'ATGGAATTCTAA' }],
+      artifactState: { customEnzymes: { malformed: true } },
+    };
+    embed(JSON.stringify(invalidState));
+    expect(() => loadInitialArtifactWorkspace()).toThrowError(expect.objectContaining({
+      code: 'MOTIF_INVALID_PRELOAD',
+      message: expect.stringContaining('No bundled sample data was substituted'),
+      details: expect.objectContaining({ operation: 'initialHydration', origin: 'script', mutated: false }),
+    }));
+
+    embed('');
+    expect(() => loadInitialArtifactWorkspace()).toThrowError(expect.objectContaining({
+      code: 'MOTIF_INVALID_PRELOAD',
+      message: expect.stringContaining('embedded payload is blank'),
+    }));
+  });
+
+  it('keeps an explicit null or empty object distinct from no payload', () => {
+    for (const value of ['null', '{}']) {
+      embed(value);
+      expect(readInitialArtifactSourceFromDom()).toMatchObject({ kind: 'payload', origin: 'script' });
+      expect(() => loadInitialArtifactWorkspace()).toThrowError(expect.objectContaining({
+        code: 'MOTIF_INVALID_PRELOAD',
+      }));
+    }
+  });
+
+  it('does not let a bare sequence overwrite malformed or ambiguous record containers', () => {
+    for (const value of [
+      { sequence: 'ATGC', records: { malformed: true } },
+      { sequence: 'ATGC', record: null },
+      { records: [{ id: 'a', sequence: 'ATGC' }], entries: [{ id: 'b', sequence: 'ATGC' }] },
+      { records: 'broken', alignments: [] },
+      {
+        records: [{ id: 'a', sequence: 'ATGC' }],
+        alignments: [{
+          id: 'orphaned', molecule: 'dna', rows: [
+            { id: 'a', name: 'A', aligned: 'ATGC', sourceRecordId: 'missing' },
+            { id: 'b', name: 'B', aligned: 'AT-C' },
+          ],
+        }],
+      },
+    ]) {
+      expect(() => prepareInitialArtifactWorkspace(value)).toThrowError(expect.objectContaining({
+        code: 'MOTIF_INVALID_PRELOAD',
+        details: expect.objectContaining({ operation: 'initialHydration', mutated: false }),
+      }));
+    }
+
+    expect(prepareInitialArtifactWorkspace({ name: 'Workspace label', notes: [] }).payload.records).toEqual([]);
+  });
+});

--- a/src/artifacts/__tests__/claude-science-primer-workspace-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-primer-workspace-guards.test.ts
@@ -4,11 +4,13 @@ import { describe, expect, it } from 'vitest';
 const component = readFileSync(new URL('../ClaudeSciencePrimerWorkspace.tsx', import.meta.url), 'utf8');
 const css = readFileSync(new URL('../claude-science-primer-workspace.css', import.meta.url), 'utf8');
 const host = readFileSync(new URL('../motif-artifact.tsx', import.meta.url), 'utf8');
+const materialization = readFileSync(new URL('../claude-science-pcr-materialization.ts', import.meta.url), 'utf8');
 
 describe('Claude Science primer workspace source guards', () => {
   it('keeps all mutations behind explicit host callbacks', () => {
     expect(component).toContain('onAddAnnotations?:');
     expect(component).toContain('onSimulatePcr?:');
+    expect(component).toContain('onCreateAmplicon?:');
     expect(component).toContain('onUseForCloning?:');
     expect(component).not.toContain('useSequenceStore');
     expect(component).not.toContain('innerHTML');
@@ -25,8 +27,10 @@ describe('Claude Science primer workspace source guards', () => {
     expect(component).toContain('initialForwardTail?: string;');
     expect(component).toContain('initialReverseTail?: string;');
     expect(component).toContain('aria-label="Cloning preparation context"');
-    expect(component).toContain("preparationContext ? 'Save primer plan' : 'Use in cloning'");
-    expect(component).toContain('It does not create an amplicon or modify the source record');
+    expect(component).toContain('Save primer plan only');
+    expect(component).toContain('Create & use amplicon');
+    expect(component).toContain('Simulate PCR saves a result only');
+    expect(component).toContain('keeps the source record unchanged');
     expect(component).toContain('No homology tail was inferred');
     expect(component).toContain("if (preferFullRecord) return { start: 1, end: sequenceLength };");
   });
@@ -39,6 +43,11 @@ describe('Claude Science primer workspace source guards', () => {
     expect(host).toContain('orientation: handoff.preparationContext.orientation');
     expect(host).toContain("if (!junction?.overlapSequence) return { forward: undefined, reverse: undefined };");
     expect(host).toContain('No prepared amplicon was created.');
+    expect(host).toContain('materializePcrAmplicon({');
+    expect(host).toContain('replacePreparedPart({');
+    expect(host).toContain('PCR simulation saved in Results only. No sequence record was created.');
+    expect(host).toContain('topology: template.topology');
+    expect(materialization).toContain('topology: sourceRecord.topology');
     expect(host).toContain('navigateCloningPrimerRecord(wrappedIndex);');
     expect(host).toContain("setShowPrimerDesign(false);\n    showWorkbenchNotice('Primer-plan worklist saved. Returned to the existing cloning draft. No amplicon was created.');");
   });

--- a/src/artifacts/__tests__/claude-science-record-lifecycle-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-record-lifecycle-guards.test.ts
@@ -15,11 +15,16 @@ function sliceBetween(source: string, startNeedle: string, endNeedle: string): s
 }
 
 describe('Claude Science record lifecycle guards', () => {
-  it('clears same-id transient state when replacing the whole inventory', () => {
-    const resetState = sliceBetween(
+  it('clears view state while preserving durable state during records-only replacement', () => {
+    const resetViewState = sliceBetween(
+      artifactSource,
+      'const resetWorkspaceViewState = useCallback',
+      'const resetRecordTransientState = useCallback',
+    );
+    const resetAllRecordState = sliceBetween(
       artifactSource,
       'const resetRecordTransientState = useCallback',
-      'useEffect(() => {\n    payloadRef.current = payload;',
+      'const resetWorkflowWindowState = useCallback',
     );
     const renderInventory = sliceBetween(
       artifactSource,
@@ -27,13 +32,16 @@ describe('Claude Science record lifecycle guards', () => {
       '// Append helper',
     );
 
-    expect(resetState).toContain('setMapRangesByRecord({});');
-    expect(resetState).toContain('setMapViewportsByRecord({});');
-    expect(resetState).toContain('setTranslationLayersByRecord({});');
-    expect(resetState).toContain('setHiddenFeatureTranslationsByRecord({});');
-    expect(resetState).toContain('sequenceScrollByRecordRef.current = {};');
-    expect(resetState).toContain('editHistoryRef.current = {};');
-    expect(renderInventory).toContain('resetRecordTransientState();');
+    expect(resetViewState).toContain('setMapRangesByRecord({});');
+    expect(resetViewState).toContain('setMapViewportsByRecord({});');
+    expect(resetViewState).toContain('sequenceScrollByRecordRef.current = {};');
+    expect(resetViewState).toContain('editHistoryRef.current = {};');
+    expect(resetViewState).not.toContain('setTranslationLayersByRecord({});');
+    expect(resetViewState).not.toContain('setHiddenFeatureTranslationsByRecord({});');
+    expect(resetAllRecordState).toContain('setTranslationLayersByRecord({});');
+    expect(resetAllRecordState).toContain('setHiddenFeatureTranslationsByRecord({});');
+    expect(renderInventory).toContain('resetWorkspaceViewState();');
+    expect(renderInventory).not.toContain('resetRecordTransientState();');
   });
 
   it('stores topology on the record so the UI, API, and exports agree', () => {

--- a/src/artifacts/__tests__/claude-science-runtime-integrity.test.ts
+++ b/src/artifacts/__tests__/claude-science-runtime-integrity.test.ts
@@ -24,6 +24,7 @@ import {
   parseImportedRecords,
   prepareArtifactDatabaseRestore,
   prepareInventoryReplacement,
+  prepareRecordsOnlyWorkspaceReplacement,
   validateRuntimeRecordInputs,
 } from '../motif-artifact';
 
@@ -59,6 +60,9 @@ describe('Claude Science runtime data-integrity behavior', () => {
       { features: [{ start: 0, end: 3, subRanges: { start: 0, end: 2 } }] },
       { sites: { enzyme: 'EcoRI' } },
       { sites: [{ enzyme: 'EcoRI', hits: [null] }] },
+      { type: 'plasmid' },
+      { molecule: 'plasmid' },
+      { topology: 'ring' },
     ];
 
     malformed.forEach((patch) => {
@@ -176,6 +180,316 @@ describe('Claude Science runtime data-integrity behavior', () => {
       records: [{ id: 'last-good', type: 'dna', sequence: 'GAATTC' }],
       artifactState: { customEnzymes: { malformed: true } },
     })).toThrow(/customEnzymes must be an array/i);
+    expect(() => prepareArtifactDatabaseRestore({
+      records: [{ id: 'last-good', type: 'dna', sequence: 'GAATTC' }],
+      artifactState: { motifsByRecord: { missing: 'GAATTC' } },
+    })).toThrow(/motifsByRecord references unknown record id: missing/i);
+    expect(() => prepareArtifactDatabaseRestore({
+      records: 'broken',
+      alignments: [],
+    })).toThrow(/malformed payload envelope/i);
+    try {
+      prepareArtifactDatabaseRestore({
+        schema: 'motif.claude-science.inventory.v99',
+        records: [{ id: 'future', type: 'dna', sequence: 'ATGC' }],
+      });
+      throw new Error('Expected unsupported schema to be rejected.');
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'MOTIF_INVALID_INVENTORY_REPLACEMENT',
+        details: expect.objectContaining({
+          issues: expect.arrayContaining([expect.objectContaining({
+            path: 'payload.schema',
+            message: expect.stringMatching(/unsupported motif inventory schema/i),
+          })]),
+        }),
+      });
+    }
+    expect(() => prepareArtifactDatabaseRestore({
+      records: [{ id: 'record-a', type: 'dna', sequence: 'ATGC' }],
+      alignments: [{
+        id: 'orphaned-alignment',
+        molecule: 'dna',
+        rows: [
+          { id: 'a', name: 'A', aligned: 'ATGC', sourceRecordId: 'missing' },
+          { id: 'b', name: 'B', aligned: 'AT-C' },
+        ],
+      }],
+    })).toThrow(/alignment rows reference unknown record id: missing/i);
+    expect(() => prepareArtifactDatabaseRestore({
+      records: [{ id: 'record-a', type: 'dna', sequence: 'ATGC' }],
+      alignment: {
+        id: 'orphaned-alias',
+        molecule: 'dna',
+        sequences: [
+          { id: 'a', name: 'A', sequence: 'ATGC', sourceRecordId: 'missing' },
+          { id: 'b', name: 'B', sequence: 'AT-C' },
+        ],
+      },
+    })).toThrow(/alignment rows reference unknown record id: missing/i);
+    expect(() => prepareArtifactDatabaseRestore({
+      records: [{ id: 'record-a', type: 'dna', sequence: 'ATGC' }],
+      alignments: {
+        id: 'plural-object',
+        molecule: 'dna',
+        rows: [
+          { id: 'a', name: 'A', aligned: 'ATGC' },
+          { id: 'b', name: 'B', aligned: 'AT-C' },
+        ],
+      },
+    })).toThrow(/alignments must be an array/i);
+    expect(prepareArtifactDatabaseRestore({ name: 'Workspace label', notes: [] }).payload.records).toEqual([]);
+  });
+
+  it('preserves compatible workspace state and rejects orphaning records-only replacements atomically', () => {
+    const current = prepareArtifactDatabaseRestore({
+      inventory: { id: 'preserved-inventory', title: 'Preserved inventory', description: 'Keep metadata' },
+      defaultMotif: 'GGCC',
+      records: [{
+        id: 'record-a',
+        name: 'Original A',
+        type: 'dna',
+        sequence: 'ATGGAATTCTAA',
+        features: [{ id: 'a', name: 'Feature A', type: 'cds', start: 0, end: 6 }],
+      }],
+      selectedRecordId: 'record-a',
+      alignments: [{
+        id: 'alignment-a',
+        name: 'Linked alignment',
+        molecule: 'dna',
+        referenceRowId: 'row-a',
+        rows: [
+          { id: 'row-a', name: 'Record A', aligned: 'ATGGAATTCTAA', sourceRecordId: 'record-a' },
+          { id: 'row-b', name: 'Variant', aligned: 'ATGGAA-TCTAA' },
+        ],
+        engine: { id: 'mafft', label: 'MAFFT', version: '7.526', mode: 'local-command' },
+      }],
+      notes: [
+        {
+          id: 'record-note',
+          body: 'Linked note',
+          format: 'plain',
+          scope: 'record',
+          recordId: 'record-a',
+          createdAt: '2026-07-12T12:00:00.000Z',
+          updatedAt: '2026-07-12T12:00:00.000Z',
+        },
+        {
+          id: 'workspace-note',
+          body: 'Workspace note',
+          format: 'plain',
+          scope: 'workspace',
+          createdAt: '2026-07-12T12:00:00.000Z',
+          updatedAt: '2026-07-12T12:00:00.000Z',
+        },
+      ],
+      workflowResults: [{
+        id: 'digest-a',
+        kind: 'digest',
+        name: 'Digest A',
+        inputRecordIds: ['record-a'],
+        outputRecordIds: ['record-a'],
+        parameters: { enzymes: ['EcoRI'] },
+        createdAt: '2026-07-12T12:05:00.000Z',
+        provenance: { source: 'motif-artifact', operation: 'digest' },
+      }],
+      analysisAssets: [{
+        id: 'asset-a',
+        name: 'report.txt',
+        mediaType: 'text/plain',
+        content: 'Inert report evidence.',
+        createdAt: '2026-07-12T12:06:00.000Z',
+        provenance: { source: 'claude-science', operation: 'report' },
+      }],
+      analysisResults: [{
+        id: 'report-a',
+        kind: 'report',
+        name: 'Linked report',
+        status: 'complete',
+        summary: 'A linked report.',
+        inputRecordIds: ['record-a'],
+        dependsOnResultIds: [],
+        assetIds: ['asset-a'],
+        parameters: {},
+        data: { format: 'plain', body: 'Review A.' },
+        createdAt: '2026-07-12T12:06:00.000Z',
+        provenance: { source: 'claude-science', operation: 'report' },
+      }],
+      artifactState: {
+        customEnzymes: [{
+          name: 'KeepI', recognitionSequence: 'GAATTC', cutOffset: 1, complementCutOffset: 5, overhang: '5prime',
+        }],
+        translationLayersByRecord: {
+          'record-a': [{ id: 'layer-a', label: 'Layer A', start: 0, end: 6, strand: 1, frame: 0 }],
+        },
+        enzymeSourcesByRecord: { 'record-a': ['common'] },
+        hiddenEnzymesByRecord: { 'record-a': ['EcoRI'] },
+        hiddenFeatureTranslationsByRecord: { 'record-a': ['feat:a'] },
+        restrictionLabelsByRecord: { 'record-a': true },
+        motifsByRecord: { 'record-a': 'GAATTC' },
+      },
+    });
+    const before = JSON.stringify(current);
+
+    const compatible = prepareRecordsOnlyWorkspaceReplacement(
+      current.payload,
+      current.artifactState,
+      [{
+        id: 'record-a',
+        name: 'Updated A',
+        type: 'dna',
+        sequence: 'ATGGAATTCTAA',
+        features: [{ id: 'a', name: 'Feature A', type: 'cds', start: 0, end: 6 }],
+      }],
+      'record-a',
+    );
+    expect(compatible.payload.records[0].name).toBe('Updated A');
+    expect(compatible.payload.inventory).toEqual(current.payload.inventory);
+    expect(compatible.payload.defaultMotif).toBe('GGCC');
+    expect(compatible.payload.alignments).toEqual(current.payload.alignments);
+    expect(compatible.payload.notes).toEqual(current.payload.notes);
+    expect(compatible.payload.workflowResults).toEqual(current.payload.workflowResults);
+    expect(compatible.payload.analysisResults).toEqual(current.payload.analysisResults);
+    expect(compatible.payload.analysisAssets).toEqual(current.payload.analysisAssets);
+    expect(compatible.artifactState).toEqual(current.artifactState);
+
+    expect(() => prepareRecordsOnlyWorkspaceReplacement(
+      current.payload,
+      current.artifactState,
+      [{ id: 'record-a', name: 'Removed feature A', type: 'dna', sequence: 'ATGGAATTCTAA' }],
+      'record-a',
+    )).toThrowError(expect.objectContaining({
+      code: 'MOTIF_INVALID_INVENTORY_REPLACEMENT',
+      details: expect.objectContaining({
+        issues: expect.arrayContaining([expect.objectContaining({
+          category: 'artifactState',
+          message: expect.stringContaining('feat:a'),
+        })]),
+      }),
+    }));
+
+    try {
+      prepareRecordsOnlyWorkspaceReplacement(
+        current.payload,
+        current.artifactState,
+        [{
+          id: 'record-a',
+          name: 'Changed A',
+          type: 'dna',
+          sequence: 'ATGCAATTCTAA',
+          features: [{ id: 'a', name: 'Feature A', type: 'cds', start: 0, end: 6 }],
+        }],
+        'record-a',
+      );
+      throw new Error('Expected biological identity change to be rejected.');
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'MOTIF_INVALID_INVENTORY_REPLACEMENT',
+        details: { operation: 'motifRenderInventory', mutated: false },
+      });
+      const categories = (error as MotifArtifactRuntimeError).details.issues as Array<{ category: string }>;
+      expect(new Set(categories.map((issue) => issue.category))).toEqual(new Set([
+        'alignment', 'note', 'workflowResult', 'analysisResult', 'artifactState',
+      ]));
+    }
+
+    try {
+      prepareRecordsOnlyWorkspaceReplacement(
+        current.payload,
+        current.artifactState,
+        [{ id: 'record-b', name: 'Unrelated B', type: 'dna', sequence: 'ATGGAATTCTAA' }],
+        'record-a',
+      );
+      throw new Error('Expected orphaning replacement to be rejected.');
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'MOTIF_INVALID_INVENTORY_REPLACEMENT',
+        details: { operation: 'motifRenderInventory', mutated: false },
+      });
+      const categories = (error as MotifArtifactRuntimeError).details.issues as Array<{ category: string }>;
+      expect(new Set(categories.map((issue) => issue.category))).toEqual(new Set([
+        'alignment', 'note', 'workflowResult', 'analysisResult', 'artifactState',
+      ]));
+    }
+
+    expect(() => prepareRecordsOnlyWorkspaceReplacement(
+      current.payload,
+      current.artifactState,
+      { records: [{ id: 'record-a', type: 'dna', sequence: 'ATGGAATTCTAA' }], alignments: [] },
+    )).toThrowError(expect.objectContaining({ code: 'MOTIF_INVALID_WORKSPACE_INPUT' }));
+    expect(JSON.stringify(current)).toBe(before);
+  });
+
+  it('rejects a records-only replacement that newly orphans a workflow output', () => {
+    const current = prepareArtifactDatabaseRestore({
+      records: [
+        { id: 'input-a', type: 'dna', sequence: 'ATGC' },
+        { id: 'product-b', type: 'dna', sequence: 'ATGC' },
+      ],
+      workflowResults: [{
+        id: 'workflow-a',
+        kind: 'digest',
+        name: 'Saved product',
+        inputRecordIds: ['input-a'],
+        outputRecordIds: ['product-b'],
+        parameters: { enzymes: ['EcoRI'] },
+        createdAt: '2026-07-12T12:00:00.000Z',
+        provenance: { source: 'motif-artifact', operation: 'digest' },
+      }],
+    });
+
+    expect(() => prepareRecordsOnlyWorkspaceReplacement(
+      current.payload,
+      current.artifactState,
+      [{ id: 'input-a', type: 'dna', sequence: 'ATGC' }],
+      'input-a',
+    )).toThrowError(expect.objectContaining({
+      code: 'MOTIF_INVALID_INVENTORY_REPLACEMENT',
+      details: expect.objectContaining({
+        operation: 'motifRenderInventory',
+        mutated: false,
+        issues: expect.arrayContaining([
+          expect.objectContaining({ category: 'workflowResult', message: expect.stringContaining('newly orphaned') }),
+        ]),
+      }),
+    }));
+  });
+
+  it('rejects biological changes referenced only inside typed analysis data', () => {
+    const current = prepareArtifactDatabaseRestore({
+      records: [
+        { id: 'target-a', type: 'dna', sequence: 'ATGC' },
+        { id: 'input-b', type: 'dna', sequence: 'CCCC' },
+      ],
+      analysisResults: [{
+        id: 'primer-a',
+        kind: 'primer_design',
+        name: 'Primer design A',
+        status: 'complete',
+        inputRecordIds: ['input-b'],
+        dependsOnResultIds: [],
+        assetIds: [],
+        parameters: {},
+        data: { targetRecordId: 'target-a', pairs: [] },
+        createdAt: '2026-07-12T12:00:00.000Z',
+        provenance: { source: 'claude-science', operation: 'primer-design' },
+      }],
+    });
+
+    expect(() => prepareRecordsOnlyWorkspaceReplacement(
+      current.payload,
+      current.artifactState,
+      [
+        { id: 'target-a', type: 'dna', sequence: 'TTTT' },
+        { id: 'input-b', type: 'dna', sequence: 'CCCC' },
+      ],
+      'target-a',
+    )).toThrowError(expect.objectContaining({
+      code: 'MOTIF_INVALID_INVENTORY_REPLACEMENT',
+      details: expect.objectContaining({
+        issues: expect.arrayContaining([expect.objectContaining({ category: 'analysisResult' })]),
+      }),
+    }));
   });
 
   it('round-trips a direct motifGetWorkspace-style snapshot without undefined object fields', () => {
@@ -543,14 +857,16 @@ describe('Claude Science runtime data-integrity behavior', () => {
     const addEnd = artifactSource.indexOf('window.motifGetInventory', addStart);
     const addHandler = artifactSource.slice(addStart, addEnd);
 
-    expect(renderHandler.indexOf('prepareInventoryReplacement(')).toBeLessThan(renderHandler.indexOf('resetRecordTransientState();'));
-    expect(renderHandler).toContain('describeRuntimePayloadSnapshot(nextPayload');
+    expect(renderHandler.indexOf('prepareRecordsOnlyWorkspaceReplacement(')).toBeLessThan(renderHandler.indexOf('resetWorkspaceViewState();'));
+    expect(renderHandler).not.toContain('resetRecordTransientState();');
+    expect(renderHandler).toContain('describeRuntimePayloadSnapshot(');
+    expect(renderHandler).toContain('nextPayload.selectedRecordId');
     expect(addHandler).toContain("validateRuntimeRecordInputs(raw, 'motifAddRecords');");
     expect(addHandler).toContain('const traceSampleEntries = [...currentPayload.records, ...additions].reduce');
     expect(addHandler).toContain('traceSampleEntries > ARTIFACT_SANGER_MAX_WORKSPACE_SAMPLE_ENTRIES');
     expect(addHandler).toContain('No records were added.');
     expect(addHandler).toContain('describeRuntimePayloadSnapshot(nextPayload');
-    expect(artifactSource).toContain('useState(loadInitialArtifactPayload)');
+    expect(artifactSource).toContain('useState(loadInitialArtifactWorkspace)');
   });
 
   it('validates UI record batches before one atomic payload commit', () => {

--- a/src/artifacts/__tests__/claude-science-sanger-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-sanger-guards.test.ts
@@ -37,6 +37,15 @@ describe('Claude Science Sanger workflow guards', () => {
     expect(artifactSource).toContain('Undo restores the trace.');
   });
 
+  it('adapts construct-verification candidates to the engine bounds before launch', () => {
+    expect(artifactSource).toContain('ARTIFACT_CONSTRUCT_VERIFICATION_TEXT_LIMITS');
+    expect(artifactSource).toContain('record.id.length > ARTIFACT_CONSTRUCT_VERIFICATION_TEXT_LIMITS.maxIdLength');
+    expect(artifactSource).toContain('record.sequence.length > ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReferenceLength');
+    expect(artifactSource).not.toContain('readCount >= ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReads');
+    expect(artifactSource).toContain('name: boundedArtifactConstructName(record.name)');
+    expect(artifactSource).toContain('excluded by verifier limits');
+  });
+
   it('offers the trace view only for an alignment row that truly links to the calls', () => {
     expect(msaSource).toContain('const traceAvailable = activeAlignment ? hasLinkedSangerTrace(activeAlignment, records) : false;');
     expect(msaSource).toContain("displayMode === 'trace'");

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -428,6 +428,7 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toContain('aria-keyshortcuts="ArrowLeft ArrowRight ArrowUp ArrowDown"');
     expect(artifactCss).toContain('.motif-cs-window-resize:focus-visible');
     expect(artifactCss).toMatch(/\.motif-cs-window-resize\s*\{[\s\S]*?width:\s*28px;[\s\S]*?height:\s*28px/);
+    expect(artifactCss).toContain('.motif-cs-shell:has(.motif-cs-inspector[data-tools-pinned="false"]) .motif-cs-window-resize {\n    right: 58px;');
   });
 
   it('limits floating-window drags to the initiating primary pointer', () => {

--- a/src/artifacts/claude-science-agent-results.css
+++ b/src/artifacts/claude-science-agent-results.css
@@ -97,6 +97,13 @@
   overflow-wrap: anywhere;
 }
 
+.motif-cs-agent-result-state {
+  display: grid;
+  justify-items: end;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+
 .motif-cs-agent-result-heading strong {
   font-size: 12px;
   line-height: 1.35;
@@ -291,6 +298,10 @@
 
   .motif-cs-agent-result-status {
     width: max-content;
+  }
+
+  .motif-cs-agent-result-state {
+    justify-items: start;
   }
 
   .motif-cs-agent-result-details dl > div {

--- a/src/artifacts/claude-science-analysis-results.ts
+++ b/src/artifacts/claude-science-analysis-results.ts
@@ -14,6 +14,7 @@ import type {
   ArtifactProvenance,
   ArtifactSequenceRange,
 } from './claude-science-workspace-collections';
+import { sha256HexSync } from './claude-science-sha256';
 
 export const MAX_ARTIFACT_ANALYSIS_RESULTS = 1_000;
 export const MAX_ARTIFACT_ANALYSIS_ASSETS = 2_000;
@@ -36,6 +37,7 @@ export const ARTIFACT_ANALYSIS_KINDS = [
   'primer_design',
   'pcr',
   'assembly_plan',
+  'construct_verification',
   'blast_search',
   'structure_model',
   'report',
@@ -127,6 +129,32 @@ export type ArtifactAssemblyPlanData = {
   junctions?: ArtifactAssemblyJunction[];
 };
 
+export type ArtifactConstructVerificationState = 'consistent' | 'needs_review' | 'inconsistent';
+
+/**
+ * Compact durable summary of a construct-verification run. Per-base depth and
+ * alignment coordinate maps stay in the live viewer; an optional inert JSON
+ * report asset can retain bounded read/variant detail without inflating every
+ * result row or workspace parse.
+ */
+export type ArtifactConstructVerificationData = {
+  referenceRecordId: string;
+  readRecordIds: string[];
+  state: ArtifactConstructVerificationState;
+  referenceLength: number;
+  coveredBases: number;
+  coverageFraction: number;
+  mappedReadCount: number;
+  requiredRegionCount: number;
+  passingRegionCount: number;
+  observedVariantCount: number;
+  expectedVariantCount: number;
+  unexpectedVariantCount: number;
+  missingExpectedVariantCount: number;
+  reasonCodes: string[];
+  verificationReportAssetId?: string;
+};
+
 export type ArtifactBlastHit = {
   accession: string;
   title: string;
@@ -184,6 +212,7 @@ type ArtifactAnalysisDataByKind = {
   primer_design: ArtifactPrimerDesignData;
   pcr: ArtifactPcrData;
   assembly_plan: ArtifactAssemblyPlanData;
+  construct_verification: ArtifactConstructVerificationData;
   blast_search: ArtifactBlastSearchData;
   structure_model: ArtifactStructureModelData;
   report: ArtifactReportData;
@@ -436,6 +465,9 @@ function normalizeAsset(value: unknown, index: number, budget: Budget): Artifact
     normalizeJsonValue(parsed, `${path}.content JSON`, budget, new WeakSet<object>(), 0);
   }
   const sha256 = value.sha256 === undefined ? undefined : normalizeSha256(value.sha256, `${path}.sha256`, budget);
+  if (sha256 !== undefined && sha256 !== sha256HexSync(content)) {
+    throw new Error(`${path}.sha256 must match the exact UTF-8 content.`);
+  }
   return {
     id,
     name,
@@ -584,6 +616,105 @@ function normalizeAssemblyData(value: unknown, path: string, budget: Budget): Ar
   };
 }
 
+function normalizeConstructVerificationData(
+  value: unknown,
+  path: string,
+  budget: Budget,
+  context: ArtifactAnalysisContext,
+): ArtifactConstructVerificationData {
+  if (!isPlainObject(value)) throw new Error(`${path} must be an object.`);
+  assertKnownKeys(value, [
+    'referenceRecordId',
+    'readRecordIds',
+    'state',
+    'referenceLength',
+    'coveredBases',
+    'coverageFraction',
+    'mappedReadCount',
+    'requiredRegionCount',
+    'passingRegionCount',
+    'observedVariantCount',
+    'expectedVariantCount',
+    'unexpectedVariantCount',
+    'missingExpectedVariantCount',
+    'reasonCodes',
+    'verificationReportAssetId',
+  ], path);
+  const referenceRecordId = normalizeId(value.referenceRecordId, `${path}.referenceRecordId`, budget);
+  const readRecordIds = normalizeStringArray(
+    value.readRecordIds,
+    `${path}.readRecordIds`,
+    MAX_ARTIFACT_ANALYSIS_RECORD_IDS - 1,
+    budget,
+    { required: true, deduplicate: true },
+  );
+  if (readRecordIds.length === 0) throw new Error(`${path}.readRecordIds must contain at least one sequencing read.`);
+  if (readRecordIds.includes(referenceRecordId)) throw new Error(`${path}.readRecordIds cannot contain the reference record.`);
+  if (context.recordLengths) {
+    if (!context.recordLengths.has(referenceRecordId)) throw new Error(`${path}.referenceRecordId does not match a workspace record.`);
+    readRecordIds.forEach((recordId, index) => {
+      if (!context.recordLengths?.has(recordId)) throw new Error(`${path}.readRecordIds[${index}] does not match a workspace record.`);
+    });
+  }
+  if (value.state !== 'consistent' && value.state !== 'needs_review' && value.state !== 'inconsistent') {
+    throw new Error(`${path}.state must be "consistent", "needs_review", or "inconsistent".`);
+  }
+  const referenceLength = finiteNumber(value.referenceLength, `${path}.referenceLength`, { min: 1, integer: true });
+  const coveredBases = finiteNumber(value.coveredBases, `${path}.coveredBases`, { min: 0, max: referenceLength, integer: true });
+  const coverageFraction = finiteNumber(value.coverageFraction, `${path}.coverageFraction`, { min: 0, max: 1 });
+  const expectedCoverageFraction = coveredBases / referenceLength;
+  if (Math.abs(coverageFraction - expectedCoverageFraction) > 1e-6) {
+    throw new Error(`${path}.coverageFraction must agree with coveredBases / referenceLength.`);
+  }
+  const mappedReadCount = finiteNumber(value.mappedReadCount, `${path}.mappedReadCount`, {
+    min: 0,
+    max: readRecordIds.length,
+    integer: true,
+  });
+  const count = (field: 'requiredRegionCount' | 'passingRegionCount' | 'observedVariantCount' | 'expectedVariantCount' | 'unexpectedVariantCount' | 'missingExpectedVariantCount'): number => (
+    finiteNumber(value[field], `${path}.${field}`, { min: 0, integer: true })
+  );
+  const requiredRegionCount = count('requiredRegionCount');
+  const passingRegionCount = count('passingRegionCount');
+  if (passingRegionCount > requiredRegionCount) {
+    throw new Error(`${path}.passingRegionCount cannot exceed requiredRegionCount.`);
+  }
+  const observedVariantCount = count('observedVariantCount');
+  const expectedVariantCount = count('expectedVariantCount');
+  const unexpectedVariantCount = count('unexpectedVariantCount');
+  const missingExpectedVariantCount = count('missingExpectedVariantCount');
+  if (unexpectedVariantCount > observedVariantCount) {
+    throw new Error(`${path}.unexpectedVariantCount cannot exceed observedVariantCount.`);
+  }
+  if (missingExpectedVariantCount > expectedVariantCount) {
+    throw new Error(`${path}.missingExpectedVariantCount cannot exceed expectedVariantCount.`);
+  }
+  const reasonCodes = normalizeTextArray(value.reasonCodes, `${path}.reasonCodes`, 500, 128, budget);
+  reasonCodes.forEach((code, index) => {
+    if (!/^[a-z][a-z0-9_]*$/.test(code)) throw new Error(`${path}.reasonCodes[${index}] must be a stable lowercase code.`);
+  });
+  const verificationReportAssetId = value.verificationReportAssetId === undefined
+    ? undefined
+    : normalizeId(value.verificationReportAssetId, `${path}.verificationReportAssetId`, budget);
+  return {
+    referenceRecordId,
+    readRecordIds,
+    state: value.state,
+    referenceLength,
+    coveredBases,
+    coverageFraction,
+    mappedReadCount,
+    requiredRegionCount,
+    passingRegionCount,
+    observedVariantCount,
+    expectedVariantCount,
+    unexpectedVariantCount,
+    missingExpectedVariantCount,
+    reasonCodes,
+    ...(verificationReportAssetId === undefined ? {} : { verificationReportAssetId }),
+  };
+}
+
 function normalizeBlastData(value: unknown, path: string, budget: Budget): ArtifactBlastSearchData {
   if (!isPlainObject(value)) throw new Error(`${path} must be an object.`);
   assertKnownKeys(value, ['program', 'database', 'databaseVersion', 'queryRecordId', 'hits'], path);
@@ -703,6 +834,7 @@ function normalizeData(kind: ArtifactAnalysisKind, value: unknown, path: string,
   if (kind === 'primer_design') return normalizePrimerDesignData(value, path, budget, context);
   if (kind === 'pcr') return normalizePcrData(value, path, budget, context);
   if (kind === 'assembly_plan') return normalizeAssemblyData(value, path, budget);
+  if (kind === 'construct_verification') return normalizeConstructVerificationData(value, path, budget, context);
   if (kind === 'blast_search') return normalizeBlastData(value, path, budget);
   if (kind === 'structure_model') return normalizeStructureData(value, path, budget);
   if (kind === 'report') return normalizeReportData(value, path, budget);
@@ -757,7 +889,7 @@ function assertUniqueIds(values: readonly { id: string }[], path: string): void 
   }
 }
 
-function resultRecordIds(result: ArtifactAnalysisResult): string[] {
+export function artifactAnalysisResultRecordIds(result: ArtifactAnalysisResult): string[] {
   const ids = [...result.inputRecordIds];
   if (result.kind === 'primer_design') ids.push(result.data.targetRecordId);
   if (result.kind === 'pcr') {
@@ -770,6 +902,9 @@ function resultRecordIds(result: ArtifactAnalysisResult): string[] {
     if (result.data.productRecordId) ids.push(result.data.productRecordId);
     result.data.junctions?.forEach((junction) => ids.push(junction.leftRecordId, junction.rightRecordId));
   }
+  if (result.kind === 'construct_verification') {
+    ids.push(result.data.referenceRecordId, ...result.data.readRecordIds);
+  }
   if (result.kind === 'blast_search') ids.push(result.data.queryRecordId);
   if (result.kind === 'structure_model') result.data.chains.forEach((chain) => { if (chain.recordId) ids.push(chain.recordId); });
   return Array.from(new Set(ids));
@@ -779,6 +914,9 @@ function resultAssetIds(result: ArtifactAnalysisResult): string[] {
   const ids = [...result.assetIds];
   if (result.kind === 'blast_search') result.data.hits.forEach((hit) => { if (hit.alignmentAssetId) ids.push(hit.alignmentAssetId); });
   if (result.kind === 'structure_model') ids.push(result.data.modelAssetId);
+  if (result.kind === 'construct_verification' && result.data.verificationReportAssetId) {
+    ids.push(result.data.verificationReportAssetId);
+  }
   if (result.kind === 'report' && result.data.bodyAssetId) ids.push(result.data.bodyAssetId);
   return Array.from(new Set(ids));
 }
@@ -787,6 +925,1356 @@ function resultDependencyIds(result: ArtifactAnalysisResult): string[] {
   const ids = [...result.dependsOnResultIds];
   if (result.kind === 'pcr' && result.data.primerDesignResultId) ids.push(result.data.primerDesignResultId);
   return Array.from(new Set(ids));
+}
+
+type ConstructVerificationAnalysisResult = Extract<ArtifactAnalysisResult, { kind: 'construct_verification' }>;
+
+const CONSTRUCT_VERIFICATION_REPORT_SCHEMA = 'motif.construct-verification-report.v1';
+const STABLE_REASON_CODE_PATTERN = /^[a-z][a-z0-9_]*$/;
+const CONSTRUCT_REPORT_READ_STATUS_SET = new Set([
+  'mapped',
+  'trimmed_read_too_short',
+  'unmapped',
+  'ambiguous_mapping',
+  'low_mapping_identity',
+  'excessive_indel',
+]);
+const CONSTRUCT_REPORT_REGION_STATUS_SET = new Set(['covered', 'uncovered', 'low_depth', 'missing_strand']);
+const CONSTRUCT_REPORT_VARIANT_TYPE_SET = new Set(['substitution', 'insertion', 'deletion']);
+const CONSTRUCT_REPORT_EXPECTED_VARIANT_STATUS_SET = new Set([
+  'observed',
+  'low_confidence',
+  'not_observed',
+  'not_covered',
+]);
+const CONSTRUCT_REPORT_THRESHOLD_KEYS = [
+  'trimQuality',
+  'trimWindow',
+  'minTrimmedReadLength',
+  'minMappingIdentity',
+  'minMappingMargin',
+  'maxIndelFraction',
+  'minCoverageFraction',
+  'minDepth',
+  'requireBothStrands',
+  'minConsensusFraction',
+  'minVariantQuality',
+  'minVariantFraction',
+] as const;
+const CONSTRUCT_REPORT_LIMITS = {
+  maxReferenceLength: 50_000,
+  maxReads: 96,
+  maxReadLength: 5_000,
+  maxRequiredRegions: 128,
+  maxRequiredRegionBases: 500_000,
+  maxExpectedVariants: 256,
+  maxObservedVariants: 2_000,
+  maxIndelLength: 24,
+  maxWorkUnits: 25_000_000,
+} as const;
+const CONSTRUCT_REPORT_REASON_LIMIT = 256;
+const CONSTRUCT_REPORT_SUPPORTING_READ_LIMIT = 8;
+const CONSTRUCT_REPORT_OBSERVED_VARIANT_LIMIT = 192;
+const CONSTRUCT_REPORT_IUPAC_CONSENSUS_PATTERN = /^[ACGTN]*$/;
+const CONSTRUCT_REPORT_CANONICAL_DNA_PATTERN = /^[ACGT]*$/;
+
+function reportObject(value: unknown, path: string): Record<string, unknown> {
+  if (!isPlainObject(value)) throw new Error(`${path} must be an object.`);
+  return value;
+}
+
+function reportArray(value: unknown, path: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${path} must be an array.`);
+  return value;
+}
+
+function reportString(value: unknown, path: string): string {
+  if (typeof value !== 'string' || value.length === 0) throw new Error(`${path} must be a nonempty string.`);
+  return value;
+}
+
+function reportSha256(value: unknown, path: string): string {
+  const sha256 = reportString(value, path).toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(sha256)) throw new Error(`${path} must be a 64-character SHA-256 value.`);
+  return sha256;
+}
+
+function reportInteger(value: unknown, path: string): number {
+  if (!Number.isInteger(value) || (value as number) < 0) throw new Error(`${path} must be a non-negative integer.`);
+  return value as number;
+}
+
+function reportSignedInteger(value: unknown, path: string): number {
+  if (!Number.isInteger(value)) throw new Error(`${path} must be an integer.`);
+  return value as number;
+}
+
+function reportFiniteNumber(value: unknown, path: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) throw new Error(`${path} must be a finite number.`);
+  return value;
+}
+
+function reportBoolean(value: unknown, path: string): boolean {
+  if (typeof value !== 'boolean') throw new Error(`${path} must be a boolean.`);
+  return value;
+}
+
+function reportIntegerBetween(value: unknown, path: string, minimum: number, maximum: number): number {
+  const integer = reportInteger(value, path);
+  if (integer < minimum || integer > maximum) {
+    throw new Error(`${path} must be an integer from ${minimum.toLocaleString()} through ${maximum.toLocaleString()}.`);
+  }
+  return integer;
+}
+
+function reportNumberBetween(value: unknown, path: string, minimum: number, maximum: number): number {
+  const number = reportFiniteNumber(value, path);
+  if (number < minimum || number > maximum) {
+    throw new Error(`${path} must be from ${minimum} through ${maximum}.`);
+  }
+  return number;
+}
+
+function reportNullableNumber(
+  value: unknown,
+  path: string,
+  minimum?: number,
+  maximum?: number,
+): number | null {
+  if (value === null) return null;
+  const number = reportFiniteNumber(value, path);
+  if (minimum !== undefined && number < minimum) throw new Error(`${path} must be at least ${minimum}.`);
+  if (maximum !== undefined && number > maximum) throw new Error(`${path} must be no greater than ${maximum}.`);
+  return number;
+}
+
+function reportIdentityText(value: unknown, path: string, maximumLength: number): string {
+  const text = reportString(value, path);
+  if (text.trim() !== text || text.length > maximumLength) {
+    throw new Error(`${path} must contain 1–${maximumLength.toLocaleString()} unpadded characters.`);
+  }
+  return text;
+}
+
+function reportOptionalIdentityText(
+  value: unknown,
+  path: string,
+  maximumLength: number,
+): string | undefined {
+  return value === undefined ? undefined : reportIdentityText(value, path, maximumLength);
+}
+
+function reportNumbersAgree(actual: number, expected: number): boolean {
+  return Object.is(actual, expected) || Math.abs(actual - expected) <= 1e-12;
+}
+
+function assertReportNumber(
+  result: ConstructVerificationAnalysisResult,
+  field: string,
+  actual: number,
+  expected: number,
+): void {
+  if (!reportNumbersAgree(actual, expected)) reportMismatch(result, field);
+}
+
+function reportMismatch(result: ConstructVerificationAnalysisResult, field: string): never {
+  throw new Error(`Analysis result "${result.id}" verification report ${field} must match the saved result.`);
+}
+
+function assertReportValue(
+  result: ConstructVerificationAnalysisResult,
+  field: string,
+  actual: unknown,
+  expected: unknown,
+): void {
+  if (!Object.is(actual, expected)) reportMismatch(result, field);
+}
+
+function assertReportArray(
+  result: ConstructVerificationAnalysisResult,
+  field: string,
+  actual: readonly unknown[],
+  expected: readonly unknown[],
+): void {
+  if (actual.length !== expected.length || actual.some((value, index) => value !== expected[index])) {
+    reportMismatch(result, field);
+  }
+}
+
+function assertReportThresholds(
+  result: ConstructVerificationAnalysisResult,
+  reportThresholds: Record<string, unknown>,
+): void {
+  const savedThresholds = result.parameters.thresholds;
+  if (!isPlainObject(savedThresholds)) reportMismatch(result, 'thresholds');
+  const reportKeys = Object.keys(reportThresholds).sort();
+  const savedKeys = Object.keys(savedThresholds).sort();
+  const expectedKeys = [...CONSTRUCT_REPORT_THRESHOLD_KEYS].sort();
+  assertReportArray(result, 'thresholds schema', reportKeys, expectedKeys);
+  assertReportArray(result, 'thresholds keys', reportKeys, savedKeys);
+  reportKeys.forEach((key) => {
+    const reportValue = reportThresholds[key];
+    const savedValue = savedThresholds[key];
+    if (
+      (typeof reportValue !== 'number' && typeof reportValue !== 'boolean')
+      || !Object.is(reportValue, savedValue)
+    ) {
+      reportMismatch(result, `thresholds.${key}`);
+    }
+  });
+  reportIntegerBetween(reportThresholds.trimQuality, 'verification report thresholds.trimQuality', 0, 255);
+  reportIntegerBetween(reportThresholds.trimWindow, 'verification report thresholds.trimWindow', 1, 100);
+  reportIntegerBetween(
+    reportThresholds.minTrimmedReadLength,
+    'verification report thresholds.minTrimmedReadLength',
+    1,
+    CONSTRUCT_REPORT_LIMITS.maxReadLength,
+  );
+  reportNumberBetween(reportThresholds.minMappingIdentity, 'verification report thresholds.minMappingIdentity', 0, 1);
+  reportNumberBetween(reportThresholds.minMappingMargin, 'verification report thresholds.minMappingMargin', 0, 1);
+  reportNumberBetween(reportThresholds.maxIndelFraction, 'verification report thresholds.maxIndelFraction', 0, 1);
+  reportNumberBetween(reportThresholds.minCoverageFraction, 'verification report thresholds.minCoverageFraction', 0, 1);
+  reportIntegerBetween(reportThresholds.minDepth, 'verification report thresholds.minDepth', 1, CONSTRUCT_REPORT_LIMITS.maxReads);
+  reportBoolean(reportThresholds.requireBothStrands, 'verification report thresholds.requireBothStrands');
+  reportNumberBetween(reportThresholds.minConsensusFraction, 'verification report thresholds.minConsensusFraction', 0, 1);
+  reportNumberBetween(reportThresholds.minVariantQuality, 'verification report thresholds.minVariantQuality', 0, 255);
+  reportNumberBetween(reportThresholds.minVariantFraction, 'verification report thresholds.minVariantFraction', 0, 1);
+}
+
+type ConstructReportRead = {
+  id: string;
+  sha256: string;
+  status: string;
+  mapped: boolean;
+  qualityProvided: boolean;
+};
+
+function validateConstructReportMapping(
+  value: unknown,
+  path: string,
+  topology: 'linear' | 'circular',
+  referenceLength: number,
+  trimmedLength: number,
+  status: string,
+  thresholds: Record<string, unknown>,
+): void {
+  const mapping = reportObject(value, path);
+  assertKnownKeys(mapping, [
+    'orientation',
+    'referenceStart',
+    'referenceEnd',
+    'wraps',
+    'referenceSpan',
+    'score',
+    'secondBestScore',
+    'mappingMargin',
+    'identity',
+    'alignedLength',
+    'matches',
+    'substitutions',
+    'insertions',
+    'deletions',
+    'indelFraction',
+  ], path);
+  if (mapping.orientation !== 'forward' && mapping.orientation !== 'reverse') {
+    throw new Error(`${path}.orientation must be forward or reverse.`);
+  }
+  const referenceStart = reportIntegerBetween(mapping.referenceStart, `${path}.referenceStart`, 0, referenceLength - 1);
+  const referenceEnd = reportIntegerBetween(mapping.referenceEnd, `${path}.referenceEnd`, 0, referenceLength);
+  const wraps = reportBoolean(mapping.wraps, `${path}.wraps`);
+  const referenceSpan = reportIntegerBetween(
+    mapping.referenceSpan,
+    `${path}.referenceSpan`,
+    1,
+    CONSTRUCT_REPORT_LIMITS.maxReadLength + (CONSTRUCT_REPORT_LIMITS.maxIndelLength * CONSTRUCT_REPORT_LIMITS.maxReadLength),
+  );
+  const score = reportSignedInteger(mapping.score, `${path}.score`);
+  const secondBestScore = mapping.secondBestScore === null
+    ? null
+    : reportSignedInteger(mapping.secondBestScore, `${path}.secondBestScore`);
+  const mappingMargin = reportNullableNumber(mapping.mappingMargin, `${path}.mappingMargin`, 0);
+  if ((secondBestScore === null) !== (mappingMargin === null)) {
+    throw new Error(`${path}.secondBestScore and mappingMargin must either both be null or both be numbers.`);
+  }
+  if (secondBestScore !== null) {
+    if (secondBestScore > score) throw new Error(`${path}.secondBestScore cannot exceed score.`);
+    const expectedMargin = (score - secondBestScore) / Math.max(1, 3 * trimmedLength);
+    if (!reportNumbersAgree(mappingMargin as number, expectedMargin)) {
+      throw new Error(`${path}.mappingMargin must agree with score, secondBestScore, and trimmedLength.`);
+    }
+  }
+  const alignedLength = reportIntegerBetween(
+    mapping.alignedLength,
+    `${path}.alignedLength`,
+    1,
+    trimmedLength + (CONSTRUCT_REPORT_LIMITS.maxIndelLength * CONSTRUCT_REPORT_LIMITS.maxReadLength),
+  );
+  const matches = reportIntegerBetween(mapping.matches, `${path}.matches`, 0, alignedLength);
+  const substitutions = reportIntegerBetween(mapping.substitutions, `${path}.substitutions`, 0, alignedLength);
+  const insertions = reportIntegerBetween(mapping.insertions, `${path}.insertions`, 0, alignedLength);
+  const deletions = reportIntegerBetween(mapping.deletions, `${path}.deletions`, 0, alignedLength);
+  if (matches + substitutions + insertions + deletions !== alignedLength) {
+    throw new Error(`${path}.alignedLength must equal matches + substitutions + insertions + deletions.`);
+  }
+  if (matches + substitutions + insertions !== trimmedLength) {
+    throw new Error(`${path} operation counts must consume exactly trimmedLength read calls.`);
+  }
+  if (matches + substitutions + deletions !== referenceSpan) {
+    throw new Error(`${path}.referenceSpan must equal matches + substitutions + deletions.`);
+  }
+  const identity = reportNumberBetween(mapping.identity, `${path}.identity`, 0, 1);
+  const indelFraction = reportNumberBetween(mapping.indelFraction, `${path}.indelFraction`, 0, 1);
+  if (!reportNumbersAgree(identity, matches / alignedLength)) {
+    throw new Error(`${path}.identity must equal matches / alignedLength.`);
+  }
+  if (!reportNumbersAgree(indelFraction, (insertions + deletions) / alignedLength)) {
+    throw new Error(`${path}.indelFraction must agree with the insertion and deletion counts.`);
+  }
+  const minimumIdentity = reportFiniteNumber(
+    thresholds.minMappingIdentity,
+    'verification report thresholds.minMappingIdentity',
+  );
+  const maximumIndelFraction = reportFiniteNumber(
+    thresholds.maxIndelFraction,
+    'verification report thresholds.maxIndelFraction',
+  );
+  const minimumMargin = reportFiniteNumber(
+    thresholds.minMappingMargin,
+    'verification report thresholds.minMappingMargin',
+  );
+  if (
+    (status === 'low_mapping_identity') !== (identity < minimumIdentity)
+    || ((status === 'mapped' || status === 'ambiguous_mapping') && indelFraction > maximumIndelFraction)
+  ) {
+    throw new Error(`${path} identity or indel evidence is inconsistent with status ${status}.`);
+  }
+  if (
+    status === 'excessive_indel'
+    && indelFraction <= maximumIndelFraction
+    && insertions + deletions <= CONSTRUCT_REPORT_LIMITS.maxIndelLength
+  ) {
+    throw new Error(`${path} cannot support excessive_indel status.`);
+  }
+  if (status === 'mapped' && secondBestScore !== null) {
+    if (secondBestScore >= score || (mappingMargin as number) < minimumMargin) {
+      throw new Error(`${path} runner-up evidence is inconsistent with mapped status.`);
+    }
+  }
+  if (
+    status === 'ambiguous_mapping'
+    && secondBestScore !== null
+    && secondBestScore !== score
+    && (mappingMargin as number) >= minimumMargin
+  ) {
+    throw new Error(`${path} runner-up evidence is inconsistent with ambiguous_mapping status.`);
+  }
+  if (topology === 'linear') {
+    if (wraps || referenceEnd !== referenceStart + referenceSpan || referenceEnd > referenceLength) {
+      throw new Error(`${path} linear coordinates must be nonwrapping and agree with referenceSpan.`);
+    }
+  } else {
+    const expectedWraps = referenceStart + referenceSpan > referenceLength;
+    const expectedEnd = expectedWraps
+      ? (referenceStart + referenceSpan) % referenceLength
+      : referenceStart + referenceSpan;
+    if (wraps !== expectedWraps || referenceEnd !== expectedEnd) {
+      throw new Error(`${path} circular coordinates must agree with wraps and referenceSpan.`);
+    }
+    if (status === 'mapped' && referenceSpan > referenceLength) {
+      throw new Error(`${path} mapped reads cannot traverse a circular reference position more than once.`);
+    }
+  }
+}
+
+function validateConstructReportRead(
+  value: unknown,
+  index: number,
+  topology: 'linear' | 'circular',
+  referenceLength: number,
+  thresholds: Record<string, unknown>,
+): ConstructReportRead {
+  const path = `verification report reads[${index}]`;
+  const read = reportObject(value, path);
+  assertKnownKeys(read, [
+    'id',
+    'name',
+    'sha256',
+    'rawLength',
+    'qualityProvided',
+    'meanQuality',
+    'status',
+    'trim',
+    'mapping',
+  ], path);
+  const id = reportIdentityText(read.id, `${path}.id`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+  reportOptionalIdentityText(read.name, `${path}.name`, MAX_ARTIFACT_ANALYSIS_NAME_LENGTH);
+  const sha256 = reportSha256(read.sha256, `${path}.sha256`);
+  const rawLength = reportIntegerBetween(read.rawLength, `${path}.rawLength`, 1, CONSTRUCT_REPORT_LIMITS.maxReadLength);
+  const qualityProvided = reportBoolean(read.qualityProvided, `${path}.qualityProvided`);
+  const meanQuality = reportNullableNumber(read.meanQuality, `${path}.meanQuality`, 0, 255);
+  const status = reportString(read.status, `${path}.status`);
+  if (!CONSTRUCT_REPORT_READ_STATUS_SET.has(status)) throw new Error(`${path}.status is not supported.`);
+
+  const trim = reportObject(read.trim, `${path}.trim`);
+  assertKnownKeys(trim, [
+    'method',
+    'rawStart',
+    'rawEnd',
+    'trimmedLength',
+    'removedFromStart',
+    'removedFromEnd',
+  ], `${path}.trim`);
+  if (trim.method !== 'quality_window' && trim.method !== 'none_missing_quality') {
+    throw new Error(`${path}.trim.method is not supported.`);
+  }
+  const rawStart = reportIntegerBetween(trim.rawStart, `${path}.trim.rawStart`, 0, rawLength);
+  const rawEnd = reportIntegerBetween(trim.rawEnd, `${path}.trim.rawEnd`, rawStart, rawLength);
+  const trimmedLength = reportIntegerBetween(trim.trimmedLength, `${path}.trim.trimmedLength`, 0, rawLength);
+  const removedFromStart = reportIntegerBetween(trim.removedFromStart, `${path}.trim.removedFromStart`, 0, rawLength);
+  const removedFromEnd = reportIntegerBetween(trim.removedFromEnd, `${path}.trim.removedFromEnd`, 0, rawLength);
+  if (
+    trimmedLength !== rawEnd - rawStart
+    || removedFromStart !== rawStart
+    || removedFromEnd !== rawLength - rawEnd
+  ) {
+    throw new Error(`${path}.trim ranges and derived lengths are inconsistent.`);
+  }
+  if (trim.method === 'none_missing_quality') {
+    if (qualityProvided || rawStart !== 0 || rawEnd !== rawLength || trimmedLength !== rawLength || meanQuality !== null) {
+      throw new Error(`${path}.trim none_missing_quality must retain the full read and omit quality evidence.`);
+    }
+  } else if (!qualityProvided || (trimmedLength > 0 && meanQuality === null)) {
+    throw new Error(`${path}.trim quality_window must agree with qualityProvided and meanQuality.`);
+  }
+
+  const minimumTrimmedLength = reportInteger(
+    thresholds.minTrimmedReadLength,
+    'verification report thresholds.minTrimmedReadLength',
+  );
+  if ((status === 'trimmed_read_too_short') !== (trimmedLength < minimumTrimmedLength)) {
+    throw new Error(`${path}.trimmedLength is inconsistent with status ${status}.`);
+  }
+
+  const requiresMapping = status !== 'trimmed_read_too_short' && status !== 'unmapped';
+  if (requiresMapping !== (read.mapping !== null)) {
+    throw new Error(`${path}.mapping presence is inconsistent with status ${status}.`);
+  }
+  if (read.mapping !== null) {
+    validateConstructReportMapping(
+      read.mapping,
+      `${path}.mapping`,
+      topology,
+      referenceLength,
+      trimmedLength,
+      status,
+      thresholds,
+    );
+  }
+  return { id, sha256, status, mapped: status === 'mapped', qualityProvided };
+}
+
+type ConstructReportRegion = {
+  id: string;
+  status: string;
+  reasonCodes: readonly string[];
+};
+
+function validateConstructReportRegion(
+  value: unknown,
+  index: number,
+  topology: 'linear' | 'circular',
+  referenceLength: number,
+  mappedReadCount: number,
+): ConstructReportRegion {
+  const path = `verification report coverage.requiredRegions[${index}]`;
+  const region = reportObject(value, path);
+  assertKnownKeys(region, [
+    'id',
+    'name',
+    'start',
+    'end',
+    'wraps',
+    'length',
+    'minDepth',
+    'requireBothStrands',
+    'coveredBases',
+    'basesMeetingMinDepth',
+    'coveredFraction',
+    'minimumDepth',
+    'maximumDepth',
+    'meanDepth',
+    'forwardCoveredBases',
+    'reverseCoveredBases',
+    'bothStrandsCoveredBases',
+    'status',
+  ], path);
+  const id = reportIdentityText(region.id, `${path}.id`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+  reportOptionalIdentityText(region.name, `${path}.name`, MAX_ARTIFACT_ANALYSIS_NAME_LENGTH);
+  const start = reportIntegerBetween(region.start, `${path}.start`, 0, referenceLength - 1);
+  const end = reportIntegerBetween(region.end, `${path}.end`, 0, referenceLength);
+  if (start === end) throw new Error(`${path} must span at least one reference base.`);
+  const wraps = reportBoolean(region.wraps, `${path}.wraps`);
+  const expectedWraps = start > end;
+  if (wraps !== expectedWraps || (wraps && topology !== 'circular')) {
+    throw new Error(`${path}.wraps is inconsistent with its topology and coordinates.`);
+  }
+  const expectedLength = wraps ? referenceLength - start + end : end - start;
+  const length = reportIntegerBetween(region.length, `${path}.length`, 1, referenceLength);
+  if (length !== expectedLength) throw new Error(`${path}.length must agree with its coordinates.`);
+  const minDepth = reportIntegerBetween(
+    region.minDepth,
+    `${path}.minDepth`,
+    1,
+    CONSTRUCT_REPORT_LIMITS.maxReads,
+  );
+  const requireBothStrands = reportBoolean(region.requireBothStrands, `${path}.requireBothStrands`);
+  const coveredBases = reportIntegerBetween(region.coveredBases, `${path}.coveredBases`, 0, length);
+  const basesMeetingMinDepth = reportIntegerBetween(
+    region.basesMeetingMinDepth,
+    `${path}.basesMeetingMinDepth`,
+    0,
+    coveredBases,
+  );
+  const coveredFraction = reportNumberBetween(region.coveredFraction, `${path}.coveredFraction`, 0, 1);
+  if (!reportNumbersAgree(coveredFraction, basesMeetingMinDepth / length)) {
+    throw new Error(`${path}.coveredFraction must equal basesMeetingMinDepth / length.`);
+  }
+  const minimumDepth = reportIntegerBetween(region.minimumDepth, `${path}.minimumDepth`, 0, mappedReadCount);
+  const maximumDepth = reportIntegerBetween(region.maximumDepth, `${path}.maximumDepth`, minimumDepth, mappedReadCount);
+  const meanDepth = reportNumberBetween(region.meanDepth, `${path}.meanDepth`, minimumDepth, maximumDepth);
+  if (length > 0 && (meanDepth < minimumDepth || meanDepth > maximumDepth)) {
+    throw new Error(`${path}.meanDepth must lie between minimumDepth and maximumDepth.`);
+  }
+  if (
+    (coveredBases === 0) !== (maximumDepth === 0)
+    || (coveredBases === length) !== (minimumDepth > 0)
+    || (basesMeetingMinDepth === 0) !== (maximumDepth < minDepth)
+    || (basesMeetingMinDepth === length) !== (minimumDepth >= minDepth)
+  ) {
+    throw new Error(`${path} depth extrema, thresholds, and covered-base counts are inconsistent.`);
+  }
+  const forwardCoveredBases = reportIntegerBetween(
+    region.forwardCoveredBases,
+    `${path}.forwardCoveredBases`,
+    0,
+    coveredBases,
+  );
+  const reverseCoveredBases = reportIntegerBetween(
+    region.reverseCoveredBases,
+    `${path}.reverseCoveredBases`,
+    0,
+    coveredBases,
+  );
+  const bothStrandsCoveredBases = reportIntegerBetween(
+    region.bothStrandsCoveredBases,
+    `${path}.bothStrandsCoveredBases`,
+    0,
+    Math.min(forwardCoveredBases, reverseCoveredBases),
+  );
+  if (bothStrandsCoveredBases !== forwardCoveredBases + reverseCoveredBases - coveredBases) {
+    throw new Error(`${path} strand coverage counts violate inclusion-exclusion.`);
+  }
+  const status = reportString(region.status, `${path}.status`);
+  if (!CONSTRUCT_REPORT_REGION_STATUS_SET.has(status)) throw new Error(`${path}.status is not supported.`);
+  const expectedStatus = coveredBases < length
+    ? 'uncovered'
+    : basesMeetingMinDepth < length
+      ? 'low_depth'
+      : requireBothStrands && bothStrandsCoveredBases < length
+        ? 'missing_strand'
+        : 'covered';
+  if (status !== expectedStatus) throw new Error(`${path}.status is inconsistent with its coverage evidence.`);
+  const reasonCodes: string[] = [];
+  if (coveredBases < length) {
+    reasonCodes.push('required_region_uncovered');
+  } else if (basesMeetingMinDepth < length) {
+    reasonCodes.push('required_region_low_depth');
+  }
+  if (requireBothStrands && coveredBases === length && bothStrandsCoveredBases < length) {
+    reasonCodes.push('required_region_missing_strand');
+  }
+  return { id, status, reasonCodes };
+}
+
+type ConstructReportObservedVariant = {
+  id: string;
+  expectedVariantId?: string;
+  confidence: 'high' | 'low';
+  depth: number;
+  alleleKey: string;
+  signature: string;
+  omittedSupportingReadIds: number;
+};
+
+type ConstructReportExpectedVariant = {
+  id: string;
+  status: 'observed' | 'low_confidence' | 'not_observed' | 'not_covered';
+  observedVariantId?: string;
+  depth: number;
+  alleleKey: string;
+  signature: string;
+};
+
+function validateConstructReportVariantAlleles(
+  value: Record<string, unknown>,
+  path: string,
+  topology: 'linear' | 'circular',
+  referenceLength: number,
+): { type: 'substitution' | 'insertion' | 'deletion'; start: number; end: number; reference: string; alternate: string } {
+  const type = reportString(value.type, `${path}.type`);
+  if (!CONSTRUCT_REPORT_VARIANT_TYPE_SET.has(type)) throw new Error(`${path}.type is not supported.`);
+  const maximumStart = type === 'insertion' && topology === 'linear' ? referenceLength : referenceLength - 1;
+  const start = reportIntegerBetween(value.referenceStart, `${path}.referenceStart`, 0, maximumStart);
+  const end = reportIntegerBetween(value.referenceEnd, `${path}.referenceEnd`, 0, referenceLength);
+  if (typeof value.reference !== 'string' || typeof value.alternate !== 'string') {
+    throw new Error(`${path}.reference and alternate must be strings.`);
+  }
+  const reference = value.reference;
+  const alternate = value.alternate;
+  if (!CONSTRUCT_REPORT_CANONICAL_DNA_PATTERN.test(reference) || !CONSTRUCT_REPORT_CANONICAL_DNA_PATTERN.test(alternate)) {
+    throw new Error(`${path} alleles must contain canonical A/C/G/T bases only.`);
+  }
+  if (type === 'substitution') {
+    if (end !== start + 1 || reference.length !== 1 || alternate.length !== 1 || reference === alternate) {
+      throw new Error(`${path} substitution alleles and coordinates are inconsistent.`);
+    }
+  } else if (type === 'insertion') {
+    if (
+      end !== start
+      || reference !== ''
+      || alternate.length < 1
+      || alternate.length > CONSTRUCT_REPORT_LIMITS.maxIndelLength
+    ) {
+      throw new Error(`${path} insertion alleles and coordinates are inconsistent.`);
+    }
+  } else if (
+    end <= start
+    || end - start > CONSTRUCT_REPORT_LIMITS.maxIndelLength
+    || reference.length !== end - start
+    || alternate !== ''
+  ) {
+    throw new Error(`${path} deletion alleles and coordinates are inconsistent.`);
+  }
+  return { type: type as 'substitution' | 'insertion' | 'deletion', start, end, reference, alternate };
+}
+
+function validateConstructReportObservedVariant(
+  value: unknown,
+  path: string,
+  topology: 'linear' | 'circular',
+  referenceLength: number,
+  mappedReadCount: number,
+  mappedReadIds: ReadonlySet<string>,
+  qualityMappedReadIds: ReadonlySet<string>,
+  thresholds: Record<string, unknown>,
+): ConstructReportObservedVariant {
+  const variant = reportObject(value, path);
+  assertKnownKeys(variant, [
+    'id',
+    'type',
+    'referenceStart',
+    'referenceEnd',
+    'reference',
+    'alternate',
+    'depth',
+    'support',
+    'supportWeight',
+    'fraction',
+    'meanQuality',
+    'confidence',
+    'supportingReadIds',
+    'expectedVariantId',
+    'omittedSupportingReadIds',
+  ], path);
+  const id = reportIdentityText(variant.id, `${path}.id`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+  const alleles = validateConstructReportVariantAlleles(variant, path, topology, referenceLength);
+  const depth = reportIntegerBetween(variant.depth, `${path}.depth`, 0, mappedReadCount);
+  const support = reportIntegerBetween(variant.support, `${path}.support`, 0, depth);
+  const supportWeight = reportNumberBetween(variant.supportWeight, `${path}.supportWeight`, 0, support * 256);
+  const fraction = reportNumberBetween(variant.fraction, `${path}.fraction`, 0, 1);
+  const meanQuality = reportNullableNumber(variant.meanQuality, `${path}.meanQuality`, 0, 255);
+  if (variant.confidence !== 'high' && variant.confidence !== 'low') {
+    throw new Error(`${path}.confidence must be high or low.`);
+  }
+  if (
+    variant.confidence === 'high'
+    && (
+      meanQuality === null
+      || meanQuality < reportFiniteNumber(thresholds.minVariantQuality, 'verification report thresholds.minVariantQuality')
+      || fraction < reportFiniteNumber(thresholds.minVariantFraction, 'verification report thresholds.minVariantFraction')
+    )
+  ) {
+    throw new Error(`${path}.confidence high is inconsistent with the saved variant thresholds.`);
+  }
+  const supportingReadIds = reportArray(variant.supportingReadIds, `${path}.supportingReadIds`).map((readId, index) => (
+    reportIdentityText(readId, `${path}.supportingReadIds[${index}]`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH)
+  ));
+  if (
+    supportingReadIds.length > CONSTRUCT_REPORT_SUPPORTING_READ_LIMIT
+    || new Set(supportingReadIds).size !== supportingReadIds.length
+    || supportingReadIds.some((readId) => !mappedReadIds.has(readId))
+  ) {
+    throw new Error(`${path}.supportingReadIds must be unique mapped reads within the compact-report limit.`);
+  }
+  const omittedSupportingReadIds = reportInteger(variant.omittedSupportingReadIds, `${path}.omittedSupportingReadIds`);
+  if (supportingReadIds.length + omittedSupportingReadIds !== support) {
+    throw new Error(`${path} included and omitted supporting read ids must equal support.`);
+  }
+  const canNameQualitySupport = supportingReadIds.some((readId) => qualityMappedReadIds.has(readId));
+  const canOmitQualitySupport = omittedSupportingReadIds > 0
+    && [...qualityMappedReadIds].some((readId) => !supportingReadIds.includes(readId));
+  if (variant.confidence === 'high' && !canNameQualitySupport && !canOmitQualitySupport) {
+    throw new Error(`${path}.confidence high requires possible quality-bearing mapped-read support.`);
+  }
+  const expectedVariantId = reportOptionalIdentityText(
+    variant.expectedVariantId,
+    `${path}.expectedVariantId`,
+    MAX_ARTIFACT_ANALYSIS_ID_LENGTH,
+  );
+  const signature = JSON.stringify([
+    id,
+    alleles.type,
+    alleles.start,
+    alleles.end,
+    alleles.reference,
+    alleles.alternate,
+    depth,
+    support,
+    supportWeight,
+    fraction,
+    meanQuality,
+    variant.confidence,
+    supportingReadIds,
+    expectedVariantId ?? null,
+    omittedSupportingReadIds,
+  ]);
+  return {
+    id,
+    ...(expectedVariantId === undefined ? {} : { expectedVariantId }),
+    confidence: variant.confidence,
+    depth,
+    alleleKey: JSON.stringify(alleles),
+    signature,
+    omittedSupportingReadIds,
+  };
+}
+
+function validateConstructReportExpectedVariant(
+  value: unknown,
+  path: string,
+  topology: 'linear' | 'circular',
+  referenceLength: number,
+  qualityMappedReadCount: number,
+): ConstructReportExpectedVariant {
+  const variant = reportObject(value, path);
+  assertKnownKeys(variant, [
+    'id',
+    'type',
+    'referenceStart',
+    'referenceEnd',
+    'reference',
+    'alternate',
+    'status',
+    'depth',
+    'observedVariantId',
+  ], path);
+  const id = reportIdentityText(variant.id, `${path}.id`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+  const alleles = validateConstructReportVariantAlleles(variant, path, topology, referenceLength);
+  const status = reportString(variant.status, `${path}.status`);
+  if (!CONSTRUCT_REPORT_EXPECTED_VARIANT_STATUS_SET.has(status)) throw new Error(`${path}.status is not supported.`);
+  const depth = reportIntegerBetween(variant.depth, `${path}.depth`, 0, qualityMappedReadCount);
+  const observedVariantId = reportOptionalIdentityText(
+    variant.observedVariantId,
+    `${path}.observedVariantId`,
+    MAX_ARTIFACT_ANALYSIS_ID_LENGTH,
+  );
+  if ((status === 'observed' || status === 'low_confidence') !== (observedVariantId !== undefined)) {
+    throw new Error(`${path}.observedVariantId presence is inconsistent with status ${status}.`);
+  }
+  if (
+    (status === 'not_covered' && depth !== 0)
+    || ((status === 'observed' || status === 'not_observed') && depth === 0)
+  ) {
+    throw new Error(`${path}.depth is inconsistent with status ${status}.`);
+  }
+  const signature = JSON.stringify([
+    id,
+    alleles.type,
+    alleles.start,
+    alleles.end,
+    alleles.reference,
+    alleles.alternate,
+    status,
+    depth,
+    observedVariantId ?? null,
+  ]);
+  return {
+    id,
+    status: status as ConstructReportExpectedVariant['status'],
+    ...(observedVariantId === undefined ? {} : { observedVariantId }),
+    depth,
+    alleleKey: JSON.stringify(alleles),
+    signature,
+  };
+}
+
+function validateConstructVerificationReport(
+  result: ConstructVerificationAnalysisResult,
+  asset: ArtifactAnalysisAsset,
+): void {
+  const path = `Analysis result "${result.id}" verification report`;
+  if (result.status !== 'complete') throw new Error(`${path} requires a complete analysis result.`);
+  if (asset.sha256 === undefined) throw new Error(`${path} asset requires a content SHA-256.`);
+  if (asset.createdAt !== result.createdAt) throw new Error(`${path} asset and result timestamps must match.`);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(asset.content);
+  } catch {
+    throw new Error(`${path} must contain valid JSON.`);
+  }
+  const report = reportObject(parsed, path);
+  assertKnownKeys(report, [
+    'schema',
+    'version',
+    'state',
+    'reasons',
+    'reference',
+    'thresholds',
+    'reads',
+    'coverage',
+    'consensus',
+    'variants',
+    'provenance',
+    'omitted',
+  ], path);
+  if (report.schema !== CONSTRUCT_VERIFICATION_REPORT_SCHEMA || report.version !== 1) {
+    throw new Error(`${path} must use ${CONSTRUCT_VERIFICATION_REPORT_SCHEMA} version 1.`);
+  }
+  assertReportValue(result, 'state', report.state, result.data.state);
+
+  if (!result.assetIds.includes(asset.id)) {
+    throw new Error(`Analysis result "${result.id}" verification report asset must also appear in assetIds.`);
+  }
+  if (!result.inputSha256s || result.inputSha256s.length !== result.inputRecordIds.length) {
+    throw new Error(`Analysis result "${result.id}" with a verification report requires ordered inputSha256s.`);
+  }
+
+  const reference = reportObject(report.reference, `${path}.reference`);
+  assertKnownKeys(reference, ['id', 'name', 'length', 'topology', 'sha256'], `${path}.reference`);
+  assertReportValue(
+    result,
+    'reference.id',
+    reportIdentityText(reference.id, `${path}.reference.id`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH),
+    result.data.referenceRecordId,
+  );
+  reportOptionalIdentityText(reference.name, `${path}.reference.name`, MAX_ARTIFACT_ANALYSIS_NAME_LENGTH);
+  const referenceLength = reportIntegerBetween(
+    reference.length,
+    `${path}.reference.length`,
+    1,
+    CONSTRUCT_REPORT_LIMITS.maxReferenceLength,
+  );
+  assertReportValue(result, 'reference.length', referenceLength, result.data.referenceLength);
+  const topology = reportString(reference.topology, `${path}.reference.topology`);
+  if (topology !== 'linear' && topology !== 'circular') throw new Error(`${path}.reference.topology is not supported.`);
+  assertReportValue(result, 'reference.topology', topology, result.parameters.topology);
+  const referenceSha256 = reportSha256(reference.sha256, `${path}.reference.sha256`);
+  assertReportValue(result, 'reference.sha256', referenceSha256, result.inputSha256s[0]);
+
+  const reportThresholds = reportObject(report.thresholds, `${path}.thresholds`);
+  assertReportThresholds(result, reportThresholds);
+
+  const reads = reportArray(report.reads, `${path}.reads`);
+  const omitted = reportObject(report.omitted, `${path}.omitted`);
+  assertKnownKeys(omitted, [
+    'reasons',
+    'reads',
+    'requiredRegions',
+    'observedVariants',
+    'expectedVariants',
+    'unexpectedVariants',
+    'missingExpectedVariants',
+    'supportingReadIds',
+  ], `${path}.omitted`);
+  if (reportInteger(omitted.reads, `${path}.omitted.reads`) !== 0) {
+    throw new Error(`${path} cannot omit read identities.`);
+  }
+  if (reads.length !== result.data.readRecordIds.length) reportMismatch(result, 'reads length');
+  const validatedReads = reads.map((value, index) => (
+    validateConstructReportRead(
+      value,
+      index,
+      topology as 'linear' | 'circular',
+      referenceLength,
+      reportThresholds,
+    )
+  ));
+  const reportReadIds = validatedReads.map((read) => read.id);
+  const reportReadSha256s = validatedReads.map((read) => read.sha256);
+  const mappedReadCount = validatedReads.filter((read) => read.mapped).length;
+  if (new Set(reportReadIds).size !== reportReadIds.length) throw new Error(`${path}.reads cannot contain duplicate ids.`);
+  assertReportArray(result, 'reads[].id', reportReadIds, result.data.readRecordIds);
+  assertReportArray(result, 'reads[].sha256', reportReadSha256s, result.inputSha256s.slice(1));
+  assertReportValue(result, 'mapped read count', mappedReadCount, result.data.mappedReadCount);
+
+  const provenance = reportObject(report.provenance, `${path}.provenance`);
+  assertKnownKeys(provenance, [
+    'engine',
+    'engineVersion',
+    'referenceSha256',
+    'readSha256s',
+    'requestSha256',
+    'workUnits',
+    'limits',
+  ], `${path}.provenance`);
+  const engine = reportString(provenance.engine, `${path}.provenance.engine`);
+  const engineVersion = reportString(provenance.engineVersion, `${path}.provenance.engineVersion`);
+  if (engine !== 'motif-construct-verification' || engineVersion !== '1') {
+    throw new Error(`${path}.provenance must identify motif-construct-verification version 1.`);
+  }
+  assertReportValue(result, 'provenance.engine', engine, result.provenance.engine);
+  assertReportValue(result, 'provenance.engineVersion', engineVersion, result.provenance.engineVersion);
+  assertReportValue(result, 'provenance.referenceSha256', reportSha256(provenance.referenceSha256, `${path}.provenance.referenceSha256`), referenceSha256);
+  const provenanceReadSha256s = reportArray(provenance.readSha256s, `${path}.provenance.readSha256s`)
+    .map((sha256, index) => reportSha256(sha256, `${path}.provenance.readSha256s[${index}]`));
+  assertReportArray(result, 'provenance.readSha256s', provenanceReadSha256s, reportReadSha256s);
+  const requestSha256 = reportSha256(provenance.requestSha256, `${path}.provenance.requestSha256`);
+  const savedRequestSha256 = reportSha256(result.parameters.requestSha256, `Analysis result "${result.id}" parameters.requestSha256`);
+  assertReportValue(result, 'provenance.requestSha256', requestSha256, savedRequestSha256);
+  const readEvidence = reportObject(
+    result.parameters.readEvidence,
+    `Analysis result "${result.id}" parameters.readEvidence`,
+  );
+  assertKnownKeys(readEvidence, ['schema', 'sha256s'], `Analysis result "${result.id}" parameters.readEvidence`);
+  if (readEvidence.schema !== 'motif.construct-read-evidence.v1') {
+    throw new Error(`Analysis result "${result.id}" parameters.readEvidence schema is not supported.`);
+  }
+  const readEvidenceSha256s = reportArray(
+    readEvidence.sha256s,
+    `Analysis result "${result.id}" parameters.readEvidence.sha256s`,
+  ).map((sha256, index) => reportSha256(
+    sha256,
+    `Analysis result "${result.id}" parameters.readEvidence.sha256s[${index}]`,
+  ));
+  if (readEvidenceSha256s.length !== reportReadIds.length) {
+    throw new Error(`Analysis result "${result.id}" parameters.readEvidence must align one-to-one with reads.`);
+  }
+  const workUnits = reportIntegerBetween(
+    provenance.workUnits,
+    `${path}.provenance.workUnits`,
+    0,
+    CONSTRUCT_REPORT_LIMITS.maxWorkUnits,
+  );
+  const provenanceLimits = reportObject(provenance.limits, `${path}.provenance.limits`);
+  assertKnownKeys(provenanceLimits, Object.keys(CONSTRUCT_REPORT_LIMITS), `${path}.provenance.limits`);
+  assertReportArray(
+    result,
+    'provenance.limits keys',
+    Object.keys(provenanceLimits).sort(),
+    Object.keys(CONSTRUCT_REPORT_LIMITS).sort(),
+  );
+  Object.entries(CONSTRUCT_REPORT_LIMITS).forEach(([key, expected]) => {
+    assertReportValue(
+      result,
+      `provenance.limits.${key}`,
+      reportInteger(provenanceLimits[key], `${path}.provenance.limits.${key}`),
+      expected,
+    );
+  });
+
+  const validateSavedProvenance = (saved: ArtifactProvenance, savedPath: string) => {
+    if (
+      saved.source !== 'motif-for-claude-science-artifact'
+      || saved.operation !== 'construct_verification'
+      || saved.actor !== 'user'
+      || saved.engine !== engine
+      || saved.engineVersion !== engineVersion
+    ) {
+      throw new Error(`${savedPath} must identify the Motif construct-verification engine and user action.`);
+    }
+    if (saved.parentIds === undefined) throw new Error(`${savedPath}.parentIds is required.`);
+    assertReportArray(result, `${savedPath}.parentIds`, saved.parentIds, result.inputRecordIds);
+    const metadata = reportObject(saved.metadata, `${savedPath}.metadata`);
+    assertKnownKeys(metadata, ['requestSha256', 'workUnits'], `${savedPath}.metadata`);
+    assertReportValue(
+      result,
+      `${savedPath}.metadata.requestSha256`,
+      reportSha256(metadata.requestSha256, `${savedPath}.metadata.requestSha256`),
+      requestSha256,
+    );
+    assertReportValue(
+      result,
+      `${savedPath}.metadata.workUnits`,
+      reportIntegerBetween(metadata.workUnits, `${savedPath}.metadata.workUnits`, 0, CONSTRUCT_REPORT_LIMITS.maxWorkUnits),
+      workUnits,
+    );
+  };
+  validateSavedProvenance(result.provenance, `Analysis result "${result.id}" provenance`);
+  validateSavedProvenance(asset.provenance, `Analysis asset "${asset.id}" provenance`);
+
+  const consensus = reportObject(report.consensus, `${path}.consensus`);
+  assertKnownKeys(consensus, ['sequence'], `${path}.consensus`);
+  if (
+    typeof consensus.sequence !== 'string'
+    || !CONSTRUCT_REPORT_IUPAC_CONSENSUS_PATTERN.test(consensus.sequence)
+    || consensus.sequence.length > referenceLength
+      + (result.data.observedVariantCount * CONSTRUCT_REPORT_LIMITS.maxIndelLength)
+  ) {
+    throw new Error(`${path}.consensus.sequence must be bounded A/C/G/T/N evidence.`);
+  }
+
+  const coverage = reportObject(report.coverage, `${path}.coverage`);
+  assertKnownKeys(coverage, [
+    'coveredBasesAtAnyDepth',
+    'basesMeetingMinDepth',
+    'coverageFraction',
+    'minimumDepth',
+    'maximumDepth',
+    'meanDepth',
+    'requiredRegions',
+  ], `${path}.coverage`);
+  const coveredBasesAtAnyDepth = reportIntegerBetween(
+    coverage.coveredBasesAtAnyDepth,
+    `${path}.coverage.coveredBasesAtAnyDepth`,
+    0,
+    referenceLength,
+  );
+  const basesMeetingMinDepth = reportIntegerBetween(
+    coverage.basesMeetingMinDepth,
+    `${path}.coverage.basesMeetingMinDepth`,
+    0,
+    coveredBasesAtAnyDepth,
+  );
+  assertReportValue(
+    result,
+    'coverage.basesMeetingMinDepth',
+    basesMeetingMinDepth,
+    result.data.coveredBases,
+  );
+  const coverageFraction = reportNumberBetween(
+    coverage.coverageFraction,
+    `${path}.coverage.coverageFraction`,
+    0,
+    1,
+  );
+  assertReportNumber(result, 'coverage.coverageFraction', coverageFraction, result.data.coverageFraction);
+  assertReportNumber(result, 'coverage.coverageFraction formula', coverageFraction, basesMeetingMinDepth / referenceLength);
+  const minimumDepth = reportIntegerBetween(
+    coverage.minimumDepth,
+    `${path}.coverage.minimumDepth`,
+    0,
+    mappedReadCount,
+  );
+  const maximumDepth = reportIntegerBetween(
+    coverage.maximumDepth,
+    `${path}.coverage.maximumDepth`,
+    minimumDepth,
+    mappedReadCount,
+  );
+  reportNumberBetween(coverage.meanDepth, `${path}.coverage.meanDepth`, minimumDepth, maximumDepth);
+  const globalMinDepth = reportInteger(
+    reportThresholds.minDepth,
+    `${path}.thresholds.minDepth`,
+  );
+  if (
+    (coveredBasesAtAnyDepth === 0) !== (maximumDepth === 0)
+    || (coveredBasesAtAnyDepth === referenceLength) !== (minimumDepth > 0)
+    || (basesMeetingMinDepth === 0) !== (maximumDepth < globalMinDepth)
+    || (basesMeetingMinDepth === referenceLength) !== (minimumDepth >= globalMinDepth)
+  ) {
+    throw new Error(`${path}.coverage depth extrema, thresholds, and covered-base counts are inconsistent.`);
+  }
+  const requiredRegions = reportArray(coverage.requiredRegions, `${path}.coverage.requiredRegions`);
+  const omittedRequiredRegions = reportInteger(omitted.requiredRegions, `${path}.omitted.requiredRegions`);
+  assertReportValue(result, 'required region count', requiredRegions.length + omittedRequiredRegions, result.data.requiredRegionCount);
+  if (omittedRequiredRegions !== 0) throw new Error(`${path} cannot omit required-region acceptance states.`);
+  if (requiredRegions.length > CONSTRUCT_REPORT_LIMITS.maxRequiredRegions) {
+    throw new Error(`${path}.coverage.requiredRegions exceeds the v1 limit.`);
+  }
+  const validatedRegions = requiredRegions.map((value, index) => validateConstructReportRegion(
+    value,
+    index,
+    topology as 'linear' | 'circular',
+    referenceLength,
+    mappedReadCount,
+  ));
+  if (new Set(validatedRegions.map((region) => region.id)).size !== validatedRegions.length) {
+    throw new Error(`${path}.coverage.requiredRegions cannot contain duplicate ids.`);
+  }
+  const passingRegionCount = validatedRegions.filter((region) => region.status === 'covered').length;
+  assertReportValue(result, 'passing region count', passingRegionCount, result.data.passingRegionCount);
+
+  const variants = reportObject(report.variants, `${path}.variants`);
+  assertKnownKeys(variants, ['observed', 'expected', 'unexpected', 'missingExpected'], `${path}.variants`);
+  const observedValues = reportArray(variants.observed, `${path}.variants.observed`);
+  const expectedValues = reportArray(variants.expected, `${path}.variants.expected`);
+  const unexpectedValues = reportArray(variants.unexpected, `${path}.variants.unexpected`);
+  const missingExpectedValues = reportArray(variants.missingExpected, `${path}.variants.missingExpected`);
+  const omittedObservedVariants = reportInteger(omitted.observedVariants, `${path}.omitted.observedVariants`);
+  const omittedUnexpectedVariants = reportInteger(omitted.unexpectedVariants, `${path}.omitted.unexpectedVariants`);
+  const omittedExpectedVariants = reportInteger(omitted.expectedVariants, `${path}.omitted.expectedVariants`);
+  const omittedMissingExpectedVariants = reportInteger(
+    omitted.missingExpectedVariants,
+    `${path}.omitted.missingExpectedVariants`,
+  );
+  const assertCompactCount = (
+    field: string,
+    displayed: number,
+    omittedCount: number,
+    total: number,
+    displayLimit: number,
+  ) => {
+    assertReportValue(result, `variants.${field} displayed count`, displayed, Math.min(total, displayLimit));
+    assertReportValue(result, `variants.${field} omitted count`, omittedCount, Math.max(0, total - displayLimit));
+  };
+  assertCompactCount(
+    'observed',
+    observedValues.length,
+    omittedObservedVariants,
+    result.data.observedVariantCount,
+    CONSTRUCT_REPORT_OBSERVED_VARIANT_LIMIT,
+  );
+  assertCompactCount(
+    'unexpected',
+    unexpectedValues.length,
+    omittedUnexpectedVariants,
+    result.data.unexpectedVariantCount,
+    CONSTRUCT_REPORT_OBSERVED_VARIANT_LIMIT,
+  );
+  assertCompactCount(
+    'expected',
+    expectedValues.length,
+    omittedExpectedVariants,
+    result.data.expectedVariantCount,
+    CONSTRUCT_REPORT_LIMITS.maxExpectedVariants,
+  );
+  assertCompactCount(
+    'missingExpected',
+    missingExpectedValues.length,
+    omittedMissingExpectedVariants,
+    result.data.missingExpectedVariantCount,
+    CONSTRUCT_REPORT_LIMITS.maxExpectedVariants,
+  );
+  if (
+    observedValues.length > CONSTRUCT_REPORT_OBSERVED_VARIANT_LIMIT
+    || unexpectedValues.length > CONSTRUCT_REPORT_OBSERVED_VARIANT_LIMIT
+    || expectedValues.length > CONSTRUCT_REPORT_LIMITS.maxExpectedVariants
+    || missingExpectedValues.length > CONSTRUCT_REPORT_LIMITS.maxExpectedVariants
+  ) {
+    throw new Error(`${path}.variants exceeds the v1 limits.`);
+  }
+  const knownReadIds = new Set(reportReadIds);
+  const mappedReadIds = new Set(validatedReads.filter((read) => read.mapped).map((read) => read.id));
+  const qualityMappedReadIds = new Set(validatedReads
+    .filter((read) => read.mapped && read.qualityProvided)
+    .map((read) => read.id));
+  const observed = observedValues.map((value, index) => validateConstructReportObservedVariant(
+    value,
+    `${path}.variants.observed[${index}]`,
+    topology as 'linear' | 'circular',
+    referenceLength,
+    mappedReadCount,
+    mappedReadIds,
+    qualityMappedReadIds,
+    reportThresholds,
+  ));
+  const unexpected = unexpectedValues.map((value, index) => validateConstructReportObservedVariant(
+    value,
+    `${path}.variants.unexpected[${index}]`,
+    topology as 'linear' | 'circular',
+    referenceLength,
+    mappedReadCount,
+    mappedReadIds,
+    qualityMappedReadIds,
+    reportThresholds,
+  ));
+  const expected = expectedValues.map((value, index) => validateConstructReportExpectedVariant(
+    value,
+    `${path}.variants.expected[${index}]`,
+    topology as 'linear' | 'circular',
+    referenceLength,
+    qualityMappedReadIds.size,
+  ));
+  const missingExpected = missingExpectedValues.map((value, index) => validateConstructReportExpectedVariant(
+    value,
+    `${path}.variants.missingExpected[${index}]`,
+    topology as 'linear' | 'circular',
+    referenceLength,
+    qualityMappedReadIds.size,
+  ));
+  const assertUniqueVariantIds = (entries: readonly { id: string }[], field: string) => {
+    if (new Set(entries.map((entry) => entry.id)).size !== entries.length) {
+      throw new Error(`${path}.variants.${field} cannot contain duplicate ids.`);
+    }
+  };
+  assertUniqueVariantIds(observed, 'observed');
+  assertUniqueVariantIds(expected, 'expected');
+  assertUniqueVariantIds(unexpected, 'unexpected');
+  assertUniqueVariantIds(missingExpected, 'missingExpected');
+  const observedById = new Map(observed.map((variant) => [variant.id, variant]));
+  const expectedById = new Map(expected.map((variant) => [variant.id, variant]));
+  observed.forEach((variant) => {
+    if (variant.expectedVariantId === undefined) return;
+    const linked = expectedById.get(variant.expectedVariantId);
+    if (
+      !linked
+      || linked.observedVariantId !== variant.id
+      || linked.alleleKey !== variant.alleleKey
+      || linked.depth > variant.depth
+    ) {
+      throw new Error(`${path}.variants observed/expected cross-links are inconsistent.`);
+    }
+  });
+  expected.forEach((variant) => {
+    if (variant.observedVariantId === undefined) return;
+    const linked = observedById.get(variant.observedVariantId);
+    if (
+      linked !== undefined
+      && (
+        linked.expectedVariantId !== variant.id
+        || linked.alleleKey !== variant.alleleKey
+        || variant.depth > linked.depth
+        || (variant.status === 'observed' ? linked.confidence !== 'high' : linked.confidence !== 'low')
+      )
+    ) {
+      throw new Error(`${path}.variants expected/observed cross-links are inconsistent.`);
+    }
+    if (linked === undefined && omittedObservedVariants === 0) {
+      throw new Error(`${path}.variants expected/observed cross-links are inconsistent.`);
+    }
+  });
+  const unexpectedById = new Map(unexpected.map((variant) => [variant.id, variant]));
+  observed.filter((variant) => variant.expectedVariantId === undefined).forEach((variant) => {
+    const matching = unexpectedById.get(variant.id);
+    if (!matching || matching.signature !== variant.signature) {
+      throw new Error(`${path}.variants.unexpected must retain every visible unexpected observed variant.`);
+    }
+  });
+  unexpected.forEach((variant) => {
+    if (variant.expectedVariantId !== undefined) {
+      throw new Error(`${path}.variants.unexpected cannot contain an expected variant link.`);
+    }
+    const matching = observedById.get(variant.id);
+    if (matching !== undefined && matching.signature !== variant.signature) {
+      throw new Error(`${path}.variants.unexpected must exactly match observed evidence.`);
+    }
+    if (matching === undefined && omittedObservedVariants === 0) {
+      throw new Error(`${path}.variants.unexpected references absent observed evidence.`);
+    }
+  });
+  const expectedMissingSignatures = expected
+    .filter((variant) => variant.status !== 'observed')
+    .map((variant) => variant.signature);
+  assertReportArray(
+    result,
+    'variants.missingExpected subset',
+    missingExpected.map((variant) => variant.signature),
+    expectedMissingSignatures,
+  );
+  const expectedSupportingOmissions = [...observed, ...unexpected]
+    .reduce((total, variant) => total + variant.omittedSupportingReadIds, 0);
+  const reportedSupportingOmissions = reportInteger(
+    omitted.supportingReadIds,
+    `${path}.omitted.supportingReadIds`,
+  );
+  if (
+    (omittedObservedVariants === 0 && omittedUnexpectedVariants === 0
+      && reportedSupportingOmissions !== expectedSupportingOmissions)
+    || reportedSupportingOmissions < expectedSupportingOmissions
+  ) {
+    throw new Error(`${path}.omitted.supportingReadIds is inconsistent with compact variant evidence.`);
+  }
+
+  const requiredReasonCodes = new Set<string>();
+  if (mappedReadCount === 0) requiredReasonCodes.add('no_usable_reads');
+  validatedReads.forEach((read) => {
+    if (!read.qualityProvided) requiredReasonCodes.add('missing_quality');
+    if (read.status === 'trimmed_read_too_short') requiredReasonCodes.add('trimmed_read_too_short');
+    else if (read.status === 'unmapped') requiredReasonCodes.add('unmapped_read');
+    else if (read.status !== 'mapped') requiredReasonCodes.add(read.status);
+  });
+  if (
+    coverageFraction
+    < reportFiniteNumber(reportThresholds.minCoverageFraction, `${path}.thresholds.minCoverageFraction`)
+  ) requiredReasonCodes.add('partial_reference_coverage');
+  validatedRegions.forEach((region) => {
+    region.reasonCodes.forEach((code) => requiredReasonCodes.add(code));
+  });
+  observed.forEach((variant) => {
+    if (variant.confidence === 'low') requiredReasonCodes.add('low_confidence_variant');
+  });
+  const visibleHighConfidenceUnexpected = unexpected.some((variant) => variant.confidence === 'high');
+  if (visibleHighConfidenceUnexpected) requiredReasonCodes.add('unexpected_variant');
+  expected.forEach((variant) => {
+    if (variant.status === 'not_covered') requiredReasonCodes.add('expected_variant_not_covered');
+    else if (variant.status === 'not_observed') requiredReasonCodes.add('expected_variant_not_observed');
+  });
+  requiredReasonCodes.forEach((code) => {
+    if (!result.data.reasonCodes.includes(code)) {
+      throw new Error(`${path} is missing required reason code ${code}.`);
+    }
+  });
+  const visibleInconsistency = visibleHighConfidenceUnexpected
+    || expected.some((variant) => variant.status === 'not_observed');
+  if (visibleInconsistency && result.data.state !== 'inconsistent') {
+    throw new Error(`${path}.state must be inconsistent for visible contradictory variant evidence.`);
+  }
+  if (requiredReasonCodes.size > 0 && result.data.state === 'consistent') {
+    throw new Error(`${path}.state cannot be consistent while review or inconsistent evidence is present.`);
+  }
+
+  const reasons = reportArray(report.reasons, `${path}.reasons`);
+  if (reasons.length > CONSTRUCT_REPORT_REASON_LIMIT) throw new Error(`${path}.reasons exceeds the v1 limit.`);
+  const reportReasonCodes: string[] = [];
+  const seenReasonCodes = new Set<string>();
+  let hasReviewReason = false;
+  let hasInconsistentReason = false;
+  const knownRegionIds = new Set(validatedRegions.map((region) => region.id));
+  const knownVariantIds = new Set([...observed, ...expected].map((variant) => variant.id));
+  reasons.forEach((value, index) => {
+    const reason = reportObject(value, `${path}.reasons[${index}]`);
+    assertKnownKeys(reason, ['code', 'severity', 'message', 'readId', 'regionId', 'variantId'], `${path}.reasons[${index}]`);
+    const code = reportIdentityText(reason.code, `${path}.reasons[${index}].code`, 128);
+    if (!STABLE_REASON_CODE_PATTERN.test(code)) throw new Error(`${path}.reasons[${index}].code is not stable.`);
+    if (reason.severity !== 'review' && reason.severity !== 'inconsistent') {
+      throw new Error(`${path}.reasons[${index}].severity is not supported.`);
+    }
+    if (reason.severity === 'review') hasReviewReason = true;
+    else hasInconsistentReason = true;
+    if (typeof reason.message !== 'string' || reason.message.length > 512) {
+      throw new Error(`${path}.reasons[${index}].message must be a string no longer than 512 characters.`);
+    }
+    const readId = reportOptionalIdentityText(reason.readId, `${path}.reasons[${index}].readId`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+    const regionId = reportOptionalIdentityText(reason.regionId, `${path}.reasons[${index}].regionId`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+    const variantId = reportOptionalIdentityText(reason.variantId, `${path}.reasons[${index}].variantId`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+    if (readId !== undefined && !knownReadIds.has(readId)) throw new Error(`${path}.reasons[${index}].readId is unknown.`);
+    if (regionId !== undefined && !knownRegionIds.has(regionId)) throw new Error(`${path}.reasons[${index}].regionId is unknown.`);
+    if (
+      variantId !== undefined
+      && !knownVariantIds.has(variantId)
+      && omittedObservedVariants === 0
+      && omittedUnexpectedVariants === 0
+    ) throw new Error(`${path}.reasons[${index}].variantId is unknown.`);
+    if (!seenReasonCodes.has(code)) {
+      seenReasonCodes.add(code);
+      reportReasonCodes.push(code);
+    }
+  });
+  assertReportArray(result, 'reason code prefix', reportReasonCodes, result.data.reasonCodes.slice(0, reportReasonCodes.length));
+  const omittedReasons = reportInteger(omitted.reasons, `${path}.omitted.reasons`);
+  if (reasons.length < CONSTRUCT_REPORT_REASON_LIMIT && omittedReasons !== 0) {
+    throw new Error(`${path}.omitted.reasons cannot be nonzero below the report limit.`);
+  }
+  if (omittedReasons === 0) {
+    assertReportArray(result, 'reason codes', reportReasonCodes, result.data.reasonCodes);
+  }
+  if (
+    (result.data.state === 'consistent' && (hasReviewReason || hasInconsistentReason || omittedReasons > 0))
+    || (result.data.state === 'needs_review' && (hasInconsistentReason || (!hasReviewReason && omittedReasons === 0)))
+    || (result.data.state === 'inconsistent' && !hasInconsistentReason && omittedReasons === 0)
+  ) {
+    throw new Error(`${path}.state is inconsistent with its reason severities.`);
+  }
 }
 
 function validateDependencies(workspace: ArtifactAnalysisWorkspace, context: ArtifactAnalysisContext): void {
@@ -801,9 +2289,25 @@ function validateDependencies(workspace: ArtifactAnalysisWorkspace, context: Art
       if (!assetIds.has(assetId)) throw new Error(`Analysis result "${result.id}" references missing asset "${assetId}".`);
     });
     if (context.recordLengths) {
-      resultRecordIds(result).forEach((recordId) => {
+      artifactAnalysisResultRecordIds(result).forEach((recordId) => {
         if (!context.recordLengths?.has(recordId)) throw new Error(`Analysis result "${result.id}" references missing record "${recordId}".`);
       });
+    }
+    if (result.kind === 'construct_verification') {
+      const expectedInputRecordIds = [result.data.referenceRecordId, ...result.data.readRecordIds];
+      if (
+        result.inputRecordIds.length !== expectedInputRecordIds.length
+        || result.inputRecordIds.some((recordId, index) => recordId !== expectedInputRecordIds[index])
+      ) {
+        throw new Error(`Analysis result "${result.id}" inputRecordIds must list the construct reference first, followed by readRecordIds in saved order.`);
+      }
+      if (result.data.verificationReportAssetId) {
+        const reportAsset = workspace.analysisAssets.find((candidate) => candidate.id === result.data.verificationReportAssetId);
+        if (reportAsset && reportAsset.mediaType !== 'application/json') {
+          throw new Error(`Analysis result "${result.id}" verification report asset must use application/json.`);
+        }
+        if (reportAsset) validateConstructVerificationReport(result, reportAsset);
+      }
     }
     if (result.kind === 'structure_model') {
       const asset = workspace.analysisAssets.find((candidate) => candidate.id === result.data.modelAssetId);
@@ -907,7 +2411,7 @@ export function getArtifactAnalysisAssetDependents(value: unknown, assetId: stri
 
 export function getArtifactAnalysisRecordDependents(value: unknown, recordId: string): string[] {
   const workspace = normalizeArtifactAnalysisWorkspace(value);
-  return workspace.analysisResults.filter((result) => resultRecordIds(result).includes(recordId)).map((result) => result.id);
+  return workspace.analysisResults.filter((result) => artifactAnalysisResultRecordIds(result).includes(recordId)).map((result) => result.id);
 }
 
 /** Workspace-shaped removal that also validates asset dependencies. */
@@ -1022,7 +2526,7 @@ export function removeArtifactAnalysisResultsForRecord(
   options: { removeOrphanAssets?: boolean } = {},
 ): ArtifactAnalysisWorkspace {
   const workspace = normalizeArtifactAnalysisWorkspace(value);
-  const directIds = workspace.analysisResults.filter((result) => resultRecordIds(result).includes(recordId)).map((result) => result.id);
+  const directIds = workspace.analysisResults.filter((result) => artifactAnalysisResultRecordIds(result).includes(recordId)).map((result) => result.id);
   if (directIds.length === 0) return workspace;
   const removedIds = collectResultCascade(workspace.analysisResults, directIds);
   const keptResults = workspace.analysisResults.filter((result) => !removedIds.has(result.id));

--- a/src/artifacts/claude-science-construct-verification-artifacts.ts
+++ b/src/artifacts/claude-science-construct-verification-artifacts.ts
@@ -1,0 +1,663 @@
+import {
+  MAX_ARTIFACT_ANALYSIS_ASSET_BYTES,
+  type ArtifactAnalysisAsset,
+  type ArtifactAnalysisResult,
+} from './claude-science-analysis-results';
+import { sha256HexSync } from './claude-science-sha256';
+
+export const ARTIFACT_CONSTRUCT_READ_EVIDENCE_SCHEMA = 'motif.construct-read-evidence.v1' as const;
+export const ARTIFACT_CONSTRUCT_VERIFICATION_REPORT_SCHEMA = 'motif.construct-verification-report.v1' as const;
+
+export const ARTIFACT_CONSTRUCT_VERIFICATION_REPORT_LIMITS = {
+  maxReasons: 256,
+  maxReads: 96,
+  maxRequiredRegions: 128,
+  maxObservedVariants: 192,
+  maxExpectedVariants: 256,
+  maxUnexpectedVariants: 192,
+  maxMissingExpectedVariants: 256,
+  maxSupportingReadIds: 8,
+  maxReasonMessageLength: 512,
+  maxStructuredNodes: 32_000,
+} as const;
+
+const MAX_SANGER_BASE_CALLS = 5_000;
+const MAX_REFERENCE_LENGTH = 50_000;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
+const IUPAC_DNA_PATTERN = /^[ACGTRYSWKMBDHVN]+$/i;
+const STABLE_REASON_CODE_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+export type ArtifactConstructReadEvidenceInput = {
+  baseCalls: string;
+  qualityScores?: readonly number[] | null;
+};
+
+export type ArtifactConstructReadEvidence = {
+  schema: typeof ARTIFACT_CONSTRUCT_READ_EVIDENCE_SCHEMA;
+  baseCalls: string;
+  qualityScores: number[] | null;
+};
+
+/**
+ * Canonical evidence deliberately excludes trace rendering and record metadata.
+ * Case normalization is explicit; whitespace and malformed/misaligned quality
+ * arrays are rejected rather than silently repaired.
+ */
+export function canonicalizeArtifactConstructReadEvidence(
+  input: ArtifactConstructReadEvidenceInput,
+): ArtifactConstructReadEvidence {
+  if (typeof input.baseCalls !== 'string'
+    || input.baseCalls.length === 0
+    || input.baseCalls.length > MAX_SANGER_BASE_CALLS
+    || !IUPAC_DNA_PATTERN.test(input.baseCalls)) {
+    throw new Error(`baseCalls must contain 1–${MAX_SANGER_BASE_CALLS.toLocaleString()} unspaced IUPAC DNA calls.`);
+  }
+  const baseCalls = input.baseCalls.toUpperCase();
+  const suppliedScores = input.qualityScores;
+  let qualityScores: number[] | null = null;
+  if (suppliedScores !== undefined && suppliedScores !== null && suppliedScores.length > 0) {
+    if (suppliedScores.length !== baseCalls.length) {
+      throw new Error('Nonempty qualityScores must contain exactly one score per base call.');
+    }
+    qualityScores = Array.from(suppliedScores, (score, index) => {
+      if (!Number.isInteger(score) || score < 0 || score > 255) {
+        throw new Error(`qualityScores[${index}] must be an integer from 0 through 255.`);
+      }
+      return score;
+    });
+  }
+  return {
+    schema: ARTIFACT_CONSTRUCT_READ_EVIDENCE_SCHEMA,
+    baseCalls,
+    qualityScores,
+  };
+}
+
+/** SHA-256 of the fixed-key canonical JSON object, and nothing else. */
+export function artifactConstructReadEvidenceSha256(
+  input: ArtifactConstructReadEvidenceInput,
+): string {
+  return sha256HexSync(JSON.stringify(canonicalizeArtifactConstructReadEvidence(input)));
+}
+
+type ConstructVerificationReasonSource = {
+  code: string;
+  severity: 'review' | 'inconsistent';
+  message: string;
+  readId?: string;
+  regionId?: string;
+  variantId?: string;
+};
+
+type ConstructVerificationThresholdsSource = {
+  trimQuality: number;
+  trimWindow: number;
+  minTrimmedReadLength: number;
+  minMappingIdentity: number;
+  minMappingMargin: number;
+  maxIndelFraction: number;
+  minCoverageFraction: number;
+  minDepth: number;
+  requireBothStrands: boolean;
+  minConsensusFraction: number;
+  minVariantQuality: number;
+  minVariantFraction: number;
+};
+
+type ConstructVerificationTrimSource = {
+  method: 'quality_window' | 'none_missing_quality';
+  rawStart: number;
+  rawEnd: number;
+  trimmedLength: number;
+  removedFromStart: number;
+  removedFromEnd: number;
+};
+
+type ConstructVerificationMappingSource = {
+  orientation: 'forward' | 'reverse';
+  referenceStart: number;
+  referenceEnd: number;
+  wraps: boolean;
+  referenceSpan: number;
+  score: number;
+  secondBestScore: number | null;
+  mappingMargin: number | null;
+  identity: number;
+  alignedLength: number;
+  matches: number;
+  substitutions: number;
+  insertions: number;
+  deletions: number;
+  indelFraction: number;
+};
+
+type ConstructVerificationReadSource = {
+  id: string;
+  name?: string;
+  sha256: string;
+  rawLength: number;
+  qualityProvided: boolean;
+  meanQuality: number | null;
+  status: 'mapped'
+    | 'trimmed_read_too_short'
+    | 'unmapped'
+    | 'ambiguous_mapping'
+    | 'low_mapping_identity'
+    | 'excessive_indel';
+  trim: ConstructVerificationTrimSource;
+  mapping: ConstructVerificationMappingSource | null;
+};
+
+type ConstructVerificationRegionSource = {
+  id: string;
+  name?: string;
+  start: number;
+  end: number;
+  wraps: boolean;
+  length: number;
+  minDepth: number;
+  requireBothStrands: boolean;
+  coveredBases: number;
+  basesMeetingMinDepth: number;
+  coveredFraction: number;
+  minimumDepth: number;
+  maximumDepth: number;
+  meanDepth: number;
+  forwardCoveredBases: number;
+  reverseCoveredBases: number;
+  bothStrandsCoveredBases: number;
+  status: 'covered' | 'uncovered' | 'low_depth' | 'missing_strand';
+};
+
+type ConstructVerificationObservedVariantSource = {
+  id: string;
+  type: 'substitution' | 'insertion' | 'deletion';
+  referenceStart: number;
+  referenceEnd: number;
+  reference: string;
+  alternate: string;
+  depth: number;
+  support: number;
+  supportWeight: number;
+  fraction: number;
+  meanQuality: number | null;
+  confidence: 'high' | 'low';
+  supportingReadIds: readonly string[];
+  expectedVariantId?: string;
+};
+
+type ConstructVerificationExpectedVariantSource = {
+  id: string;
+  type: 'substitution' | 'insertion' | 'deletion';
+  referenceStart: number;
+  referenceEnd: number;
+  reference: string;
+  alternate: string;
+  status: 'observed' | 'low_confidence' | 'not_observed' | 'not_covered';
+  depth: number;
+  observedVariantId?: string;
+};
+
+type ConstructVerificationLimitsSource = {
+  readonly maxReferenceLength: number;
+  readonly maxReads: number;
+  readonly maxReadLength: number;
+  readonly maxRequiredRegions: number;
+  readonly maxRequiredRegionBases: number;
+  readonly maxExpectedVariants: number;
+  readonly maxObservedVariants: number;
+  readonly maxIndelLength: number;
+  readonly maxWorkUnits: number;
+};
+
+/**
+ * Persistence-facing structural subset of the pure verification result. The
+ * engine's full result is directly assignable while heavy evidence stays out
+ * of this module's compile-time dependency surface.
+ */
+export type ArtifactConstructVerificationPersistenceSource = {
+  schema: 'motif.construct-verification.v1';
+  version: 1;
+  state: 'consistent' | 'needs_review' | 'inconsistent';
+  reasons: readonly ConstructVerificationReasonSource[];
+  reference: {
+    id: string;
+    name?: string;
+    sequence: string;
+    length: number;
+    topology: 'linear' | 'circular';
+    sha256: string;
+  };
+  thresholds: ConstructVerificationThresholdsSource;
+  reads: readonly ConstructVerificationReadSource[];
+  coverage: {
+    coveredBases: number;
+    basesMeetingMinDepth: number;
+    coveredFraction: number;
+    minimumDepth: number;
+    maximumDepth: number;
+    meanDepth: number;
+    requiredRegions: readonly ConstructVerificationRegionSource[];
+  };
+  consensus: {
+    sequence: string;
+  };
+  variants: {
+    observed: readonly ConstructVerificationObservedVariantSource[];
+    expected: readonly ConstructVerificationExpectedVariantSource[];
+    unexpected: readonly ConstructVerificationObservedVariantSource[];
+    missingExpected: readonly ConstructVerificationExpectedVariantSource[];
+  };
+  provenance: {
+    engine: 'motif-construct-verification';
+    engineVersion: '1';
+    referenceSha256: string;
+    readSha256s: readonly string[];
+    requestSha256: string;
+    workUnits: number;
+    limits: ConstructVerificationLimitsSource;
+  };
+};
+
+export type ArtifactConstructVerificationBuildIdentity = {
+  resultId: string;
+  assetId: string;
+  createdAt: string;
+};
+
+export type ArtifactConstructVerificationAnalysisResult = Extract<
+  ArtifactAnalysisResult,
+  { kind: 'construct_verification' }
+>;
+
+export type ArtifactConstructVerificationArtifacts = {
+  asset: ArtifactAnalysisAsset;
+  result: ArtifactConstructVerificationAnalysisResult;
+};
+
+export type ArtifactConstructVerificationDuplicateIdentity = {
+  engine: string;
+  engineVersion: string;
+  requestSha256: string;
+};
+
+function normalizeSha256(value: string, path: string): string {
+  if (typeof value !== 'string' || !SHA256_PATTERN.test(value)) {
+    throw new Error(`${path} must be a 64-character SHA-256 value.`);
+  }
+  return value.toLowerCase();
+}
+
+function validateIdentityText(value: string, path: string, maximumLength: number): string {
+  if (typeof value !== 'string' || value.trim() !== value || value.length === 0 || value.length > maximumLength) {
+    throw new Error(`${path} must contain 1–${maximumLength} nonblank, unpadded characters.`);
+  }
+  return value;
+}
+
+function boundedReportText(value: string, maximumLength: number): string {
+  if (value.length <= maximumLength) return value;
+  return `${value.slice(0, Math.max(0, maximumLength - 1))}…`;
+}
+
+function uniqueReasonCodes(reasons: readonly ConstructVerificationReasonSource[]): string[] {
+  const codes: string[] = [];
+  const seen = new Set<string>();
+  for (const reason of reasons) {
+    if (!STABLE_REASON_CODE_PATTERN.test(reason.code) || reason.code.length > 128) {
+      throw new Error(`Construct verification reason code "${reason.code}" is not a stable bounded code.`);
+    }
+    if (seen.has(reason.code)) continue;
+    seen.add(reason.code);
+    codes.push(reason.code);
+    if (codes.length === 500) break;
+  }
+  return codes;
+}
+
+function reportReasons(reasons: readonly ConstructVerificationReasonSource[]) {
+  return reasons.slice(0, ARTIFACT_CONSTRUCT_VERIFICATION_REPORT_LIMITS.maxReasons).map((reason) => ({
+    code: reason.code,
+    severity: reason.severity,
+    message: boundedReportText(reason.message, ARTIFACT_CONSTRUCT_VERIFICATION_REPORT_LIMITS.maxReasonMessageLength),
+    ...(reason.readId === undefined ? {} : { readId: reason.readId }),
+    ...(reason.regionId === undefined ? {} : { regionId: reason.regionId }),
+    ...(reason.variantId === undefined ? {} : { variantId: reason.variantId }),
+  }));
+}
+
+function reportMapping(mapping: ConstructVerificationMappingSource | null) {
+  if (mapping === null) return null;
+  return {
+    orientation: mapping.orientation,
+    referenceStart: mapping.referenceStart,
+    referenceEnd: mapping.referenceEnd,
+    wraps: mapping.wraps,
+    referenceSpan: mapping.referenceSpan,
+    score: mapping.score,
+    secondBestScore: mapping.secondBestScore,
+    mappingMargin: mapping.mappingMargin,
+    identity: mapping.identity,
+    alignedLength: mapping.alignedLength,
+    matches: mapping.matches,
+    substitutions: mapping.substitutions,
+    insertions: mapping.insertions,
+    deletions: mapping.deletions,
+    indelFraction: mapping.indelFraction,
+  };
+}
+
+function reportReads(reads: readonly ConstructVerificationReadSource[]) {
+  return reads.slice(0, ARTIFACT_CONSTRUCT_VERIFICATION_REPORT_LIMITS.maxReads).map((read) => ({
+    id: read.id,
+    ...(read.name === undefined ? {} : { name: read.name }),
+    sha256: read.sha256,
+    rawLength: read.rawLength,
+    qualityProvided: read.qualityProvided,
+    meanQuality: read.meanQuality,
+    status: read.status,
+    trim: { ...read.trim },
+    mapping: reportMapping(read.mapping),
+  }));
+}
+
+function reportRegions(regions: readonly ConstructVerificationRegionSource[]) {
+  return regions.slice(0, ARTIFACT_CONSTRUCT_VERIFICATION_REPORT_LIMITS.maxRequiredRegions).map((region) => ({
+    id: region.id,
+    ...(region.name === undefined ? {} : { name: region.name }),
+    start: region.start,
+    end: region.end,
+    wraps: region.wraps,
+    length: region.length,
+    minDepth: region.minDepth,
+    requireBothStrands: region.requireBothStrands,
+    coveredBases: region.coveredBases,
+    basesMeetingMinDepth: region.basesMeetingMinDepth,
+    coveredFraction: region.coveredFraction,
+    minimumDepth: region.minimumDepth,
+    maximumDepth: region.maximumDepth,
+    meanDepth: region.meanDepth,
+    forwardCoveredBases: region.forwardCoveredBases,
+    reverseCoveredBases: region.reverseCoveredBases,
+    bothStrandsCoveredBases: region.bothStrandsCoveredBases,
+    status: region.status,
+  }));
+}
+
+function reportObservedVariants(
+  variants: readonly ConstructVerificationObservedVariantSource[],
+  maximum: number,
+) {
+  return variants.slice(0, maximum).map((variant) => ({
+    id: variant.id,
+    type: variant.type,
+    referenceStart: variant.referenceStart,
+    referenceEnd: variant.referenceEnd,
+    reference: variant.reference,
+    alternate: variant.alternate,
+    depth: variant.depth,
+    support: variant.support,
+    supportWeight: variant.supportWeight,
+    fraction: variant.fraction,
+    meanQuality: variant.meanQuality,
+    confidence: variant.confidence,
+    supportingReadIds: variant.supportingReadIds.slice(
+      0,
+      ARTIFACT_CONSTRUCT_VERIFICATION_REPORT_LIMITS.maxSupportingReadIds,
+    ),
+    ...(variant.expectedVariantId === undefined ? {} : { expectedVariantId: variant.expectedVariantId }),
+    omittedSupportingReadIds: Math.max(
+      0,
+      variant.supportingReadIds.length - ARTIFACT_CONSTRUCT_VERIFICATION_REPORT_LIMITS.maxSupportingReadIds,
+    ),
+  }));
+}
+
+function reportExpectedVariants(
+  variants: readonly ConstructVerificationExpectedVariantSource[],
+  maximum: number,
+) {
+  return variants.slice(0, maximum).map((variant) => ({
+    id: variant.id,
+    type: variant.type,
+    referenceStart: variant.referenceStart,
+    referenceEnd: variant.referenceEnd,
+    reference: variant.reference,
+    alternate: variant.alternate,
+    status: variant.status,
+    depth: variant.depth,
+    ...(variant.observedVariantId === undefined ? {} : { observedVariantId: variant.observedVariantId }),
+  }));
+}
+
+function countStructuredNodes(value: unknown): number {
+  if (value === null || typeof value !== 'object') return 1;
+  if (Array.isArray(value)) return 1 + value.reduce((total, item) => total + countStructuredNodes(item), 0);
+  return 1 + Object.values(value).reduce((total, item) => total + countStructuredNodes(item), 0);
+}
+
+function createReport(result: ArtifactConstructVerificationPersistenceSource) {
+  const limits = ARTIFACT_CONSTRUCT_VERIFICATION_REPORT_LIMITS;
+  const report = {
+    schema: ARTIFACT_CONSTRUCT_VERIFICATION_REPORT_SCHEMA,
+    version: 1,
+    state: result.state,
+    reasons: reportReasons(result.reasons),
+    reference: {
+      id: result.reference.id,
+      ...(result.reference.name === undefined ? {} : { name: result.reference.name }),
+      length: result.reference.length,
+      topology: result.reference.topology,
+      sha256: result.reference.sha256,
+    },
+    thresholds: { ...result.thresholds },
+    reads: reportReads(result.reads),
+    coverage: {
+      coveredBasesAtAnyDepth: result.coverage.coveredBases,
+      basesMeetingMinDepth: result.coverage.basesMeetingMinDepth,
+      coverageFraction: result.reference.length === 0
+        ? 0
+        : result.coverage.basesMeetingMinDepth / result.reference.length,
+      minimumDepth: result.coverage.minimumDepth,
+      maximumDepth: result.coverage.maximumDepth,
+      meanDepth: result.coverage.meanDepth,
+      requiredRegions: reportRegions(result.coverage.requiredRegions),
+    },
+    consensus: {
+      sequence: result.consensus.sequence,
+    },
+    variants: {
+      observed: reportObservedVariants(result.variants.observed, limits.maxObservedVariants),
+      expected: reportExpectedVariants(result.variants.expected, limits.maxExpectedVariants),
+      unexpected: reportObservedVariants(result.variants.unexpected, limits.maxUnexpectedVariants),
+      missingExpected: reportExpectedVariants(result.variants.missingExpected, limits.maxMissingExpectedVariants),
+    },
+    provenance: {
+      engine: result.provenance.engine,
+      engineVersion: result.provenance.engineVersion,
+      referenceSha256: result.provenance.referenceSha256,
+      readSha256s: [...result.provenance.readSha256s],
+      requestSha256: result.provenance.requestSha256,
+      workUnits: result.provenance.workUnits,
+      limits: { ...result.provenance.limits },
+    },
+    omitted: {
+      reasons: Math.max(0, result.reasons.length - limits.maxReasons),
+      reads: Math.max(0, result.reads.length - limits.maxReads),
+      requiredRegions: Math.max(0, result.coverage.requiredRegions.length - limits.maxRequiredRegions),
+      observedVariants: Math.max(0, result.variants.observed.length - limits.maxObservedVariants),
+      expectedVariants: Math.max(0, result.variants.expected.length - limits.maxExpectedVariants),
+      unexpectedVariants: Math.max(0, result.variants.unexpected.length - limits.maxUnexpectedVariants),
+      missingExpectedVariants: Math.max(0, result.variants.missingExpected.length - limits.maxMissingExpectedVariants),
+      supportingReadIds:
+        [...result.variants.observed, ...result.variants.unexpected]
+          .reduce((total, variant) => total + Math.max(0, variant.supportingReadIds.length - limits.maxSupportingReadIds), 0),
+    },
+  };
+  const nodes = countStructuredNodes(report);
+  if (nodes > limits.maxStructuredNodes) {
+    throw new Error(`Construct verification report exceeds the ${limits.maxStructuredNodes.toLocaleString()}-node compact-report limit.`);
+  }
+  return report;
+}
+
+function validateSourceForPersistence(
+  result: ArtifactConstructVerificationPersistenceSource,
+  readEvidenceSha256s: readonly string[],
+): { inputRecordIds: string[]; inputSha256s: string[]; evidenceSha256s: string[] } {
+  if (result.reference.length < 1
+    || result.reference.length > MAX_REFERENCE_LENGTH
+    || result.reference.sequence.length !== result.reference.length) {
+    throw new Error('Construct verification reference length is invalid or inconsistent with its sequence.');
+  }
+  if (result.reads.length === 0) throw new Error('Construct verification persistence requires at least one sequencing read.');
+  const inputRecordIds = [result.reference.id, ...result.reads.map((read) => read.id)];
+  if (new Set(inputRecordIds).size !== inputRecordIds.length) {
+    throw new Error('Construct verification reference and read ids must be distinct.');
+  }
+  if (readEvidenceSha256s.length !== result.reads.length) {
+    throw new Error('Ordered read-evidence SHA-256 values must align one-to-one with sequencing reads.');
+  }
+  const referenceSha256 = normalizeSha256(result.reference.sha256, 'reference.sha256');
+  if (referenceSha256 !== sha256HexSync(result.reference.sequence.toUpperCase())) {
+    throw new Error('reference.sha256 must match the uppercase reference sequence.');
+  }
+  const readSha256s = result.reads.map((read, index) => normalizeSha256(read.sha256, `reads[${index}].sha256`));
+  const inputSha256s = [
+    referenceSha256,
+    ...readSha256s,
+  ];
+  const evidenceSha256s = readEvidenceSha256s.map((sha256, index) => (
+    normalizeSha256(sha256, `readEvidenceSha256s[${index}]`)
+  ));
+  const provenanceReferenceSha256 = normalizeSha256(
+    result.provenance.referenceSha256,
+    'provenance.referenceSha256',
+  );
+  if (provenanceReferenceSha256 !== referenceSha256) {
+    throw new Error('provenance.referenceSha256 must match reference.sha256.');
+  }
+  normalizeSha256(result.provenance.requestSha256, 'provenance.requestSha256');
+  const provenanceReadSha256s = result.provenance.readSha256s.map((sha256, index) => (
+    normalizeSha256(sha256, `provenance.readSha256s[${index}]`)
+  ));
+  if (provenanceReadSha256s.length !== readSha256s.length
+    || provenanceReadSha256s.some((sha256, index) => sha256 !== readSha256s[index])) {
+    throw new Error('provenance.readSha256s must match reads[].sha256 in input order.');
+  }
+  if (result.coverage.basesMeetingMinDepth < 0
+    || result.coverage.basesMeetingMinDepth > result.reference.length
+    || !Number.isInteger(result.coverage.basesMeetingMinDepth)) {
+    throw new Error('coverage.basesMeetingMinDepth must be an integer within the reference length.');
+  }
+  return { inputRecordIds, inputSha256s, evidenceSha256s };
+}
+
+export function buildArtifactConstructVerificationArtifacts(
+  verification: ArtifactConstructVerificationPersistenceSource,
+  readEvidenceSha256s: readonly string[],
+  identity: ArtifactConstructVerificationBuildIdentity,
+): ArtifactConstructVerificationArtifacts {
+  const resultId = validateIdentityText(identity.resultId, 'identity.resultId', 160);
+  const assetId = validateIdentityText(identity.assetId, 'identity.assetId', 160);
+  if (resultId === assetId) throw new Error('Construct verification result and asset ids must be distinct.');
+  if (typeof identity.createdAt !== 'string'
+    || identity.createdAt.length > 64
+    || !/^\d{4}-\d{2}-\d{2}T/.test(identity.createdAt)
+    || !Number.isFinite(Date.parse(identity.createdAt))) {
+    throw new Error('identity.createdAt must be a valid ISO 8601 date-time.');
+  }
+  const { inputRecordIds, inputSha256s, evidenceSha256s } = validateSourceForPersistence(
+    verification,
+    readEvidenceSha256s,
+  );
+  const report = createReport(verification);
+  const content = `${JSON.stringify(report, null, 2)}\n`;
+  const contentBytes = new TextEncoder().encode(content).byteLength;
+  if (contentBytes > MAX_ARTIFACT_ANALYSIS_ASSET_BYTES) {
+    throw new Error(`Construct verification report is ${contentBytes.toLocaleString()} bytes; the maximum is ${MAX_ARTIFACT_ANALYSIS_ASSET_BYTES.toLocaleString()} bytes.`);
+  }
+  const provenance: ArtifactAnalysisAsset['provenance'] = {
+    source: 'motif-for-claude-science-artifact',
+    operation: 'construct_verification',
+    actor: 'user',
+    engine: verification.provenance.engine,
+    engineVersion: verification.provenance.engineVersion,
+    parentIds: [...inputRecordIds],
+    metadata: {
+      requestSha256: normalizeSha256(verification.provenance.requestSha256, 'provenance.requestSha256'),
+      workUnits: verification.provenance.workUnits,
+    },
+  };
+  const asset: ArtifactAnalysisAsset = {
+    id: assetId,
+    name: 'construct-verification-report.json',
+    mediaType: 'application/json',
+    content,
+    sha256: sha256HexSync(content),
+    createdAt: identity.createdAt,
+    provenance,
+  };
+  const coveredBases = verification.coverage.basesMeetingMinDepth;
+  const coverageFraction = coveredBases / verification.reference.length;
+  const mappedReadCount = verification.reads.filter((read) => read.status === 'mapped').length;
+  const passingRegionCount = verification.coverage.requiredRegions.filter((region) => region.status === 'covered').length;
+  const result: ArtifactConstructVerificationAnalysisResult = {
+    id: resultId,
+    kind: 'construct_verification',
+    name: boundedReportText(
+      `Construct verification — ${verification.reference.name ?? verification.reference.id}`,
+      256,
+    ),
+    status: 'complete',
+    summary: `${verification.state.replace('_', ' ')} · ${mappedReadCount}/${verification.reads.length} reads mapped · ${(coverageFraction * 100).toFixed(1)}% at ≥${verification.thresholds.minDepth}×`,
+    inputRecordIds,
+    inputSha256s,
+    dependsOnResultIds: [],
+    assetIds: [assetId],
+    parameters: {
+      topology: verification.reference.topology,
+      requestSha256: normalizeSha256(verification.provenance.requestSha256, 'provenance.requestSha256'),
+      thresholds: { ...verification.thresholds },
+      readEvidence: {
+        schema: ARTIFACT_CONSTRUCT_READ_EVIDENCE_SCHEMA,
+        sha256s: evidenceSha256s,
+      },
+    },
+    data: {
+      referenceRecordId: verification.reference.id,
+      readRecordIds: verification.reads.map((read) => read.id),
+      state: verification.state,
+      referenceLength: verification.reference.length,
+      // The durable validator defines coverage as bases meeting the run's
+      // minimum depth, not merely bases touched by any alignment.
+      coveredBases,
+      coverageFraction,
+      mappedReadCount,
+      requiredRegionCount: verification.coverage.requiredRegions.length,
+      passingRegionCount,
+      observedVariantCount: verification.variants.observed.length,
+      expectedVariantCount: verification.variants.expected.length,
+      unexpectedVariantCount: verification.variants.unexpected.length,
+      missingExpectedVariantCount: verification.variants.missingExpected.length,
+      reasonCodes: uniqueReasonCodes(verification.reasons),
+      verificationReportAssetId: assetId,
+    },
+    createdAt: identity.createdAt,
+    provenance,
+  };
+  return { asset, result };
+}
+
+/** Exact saved-run identity; no sequence/name/UI heuristics participate. */
+export function findDuplicateArtifactConstructVerificationResult(
+  results: readonly ArtifactAnalysisResult[],
+  identity: ArtifactConstructVerificationDuplicateIdentity,
+): ArtifactConstructVerificationAnalysisResult | undefined {
+  return results.find((result): result is ArtifactConstructVerificationAnalysisResult => (
+    result.kind === 'construct_verification'
+    && result.provenance.engine === identity.engine
+    && result.provenance.engineVersion === identity.engineVersion
+    && result.parameters.requestSha256 === identity.requestSha256
+  ));
+}

--- a/src/artifacts/claude-science-construct-verification-workspace.css
+++ b/src/artifacts/claude-science-construct-verification-workspace.css
@@ -1,0 +1,618 @@
+.motif-cs-verification-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: grid;
+  place-items: center;
+  padding: 16px;
+  background: color-mix(in srgb, var(--app-bg) 66%, transparent);
+}
+
+.motif-cs-verification-workspace {
+  container-type: inline-size;
+  width: min(1120px, calc(100vw - 32px));
+  height: min(780px, calc(100dvh - 32px));
+  min-width: min(640px, calc(100vw - 16px));
+  min-height: min(500px, calc(100dvh - 16px));
+  max-width: calc(100vw - 16px);
+  max-height: calc(100dvh - 16px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  resize: both;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  box-shadow: var(--elevation-popover);
+  font: 11px/1.45 var(--font-ui);
+}
+
+.motif-cs-verification-workspace[data-embedded] {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  max-width: none;
+  max-height: none;
+  resize: none;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.motif-cs-verification-workspace button,
+.motif-cs-verification-workspace input,
+.motif-cs-verification-workspace select {
+  font: inherit;
+}
+
+.motif-cs-verification-workspace button:focus-visible,
+.motif-cs-verification-workspace input:focus-visible,
+.motif-cs-verification-workspace select:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.motif-cs-verification-workspace-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 72px;
+  padding: 14px 16px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-primary);
+}
+
+.motif-cs-verification-workspace-header > div {
+  min-width: 0;
+}
+
+.motif-cs-verification-workspace-header span,
+.motif-cs-verification-intro > span,
+.motif-cs-verification-section-index {
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: 740;
+  letter-spacing: 0.085em;
+  text-transform: uppercase;
+}
+
+.motif-cs-verification-workspace-header h2 {
+  margin: 1px 0 0;
+  font-size: 19px;
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+}
+
+.motif-cs-verification-workspace-header p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.motif-cs-verification-icon-button {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 21px !important;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.motif-cs-verification-icon-button:hover {
+  border-color: var(--border);
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.motif-cs-verification-workspace-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(278px, 330px) minmax(0, 1fr);
+  overflow: hidden;
+}
+
+.motif-cs-verification-setup,
+.motif-cs-verification-output {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  scrollbar-gutter: stable;
+}
+
+.motif-cs-verification-setup {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  border-right: 1px solid var(--border-subtle);
+  background: var(--panel-bg);
+}
+
+.motif-cs-verification-intro {
+  display: grid;
+  gap: 3px;
+  padding: 13px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--accent) 3%, var(--bg-primary));
+}
+
+.motif-cs-verification-intro > strong {
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.motif-cs-verification-intro > p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.motif-cs-verification-form-section {
+  position: relative;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.motif-cs-verification-section-index {
+  display: grid;
+  place-items: start center;
+  padding-top: 13px;
+  border-right: 1px solid var(--border-subtle);
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.motif-cs-verification-section-content {
+  min-width: 0;
+  padding: 12px 13px 13px;
+}
+
+.motif-cs-verification-field {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.motif-cs-verification-field > span,
+.motif-cs-verification-read-heading strong,
+.motif-cs-verification-acceptance-heading strong {
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 680;
+}
+
+.motif-cs-verification-field select,
+.motif-cs-verification-field input[type="number"] {
+  width: 100%;
+  min-width: 0;
+  min-height: 30px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--control-bg);
+  color: var(--text-primary);
+}
+
+.motif-cs-verification-field select:hover,
+.motif-cs-verification-field input[type="number"]:hover {
+  border-color: var(--border-strong);
+}
+
+.motif-cs-verification-field select:disabled,
+.motif-cs-verification-field input:disabled {
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+
+.motif-cs-verification-record-detail {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font: 9.5px/1.45 var(--font-mono);
+  overflow-wrap: anywhere;
+}
+
+.motif-cs-verification-read-fieldset > legend,
+.motif-cs-verification-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.motif-cs-verification-read-heading,
+.motif-cs-verification-acceptance-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.motif-cs-verification-read-heading > div:first-child,
+.motif-cs-verification-acceptance-heading {
+  min-width: 0;
+}
+
+.motif-cs-verification-read-heading > div:first-child {
+  display: grid;
+  gap: 1px;
+}
+
+.motif-cs-verification-read-heading span,
+.motif-cs-verification-acceptance-heading span {
+  color: var(--text-muted);
+  font-size: 9px;
+}
+
+.motif-cs-verification-read-actions {
+  display: flex;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+
+.motif-cs-verification-read-actions button {
+  min-height: 24px;
+  padding: 2px 7px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--control-bg);
+  color: var(--text-secondary);
+  font-size: 9.5px;
+  cursor: pointer;
+}
+
+.motif-cs-verification-read-actions button:hover:not(:disabled) {
+  background: var(--control-hover);
+  color: var(--text-primary);
+}
+
+.motif-cs-verification-read-actions button:disabled {
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.motif-cs-verification-read-list {
+  max-height: 216px;
+  margin-top: 8px;
+  overflow: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+}
+
+.motif-cs-verification-read-option {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  align-items: start;
+  gap: 7px;
+  min-width: 0;
+  padding: 8px 9px;
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
+}
+
+.motif-cs-verification-read-option:last-child {
+  border-bottom: 0;
+}
+
+.motif-cs-verification-read-option:hover {
+  background: var(--bg-hover);
+}
+
+.motif-cs-verification-read-option input {
+  margin: 2px 0 0;
+  accent-color: var(--accent);
+}
+
+.motif-cs-verification-read-option > span {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.motif-cs-verification-read-option strong,
+.motif-cs-verification-read-option small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.motif-cs-verification-read-option strong {
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.motif-cs-verification-read-option small {
+  color: var(--text-muted);
+  font: 9px/1.35 var(--font-mono);
+}
+
+.motif-cs-verification-empty-evidence {
+  margin: 8px 0 0;
+  padding: 9px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: 9.5px;
+  line-height: 1.5;
+}
+
+.motif-cs-verification-acceptance-heading {
+  display: grid;
+  justify-content: stretch;
+  gap: 1px;
+}
+
+.motif-cs-verification-criteria-grid {
+  display: grid;
+  gap: 10px;
+  margin-top: 9px;
+}
+
+.motif-cs-verification-strand-toggle {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  align-items: start;
+  gap: 7px;
+  cursor: pointer;
+}
+
+.motif-cs-verification-strand-toggle input {
+  margin: 2px 0 0;
+  accent-color: var(--accent);
+}
+
+.motif-cs-verification-strand-toggle > span {
+  display: grid;
+  gap: 1px;
+}
+
+.motif-cs-verification-strand-toggle strong {
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+
+.motif-cs-verification-strand-toggle small {
+  color: var(--text-muted);
+  font-size: 9px;
+  line-height: 1.4;
+}
+
+.motif-cs-verification-action-bar {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  display: grid;
+  gap: 9px;
+  margin-top: auto;
+  padding: 11px 13px 12px;
+  border-top: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--panel-bg) 92%, var(--bg-primary));
+}
+
+.motif-cs-verification-messages {
+  min-height: 28px;
+  color: var(--text-muted);
+  font-size: 9.5px;
+  line-height: 1.45;
+}
+
+.motif-cs-verification-messages p {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.motif-cs-verification-error {
+  color: var(--red);
+}
+
+.motif-cs-verification-status {
+  color: var(--text-secondary);
+}
+
+.motif-cs-verification-buttons {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 7px;
+}
+
+.motif-cs-verification-primary-button,
+.motif-cs-verification-secondary-button {
+  min-height: 32px;
+  padding: 5px 9px;
+  border-radius: var(--radius-sm);
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.motif-cs-verification-primary-button {
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--text-on-accent);
+}
+
+.motif-cs-verification-secondary-button {
+  border: 1px solid var(--border);
+  background: var(--control-bg);
+  color: var(--text-secondary);
+}
+
+.motif-cs-verification-primary-button:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.motif-cs-verification-secondary-button:hover:not(:disabled) {
+  background: var(--control-hover);
+  color: var(--text-primary);
+}
+
+.motif-cs-verification-primary-button:disabled,
+.motif-cs-verification-secondary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.motif-cs-verification-output {
+  padding: 12px;
+  background: var(--bg-primary);
+}
+
+.motif-cs-verification-awaiting {
+  position: relative;
+  min-height: 100%;
+  display: grid;
+  align-content: center;
+  justify-items: start;
+  gap: 5px;
+  padding: clamp(18px, 6cqi, 52px);
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(var(--border-subtle) 1px, transparent 1px),
+    linear-gradient(90deg, var(--border-subtle) 1px, transparent 1px),
+    var(--panel-bg);
+  background-size: 28px 28px;
+}
+
+.motif-cs-verification-awaiting::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: var(--accent);
+}
+
+.motif-cs-verification-awaiting > span {
+  color: var(--accent);
+  font: 700 9px/1.3 var(--font-mono);
+  letter-spacing: 0.08em;
+}
+
+.motif-cs-verification-awaiting > strong {
+  max-width: 28ch;
+  font-size: clamp(17px, 3.5cqi, 25px);
+  line-height: 1.16;
+  letter-spacing: -0.02em;
+}
+
+.motif-cs-verification-awaiting > p {
+  max-width: 56ch;
+  margin: 2px 0 12px;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  line-height: 1.55;
+}
+
+.motif-cs-verification-awaiting dl {
+  width: min(100%, 520px);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0;
+  border: 1px solid var(--border);
+  background: var(--bg-primary);
+}
+
+.motif-cs-verification-awaiting dl > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  padding: 8px 9px;
+  border-right: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.motif-cs-verification-awaiting dt,
+.motif-cs-verification-awaiting dd {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.motif-cs-verification-awaiting dt {
+  color: var(--text-muted);
+  font-size: 8.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.055em;
+}
+
+.motif-cs-verification-awaiting dd {
+  color: var(--text-primary);
+  font: 650 10px/1.35 var(--font-mono);
+}
+
+@container (max-width: 700px) {
+  .motif-cs-verification-workspace-body {
+    display: block;
+    overflow: auto;
+  }
+
+  .motif-cs-verification-setup,
+  .motif-cs-verification-output {
+    overflow: visible;
+  }
+
+  .motif-cs-verification-setup {
+    border-right: 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .motif-cs-verification-action-bar {
+    position: static;
+  }
+
+  .motif-cs-verification-output {
+    min-height: 360px;
+  }
+}
+
+@container (max-width: 420px) {
+  .motif-cs-verification-section-content {
+    padding-inline: 10px;
+  }
+
+  .motif-cs-verification-read-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .motif-cs-verification-read-actions button {
+    flex: 1 1 0;
+  }
+
+  .motif-cs-verification-buttons {
+    grid-template-columns: 1fr;
+  }
+
+  .motif-cs-verification-awaiting dl {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/artifacts/claude-science-construct-verification.css
+++ b/src/artifacts/claude-science-construct-verification.css
@@ -1,0 +1,449 @@
+.motif-cs-construct-verification {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 11px;
+}
+
+.motif-cs-construct-verification-verdict {
+  --motif-cs-verification-state-color: var(--text-muted);
+  display: grid;
+  grid-template-columns: 4px minmax(0, 1fr) auto;
+  align-items: stretch;
+  min-width: 0;
+  border-bottom: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--motif-cs-verification-state-color) 4%, var(--panel-bg));
+}
+
+.motif-cs-construct-verification-verdict[data-verdict="consistent"] {
+  --motif-cs-verification-state-color: var(--green);
+}
+
+.motif-cs-construct-verification-verdict[data-verdict="needs_review"] {
+  --motif-cs-verification-state-color: var(--amber);
+}
+
+.motif-cs-construct-verification-verdict[data-verdict="inconsistent"] {
+  --motif-cs-verification-state-color: var(--red);
+}
+
+.motif-cs-construct-verification-rail {
+  background: var(--motif-cs-verification-state-color);
+}
+
+.motif-cs-construct-verification-heading {
+  display: grid;
+  align-content: center;
+  gap: 2px;
+  min-width: 0;
+  padding: 10px 12px;
+}
+
+.motif-cs-construct-verification-eyebrow,
+.motif-cs-construct-verification-section-heading > span,
+.motif-cs-construct-verification-table th {
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: 740;
+  letter-spacing: 0.065em;
+  text-transform: uppercase;
+}
+
+.motif-cs-construct-verification-heading strong {
+  color: var(--motif-cs-verification-state-color);
+  font-size: 14px;
+  line-height: 1.25;
+}
+
+.motif-cs-construct-verification-heading p {
+  max-width: 72ch;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.motif-cs-construct-verification-reference {
+  align-self: center;
+  display: grid;
+  justify-items: end;
+  gap: 2px;
+  min-width: 0;
+  max-width: 220px;
+  padding: 10px 12px;
+  border-left: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  text-align: right;
+}
+
+.motif-cs-construct-verification-reference strong {
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 10.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.motif-cs-construct-verification-facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(105px, 1fr));
+  margin: 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.motif-cs-construct-verification-facts > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  padding: 9px 11px;
+  border-right: 1px solid var(--border-subtle);
+}
+
+.motif-cs-construct-verification-facts > div:last-child {
+  border-right: 0;
+}
+
+.motif-cs-construct-verification-facts dt,
+.motif-cs-construct-verification-facts dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.motif-cs-construct-verification-facts dt {
+  color: var(--text-muted);
+  font-size: 9.5px;
+}
+
+.motif-cs-construct-verification-facts dd {
+  color: var(--text-primary);
+  font: 650 11px/1.35 var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.motif-cs-construct-verification-coverage {
+  display: grid;
+  gap: 5px;
+  padding: 9px 11px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--panel-bg);
+}
+
+.motif-cs-construct-verification-coverage-label {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--text-muted);
+  font-size: 9.5px;
+}
+
+.motif-cs-construct-verification-coverage-label strong {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.motif-cs-construct-verification-coverage progress {
+  width: 100%;
+  height: 5px;
+  overflow: hidden;
+  border: 0;
+  border-radius: 999px;
+  background: var(--bg-tertiary);
+  color: var(--accent);
+  accent-color: var(--accent);
+}
+
+.motif-cs-construct-verification-coverage progress::-webkit-progress-bar {
+  background: var(--bg-tertiary);
+}
+
+.motif-cs-construct-verification-coverage progress::-webkit-progress-value {
+  border-radius: inherit;
+  background: var(--accent);
+}
+
+.motif-cs-construct-verification-coverage progress::-moz-progress-bar {
+  border-radius: inherit;
+  background: var(--accent);
+}
+
+.motif-cs-construct-verification-section {
+  min-width: 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.motif-cs-construct-verification-section:last-child {
+  border-bottom: 0;
+}
+
+.motif-cs-construct-verification-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 34px;
+  padding: 7px 11px;
+  background: var(--panel-bg);
+}
+
+.motif-cs-construct-verification-section-heading > span {
+  color: var(--text-secondary);
+}
+
+.motif-cs-construct-verification-section-heading > small {
+  color: var(--text-muted);
+  font: 9.5px/1.3 var(--font-mono);
+  white-space: nowrap;
+}
+
+.motif-cs-construct-verification-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 9.5px;
+}
+
+.motif-cs-construct-verification-filter select {
+  min-height: 26px;
+  max-width: 160px;
+  padding: 3px 23px 3px 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--control-bg);
+  color: var(--text-primary);
+  font-size: 10px;
+}
+
+.motif-cs-construct-verification-filter select:focus-visible,
+.motif-cs-construct-verification-disclosure > summary:focus-visible,
+.motif-cs-construct-verification-table-scroll:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.motif-cs-construct-verification-reasons {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.motif-cs-construct-verification-reason {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px;
+  padding: 8px 11px;
+  border-top: 1px solid var(--border-subtle);
+  content-visibility: auto;
+  contain-intrinsic-size: auto 38px;
+}
+
+.motif-cs-construct-verification-reason:first-child {
+  border-top: 0;
+}
+
+.motif-cs-construct-verification-reason-code,
+.motif-cs-construct-verification-tag {
+  width: max-content;
+  max-width: 100%;
+  padding: 2px 5px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--control-bg);
+  color: var(--text-secondary);
+  font: 650 9px/1.35 var(--font-mono);
+}
+
+.motif-cs-construct-verification-reason > span:last-child {
+  min-width: 0;
+  color: var(--text-secondary);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.motif-cs-construct-verification-table-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+}
+
+.motif-cs-construct-verification-table {
+  width: 100%;
+  min-width: 620px;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+.motif-cs-construct-verification-table th,
+.motif-cs-construct-verification-table td {
+  padding: 7px 9px;
+  border-top: 1px solid var(--border-subtle);
+  text-align: left;
+  vertical-align: top;
+}
+
+.motif-cs-construct-verification-table th {
+  border-top: 0;
+  background: color-mix(in srgb, var(--panel-bg) 88%, var(--bg-primary));
+  white-space: nowrap;
+}
+
+.motif-cs-construct-verification-table td {
+  color: var(--text-secondary);
+}
+
+.motif-cs-construct-verification-table td[data-numeric],
+.motif-cs-construct-verification-table td[data-sequence] {
+  font-family: var(--font-mono);
+}
+
+.motif-cs-construct-verification-table td[data-sequence] {
+  color: var(--text-primary);
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.motif-cs-construct-verification-tag[data-classification="expected"] {
+  border-color: color-mix(in srgb, var(--green) 36%, var(--border));
+  color: var(--green);
+}
+
+.motif-cs-construct-verification-tag[data-classification="unexpected"] {
+  border-color: color-mix(in srgb, var(--red) 38%, var(--border));
+  color: var(--red);
+}
+
+.motif-cs-construct-verification-tag[data-classification="missing_expected"] {
+  border-color: color-mix(in srgb, var(--red) 38%, var(--border));
+  color: var(--red);
+}
+
+.motif-cs-construct-verification-tag[data-classification="observed"],
+.motif-cs-construct-verification-tag[data-classification="uncertain"] {
+  border-color: color-mix(in srgb, var(--amber) 42%, var(--border));
+  color: var(--amber);
+}
+
+.motif-cs-construct-verification-empty {
+  padding: 12px 11px;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.motif-cs-construct-verification-disclosure {
+  padding: 0 11px 9px;
+}
+
+.motif-cs-construct-verification-disclosure > summary {
+  width: max-content;
+  max-width: 100%;
+  padding: 5px 0;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.motif-cs-construct-verification-disclosure > summary:hover {
+  color: var(--accent);
+}
+
+.motif-cs-construct-verification-read-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 6px;
+  padding-top: 3px;
+}
+
+.motif-cs-construct-verification-read {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--panel-bg);
+  content-visibility: auto;
+  contain-intrinsic-size: auto 74px;
+}
+
+.motif-cs-construct-verification-read > strong,
+.motif-cs-construct-verification-read > span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.motif-cs-construct-verification-read > strong {
+  font-size: 10.5px;
+}
+
+.motif-cs-construct-verification-read > span {
+  color: var(--text-muted);
+  font: 9.5px/1.4 var(--font-mono);
+}
+
+.motif-cs-construct-verification-provenance {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+  padding: 6px 11px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--panel-bg);
+  color: var(--text-muted);
+  font: 9px/1.35 var(--font-mono);
+}
+
+.motif-cs-construct-verification-provenance > span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 640px) {
+  .motif-cs-construct-verification-verdict {
+    grid-template-columns: 4px minmax(0, 1fr);
+  }
+
+  .motif-cs-construct-verification-reference {
+    grid-column: 2;
+    align-items: start;
+    justify-items: start;
+    max-width: none;
+    padding-top: 0;
+    border-left: 0;
+    text-align: left;
+  }
+
+  .motif-cs-construct-verification-facts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .motif-cs-construct-verification-facts > div:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .motif-cs-construct-verification-section-heading {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .motif-cs-construct-verification-filter {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .motif-cs-construct-verification-filter select {
+    flex: 1 1 auto;
+    max-width: none;
+  }
+}

--- a/src/artifacts/claude-science-construct-verification.ts
+++ b/src/artifacts/claude-science-construct-verification.ts
@@ -1,0 +1,2619 @@
+import { reverseComplement } from '../bio/reverse-complement';
+import { sha256HexSync } from './claude-science-sha256';
+
+/** Deterministic, store-free construct verification for bounded Sanger reads. */
+
+export const ARTIFACT_CONSTRUCT_VERIFICATION_SCHEMA = 'motif.construct-verification.v1' as const;
+export const ARTIFACT_CONSTRUCT_VERIFICATION_VERSION = 1 as const;
+
+export const ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS = {
+  maxReferenceLength: 50_000,
+  maxReads: 96,
+  maxReadLength: 5_000,
+  maxRequiredRegions: 128,
+  maxRequiredRegionBases: 500_000,
+  maxExpectedVariants: 256,
+  maxObservedVariants: 2_000,
+  maxIndelLength: 24,
+  maxWorkUnits: 25_000_000,
+} as const;
+
+export const ARTIFACT_CONSTRUCT_VERIFICATION_TEXT_LIMITS = {
+  maxIdLength: 160,
+  maxNameLength: 256,
+} as const;
+
+export type ArtifactConstructVerificationErrorCode =
+  | 'invalid_input'
+  | 'too_large'
+  | 'work_budget';
+
+export class ArtifactConstructVerificationError extends Error {
+  readonly code: ArtifactConstructVerificationErrorCode;
+
+  constructor(code: ArtifactConstructVerificationErrorCode, message: string) {
+    super(message);
+    this.name = 'ArtifactConstructVerificationError';
+    this.code = code;
+  }
+}
+
+export type ArtifactConstructReferenceInput = {
+  id: string;
+  name?: string;
+  sequence: string;
+  topology: 'linear' | 'circular';
+  sha256: string;
+};
+
+export type ArtifactConstructReadInput = {
+  id: string;
+  name?: string;
+  baseCalls: string;
+  qualityScores?: readonly number[];
+  sha256: string;
+};
+
+export type ArtifactConstructRequiredRegionInput = {
+  id: string;
+  name?: string;
+  start: number;
+  end: number;
+  minDepth?: number;
+  requireBothStrands?: boolean;
+};
+
+export type ArtifactConstructVariantType = 'substitution' | 'insertion' | 'deletion';
+
+export type ArtifactConstructExpectedVariantInput = {
+  id: string;
+  type: ArtifactConstructVariantType;
+  referenceStart: number;
+  referenceEnd: number;
+  reference: string;
+  alternate: string;
+};
+
+export type ArtifactConstructVerificationThresholds = {
+  trimQuality: number;
+  trimWindow: number;
+  minTrimmedReadLength: number;
+  minMappingIdentity: number;
+  minMappingMargin: number;
+  maxIndelFraction: number;
+  minCoverageFraction: number;
+  minDepth: number;
+  requireBothStrands: boolean;
+  minConsensusFraction: number;
+  minVariantQuality: number;
+  minVariantFraction: number;
+};
+
+export type ArtifactConstructVerificationInput = {
+  reference: ArtifactConstructReferenceInput;
+  reads: readonly ArtifactConstructReadInput[];
+  requiredRegions?: readonly ArtifactConstructRequiredRegionInput[];
+  expectedVariants?: readonly ArtifactConstructExpectedVariantInput[];
+  thresholds?: Partial<ArtifactConstructVerificationThresholds>;
+};
+
+export const DEFAULT_ARTIFACT_CONSTRUCT_VERIFICATION_THRESHOLDS: Readonly<ArtifactConstructVerificationThresholds> = {
+  trimQuality: 20,
+  trimWindow: 12,
+  minTrimmedReadLength: 40,
+  minMappingIdentity: 0.82,
+  minMappingMargin: 0.03,
+  maxIndelFraction: 0.12,
+  minCoverageFraction: 1,
+  minDepth: 1,
+  requireBothStrands: false,
+  minConsensusFraction: 0.7,
+  minVariantQuality: 20,
+  minVariantFraction: 0.6,
+};
+
+export type ArtifactConstructVerificationReasonCode =
+  | 'missing_quality'
+  | 'trimmed_read_too_short'
+  | 'unmapped_read'
+  | 'ambiguous_mapping'
+  | 'low_mapping_identity'
+  | 'excessive_indel'
+  | 'no_usable_reads'
+  | 'partial_reference_coverage'
+  | 'required_region_uncovered'
+  | 'required_region_low_depth'
+  | 'required_region_missing_strand'
+  | 'unexpected_variant'
+  | 'low_confidence_variant'
+  | 'expected_variant_not_observed'
+  | 'expected_variant_not_covered'
+  | 'conflicting_consensus';
+
+export type ArtifactConstructVerificationReason = {
+  code: ArtifactConstructVerificationReasonCode;
+  severity: 'review' | 'inconsistent';
+  message: string;
+  readId?: string;
+  regionId?: string;
+  variantId?: string;
+};
+
+export type ArtifactConstructReadStatus =
+  | 'mapped'
+  | 'trimmed_read_too_short'
+  | 'unmapped'
+  | 'ambiguous_mapping'
+  | 'low_mapping_identity'
+  | 'excessive_indel';
+
+export type ArtifactConstructReadTrim = {
+  method: 'quality_window' | 'none_missing_quality';
+  rawStart: number;
+  rawEnd: number;
+  trimmedLength: number;
+  removedFromStart: number;
+  removedFromEnd: number;
+};
+
+export type ArtifactConstructAlignmentOperation =
+  | 'match'
+  | 'substitution'
+  | 'insertion'
+  | 'deletion';
+
+export type ArtifactConstructAlignmentColumn = {
+  operation: ArtifactConstructAlignmentOperation;
+  /** Normalized reference coordinate, or null for a read insertion. */
+  referencePosition: number | null;
+  /** Insertion coordinate for an insertion column, otherwise null. */
+  referenceBoundary: number | null;
+  /** Index in the original, untrimmed baseCalls string; retained on reverse mappings. */
+  rawCallIndex: number | null;
+  /** Index in the oriented trimmed read; null for a reference deletion. */
+  orientedCallIndex: number | null;
+  referenceBase: string | null;
+  /** Base in reference orientation, not a replacement/re-basecall of the raw call. */
+  readBase: string | null;
+  /** Original baseCalls character before orientation, or null for a deletion. */
+  rawBase: string | null;
+  qualityScore: number | null;
+};
+
+export type ArtifactConstructCoordinateMap = {
+  columns: ArtifactConstructAlignmentColumn[];
+  /** Parallel to columns; convenient explicit maps retain null gap entries. */
+  referencePositions: Array<number | null>;
+  rawCallIndices: Array<number | null>;
+};
+
+export type ArtifactConstructReadMapping = {
+  orientation: 'forward' | 'reverse';
+  referenceStart: number;
+  referenceEnd: number;
+  wraps: boolean;
+  referenceSpan: number;
+  score: number;
+  secondBestScore: number | null;
+  mappingMargin: number | null;
+  identity: number;
+  alignedLength: number;
+  matches: number;
+  substitutions: number;
+  insertions: number;
+  deletions: number;
+  indelFraction: number;
+  coordinateMap: ArtifactConstructCoordinateMap;
+};
+
+export type ArtifactConstructReadVerification = {
+  id: string;
+  name?: string;
+  /** SHA-256 of normalized baseCalls, not a digest of derived evidence. */
+  sha256: string;
+  rawLength: number;
+  qualityProvided: boolean;
+  meanQuality: number | null;
+  status: ArtifactConstructReadStatus;
+  trim: ArtifactConstructReadTrim;
+  mapping: ArtifactConstructReadMapping | null;
+};
+
+export type ArtifactConstructRegionCoverage = {
+  id: string;
+  name?: string;
+  start: number;
+  end: number;
+  wraps: boolean;
+  length: number;
+  minDepth: number;
+  requireBothStrands: boolean;
+  coveredBases: number;
+  basesMeetingMinDepth: number;
+  coveredFraction: number;
+  minimumDepth: number;
+  maximumDepth: number;
+  meanDepth: number;
+  forwardCoveredBases: number;
+  reverseCoveredBases: number;
+  bothStrandsCoveredBases: number;
+  status: 'covered' | 'uncovered' | 'low_depth' | 'missing_strand';
+};
+
+export type ArtifactConstructCoverage = {
+  /** Per-base canonical callable depth; deletion alleles count as callable spanning evidence. */
+  depth: number[];
+  forward: number[];
+  reverse: number[];
+  coveredBases: number;
+  basesMeetingMinDepth: number;
+  coveredFraction: number;
+  minimumDepth: number;
+  maximumDepth: number;
+  meanDepth: number;
+  requiredRegions: ArtifactConstructRegionCoverage[];
+};
+
+export type ArtifactConstructConsensusAllele = {
+  allele: 'A' | 'C' | 'G' | 'T' | '-';
+  count: number;
+  weight: number;
+  fraction: number;
+};
+
+export type ArtifactConstructConsensusCall = {
+  referencePosition: number;
+  referenceBase: string;
+  call: 'A' | 'C' | 'G' | 'T' | '-' | 'N';
+  status: 'uncovered' | 'reference' | 'variant' | 'conflict';
+  depth: number;
+  forwardDepth: number;
+  reverseDepth: number;
+  fraction: number;
+  alleles: ArtifactConstructConsensusAllele[];
+};
+
+export type ArtifactConstructObservedVariant = {
+  id: string;
+  type: ArtifactConstructVariantType;
+  referenceStart: number;
+  referenceEnd: number;
+  reference: string;
+  alternate: string;
+  depth: number;
+  support: number;
+  supportWeight: number;
+  fraction: number;
+  meanQuality: number | null;
+  confidence: 'high' | 'low';
+  supportingReadIds: string[];
+  expectedVariantId?: string;
+};
+
+export type ArtifactConstructExpectedVariantResult = ArtifactConstructExpectedVariantInput & {
+  status: 'observed' | 'low_confidence' | 'not_observed' | 'not_covered';
+  depth: number;
+  observedVariantId?: string;
+};
+
+export type ArtifactConstructVariantSummary = {
+  observed: ArtifactConstructObservedVariant[];
+  expected: ArtifactConstructExpectedVariantResult[];
+  unexpected: ArtifactConstructObservedVariant[];
+  missingExpected: ArtifactConstructExpectedVariantResult[];
+};
+
+export type ArtifactConstructConsensus = {
+  /** Reference-oriented sequence; N marks conflicts/uncovered calls and deletions are omitted. */
+  sequence: string;
+  calls: ArtifactConstructConsensusCall[];
+  variants: ArtifactConstructObservedVariant[];
+};
+
+export type ArtifactConstructVerificationProvenance = {
+  engine: 'motif-construct-verification';
+  engineVersion: '1';
+  referenceSha256: string;
+  /** Input-order SHA-256 values of normalized baseCalls. */
+  readSha256s: string[];
+  requestSha256: string;
+  workUnits: number;
+  limits: typeof ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS;
+};
+
+export type ArtifactConstructVerificationResult = {
+  schema: typeof ARTIFACT_CONSTRUCT_VERIFICATION_SCHEMA;
+  version: typeof ARTIFACT_CONSTRUCT_VERIFICATION_VERSION;
+  state: 'consistent' | 'needs_review' | 'inconsistent';
+  reasons: ArtifactConstructVerificationReason[];
+  reference: {
+    id: string;
+    name?: string;
+    sequence: string;
+    length: number;
+    topology: 'linear' | 'circular';
+    sha256: string;
+  };
+  thresholds: ArtifactConstructVerificationThresholds;
+  reads: ArtifactConstructReadVerification[];
+  coverage: ArtifactConstructCoverage;
+  consensus: ArtifactConstructConsensus;
+  variants: ArtifactConstructVariantSummary;
+  provenance: ArtifactConstructVerificationProvenance;
+};
+
+const ID_MAX_LENGTH = ARTIFACT_CONSTRUCT_VERIFICATION_TEXT_LIMITS.maxIdLength;
+const NAME_MAX_LENGTH = ARTIFACT_CONSTRUCT_VERIFICATION_TEXT_LIMITS.maxNameLength;
+const IUPAC_DNA_PATTERN = /^[ACGTRYSWKMBDHVN]+$/;
+const CANONICAL_DNA_PATTERN = /^[ACGT]*$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
+const MAX_MAPPING_CANDIDATES_PER_ORIENTATION = 16;
+const EXHAUSTIVE_MAPPING_WORK_FRACTION = 0.92;
+const NEGATIVE_INFINITY = -1_000_000_000;
+const MATCH_SCORE = 3;
+const AMBIGUOUS_MATCH_SCORE = 1;
+const MISMATCH_SCORE = -3;
+const GAP_SCORE = -4;
+
+const IUPAC_MASK: Readonly<Record<string, number>> = {
+  A: 1,
+  C: 2,
+  G: 4,
+  T: 8,
+  R: 5,
+  Y: 10,
+  S: 6,
+  W: 9,
+  K: 12,
+  M: 3,
+  B: 14,
+  D: 13,
+  H: 11,
+  V: 7,
+  N: 15,
+};
+
+type NormalizedReference = {
+  id: string;
+  name?: string;
+  sequence: string;
+  topology: 'linear' | 'circular';
+  sha256: string;
+};
+
+type NormalizedRead = {
+  id: string;
+  name?: string;
+  baseCalls: string;
+  qualityScores: number[] | null;
+  sha256: string;
+};
+
+type NormalizedRegion = ArtifactConstructRequiredRegionInput & {
+  wraps: boolean;
+  length: number;
+  positions: number[];
+  effectiveMinDepth: number;
+  effectiveRequireBothStrands: boolean;
+};
+
+type NormalizedInput = {
+  reference: NormalizedReference;
+  reads: NormalizedRead[];
+  requiredRegions: NormalizedRegion[];
+  expectedVariants: ArtifactConstructExpectedVariantInput[];
+  thresholds: ArtifactConstructVerificationThresholds;
+};
+
+type OrientedRead = {
+  orientation: 'forward' | 'reverse';
+  sequence: string;
+  rawCallIndices: number[];
+  qualityScores: Array<number | null>;
+  rawBases: string[];
+};
+
+type CandidateStart = {
+  start: number;
+  votes: number;
+};
+
+type CandidateSearch = {
+  candidates: CandidateStart[];
+  /** True when a seed-supported locus was omitted solely to preserve the bounded search. */
+  truncated: boolean;
+};
+
+type ScoredCandidate = {
+  orientation: 'forward' | 'reverse';
+  candidateStart: number;
+  score: number;
+};
+
+type AlignmentResult = {
+  mapping: ArtifactConstructReadMapping;
+  maximumIndelRun: number;
+};
+
+type AlleleEvidence = {
+  count: number;
+  weight: number;
+};
+
+type VariantEvidence = {
+  type: ArtifactConstructVariantType;
+  referenceStart: number;
+  referenceEnd: number;
+  reference: string;
+  alternate: string;
+  readIds: Set<string>;
+  weightByRead: Map<string, number>;
+  qualityByRead: Map<string, number | null>;
+};
+
+class WorkCounter {
+  private count = 0;
+
+  spend(units = 1): void {
+    this.count += units;
+    if (this.count > ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxWorkUnits) {
+      throw new ArtifactConstructVerificationError(
+        'work_budget',
+        `Construct verification exceeded the deterministic ${ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxWorkUnits.toLocaleString()}-unit work budget.`,
+      );
+    }
+  }
+
+  value(): number {
+    return this.count;
+  }
+}
+
+function fail(code: ArtifactConstructVerificationErrorCode, message: string): never {
+  throw new ArtifactConstructVerificationError(code, message);
+}
+
+function recordValue(value: unknown, path: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    fail('invalid_input', `${path} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function normalizeId(value: unknown, path: string): string {
+  if (typeof value !== 'string') fail('invalid_input', `${path} must be a string.`);
+  const normalized = value.trim();
+  if (!normalized || normalized.length > ID_MAX_LENGTH) {
+    fail('invalid_input', `${path} must contain 1–${ID_MAX_LENGTH} nonblank characters.`);
+  }
+  return normalized;
+}
+
+function normalizeName(value: unknown, path: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') fail('invalid_input', `${path} must be a string when provided.`);
+  const normalized = value.trim();
+  if (!normalized || normalized.length > NAME_MAX_LENGTH) {
+    fail('invalid_input', `${path} must contain 1–${NAME_MAX_LENGTH} nonblank characters when provided.`);
+  }
+  return normalized;
+}
+
+function normalizeDna(value: unknown, path: string, maximumLength: number): string {
+  if (typeof value !== 'string') fail('invalid_input', `${path} must be a DNA string.`);
+  const normalized = value.replace(/\s+/g, '').toUpperCase();
+  if (!normalized) fail('invalid_input', `${path} must contain at least one DNA base.`);
+  if (normalized.length > maximumLength) {
+    fail('too_large', `${path} exceeds the ${maximumLength.toLocaleString()}-base limit.`);
+  }
+  if (!IUPAC_DNA_PATTERN.test(normalized)) {
+    fail('invalid_input', `${path} must contain only IUPAC DNA bases (no gaps or U residues).`);
+  }
+  return normalized;
+}
+
+function normalizeSha256(value: unknown, sequence: string, path: string): string {
+  if (typeof value !== 'string' || !SHA256_PATTERN.test(value)) {
+    fail('invalid_input', `${path} must be a 64-character SHA-256 digest.`);
+  }
+  const normalized = value.toLowerCase();
+  if (normalized !== sha256HexSync(sequence)) {
+    fail('invalid_input', `${path} does not match the normalized DNA sequence.`);
+  }
+  return normalized;
+}
+
+function finiteNumber(value: unknown, path: string, minimum: number, maximum: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < minimum || value > maximum) {
+    fail('invalid_input', `${path} must be a finite number from ${minimum} through ${maximum}.`);
+  }
+  return value;
+}
+
+function boundedInteger(value: unknown, path: string, minimum: number, maximum: number): number {
+  const normalized = finiteNumber(value, path, minimum, maximum);
+  if (!Number.isInteger(normalized)) fail('invalid_input', `${path} must be an integer.`);
+  return normalized;
+}
+
+function normalizeThresholds(value: unknown): ArtifactConstructVerificationThresholds {
+  const source = value === undefined ? {} : recordValue(value, 'thresholds');
+  const defaults = DEFAULT_ARTIFACT_CONSTRUCT_VERIFICATION_THRESHOLDS;
+  return {
+    trimQuality: boundedInteger(source.trimQuality ?? defaults.trimQuality, 'thresholds.trimQuality', 0, 255),
+    trimWindow: boundedInteger(source.trimWindow ?? defaults.trimWindow, 'thresholds.trimWindow', 1, 100),
+    minTrimmedReadLength: boundedInteger(
+      source.minTrimmedReadLength ?? defaults.minTrimmedReadLength,
+      'thresholds.minTrimmedReadLength',
+      1,
+      ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReadLength,
+    ),
+    minMappingIdentity: finiteNumber(
+      source.minMappingIdentity ?? defaults.minMappingIdentity,
+      'thresholds.minMappingIdentity',
+      0,
+      1,
+    ),
+    minMappingMargin: finiteNumber(
+      source.minMappingMargin ?? defaults.minMappingMargin,
+      'thresholds.minMappingMargin',
+      0,
+      1,
+    ),
+    maxIndelFraction: finiteNumber(
+      source.maxIndelFraction ?? defaults.maxIndelFraction,
+      'thresholds.maxIndelFraction',
+      0,
+      1,
+    ),
+    minCoverageFraction: finiteNumber(
+      source.minCoverageFraction ?? defaults.minCoverageFraction,
+      'thresholds.minCoverageFraction',
+      0,
+      1,
+    ),
+    minDepth: boundedInteger(
+      source.minDepth ?? defaults.minDepth,
+      'thresholds.minDepth',
+      1,
+      ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReads,
+    ),
+    requireBothStrands: (() => {
+      const candidate = source.requireBothStrands ?? defaults.requireBothStrands;
+      if (typeof candidate !== 'boolean') {
+        fail('invalid_input', 'thresholds.requireBothStrands must be a boolean.');
+      }
+      return candidate;
+    })(),
+    minConsensusFraction: finiteNumber(
+      source.minConsensusFraction ?? defaults.minConsensusFraction,
+      'thresholds.minConsensusFraction',
+      0,
+      1,
+    ),
+    minVariantQuality: finiteNumber(
+      source.minVariantQuality ?? defaults.minVariantQuality,
+      'thresholds.minVariantQuality',
+      0,
+      255,
+    ),
+    minVariantFraction: finiteNumber(
+      source.minVariantFraction ?? defaults.minVariantFraction,
+      'thresholds.minVariantFraction',
+      0,
+      1,
+    ),
+  };
+}
+
+function normalizeReference(value: unknown): NormalizedReference {
+  const source = recordValue(value, 'reference');
+  const id = normalizeId(source.id, 'reference.id');
+  const name = normalizeName(source.name, 'reference.name');
+  const sequence = normalizeDna(
+    source.sequence,
+    'reference.sequence',
+    ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReferenceLength,
+  );
+  if (source.topology !== 'linear' && source.topology !== 'circular') {
+    fail('invalid_input', 'reference.topology must be "linear" or "circular".');
+  }
+  const sha256 = normalizeSha256(source.sha256, sequence, 'reference.sha256');
+  return {
+    id,
+    ...(name === undefined ? {} : { name }),
+    sequence,
+    topology: source.topology,
+    sha256,
+  };
+}
+
+function normalizeReads(value: unknown): NormalizedRead[] {
+  if (!Array.isArray(value)) fail('invalid_input', 'reads must be an array.');
+  if (value.length > ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReads) {
+    fail('too_large', `reads exceeds the ${ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReads}-read limit.`);
+  }
+  const seenIds = new Set<string>();
+  return value.map((item, index) => {
+    const path = `reads[${index}]`;
+    const source = recordValue(item, path);
+    const id = normalizeId(source.id, `${path}.id`);
+    if (seenIds.has(id)) fail('invalid_input', `${path}.id duplicates read id "${id}".`);
+    seenIds.add(id);
+    const name = normalizeName(source.name, `${path}.name`);
+    const baseCalls = normalizeDna(
+      source.baseCalls,
+      `${path}.baseCalls`,
+      ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReadLength,
+    );
+    const sha256 = normalizeSha256(source.sha256, baseCalls, `${path}.sha256`);
+    let qualityScores: number[] | null = null;
+    if (source.qualityScores !== undefined) {
+      if (!Array.isArray(source.qualityScores) || source.qualityScores.length !== baseCalls.length) {
+        fail('invalid_input', `${path}.qualityScores must contain exactly one score per normalized base call.`);
+      }
+      qualityScores = source.qualityScores.map((score, scoreIndex) => boundedInteger(
+        score,
+        `${path}.qualityScores[${scoreIndex}]`,
+        0,
+        255,
+      ));
+    }
+    return {
+      id,
+      ...(name === undefined ? {} : { name }),
+      baseCalls,
+      qualityScores,
+      sha256,
+    };
+  });
+}
+
+function regionPositions(start: number, end: number, length: number, wraps: boolean): number[] {
+  const positions: number[] = [];
+  if (!wraps) {
+    for (let position = start; position < end; position += 1) positions.push(position);
+    return positions;
+  }
+  for (let position = start; position < length; position += 1) positions.push(position);
+  for (let position = 0; position < end; position += 1) positions.push(position);
+  return positions;
+}
+
+function normalizeRegions(
+  value: unknown,
+  reference: NormalizedReference,
+  thresholds: ArtifactConstructVerificationThresholds,
+): NormalizedRegion[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) fail('invalid_input', 'requiredRegions must be an array when provided.');
+  if (value.length > ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxRequiredRegions) {
+    fail('too_large', `requiredRegions exceeds the ${ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxRequiredRegions}-region limit.`);
+  }
+  const seenIds = new Set<string>();
+  let totalRegionBases = 0;
+  return value.map((item, index) => {
+    const path = `requiredRegions[${index}]`;
+    const source = recordValue(item, path);
+    const id = normalizeId(source.id, `${path}.id`);
+    if (seenIds.has(id)) fail('invalid_input', `${path}.id duplicates region id "${id}".`);
+    seenIds.add(id);
+    const name = normalizeName(source.name, `${path}.name`);
+    const start = boundedInteger(source.start, `${path}.start`, 0, reference.sequence.length - 1);
+    const end = boundedInteger(source.end, `${path}.end`, 0, reference.sequence.length);
+    if (start === end) fail('invalid_input', `${path} must span at least one reference base.`);
+    const wraps = start > end;
+    if (wraps && reference.topology !== 'circular') {
+      fail('invalid_input', `${path} may wrap only on a circular reference.`);
+    }
+    const minDepth = source.minDepth === undefined
+      ? undefined
+      : boundedInteger(
+        source.minDepth,
+        `${path}.minDepth`,
+        1,
+        ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReads,
+      );
+    if (source.requireBothStrands !== undefined && typeof source.requireBothStrands !== 'boolean') {
+      fail('invalid_input', `${path}.requireBothStrands must be a boolean when provided.`);
+    }
+    const positions = regionPositions(start, end, reference.sequence.length, wraps);
+    totalRegionBases += positions.length;
+    if (totalRegionBases > ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxRequiredRegionBases) {
+      fail(
+        'too_large',
+        `requiredRegions exceeds the cumulative ${ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxRequiredRegionBases.toLocaleString()}-base interval limit.`,
+      );
+    }
+    return {
+      id,
+      ...(name === undefined ? {} : { name }),
+      start,
+      end,
+      ...(minDepth === undefined ? {} : { minDepth }),
+      ...(source.requireBothStrands === undefined
+        ? {}
+        : { requireBothStrands: source.requireBothStrands }),
+      wraps,
+      length: positions.length,
+      positions,
+      effectiveMinDepth: minDepth ?? thresholds.minDepth,
+      effectiveRequireBothStrands: source.requireBothStrands ?? thresholds.requireBothStrands,
+    };
+  });
+}
+
+function referenceSlice(sequence: string, start: number, end: number): string {
+  return sequence.slice(start, end);
+}
+
+function normalizeExpectedVariants(
+  value: unknown,
+  reference: NormalizedReference,
+): ArtifactConstructExpectedVariantInput[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) fail('invalid_input', 'expectedVariants must be an array when provided.');
+  if (value.length > ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxExpectedVariants) {
+    fail('too_large', `expectedVariants exceeds the ${ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxExpectedVariants}-variant limit.`);
+  }
+  const seenIds = new Set<string>();
+  const seenVariants = new Set<string>();
+  return value.map((item, index) => {
+    const path = `expectedVariants[${index}]`;
+    const source = recordValue(item, path);
+    const id = normalizeId(source.id, `${path}.id`);
+    if (seenIds.has(id)) fail('invalid_input', `${path}.id duplicates expected variant id "${id}".`);
+    seenIds.add(id);
+    if (source.type !== 'substitution' && source.type !== 'insertion' && source.type !== 'deletion') {
+      fail('invalid_input', `${path}.type must be substitution, insertion, or deletion.`);
+    }
+    const maximumCoordinate = source.type === 'insertion' && reference.topology === 'linear'
+      ? reference.sequence.length
+      : reference.sequence.length - 1;
+    const referenceStart = boundedInteger(
+      source.referenceStart,
+      `${path}.referenceStart`,
+      0,
+      maximumCoordinate,
+    );
+    const referenceEnd = boundedInteger(
+      source.referenceEnd,
+      `${path}.referenceEnd`,
+      0,
+      reference.sequence.length,
+    );
+    if (typeof source.reference !== 'string' || typeof source.alternate !== 'string') {
+      fail('invalid_input', `${path}.reference and ${path}.alternate must be DNA strings.`);
+    }
+    const referenceAllele = source.reference.toUpperCase();
+    const alternate = source.alternate.toUpperCase();
+    if (!CANONICAL_DNA_PATTERN.test(referenceAllele) || !CANONICAL_DNA_PATTERN.test(alternate)) {
+      fail('invalid_input', `${path} alleles must contain canonical A, C, G, and T bases only.`);
+    }
+    if (source.type === 'substitution') {
+      if (
+        referenceEnd !== referenceStart + 1
+        || referenceAllele.length !== 1
+        || alternate.length !== 1
+        || referenceAllele === alternate
+      ) {
+        fail('invalid_input', `${path} substitution must describe one changed reference base.`);
+      }
+    } else if (source.type === 'insertion') {
+      if (
+        referenceEnd !== referenceStart
+        || referenceAllele !== ''
+        || alternate.length < 1
+        || alternate.length > ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxIndelLength
+      ) {
+        fail('invalid_input', `${path} insertion must use an empty reference allele and 1–${ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxIndelLength} alternate bases at a zero-width coordinate.`);
+      }
+    } else if (
+      referenceEnd <= referenceStart
+      || referenceAllele.length !== referenceEnd - referenceStart
+      || referenceAllele.length > ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxIndelLength
+      || alternate !== ''
+    ) {
+      fail('invalid_input', `${path} deletion must use a bounded nonempty reference interval and an empty alternate allele.`);
+    }
+    if (source.type !== 'insertion') {
+      const actualReference = referenceSlice(reference.sequence, referenceStart, referenceEnd);
+      if (actualReference !== referenceAllele) {
+        fail('invalid_input', `${path}.reference does not match the supplied reference sequence.`);
+      }
+    }
+    const supplied: ArtifactConstructExpectedVariantInput = {
+      id,
+      type: source.type,
+      referenceStart,
+      referenceEnd,
+      reference: referenceAllele,
+      alternate,
+    };
+    const canonical = canonicalVariant(supplied, reference);
+    const normalized: ArtifactConstructExpectedVariantInput = { id, ...canonical };
+    const key = variantKey(normalized);
+    if (seenVariants.has(key)) fail('invalid_input', `${path} duplicates another expected variant.`);
+    seenVariants.add(key);
+    return normalized;
+  });
+}
+
+function normalizeInput(value: ArtifactConstructVerificationInput): NormalizedInput {
+  const source = recordValue(value, 'input');
+  const thresholds = normalizeThresholds(source.thresholds);
+  const reference = normalizeReference(source.reference);
+  return {
+    reference,
+    reads: normalizeReads(source.reads),
+    requiredRegions: normalizeRegions(source.requiredRegions, reference, thresholds),
+    expectedVariants: normalizeExpectedVariants(source.expectedVariants, reference),
+    thresholds,
+  };
+}
+
+function modulo(value: number, modulus: number): number {
+  return ((value % modulus) + modulus) % modulus;
+}
+
+function canonicalBase(value: string): value is 'A' | 'C' | 'G' | 'T' {
+  return value === 'A' || value === 'C' || value === 'G' || value === 'T';
+}
+
+function basesCompatible(left: string, right: string): boolean {
+  return ((IUPAC_MASK[left] ?? 0) & (IUPAC_MASK[right] ?? 0)) !== 0;
+}
+
+function baseAlignmentScore(referenceBase: string, readBase: string): number {
+  if (referenceBase === readBase) return MATCH_SCORE;
+  if (basesCompatible(referenceBase, readBase)) return AMBIGUOUS_MATCH_SCORE;
+  return MISMATCH_SCORE;
+}
+
+function normalizedReferencePosition(
+  absolutePosition: number,
+  reference: NormalizedReference,
+): number | null {
+  if (reference.topology === 'circular') return modulo(absolutePosition, reference.sequence.length);
+  if (absolutePosition < 0 || absolutePosition >= reference.sequence.length) return null;
+  return absolutePosition;
+}
+
+function normalizedReferenceBoundary(
+  absoluteBoundary: number,
+  reference: NormalizedReference,
+): number | null {
+  if (reference.topology === 'circular') return modulo(absoluteBoundary, reference.sequence.length);
+  if (absoluteBoundary < 0 || absoluteBoundary > reference.sequence.length) return null;
+  return absoluteBoundary;
+}
+
+function referenceBaseAt(absolutePosition: number, reference: NormalizedReference): string | null {
+  const position = normalizedReferencePosition(absolutePosition, reference);
+  return position === null ? null : reference.sequence[position];
+}
+
+function qualityWeight(score: number | null): number {
+  return score === null ? 1 : score + 1;
+}
+
+function readTrim(
+  read: NormalizedRead,
+  thresholds: ArtifactConstructVerificationThresholds,
+  work: WorkCounter,
+): { trim: ArtifactConstructReadTrim; meanQuality: number | null } {
+  const length = read.baseCalls.length;
+  if (read.qualityScores === null) {
+    return {
+      trim: {
+        method: 'none_missing_quality',
+        rawStart: 0,
+        rawEnd: length,
+        trimmedLength: length,
+        removedFromStart: 0,
+        removedFromEnd: 0,
+      },
+      meanQuality: null,
+    };
+  }
+
+  const prefix = new Float64Array(length + 1);
+  for (let index = 0; index < length; index += 1) {
+    prefix[index + 1] = prefix[index] + read.qualityScores[index];
+    work.spend();
+  }
+  const window = Math.min(length, thresholds.trimWindow);
+  let start = -1;
+  for (let index = 0; index + window <= length; index += 1) {
+    work.spend();
+    const mean = (prefix[index + window] - prefix[index]) / window;
+    if (mean >= thresholds.trimQuality) {
+      start = index;
+      break;
+    }
+  }
+  let end = -1;
+  if (start >= 0) {
+    for (let candidateEnd = length; candidateEnd - window >= start; candidateEnd -= 1) {
+      work.spend();
+      const mean = (prefix[candidateEnd] - prefix[candidateEnd - window]) / window;
+      if (mean >= thresholds.trimQuality) {
+        end = candidateEnd;
+        break;
+      }
+    }
+  }
+  if (start < 0 || end < start) {
+    start = 0;
+    end = 0;
+  }
+  const trimmedLength = end - start;
+  return {
+    trim: {
+      method: 'quality_window',
+      rawStart: start,
+      rawEnd: end,
+      trimmedLength,
+      removedFromStart: start,
+      removedFromEnd: length - end,
+    },
+    meanQuality: trimmedLength === 0 ? null : (prefix[end] - prefix[start]) / trimmedLength,
+  };
+}
+
+function orientRead(
+  read: NormalizedRead,
+  trim: ArtifactConstructReadTrim,
+  orientation: 'forward' | 'reverse',
+): OrientedRead {
+  const trimmed = read.baseCalls.slice(trim.rawStart, trim.rawEnd);
+  const sequence = orientation === 'forward' ? trimmed : reverseComplement(trimmed).toUpperCase();
+  const rawCallIndices = new Array<number>(trim.trimmedLength);
+  const qualityScores = new Array<number | null>(trim.trimmedLength);
+  const rawBases = new Array<string>(trim.trimmedLength);
+  for (let orientedIndex = 0; orientedIndex < trim.trimmedLength; orientedIndex += 1) {
+    const rawIndex = orientation === 'forward'
+      ? trim.rawStart + orientedIndex
+      : trim.rawEnd - 1 - orientedIndex;
+    rawCallIndices[orientedIndex] = rawIndex;
+    qualityScores[orientedIndex] = read.qualityScores?.[rawIndex] ?? null;
+    rawBases[orientedIndex] = read.baseCalls[rawIndex];
+  }
+  return { orientation, sequence, rawCallIndices, qualityScores, rawBases };
+}
+
+type ReferenceSeedIndex = Map<string, number[]>;
+type ReferenceSeedIndexCache = Map<number, ReferenceSeedIndex>;
+
+function seedAt(reference: NormalizedReference, start: number, length: number): string | null {
+  if (reference.topology === 'linear') {
+    if (start + length > reference.sequence.length) return null;
+    return reference.sequence.slice(start, start + length);
+  }
+  let seed = '';
+  for (let offset = 0; offset < length; offset += 1) {
+    seed += reference.sequence[modulo(start + offset, reference.sequence.length)];
+  }
+  return seed;
+}
+
+function referenceSeedIndex(
+  reference: NormalizedReference,
+  seedLength: number,
+  cache: ReferenceSeedIndexCache,
+  work: WorkCounter,
+): ReferenceSeedIndex {
+  const cached = cache.get(seedLength);
+  if (cached !== undefined) return cached;
+  const index: ReferenceSeedIndex = new Map();
+  const finalStart = reference.topology === 'circular'
+    ? reference.sequence.length - 1
+    : reference.sequence.length - seedLength;
+  for (let start = 0; start <= finalStart; start += 1) {
+    work.spend();
+    const seed = seedAt(reference, start, seedLength);
+    if (seed === null || !CANONICAL_DNA_PATTERN.test(seed)) continue;
+    const positions = index.get(seed);
+    if (positions === undefined) index.set(seed, [start]);
+    else positions.push(start);
+  }
+  cache.set(seedLength, index);
+  return index;
+}
+
+function seedOffsets(readLength: number, seedLength: number): number[] {
+  if (seedLength > readLength) return [];
+  const finalOffset = readLength - seedLength;
+  const stride = Math.max(1, Math.floor(Math.max(1, finalOffset) / 24));
+  const offsets: number[] = [];
+  for (let offset = 0; offset <= finalOffset; offset += stride) offsets.push(offset);
+  if (offsets.at(-1) !== finalOffset) offsets.push(finalOffset);
+  return offsets;
+}
+
+function startDistance(
+  left: number,
+  right: number,
+  reference: NormalizedReference,
+): number {
+  const direct = Math.abs(left - right);
+  return reference.topology === 'circular'
+    ? Math.min(direct, reference.sequence.length - direct)
+    : direct;
+}
+
+function selectCandidateStarts(
+  votes: Map<number, number>,
+  reference: NormalizedReference,
+): CandidateSearch {
+  const ranked = [...votes.entries()]
+    .map(([start, count]) => ({ start, votes: count }))
+    .sort((left, right) => right.votes - left.votes || left.start - right.start);
+  const selected: CandidateStart[] = [];
+  let truncated = false;
+  const clusterRadius = ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxIndelLength * 2;
+  for (const candidate of ranked) {
+    // Lower-vote offsets in the same indel-sized neighborhood are alternate
+    // seed estimates of one locus. Equal-vote loci stay distinct so short or
+    // tandem repeats cannot be promoted to a unique mapping.
+    if (selected.some((existing) => (
+      existing.votes > candidate.votes
+      && startDistance(existing.start, candidate.start, reference) <= clusterRadius
+    ))) {
+      truncated = true;
+      continue;
+    }
+    if (selected.length >= MAX_MAPPING_CANDIDATES_PER_ORIENTATION) {
+      truncated = true;
+      break;
+    }
+    selected.push(candidate);
+  }
+  return {
+    candidates: selected.sort((left, right) => left.start - right.start),
+    truncated,
+  };
+}
+
+function mappingCandidates(
+  oriented: OrientedRead,
+  reference: NormalizedReference,
+  cache: ReferenceSeedIndexCache,
+  work: WorkCounter,
+): CandidateSearch {
+  const readLength = oriented.sequence.length;
+  const primaryLength = Math.min(11, Math.max(1, Math.floor(readLength / 4)));
+  const seedLengths = [...new Set([
+    primaryLength,
+    Math.min(primaryLength, 5),
+    Math.min(primaryLength, 3),
+    1,
+  ])].filter((length) => length <= readLength);
+
+  const aggregateVotes = new Map<number, number>();
+  let truncated = false;
+
+  for (const seedLength of seedLengths) {
+    const index = referenceSeedIndex(reference, seedLength, cache, work);
+    const votes = new Map<number, number>();
+    for (const readOffset of seedOffsets(readLength, seedLength)) {
+      const seed = oriented.sequence.slice(readOffset, readOffset + seedLength);
+      work.spend();
+      if (!CANONICAL_DNA_PATTERN.test(seed)) continue;
+      const referencePositions = index.get(seed);
+      if (referencePositions === undefined) continue;
+      // Every occurrence participates. The work counter bounds repetitive
+      // inputs; silently truncating the list could turn missing contenders
+      // into a false claim of unique mapping.
+      for (let occurrence = 0; occurrence < referencePositions.length; occurrence += 1) {
+        work.spend();
+        const referencePosition = referencePositions[occurrence];
+        let start = referencePosition - readOffset;
+        if (reference.topology === 'circular') {
+          start = modulo(start, reference.sequence.length);
+        } else if (
+          start < -ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxIndelLength
+          || start >= reference.sequence.length
+        ) {
+          continue;
+        }
+        votes.set(start, (votes.get(start) ?? 0) + 1);
+      }
+    }
+    // Retain bounded contenders from every seed scale. A single incidental
+    // long seed must not prevent the true, slightly noisy locus from being
+    // recovered by shorter seeds.
+    const selection = selectCandidateStarts(votes, reference);
+    truncated ||= selection.truncated;
+    for (const candidate of selection.candidates) {
+      const weightedVotes = candidate.votes * seedLength;
+      aggregateVotes.set(
+        candidate.start,
+        Math.max(aggregateVotes.get(candidate.start) ?? 0, weightedVotes),
+      );
+    }
+  }
+
+  if (aggregateVotes.size > 0) {
+    const selection = selectCandidateStarts(aggregateVotes, reference);
+    return {
+      candidates: selection.candidates,
+      truncated: truncated || selection.truncated,
+    };
+  }
+
+  if (readLength <= 16 || reference.sequence.length <= 512) {
+    const votes = new Map<number, number>();
+    const first = reference.topology === 'linear'
+      ? -Math.min(ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxIndelLength, readLength)
+      : 0;
+    const last = reference.sequence.length - 1;
+    for (let start = first; start <= last; start += 1) {
+      votes.set(start, 1);
+      work.spend();
+    }
+    const selection = selectCandidateStarts(votes, reference);
+    return {
+      candidates: selection.candidates,
+      truncated: truncated || selection.truncated,
+    };
+  }
+  return { candidates: [], truncated };
+}
+
+function exhaustiveMappingWorkEstimate(
+  readLength: number,
+  reference: NormalizedReference,
+  band: number,
+): number {
+  const candidateCount = reference.topology === 'circular'
+    ? reference.sequence.length
+    : reference.sequence.length + Math.min(band, readLength);
+  const dynamicProgrammingWidth = (band * 2) + 3;
+  const scoringPasses = candidateCount * 2;
+  // A fixed alignment path can fall inside at most 2*band+1 integer-centered
+  // bands for one orientation. After the best traceback, that many duplicate
+  // paths may need to be skipped before the first scientifically distinct
+  // runner-up is found. The opposite orientation is already a distinct path.
+  // This is a complete bound, while avoiding an unnecessary traceback reserve
+  // for every start that was already scored.
+  const tracebackPasses = Math.min(scoringPasses, (band * 2) + 2);
+  return (scoringPasses + tracebackPasses)
+    * readLength
+    * dynamicProgrammingWidth;
+}
+
+function exhaustiveAlignmentBand(
+  readLength: number,
+  reference: NormalizedReference,
+  maxIndelFraction: number,
+): number {
+  const maximumCumulativeIndels = maxIndelFraction >= 1
+    ? reference.sequence.length + readLength
+    : Math.ceil((maxIndelFraction * readLength) / Math.max(Number.EPSILON, 1 - maxIndelFraction));
+  // Every allowed path has a diagonal range no larger than its cumulative
+  // indel count. Enumerating all integer centers with half that range covers it.
+  return Math.max(
+    ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxIndelLength,
+    Math.ceil(maximumCumulativeIndels / 2),
+  );
+}
+
+function exhaustiveCandidateStarts(
+  readLength: number,
+  reference: NormalizedReference,
+  band: number,
+): CandidateStart[] {
+  const first = reference.topology === 'linear'
+    ? -Math.min(band, readLength)
+    : 0;
+  const last = reference.sequence.length - 1;
+  const candidates: CandidateStart[] = [];
+  for (let start = first; start <= last; start += 1) candidates.push({ start, votes: 0 });
+  return candidates;
+}
+
+function exactOccurrenceStarts(
+  oriented: OrientedRead,
+  reference: NormalizedReference,
+  work: WorkCounter,
+): number[] {
+  work.spend(Math.max(1, reference.sequence.length));
+  if (!CANONICAL_DNA_PATTERN.test(oriented.sequence)) return [];
+  if (reference.topology === 'linear') {
+    if (oriented.sequence.length > reference.sequence.length) return [];
+    const starts: number[] = [];
+    let start = reference.sequence.indexOf(oriented.sequence);
+    while (start >= 0) {
+      starts.push(start);
+      if (starts.length >= 2) break;
+      start = reference.sequence.indexOf(oriented.sequence, start + 1);
+    }
+    return starts;
+  }
+  // Multi-lap circular reads are never promoted by this shortcut; the regular
+  // mapper must keep their repeated coordinates review-only.
+  if (oriented.sequence.length > reference.sequence.length) return [];
+  const searchable = reference.sequence
+    + reference.sequence.slice(0, Math.max(0, oriented.sequence.length - 1));
+  const starts: number[] = [];
+  let start = searchable.indexOf(oriented.sequence);
+  while (start >= 0 && start < reference.sequence.length) {
+    starts.push(start);
+    if (starts.length >= 2) break;
+    start = searchable.indexOf(oriented.sequence, start + 1);
+  }
+  return starts;
+}
+
+function exactMappingCandidates(
+  orientedReads: readonly OrientedRead[],
+  reference: NormalizedReference,
+  work: WorkCounter,
+): Array<{ orientation: OrientedRead['orientation']; start: number }> {
+  const candidates: Array<{ orientation: OrientedRead['orientation']; start: number }> = [];
+  for (const oriented of orientedReads) {
+    for (const start of exactOccurrenceStarts(oriented, reference, work)) {
+      candidates.push({ orientation: oriented.orientation, start });
+      // Two exact canonical occurrences already prove non-uniqueness. More
+      // occurrences cannot change the safe classification.
+      if (candidates.length >= 2) return candidates;
+    }
+  }
+  return candidates;
+}
+
+type BandedAlignmentRun = {
+  score: number;
+  alignment: AlignmentResult | null;
+};
+
+function runBandedAlignment(
+  oriented: OrientedRead,
+  reference: NormalizedReference,
+  candidateStart: number,
+  band: number,
+  work: WorkCounter,
+  includeTraceback: boolean,
+): BandedAlignmentRun {
+  const readLength = oriented.sequence.length;
+  const rawWindowStart = candidateStart - band;
+  const rawWindowEnd = candidateStart + readLength + band;
+  const windowStart = reference.topology === 'linear' ? Math.max(0, rawWindowStart) : rawWindowStart;
+  const windowEnd = reference.topology === 'linear'
+    ? Math.min(reference.sequence.length, rawWindowEnd)
+    : rawWindowEnd;
+  const windowLength = windowEnd - windowStart;
+  if (windowLength <= 0) return { score: NEGATIVE_INFINITY, alignment: null };
+  const expectedOffset = candidateStart - windowStart;
+  const width = (band * 2) + 3;
+  const previous = new Int32Array(windowLength + 1);
+  const current = new Int32Array(windowLength + 1);
+  const rowStarts = includeTraceback ? new Int32Array(readLength + 1) : null;
+  const traces = includeTraceback ? new Uint8Array((readLength + 1) * width) : null;
+
+  let previousStart = Math.max(0, expectedOffset - band);
+  let previousEnd = Math.min(windowLength, expectedOffset + band);
+  for (let column = previousStart; column <= previousEnd; column += 1) previous[column] = 0;
+  if (rowStarts !== null) rowStarts[0] = previousStart;
+
+  for (let row = 1; row <= readLength; row += 1) {
+    const expectedColumn = expectedOffset + row;
+    const currentStart = Math.max(0, expectedColumn - band);
+    const currentEnd = Math.min(windowLength, expectedColumn + band);
+    if (rowStarts !== null) rowStarts[row] = currentStart;
+    for (let column = currentStart; column <= currentEnd; column += 1) {
+      work.spend();
+      let bestScore = NEGATIVE_INFINITY;
+      let direction = 0;
+      if (
+        column > 0
+        && column - 1 >= previousStart
+        && column - 1 <= previousEnd
+      ) {
+        const referenceBase = referenceBaseAt(windowStart + column - 1, reference);
+        if (referenceBase !== null) {
+          bestScore = previous[column - 1]
+            + baseAlignmentScore(referenceBase, oriented.sequence[row - 1]);
+          direction = 1;
+        }
+      }
+      if (column >= previousStart && column <= previousEnd) {
+        const insertionScore = previous[column] + GAP_SCORE;
+        if (insertionScore > bestScore) {
+          bestScore = insertionScore;
+          direction = 2;
+        }
+      }
+      if (column > currentStart) {
+        const deletionScore = current[column - 1] + GAP_SCORE;
+        if (deletionScore > bestScore) {
+          bestScore = deletionScore;
+          direction = 3;
+        }
+      }
+      current[column] = bestScore;
+      if (traces !== null) traces[(row * width) + (column - currentStart)] = direction;
+    }
+    for (let column = currentStart; column <= currentEnd; column += 1) {
+      previous[column] = current[column];
+    }
+    previousStart = currentStart;
+    previousEnd = currentEnd;
+  }
+
+  const expectedEnd = expectedOffset + readLength;
+  let endColumn = -1;
+  let bestScore = NEGATIVE_INFINITY;
+  for (let column = previousStart; column <= previousEnd; column += 1) {
+    const score = previous[column];
+    if (
+      score > bestScore
+      || (
+        score === bestScore
+        && (
+          endColumn < 0
+          || Math.abs(column - expectedEnd) < Math.abs(endColumn - expectedEnd)
+          || (
+            Math.abs(column - expectedEnd) === Math.abs(endColumn - expectedEnd)
+            && column < endColumn
+          )
+        )
+      )
+    ) {
+      bestScore = score;
+      endColumn = column;
+    }
+  }
+  if (!includeTraceback || traces === null || rowStarts === null || endColumn < 0) {
+    return { score: bestScore, alignment: null };
+  }
+
+  const reversedColumns: Array<{
+    column: ArtifactConstructAlignmentColumn;
+    absoluteReferencePosition: number | null;
+  }> = [];
+  let row = readLength;
+  let column = endColumn;
+  while (row > 0) {
+    const rowStart = rowStarts[row];
+    const traceOffset = column - rowStart;
+    if (traceOffset < 0 || traceOffset >= width) return { score: bestScore, alignment: null };
+    const direction = traces[(row * width) + traceOffset];
+    if (direction === 1) {
+      const absoluteReferencePosition = windowStart + column - 1;
+      const referencePosition = normalizedReferencePosition(absoluteReferencePosition, reference);
+      const referenceBase = referenceBaseAt(absoluteReferencePosition, reference);
+      const orientedIndex = row - 1;
+      const readBase = oriented.sequence[orientedIndex];
+      if (referencePosition === null || referenceBase === null) {
+        return { score: bestScore, alignment: null };
+      }
+      reversedColumns.push({
+        absoluteReferencePosition,
+        column: {
+          operation: referenceBase === readBase && canonicalBase(referenceBase)
+            ? 'match'
+            : 'substitution',
+          referencePosition,
+          referenceBoundary: null,
+          rawCallIndex: oriented.rawCallIndices[orientedIndex],
+          orientedCallIndex: orientedIndex,
+          referenceBase,
+          readBase,
+          rawBase: oriented.rawBases[orientedIndex],
+          qualityScore: oriented.qualityScores[orientedIndex],
+        },
+      });
+      row -= 1;
+      column -= 1;
+    } else if (direction === 2) {
+      const orientedIndex = row - 1;
+      const boundary = normalizedReferenceBoundary(windowStart + column, reference);
+      if (boundary === null) return { score: bestScore, alignment: null };
+      reversedColumns.push({
+        absoluteReferencePosition: null,
+        column: {
+          operation: 'insertion',
+          referencePosition: null,
+          referenceBoundary: boundary,
+          rawCallIndex: oriented.rawCallIndices[orientedIndex],
+          orientedCallIndex: orientedIndex,
+          referenceBase: null,
+          readBase: oriented.sequence[orientedIndex],
+          rawBase: oriented.rawBases[orientedIndex],
+          qualityScore: oriented.qualityScores[orientedIndex],
+        },
+      });
+      row -= 1;
+    } else if (direction === 3) {
+      const absoluteReferencePosition = windowStart + column - 1;
+      const referencePosition = normalizedReferencePosition(absoluteReferencePosition, reference);
+      const referenceBase = referenceBaseAt(absoluteReferencePosition, reference);
+      if (referencePosition === null || referenceBase === null) {
+        return { score: bestScore, alignment: null };
+      }
+      reversedColumns.push({
+        absoluteReferencePosition,
+        column: {
+          operation: 'deletion',
+          referencePosition,
+          referenceBoundary: null,
+          rawCallIndex: null,
+          orientedCallIndex: null,
+          referenceBase,
+          readBase: null,
+          rawBase: null,
+          qualityScore: null,
+        },
+      });
+      column -= 1;
+    } else {
+      return { score: bestScore, alignment: null };
+    }
+  }
+
+  const traced = reversedColumns.reverse();
+  const referenceColumns = traced.filter((entry) => entry.absoluteReferencePosition !== null);
+  if (referenceColumns.length === 0) return { score: bestScore, alignment: null };
+  const firstAbsolute = referenceColumns[0].absoluteReferencePosition as number;
+  const lastAbsolute = referenceColumns.at(-1)?.absoluteReferencePosition as number;
+  const referenceSpan = lastAbsolute - firstAbsolute + 1;
+  const referenceStart = normalizedReferencePosition(firstAbsolute, reference) as number;
+  let referenceEnd: number;
+  let wraps = false;
+  if (reference.topology === 'linear') {
+    referenceEnd = lastAbsolute + 1;
+  } else {
+    wraps = Math.floor(firstAbsolute / reference.sequence.length)
+      !== Math.floor(lastAbsolute / reference.sequence.length);
+    referenceEnd = wraps
+      ? modulo(lastAbsolute + 1, reference.sequence.length)
+      : referenceStart + referenceSpan;
+  }
+  const columns = traced.map((entry) => entry.column);
+  let matches = 0;
+  let substitutions = 0;
+  let insertions = 0;
+  let deletions = 0;
+  let maximumIndelRun = 0;
+  let currentIndelRun = 0;
+  let currentIndelOperation: 'insertion' | 'deletion' | null = null;
+  for (const alignmentColumn of columns) {
+    if (alignmentColumn.operation === 'match') matches += 1;
+    else if (alignmentColumn.operation === 'substitution') substitutions += 1;
+    else if (alignmentColumn.operation === 'insertion') insertions += 1;
+    else deletions += 1;
+    if (alignmentColumn.operation === 'insertion' || alignmentColumn.operation === 'deletion') {
+      if (alignmentColumn.operation === currentIndelOperation) currentIndelRun += 1;
+      else {
+        currentIndelOperation = alignmentColumn.operation;
+        currentIndelRun = 1;
+      }
+      maximumIndelRun = Math.max(maximumIndelRun, currentIndelRun);
+    } else {
+      currentIndelOperation = null;
+      currentIndelRun = 0;
+    }
+  }
+  const alignedLength = columns.length;
+  const identity = alignedLength === 0 ? 0 : matches / alignedLength;
+  const indelFraction = alignedLength === 0 ? 0 : (insertions + deletions) / alignedLength;
+  return {
+    score: bestScore,
+    alignment: {
+      maximumIndelRun,
+      mapping: {
+        orientation: oriented.orientation,
+        referenceStart,
+        referenceEnd,
+        wraps,
+        referenceSpan,
+        score: bestScore,
+        secondBestScore: null,
+        mappingMargin: null,
+        identity,
+        alignedLength,
+        matches,
+        substitutions,
+        insertions,
+        deletions,
+        indelFraction,
+        coordinateMap: {
+          columns,
+          referencePositions: columns.map((entry) => entry.referencePosition),
+          rawCallIndices: columns.map((entry) => entry.rawCallIndex),
+        },
+      },
+    },
+  };
+}
+
+function alignmentPathSignature(mapping: ArtifactConstructReadMapping): string {
+  return `${mapping.orientation}|${mapping.coordinateMap.columns.map((column) => (
+    `${column.operation[0]}:${column.referencePosition ?? `b${column.referenceBoundary}`}:${column.rawCallIndex ?? '-'}`
+  )).join(',')}`;
+}
+
+function circularMappingRepeatsReferencePosition(mapping: ArtifactConstructReadMapping): boolean {
+  const seen = new Set<number>();
+  for (const position of mapping.coordinateMap.referencePositions) {
+    if (position === null) continue;
+    if (seen.has(position)) return true;
+    seen.add(position);
+  }
+  return false;
+}
+
+function mapRead(
+  read: NormalizedRead,
+  trim: ArtifactConstructReadTrim,
+  reference: NormalizedReference,
+  thresholds: ArtifactConstructVerificationThresholds,
+  seedCache: ReferenceSeedIndexCache,
+  work: WorkCounter,
+  exhaustiveSearchBudget: number,
+): { status: ArtifactConstructReadStatus; alignment: AlignmentResult | null } {
+  const orientedReads = [
+    orientRead(read, trim, 'forward'),
+    orientRead(read, trim, 'reverse'),
+  ];
+  const exactCandidates = exactMappingCandidates(orientedReads, reference, work);
+  // Two exact occurrences prove ambiguity immediately. One exact occurrence
+  // proves only that the global maximum is unique; it does not prove the
+  // configured separation from a near-exact runner-up. Use the one-hit
+  // shortcut only when no positive mapping margin was requested.
+  const useExactShortcut = exactCandidates.length >= 2
+    || (exactCandidates.length === 1 && thresholds.minMappingMargin === 0);
+  const exhaustiveBand = exhaustiveAlignmentBand(
+    trim.trimmedLength,
+    reference,
+    thresholds.maxIndelFraction,
+  );
+  const useExhaustiveSearch = !useExactShortcut
+    && exhaustiveMappingWorkEstimate(
+      trim.trimmedLength,
+      reference,
+      exhaustiveBand,
+    ) <= exhaustiveSearchBudget;
+  const exhaustiveCandidates = useExhaustiveSearch
+    ? exhaustiveCandidateStarts(trim.trimmedLength, reference, exhaustiveBand)
+    : null;
+  const alignmentBand = exhaustiveCandidates === null
+    ? ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxIndelLength
+    : exhaustiveBand;
+  const scored: ScoredCandidate[] = [];
+  // Sampled seeds schedule a useful tentative alignment, but they are not a
+  // completeness proof. Only a unique exact global maximum or an exhaustive
+  // bounded start scan may support a claim of unique mapping.
+  let candidateSearchIncomplete = !useExactShortcut && exhaustiveCandidates === null;
+  for (const oriented of orientedReads) {
+    const search: CandidateSearch = useExactShortcut
+      ? {
+          candidates: exactCandidates
+            .filter((candidate) => candidate.orientation === oriented.orientation)
+            .map((candidate) => ({ start: candidate.start, votes: 0 })),
+          truncated: false,
+        }
+      : exhaustiveCandidates !== null
+        ? { candidates: exhaustiveCandidates, truncated: false }
+        : mappingCandidates(oriented, reference, seedCache, work);
+    candidateSearchIncomplete ||= search.truncated;
+    for (const candidate of search.candidates) {
+      const run = runBandedAlignment(
+        oriented,
+        reference,
+        candidate.start,
+        alignmentBand,
+        work,
+        false,
+      );
+      if (run.score > NEGATIVE_INFINITY / 2) {
+        scored.push({
+          orientation: oriented.orientation,
+          candidateStart: candidate.start,
+          score: run.score,
+        });
+      }
+    }
+  }
+  scored.sort((left, right) => (
+    right.score - left.score
+    || (left.orientation === right.orientation ? 0 : left.orientation === 'forward' ? -1 : 1)
+    || left.candidateStart - right.candidateStart
+  ));
+  const best = scored[0];
+  if (best === undefined) return { status: 'unmapped', alignment: null };
+  const oriented = orientedReads.find((entry) => entry.orientation === best.orientation) as OrientedRead;
+  const rerun = runBandedAlignment(
+    oriented,
+    reference,
+    best.candidateStart,
+    alignmentBand,
+    work,
+    true,
+  );
+  if (rerun.alignment === null) return { status: 'unmapped', alignment: null };
+  const bestSignature = alignmentPathSignature(rerun.alignment.mapping);
+
+  if (rerun.alignment.mapping.identity < thresholds.minMappingIdentity) {
+    return { status: 'low_mapping_identity', alignment: rerun.alignment };
+  }
+  if (
+    rerun.alignment.maximumIndelRun > ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxIndelLength
+    || rerun.alignment.mapping.indelFraction > thresholds.maxIndelFraction
+  ) {
+    return { status: 'excessive_indel', alignment: rerun.alignment };
+  }
+  if (
+    reference.topology === 'circular'
+    && circularMappingRepeatsReferencePosition(rerun.alignment.mapping)
+  ) {
+    return { status: 'ambiguous_mapping', alignment: rerun.alignment };
+  }
+  // A sampled or bounded candidate search is a scheduling aid, never evidence
+  // of uniqueness. If either orientation was not exhaustively proven, an
+  // unscored contender could tie the display alignment, so keep it review-only.
+  if (candidateSearchIncomplete) {
+    return { status: 'ambiguous_mapping', alignment: rerun.alignment };
+  }
+  let secondBestScore: number | null = null;
+  for (let contenderIndex = 1; contenderIndex < scored.length; contenderIndex += 1) {
+    const contender = scored[contenderIndex];
+    const contenderRead = orientedReads.find((entry) => (
+      entry.orientation === contender.orientation
+    )) as OrientedRead;
+    const contenderRun = runBandedAlignment(
+      contenderRead,
+      reference,
+      contender.candidateStart,
+      alignmentBand,
+      work,
+      true,
+    );
+    const contenderSignature = contenderRun.alignment === null
+      ? undefined
+      : alignmentPathSignature(contenderRun.alignment.mapping);
+    if (contenderSignature !== undefined && contenderSignature !== bestSignature) {
+      secondBestScore = contender.score;
+      break;
+    }
+  }
+  const mappingMargin = secondBestScore === null
+    ? null
+    : (best.score - secondBestScore) / Math.max(1, MATCH_SCORE * trim.trimmedLength);
+  rerun.alignment.mapping.secondBestScore = secondBestScore;
+  rerun.alignment.mapping.mappingMargin = mappingMargin;
+  if (
+    secondBestScore !== null
+    && (secondBestScore === best.score || (mappingMargin ?? 0) < thresholds.minMappingMargin)
+  ) {
+    return { status: 'ambiguous_mapping', alignment: rerun.alignment };
+  }
+  return { status: 'mapped', alignment: rerun.alignment };
+}
+
+function reason(
+  code: ArtifactConstructVerificationReasonCode,
+  severity: ArtifactConstructVerificationReason['severity'],
+  message: string,
+  ids: Pick<ArtifactConstructVerificationReason, 'readId' | 'regionId' | 'variantId'> = {},
+): ArtifactConstructVerificationReason {
+  return {
+    code,
+    severity,
+    message,
+    ...(ids.readId === undefined ? {} : { readId: ids.readId }),
+    ...(ids.regionId === undefined ? {} : { regionId: ids.regionId }),
+    ...(ids.variantId === undefined ? {} : { variantId: ids.variantId }),
+  };
+}
+
+function readReason(read: NormalizedRead, status: ArtifactConstructReadStatus): ArtifactConstructVerificationReason {
+  const label = read.name ?? read.id;
+  if (status === 'trimmed_read_too_short') {
+    return reason('trimmed_read_too_short', 'review', `${label} is too short after quality-aware end trimming.`, { readId: read.id });
+  }
+  if (status === 'ambiguous_mapping') {
+    return reason('ambiguous_mapping', 'review', `${label} does not have a unique best reference mapping.`, { readId: read.id });
+  }
+  if (status === 'low_mapping_identity') {
+    return reason('low_mapping_identity', 'review', `${label}'s best mapping is below the minimum identity.`, { readId: read.id });
+  }
+  if (status === 'excessive_indel') {
+    return reason('excessive_indel', 'review', `${label}'s best mapping exceeds the bounded indel allowance.`, { readId: read.id });
+  }
+  return reason('unmapped_read', 'review', `${label} could not be mapped to the reference.`, { readId: read.id });
+}
+
+function variantKey(
+  variant: Pick<
+    ArtifactConstructExpectedVariantInput,
+    'type' | 'referenceStart' | 'referenceEnd' | 'reference' | 'alternate'
+  >,
+): string {
+  return [
+    variant.type,
+    variant.referenceStart,
+    variant.referenceEnd,
+    variant.reference,
+    variant.alternate,
+  ].join(':');
+}
+
+type VariantDescriptor = Pick<
+  ArtifactConstructExpectedVariantInput,
+  'type' | 'referenceStart' | 'referenceEnd' | 'reference' | 'alternate'
+>;
+
+/**
+ * Left-normalize indels. Linear references use the conventional leftmost
+ * representation. Circular references have no intrinsic left edge, so all
+ * equivalent rotations (at most one lap) are considered and the lowest
+ * numeric boundary, then lexical allele, is canonical.
+ */
+function canonicalVariant(
+  variant: VariantDescriptor,
+  reference: NormalizedReference,
+): VariantDescriptor {
+  if (variant.type === 'substitution') return { ...variant };
+  const sequenceLength = reference.sequence.length;
+  const allele = variant.type === 'insertion' ? variant.alternate : variant.reference;
+  let start = variant.referenceStart;
+  let rotatedAllele = allele;
+  const representations: Array<{ start: number; allele: string }> = [{ start, allele: rotatedAllele }];
+  const seen = new Set([`${start}:${rotatedAllele}`]);
+  const stepLimit = reference.topology === 'circular' ? sequenceLength : start;
+  for (let step = 0; step < stepLimit; step += 1) {
+    if (rotatedAllele.length === 0 || (reference.topology === 'linear' && start === 0)) break;
+    const previousPosition = reference.topology === 'circular'
+      ? modulo(start - 1, sequenceLength)
+      : start - 1;
+    const finalAlleleBase = rotatedAllele.at(-1) as string;
+    if (reference.sequence[previousPosition] !== finalAlleleBase) break;
+    start = reference.topology === 'circular' ? previousPosition : start - 1;
+    rotatedAllele = finalAlleleBase + rotatedAllele.slice(0, -1);
+    const state = `${start}:${rotatedAllele}`;
+    if (seen.has(state)) break;
+    seen.add(state);
+    representations.push({ start, allele: rotatedAllele });
+  }
+  const length = allele.length;
+  const representable = representations.filter((entry) => (
+    variant.type === 'insertion'
+    || entry.start + length <= sequenceLength
+  ));
+  const selected = (reference.topology === 'circular'
+    ? representable.sort((left, right) => left.start - right.start || left.allele.localeCompare(right.allele))[0]
+    : representable.at(-1)) ?? representations[0];
+  if (variant.type === 'insertion') {
+    return {
+      type: 'insertion',
+      referenceStart: selected.start,
+      referenceEnd: selected.start,
+      reference: '',
+      alternate: selected.allele,
+    };
+  }
+  return {
+    type: 'deletion',
+    referenceStart: selected.start,
+    referenceEnd: selected.start + length,
+    reference: selected.allele,
+    alternate: '',
+  };
+}
+
+function variantTypeRank(type: ArtifactConstructVariantType): number {
+  if (type === 'substitution') return 0;
+  if (type === 'insertion') return 1;
+  return 2;
+}
+
+function compareVariants(
+  left: Pick<ArtifactConstructObservedVariant, 'referenceStart' | 'referenceEnd' | 'type' | 'reference' | 'alternate'>,
+  right: Pick<ArtifactConstructObservedVariant, 'referenceStart' | 'referenceEnd' | 'type' | 'reference' | 'alternate'>,
+): number {
+  return left.referenceStart - right.referenceStart
+    || left.referenceEnd - right.referenceEnd
+    || variantTypeRank(left.type) - variantTypeRank(right.type)
+    || left.reference.localeCompare(right.reference)
+    || left.alternate.localeCompare(right.alternate);
+}
+
+function nearestColumnQuality(
+  columns: readonly ArtifactConstructAlignmentColumn[],
+  index: number,
+): number | null {
+  for (let distance = 1; distance < columns.length; distance += 1) {
+    const left = columns[index - distance]?.qualityScore;
+    const right = columns[index + distance]?.qualityScore;
+    if (left !== undefined && left !== null && right !== undefined && right !== null) {
+      return (left + right) / 2;
+    }
+    if (left !== undefined && left !== null) return left;
+    if (right !== undefined && right !== null) return right;
+  }
+  return null;
+}
+
+function addVariantEvidence(
+  evidenceByKey: Map<string, VariantEvidence>,
+  variant: VariantDescriptor,
+  readId: string,
+  qualityScores: readonly (number | null)[],
+  reference: NormalizedReference,
+): void {
+  const normalizedVariant = canonicalVariant(variant, reference);
+  const key = variantKey(normalizedVariant);
+  let evidence = evidenceByKey.get(key);
+  if (evidence === undefined) {
+    if (evidenceByKey.size >= ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxObservedVariants) {
+      fail(
+        'work_budget',
+        `Construct verification exceeded the ${ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxObservedVariants.toLocaleString()}-variant evidence limit.`,
+      );
+    }
+    evidence = {
+      ...normalizedVariant,
+      readIds: new Set(),
+      weightByRead: new Map(),
+      qualityByRead: new Map(),
+    };
+    evidenceByKey.set(key, evidence);
+  }
+  if (evidence.readIds.has(readId)) return;
+  evidence.readIds.add(readId);
+  const knownScores = qualityScores.filter((score): score is number => score !== null);
+  const eventQuality = knownScores.length === 0
+    ? null
+    : knownScores.reduce((total, score) => total + score, 0) / knownScores.length;
+  evidence.weightByRead.set(readId, qualityWeight(eventQuality));
+  evidence.qualityByRead.set(readId, eventQuality);
+}
+
+function collectReadVariantEvidence(
+  readId: string,
+  columns: readonly ArtifactConstructAlignmentColumn[],
+  evidenceByKey: Map<string, VariantEvidence>,
+  reference: NormalizedReference,
+): void {
+  for (let index = 0; index < columns.length; index += 1) {
+    const column = columns[index];
+    if (
+      column.operation === 'substitution'
+      && column.referencePosition !== null
+      && column.referenceBase !== null
+      && column.readBase !== null
+      && canonicalBase(column.referenceBase)
+      && canonicalBase(column.readBase)
+    ) {
+      addVariantEvidence(evidenceByKey, {
+        type: 'substitution',
+        referenceStart: column.referencePosition,
+        referenceEnd: column.referencePosition + 1,
+        reference: column.referenceBase,
+        alternate: column.readBase,
+      }, readId, [column.qualityScore], reference);
+      continue;
+    }
+
+    if (column.operation === 'insertion' && column.referenceBoundary !== null) {
+      const boundary = column.referenceBoundary;
+      let alternate = '';
+      const qualities: Array<number | null> = [];
+      let finalIndex = index;
+      while (
+        finalIndex < columns.length
+        && columns[finalIndex].operation === 'insertion'
+        && columns[finalIndex].referenceBoundary === boundary
+      ) {
+        alternate += columns[finalIndex].readBase ?? '';
+        qualities.push(columns[finalIndex].qualityScore);
+        finalIndex += 1;
+      }
+      if (
+        alternate.length > 0
+        && alternate.length <= ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxIndelLength
+        && CANONICAL_DNA_PATTERN.test(alternate)
+      ) {
+        addVariantEvidence(evidenceByKey, {
+          type: 'insertion',
+          referenceStart: boundary,
+          referenceEnd: boundary,
+          reference: '',
+          alternate,
+        }, readId, qualities, reference);
+      }
+      index = finalIndex - 1;
+      continue;
+    }
+
+    if (
+      column.operation === 'deletion'
+      && column.referencePosition !== null
+      && column.referenceBase !== null
+    ) {
+      const start = column.referencePosition;
+      let end = start;
+      let deleted = '';
+      let finalIndex = index;
+      while (finalIndex < columns.length) {
+        const candidate = columns[finalIndex];
+        if (
+          candidate.operation !== 'deletion'
+          || candidate.referencePosition === null
+          || candidate.referenceBase === null
+          || candidate.referencePosition !== end
+        ) break;
+        deleted += candidate.referenceBase;
+        end += 1;
+        finalIndex += 1;
+      }
+      if (
+        deleted.length > 0
+        && deleted.length <= ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxIndelLength
+        && CANONICAL_DNA_PATTERN.test(deleted)
+      ) {
+        addVariantEvidence(evidenceByKey, {
+          type: 'deletion',
+          referenceStart: start,
+          referenceEnd: end,
+          reference: deleted,
+          alternate: '',
+        }, readId, [nearestColumnQuality(columns, index)], reference);
+      }
+      index = finalIndex - 1;
+    }
+  }
+}
+
+type EvidenceCollection = {
+  depth: number[];
+  forward: number[];
+  reverse: number[];
+  positionWeights: Array<Map<string, number>>;
+  positionQualities: Array<Map<string, number | null>>;
+  alleles: Array<Map<ArtifactConstructConsensusAllele['allele'], AlleleEvidence>>;
+  variants: Map<string, VariantEvidence>;
+};
+
+function collectEvidence(
+  reads: readonly ArtifactConstructReadVerification[],
+  reference: NormalizedReference,
+): EvidenceCollection {
+  const referenceLength = reference.sequence.length;
+  const depth = new Array<number>(referenceLength).fill(0);
+  const forward = new Array<number>(referenceLength).fill(0);
+  const reverse = new Array<number>(referenceLength).fill(0);
+  const positionWeights = Array.from({ length: referenceLength }, () => new Map<string, number>());
+  const positionQualities = Array.from(
+    { length: referenceLength },
+    () => new Map<string, number | null>(),
+  );
+  const alleles = Array.from(
+    { length: referenceLength },
+    () => new Map<ArtifactConstructConsensusAllele['allele'], AlleleEvidence>(),
+  );
+  const variants = new Map<string, VariantEvidence>();
+
+  for (const read of reads) {
+    if (read.status !== 'mapped' || read.mapping === null) continue;
+    const seenPositions = new Set<number>();
+    const columns = read.mapping.coordinateMap.columns;
+    for (let index = 0; index < columns.length; index += 1) {
+      const column = columns[index];
+      const position = column.referencePosition;
+      if (position === null || seenPositions.has(position)) continue;
+      let allele: ArtifactConstructConsensusAllele['allele'] | null = null;
+      if (column.operation === 'deletion') allele = '-';
+      else if (column.readBase !== null && canonicalBase(column.readBase)) allele = column.readBase;
+      // IUPAC ambiguity is a no-call, not accepted depth. This keeps N-rich
+      // reads from manufacturing coverage or a contradictory consensus.
+      if (allele === null) continue;
+      seenPositions.add(position);
+      depth[position] += 1;
+      if (read.mapping.orientation === 'forward') forward[position] += 1;
+      else reverse[position] += 1;
+
+      const score = column.operation === 'deletion'
+        ? nearestColumnQuality(columns, index)
+        : column.qualityScore;
+      const weight = qualityWeight(score);
+      positionWeights[position].set(read.id, weight);
+      positionQualities[position].set(read.id, score);
+      const existing = alleles[position].get(allele) ?? { count: 0, weight: 0 };
+      existing.count += 1;
+      existing.weight += weight;
+      alleles[position].set(allele, existing);
+    }
+    collectReadVariantEvidence(read.id, columns, variants, reference);
+  }
+  return { depth, forward, reverse, positionWeights, positionQualities, alleles, variants };
+}
+
+function summarizeCoverage(
+  evidence: EvidenceCollection,
+  regions: readonly NormalizedRegion[],
+  thresholds: ArtifactConstructVerificationThresholds,
+  reasons: ArtifactConstructVerificationReason[],
+): ArtifactConstructCoverage {
+  const referenceLength = evidence.depth.length;
+  const coveredBases = evidence.depth.filter((value) => value > 0).length;
+  const basesMeetingMinDepth = evidence.depth.filter((value) => value >= thresholds.minDepth).length;
+  const requiredRegions = regions.map((region): ArtifactConstructRegionCoverage => {
+    const depths = region.positions.map((position) => evidence.depth[position]);
+    const regionCoveredBases = depths.filter((value) => value > 0).length;
+    const regionBasesMeetingDepth = depths.filter((value) => value >= region.effectiveMinDepth).length;
+    const forwardCoveredBases = region.positions.filter((position) => evidence.forward[position] > 0).length;
+    const reverseCoveredBases = region.positions.filter((position) => evidence.reverse[position] > 0).length;
+    const bothStrandsCoveredBases = region.positions.filter((position) => (
+      evidence.forward[position] > 0 && evidence.reverse[position] > 0
+    )).length;
+    let status: ArtifactConstructRegionCoverage['status'] = 'covered';
+    if (regionCoveredBases < region.length) {
+      status = 'uncovered';
+      reasons.push(reason(
+        'required_region_uncovered',
+        'review',
+        `${region.name ?? region.id} is not covered across its full required interval.`,
+        { regionId: region.id },
+      ));
+    } else if (regionBasesMeetingDepth < region.length) {
+      status = 'low_depth';
+      reasons.push(reason(
+        'required_region_low_depth',
+        'review',
+        `${region.name ?? region.id} is below its required depth at one or more bases.`,
+        { regionId: region.id },
+      ));
+    }
+    if (
+      region.effectiveRequireBothStrands
+      && regionCoveredBases === region.length
+      && bothStrandsCoveredBases < region.length
+    ) {
+      if (status === 'covered') status = 'missing_strand';
+      reasons.push(reason(
+        'required_region_missing_strand',
+        'review',
+        `${region.name ?? region.id} lacks bidirectional support at one or more bases.`,
+        { regionId: region.id },
+      ));
+    }
+    return {
+      id: region.id,
+      ...(region.name === undefined ? {} : { name: region.name }),
+      start: region.start,
+      end: region.end,
+      wraps: region.wraps,
+      length: region.length,
+      minDepth: region.effectiveMinDepth,
+      requireBothStrands: region.effectiveRequireBothStrands,
+      coveredBases: regionCoveredBases,
+      basesMeetingMinDepth: regionBasesMeetingDepth,
+      coveredFraction: region.length === 0 ? 0 : regionBasesMeetingDepth / region.length,
+      minimumDepth: Math.min(...depths),
+      maximumDepth: Math.max(...depths),
+      meanDepth: depths.reduce((total, value) => total + value, 0) / region.length,
+      forwardCoveredBases,
+      reverseCoveredBases,
+      bothStrandsCoveredBases,
+      status,
+    };
+  });
+
+  const coveredFraction = referenceLength === 0 ? 0 : basesMeetingMinDepth / referenceLength;
+  if (coveredFraction < thresholds.minCoverageFraction) {
+    reasons.push(reason(
+      'partial_reference_coverage',
+      'review',
+      `Only ${(coveredFraction * 100).toFixed(1)}% of reference bases meet the minimum depth.`,
+    ));
+  }
+  return {
+    depth: evidence.depth,
+    forward: evidence.forward,
+    reverse: evidence.reverse,
+    coveredBases,
+    basesMeetingMinDepth,
+    coveredFraction,
+    minimumDepth: Math.min(...evidence.depth),
+    maximumDepth: Math.max(...evidence.depth),
+    meanDepth: evidence.depth.reduce((total, value) => total + value, 0) / referenceLength,
+    requiredRegions,
+  };
+}
+
+type VariantSpanSupport = {
+  readIds: Set<string>;
+  highQualityReadIds: Set<string>;
+  depth: number;
+  totalWeight: number;
+  highQualityDepth: number;
+};
+
+function variantSpanPositions(
+  variant: Pick<ArtifactConstructExpectedVariantInput, 'type' | 'referenceStart' | 'referenceEnd'>,
+  reference: NormalizedReference,
+): number[] {
+  if (variant.type === 'substitution') return [variant.referenceStart];
+  if (variant.type === 'deletion') {
+    return Array.from(
+      { length: variant.referenceEnd - variant.referenceStart },
+      (_, offset) => variant.referenceStart + offset,
+    );
+  }
+  const coordinate = variant.referenceStart;
+  if (reference.topology === 'circular') {
+    return [...new Set([
+      modulo(coordinate - 1, reference.sequence.length),
+      modulo(coordinate, reference.sequence.length),
+    ])];
+  }
+  if (coordinate === 0) return [0];
+  if (coordinate === reference.sequence.length) return [reference.sequence.length - 1];
+  return [coordinate - 1, coordinate];
+}
+
+function variantSpanSupport(
+  variant: Pick<ArtifactConstructExpectedVariantInput, 'type' | 'referenceStart' | 'referenceEnd'>,
+  evidence: EvidenceCollection,
+  reference: NormalizedReference,
+  minimumQuality: number,
+): VariantSpanSupport {
+  const positions = variantSpanPositions(variant, reference);
+  const firstQualities = evidence.positionQualities[positions[0]];
+  const readIds = new Set<string>();
+  const highQualityReadIds = new Set<string>();
+  let totalWeight = 0;
+  let highQualityDepth = 0;
+  if (firstQualities === undefined) {
+    return { readIds, highQualityReadIds, depth: 0, totalWeight, highQualityDepth };
+  }
+  for (const readId of firstQualities.keys()) {
+    const qualities: Array<number | null> = [];
+    let spans = true;
+    for (const position of positions) {
+      const atPosition = evidence.positionQualities[position];
+      if (atPosition === undefined || !atPosition.has(readId)) {
+        spans = false;
+        break;
+      }
+      qualities.push(atPosition.get(readId) ?? null);
+    }
+    if (!spans) continue;
+    readIds.add(readId);
+    const known = qualities.filter((quality): quality is number => quality !== null);
+    const conservativeQuality = known.length === qualities.length
+      ? Math.min(...known)
+      : null;
+    totalWeight += qualityWeight(conservativeQuality);
+    if (conservativeQuality !== null && conservativeQuality >= minimumQuality) {
+      highQualityDepth += 1;
+      highQualityReadIds.add(readId);
+    }
+  }
+  return { readIds, highQualityReadIds, depth: readIds.size, totalWeight, highQualityDepth };
+}
+
+function observedVariants(
+  evidence: EvidenceCollection,
+  reference: NormalizedReference,
+  thresholds: ArtifactConstructVerificationThresholds,
+): ArtifactConstructObservedVariant[] {
+  return [...evidence.variants.values()]
+    .map((variant): ArtifactConstructObservedVariant => {
+      const span = variantSpanSupport(variant, evidence, reference, thresholds.minVariantQuality);
+      const supportingReadIds = [...variant.readIds]
+        .filter((readId) => span.readIds.has(readId))
+        .sort();
+      const depth = span.depth;
+      const support = supportingReadIds.length;
+      const supportWeight = supportingReadIds.reduce(
+        (total, readId) => total + (variant.weightByRead.get(readId) ?? 0),
+        0,
+      );
+      const fraction = span.totalWeight > 0
+        ? Math.min(1, supportWeight / span.totalWeight)
+        : depth > 0 ? Math.min(1, support / depth) : 0;
+      const knownQualities = supportingReadIds
+        .map((readId) => variant.qualityByRead.get(readId) ?? null)
+        .filter((quality): quality is number => quality !== null);
+      const meanQuality = knownQualities.length === 0
+        ? null
+        : knownQualities.reduce((total, quality) => total + quality, 0) / knownQualities.length;
+      const confidence = fraction >= thresholds.minVariantFraction
+        && meanQuality !== null
+        && meanQuality >= thresholds.minVariantQuality
+        && supportingReadIds.some((readId) => span.highQualityReadIds.has(readId))
+        ? 'high'
+        : 'low';
+      const key = variantKey(variant);
+      return {
+        id: `observed:${variant.type}:${variant.referenceStart}:${sha256HexSync(key).slice(0, 12)}`,
+        type: variant.type,
+        referenceStart: variant.referenceStart,
+        referenceEnd: variant.referenceEnd,
+        reference: variant.reference,
+        alternate: variant.alternate,
+        depth,
+        support,
+        supportWeight,
+        fraction,
+        meanQuality,
+        confidence,
+        supportingReadIds,
+      };
+    })
+    .sort(compareVariants);
+}
+
+function callConsensus(
+  evidence: EvidenceCollection,
+  reference: NormalizedReference,
+  observed: readonly ArtifactConstructObservedVariant[],
+  thresholds: ArtifactConstructVerificationThresholds,
+  reasons: ArtifactConstructVerificationReason[],
+): ArtifactConstructConsensus {
+  const alleleOrder: readonly ArtifactConstructConsensusAllele['allele'][] = ['A', 'C', 'G', 'T', '-'];
+  let conflictCount = 0;
+  const calls = evidence.alleles.map((positionEvidence, referencePosition): ArtifactConstructConsensusCall => {
+    const totalWeight = [...positionEvidence.values()]
+      .reduce((total, entry) => total + entry.weight, 0);
+    const alleles = alleleOrder
+      .flatMap((allele): ArtifactConstructConsensusAllele[] => {
+        const entry = positionEvidence.get(allele);
+        return entry === undefined ? [] : [{
+          allele,
+          count: entry.count,
+          weight: entry.weight,
+          fraction: totalWeight === 0 ? 0 : entry.weight / totalWeight,
+        }];
+      })
+      .sort((left, right) => (
+        right.weight - left.weight
+        || alleleOrder.indexOf(left.allele) - alleleOrder.indexOf(right.allele)
+      ));
+    if (evidence.depth[referencePosition] === 0) {
+      return {
+        referencePosition,
+        referenceBase: reference.sequence[referencePosition],
+        call: 'N',
+        status: 'uncovered',
+        depth: 0,
+        forwardDepth: 0,
+        reverseDepth: 0,
+        fraction: 0,
+        alleles,
+      };
+    }
+    const leading = alleles[0];
+    const tied = leading !== undefined && alleles[1]?.weight === leading.weight;
+    if (leading === undefined || tied || leading.fraction < thresholds.minConsensusFraction) {
+      conflictCount += 1;
+      return {
+        referencePosition,
+        referenceBase: reference.sequence[referencePosition],
+        call: 'N',
+        status: 'conflict',
+        depth: evidence.depth[referencePosition],
+        forwardDepth: evidence.forward[referencePosition],
+        reverseDepth: evidence.reverse[referencePosition],
+        fraction: leading?.fraction ?? 0,
+        alleles,
+      };
+    }
+    const call = leading.allele;
+    const referenceBase = reference.sequence[referencePosition];
+    const changesReference = call === '-' || !basesCompatible(referenceBase, call);
+    if (changesReference) {
+      const supportedEdit = observed.some((variant) => {
+        if (variant.confidence !== 'high' || variant.fraction < thresholds.minConsensusFraction) return false;
+        if (call === '-') {
+          return variant.type === 'deletion'
+            && referencePosition >= variant.referenceStart
+            && referencePosition < variant.referenceEnd;
+        }
+        return variant.type === 'substitution'
+          && variant.referenceStart === referencePosition
+          && variant.alternate === call;
+      });
+      // A winning low/no-quality alternate is provisional evidence, not a
+      // sequence edit. Its low_confidence_variant reason keeps the verdict at
+      // review without manufacturing a contradictory consensus.
+      if (!supportedEdit) {
+        return {
+          referencePosition,
+          referenceBase,
+          call: 'N',
+          status: 'conflict',
+          depth: evidence.depth[referencePosition],
+          forwardDepth: evidence.forward[referencePosition],
+          reverseDepth: evidence.reverse[referencePosition],
+          fraction: leading.fraction,
+          alleles,
+        };
+      }
+    }
+    return {
+      referencePosition,
+      referenceBase,
+      call,
+      status: changesReference ? 'variant' : 'reference',
+      depth: evidence.depth[referencePosition],
+      forwardDepth: evidence.forward[referencePosition],
+      reverseDepth: evidence.reverse[referencePosition],
+      fraction: leading.fraction,
+      alleles,
+    };
+  });
+
+  const consensusInsertions = new Map<number, ArtifactConstructObservedVariant[]>();
+  const consensusVariants = observed.filter((variant) => {
+    if (variant.confidence !== 'high' || variant.fraction < thresholds.minConsensusFraction) return false;
+    if (variant.type === 'substitution') {
+      return calls[variant.referenceStart]?.call === variant.alternate;
+    }
+    if (variant.type === 'deletion') {
+      for (let position = variant.referenceStart; position < variant.referenceEnd; position += 1) {
+        if (calls[position]?.call !== '-') return false;
+      }
+      return true;
+    }
+    const atBoundary = consensusInsertions.get(variant.referenceStart) ?? [];
+    atBoundary.push(variant);
+    consensusInsertions.set(variant.referenceStart, atBoundary);
+    return true;
+  });
+  const conflictingInsertionIds = new Set<string>();
+  for (const variants of consensusInsertions.values()) {
+    if (variants.length <= 1) continue;
+    conflictCount += 1;
+    for (const variant of variants) conflictingInsertionIds.add(variant.id);
+  }
+  const acceptedConsensusVariants = consensusVariants.filter((variant) => !conflictingInsertionIds.has(variant.id));
+  const insertionByBoundary = new Map<number, string>();
+  for (const variant of acceptedConsensusVariants) {
+    if (variant.type === 'insertion') insertionByBoundary.set(variant.referenceStart, variant.alternate);
+  }
+  let sequence = '';
+  for (let position = 0; position < calls.length; position += 1) {
+    sequence += insertionByBoundary.get(position) ?? '';
+    const call = calls[position].call;
+    if (call !== '-') sequence += call;
+  }
+  if (reference.topology === 'linear') sequence += insertionByBoundary.get(reference.sequence.length) ?? '';
+  if (conflictCount > 0) {
+    reasons.push(reason(
+      'conflicting_consensus',
+      'inconsistent',
+      `${conflictCount.toLocaleString()} reference position${conflictCount === 1 ? '' : 's'} lack a unique quality-weighted consensus.`,
+    ));
+  }
+  return { sequence, calls, variants: acceptedConsensusVariants };
+}
+
+function summarizeVariants(
+  initialObserved: readonly ArtifactConstructObservedVariant[],
+  expectedInputs: readonly ArtifactConstructExpectedVariantInput[],
+  evidence: EvidenceCollection,
+  reference: NormalizedReference,
+  thresholds: ArtifactConstructVerificationThresholds,
+  reasons: ArtifactConstructVerificationReason[],
+): ArtifactConstructVariantSummary {
+  const expectedByKey = new Map(expectedInputs.map((variant) => [variantKey(variant), variant]));
+  const observed = initialObserved.map((variant): ArtifactConstructObservedVariant => {
+    const expected = expectedByKey.get(variantKey(variant));
+    return expected === undefined ? variant : { ...variant, expectedVariantId: expected.id };
+  });
+  const observedByKey = new Map(observed.map((variant) => [variantKey(variant), variant]));
+  const expected = expectedInputs.map((variant): ArtifactConstructExpectedVariantResult => {
+    const matching = observedByKey.get(variantKey(variant));
+    const span = variantSpanSupport(variant, evidence, reference, 0);
+    const highQualitySpan = variantSpanSupport(
+      variant,
+      evidence,
+      reference,
+      thresholds.minVariantQuality,
+    );
+    const depth = highQualitySpan.highQualityDepth;
+    if (matching?.confidence === 'high') {
+      return { ...variant, status: 'observed', depth, observedVariantId: matching.id };
+    }
+    if (matching !== undefined) {
+      return { ...variant, status: 'low_confidence', depth, observedVariantId: matching.id };
+    }
+    if (depth === 0 || span.depth === 0) return { ...variant, status: 'not_covered', depth };
+    return { ...variant, status: 'not_observed', depth };
+  });
+  const unexpected = observed.filter((variant) => variant.expectedVariantId === undefined);
+  const missingExpected = expected.filter((variant) => variant.status !== 'observed');
+
+  for (const variant of observed) {
+    if (variant.confidence === 'low') {
+      reasons.push(reason(
+        'low_confidence_variant',
+        'review',
+        `${variant.id} has variant evidence below the configured quality or fraction threshold.`,
+        { variantId: variant.id },
+      ));
+    } else if (variant.expectedVariantId === undefined) {
+      reasons.push(reason(
+        'unexpected_variant',
+        'inconsistent',
+        `${variant.id} is a high-confidence variant not present in expectedVariants.`,
+        { variantId: variant.id },
+      ));
+    }
+  }
+  for (const variant of expected) {
+    if (variant.status === 'not_covered') {
+      reasons.push(reason(
+        'expected_variant_not_covered',
+        'review',
+        `${variant.id} is not covered by a usable read.`,
+        { variantId: variant.id },
+      ));
+    } else if (variant.status === 'not_observed') {
+      reasons.push(reason(
+        'expected_variant_not_observed',
+        'inconsistent',
+        `${variant.id} is covered but its expected allele was not observed.`,
+        { variantId: variant.id },
+      ));
+    }
+  }
+  return { observed, expected, unexpected, missingExpected };
+}
+
+function requestSha256(input: NormalizedInput): string {
+  return sha256HexSync(JSON.stringify({
+    schema: ARTIFACT_CONSTRUCT_VERIFICATION_SCHEMA,
+    version: ARTIFACT_CONSTRUCT_VERIFICATION_VERSION,
+    reference: {
+      id: input.reference.id,
+      sequence: input.reference.sequence,
+      topology: input.reference.topology,
+      sha256: input.reference.sha256,
+    },
+    reads: input.reads.map((read) => ({
+      id: read.id,
+      baseCalls: read.baseCalls,
+      qualityScores: read.qualityScores,
+      sha256: read.sha256,
+    })).sort((left, right) => left.id.localeCompare(right.id)),
+    requiredRegions: input.requiredRegions.map((region) => ({
+      id: region.id,
+      start: region.start,
+      end: region.end,
+      minDepth: region.effectiveMinDepth,
+      requireBothStrands: region.effectiveRequireBothStrands,
+    })).sort((left, right) => left.id.localeCompare(right.id)),
+    expectedVariants: [...input.expectedVariants].sort((left, right) => left.id.localeCompare(right.id)),
+    thresholds: input.thresholds,
+  }));
+}
+
+export function verifyArtifactConstruct(
+  input: ArtifactConstructVerificationInput,
+): ArtifactConstructVerificationResult {
+  const normalized = normalizeInput(input);
+  const work = new WorkCounter();
+  const reasons: ArtifactConstructVerificationReason[] = [];
+  const seedCache: ReferenceSeedIndexCache = new Map();
+  const exhaustiveSearchBudget = Math.floor(
+    (ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxWorkUnits * EXHAUSTIVE_MAPPING_WORK_FRACTION)
+      / Math.max(1, normalized.reads.length),
+  );
+  const reads = normalized.reads.map((read): ArtifactConstructReadVerification => {
+    const { trim, meanQuality } = readTrim(read, normalized.thresholds, work);
+    if (read.qualityScores === null) {
+      reasons.push(reason(
+        'missing_quality',
+        'review',
+        `${read.name ?? read.id} has no quality scores; its calls were not re-based or quality-trimmed.`,
+        { readId: read.id },
+      ));
+    }
+    let status: ArtifactConstructReadStatus;
+    let mapping: ArtifactConstructReadMapping | null = null;
+    if (trim.trimmedLength < normalized.thresholds.minTrimmedReadLength) {
+      status = 'trimmed_read_too_short';
+    } else {
+      const mapped = mapRead(
+        read,
+        trim,
+        normalized.reference,
+        normalized.thresholds,
+        seedCache,
+        work,
+        exhaustiveSearchBudget,
+      );
+      status = mapped.status;
+      mapping = mapped.alignment?.mapping ?? null;
+    }
+    if (status !== 'mapped') reasons.push(readReason(read, status));
+    return {
+      id: read.id,
+      ...(read.name === undefined ? {} : { name: read.name }),
+      sha256: read.sha256,
+      rawLength: read.baseCalls.length,
+      qualityProvided: read.qualityScores !== null,
+      meanQuality,
+      status,
+      trim,
+      mapping,
+    };
+  });
+
+  const usableReadCount = reads.filter((read) => read.status === 'mapped').length;
+  if (usableReadCount === 0) {
+    reasons.push(reason(
+      'no_usable_reads',
+      'review',
+      'No read passed trimming, unique mapping, identity, and bounded-indel checks.',
+    ));
+  }
+  const evidence = collectEvidence(reads, normalized.reference);
+  const coverage = summarizeCoverage(
+    evidence,
+    normalized.requiredRegions,
+    normalized.thresholds,
+    reasons,
+  );
+  const initialObserved = observedVariants(
+    evidence,
+    normalized.reference,
+    normalized.thresholds,
+  );
+  const variants = summarizeVariants(
+    initialObserved,
+    normalized.expectedVariants,
+    evidence,
+    normalized.reference,
+    normalized.thresholds,
+    reasons,
+  );
+  const consensus = callConsensus(
+    evidence,
+    normalized.reference,
+    variants.observed,
+    normalized.thresholds,
+    reasons,
+  );
+  const state: ArtifactConstructVerificationResult['state'] = reasons.some((entry) => (
+    entry.severity === 'inconsistent'
+  ))
+    ? 'inconsistent'
+    : reasons.length > 0 ? 'needs_review' : 'consistent';
+
+  return {
+    schema: ARTIFACT_CONSTRUCT_VERIFICATION_SCHEMA,
+    version: ARTIFACT_CONSTRUCT_VERIFICATION_VERSION,
+    state,
+    reasons,
+    reference: {
+      id: normalized.reference.id,
+      ...(normalized.reference.name === undefined ? {} : { name: normalized.reference.name }),
+      sequence: normalized.reference.sequence,
+      length: normalized.reference.sequence.length,
+      topology: normalized.reference.topology,
+      sha256: normalized.reference.sha256,
+    },
+    thresholds: { ...normalized.thresholds },
+    reads,
+    coverage,
+    consensus,
+    variants,
+    provenance: {
+      engine: 'motif-construct-verification',
+      engineVersion: '1',
+      referenceSha256: normalized.reference.sha256,
+      readSha256s: normalized.reads.map((read) => read.sha256),
+      requestSha256: requestSha256(normalized),
+      workUnits: work.value(),
+      limits: ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS,
+    },
+  };
+}

--- a/src/artifacts/claude-science-freshness.css
+++ b/src/artifacts/claude-science-freshness.css
@@ -1,0 +1,55 @@
+.motif-cs-freshness {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
+  min-width: 0;
+}
+
+.motif-cs-freshness-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: max-content;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--control-bg);
+  color: var(--text-secondary);
+  font-size: 9.5px;
+  font-weight: 720;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.motif-cs-freshness-badge > span {
+  width: 5px;
+  height: 5px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: currentcolor;
+}
+
+.motif-cs-freshness[data-freshness="fresh"] .motif-cs-freshness-badge {
+  border-color: color-mix(in srgb, var(--green) 36%, var(--border));
+  color: var(--green);
+}
+
+.motif-cs-freshness[data-freshness="stale"] .motif-cs-freshness-badge {
+  border-color: color-mix(in srgb, var(--red) 38%, var(--border));
+  color: var(--red);
+}
+
+.motif-cs-freshness[data-freshness="unverified"] .motif-cs-freshness-badge {
+  border-color: color-mix(in srgb, var(--amber) 42%, var(--border));
+  color: var(--amber);
+}
+
+.motif-cs-freshness-reason {
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 9.5px;
+  font-weight: 450;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}

--- a/src/artifacts/claude-science-freshness.ts
+++ b/src/artifacts/claude-science-freshness.ts
@@ -1,0 +1,543 @@
+/**
+ * Pure freshness evaluation for portable scientific results.
+ *
+ * A saved result is fresh only when every current input can be matched to its
+ * saved attestation. Missing records and positive mismatches are stale; missing
+ * or malformed attestations are unverified. The evaluators never mutate the
+ * supplied records/results and never read wall-clock or browser state.
+ */
+
+import type { Topology } from '../bio/types';
+import type { ArtifactAnalysisResult } from './claude-science-analysis-results';
+import type { ArtifactAlignment } from './claude-science-msa';
+import { SHA256_HEX_PATTERN, sha256HexSync } from './claude-science-sha256';
+import type { ArtifactWorkflowResult } from './claude-science-workspace-collections';
+
+export type ScientificFreshnessState = 'fresh' | 'stale' | 'unverified';
+export type ScientificFreshnessReasonState = Exclude<ScientificFreshnessState, 'fresh'>;
+
+export const CONSTRUCT_READ_EVIDENCE_SCHEMA = 'motif.construct-read-evidence.v1';
+
+export type ScientificFreshnessReasonCode =
+  | 'record_missing'
+  | 'sequence_attestation_missing'
+  | 'sequence_attestation_invalid'
+  | 'sequence_hash_mismatch'
+  | 'topology_attestation_missing'
+  | 'topology_attestation_invalid'
+  | 'topology_mismatch'
+  | 'end_chemistry_attestation_missing'
+  | 'end_chemistry_attestation_invalid'
+  | 'end_chemistry_missing'
+  | 'end_chemistry_mismatch'
+  | 'sanger_evidence_attestation_missing'
+  | 'sanger_evidence_attestation_invalid'
+  | 'sanger_evidence_attestation_misaligned'
+  | 'sanger_evidence_missing'
+  | 'sanger_evidence_hash_mismatch'
+  | 'alignment_row_source_unattested';
+
+export type ScientificFreshnessField =
+  | 'sequence'
+  | 'topology'
+  | 'left_end'
+  | 'right_end'
+  | 'sanger_evidence'
+  | 'source_record';
+
+export type ScientificFreshnessReason = {
+  code: ScientificFreshnessReasonCode;
+  state: ScientificFreshnessReasonState;
+  message: string;
+  recordId?: string;
+  rowId?: string;
+  field?: ScientificFreshnessField;
+  expected?: string;
+  actual?: string;
+};
+
+export type ScientificFreshnessEvaluation = {
+  state: ScientificFreshnessState;
+  reasons: ScientificFreshnessReason[];
+  affectedRecordIds: string[];
+};
+
+export type ScientificFreshnessEndType = 'blunt' | '5prime' | '3prime';
+
+/** Structural subset accepted directly from the workbench's private record type. */
+export type ScientificFreshnessRecord = {
+  id: string;
+  sequence: string;
+  topology: Topology;
+  overhang5?: string;
+  overhang3?: string;
+  overhang5Type?: ScientificFreshnessEndType;
+  overhang3Type?: ScientificFreshnessEndType;
+  /** SHA-256 of the bounded Sanger evidence payload, separate from sequence identity. */
+  sangerEvidenceSha256?: string;
+};
+
+/** Compact immutable-by-convention lookup entry shared across batch evaluations. */
+export type ScientificFreshnessRecordSnapshot = {
+  id: string;
+  sequenceSha256: string;
+  topology: Topology;
+  overhang5?: string;
+  overhang3?: string;
+  overhang5Type?: ScientificFreshnessEndType;
+  overhang3Type?: ScientificFreshnessEndType;
+  sangerEvidenceSha256?: string;
+};
+
+export type ScientificFreshnessRecordIndex = ReadonlyMap<string, ScientificFreshnessRecordSnapshot>;
+
+type SavedEnd = {
+  sequence: string;
+  type: ScientificFreshnessEndType;
+};
+
+type SavedEndAttestations = {
+  left?: SavedEnd;
+  right?: SavedEnd;
+  invalidLeft?: boolean;
+  invalidRight?: boolean;
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isTopology(value: unknown): value is Topology {
+  return value === 'linear' || value === 'circular';
+}
+
+function normalizedEndSequence(value: string): string {
+  return value.toUpperCase();
+}
+
+function formatEnd(end: SavedEnd): string {
+  return `${end.type}:${normalizedEndSequence(end.sequence) || 'blunt'}`;
+}
+
+function savedEnd(value: unknown): SavedEnd | null {
+  if (!isPlainObject(value)) return null;
+  const type = value.type;
+  const sequence = value.sequence;
+  if (type !== 'blunt' && type !== '5prime' && type !== '3prime') return null;
+  if (typeof sequence !== 'string') return null;
+  const normalizedSequence = normalizedEndSequence(sequence);
+  if (type === 'blunt' ? normalizedSequence !== '' : !/^[ACGT]+$/.test(normalizedSequence)) return null;
+  return { type, sequence: normalizedSequence };
+}
+
+function reason(
+  code: ScientificFreshnessReasonCode,
+  state: ScientificFreshnessReasonState,
+  message: string,
+  details: Omit<ScientificFreshnessReason, 'code' | 'state' | 'message'> = {},
+): ScientificFreshnessReason {
+  return { code, state, message, ...details };
+}
+
+function finishEvaluation(reasons: ScientificFreshnessReason[]): ScientificFreshnessEvaluation {
+  const state: ScientificFreshnessState = reasons.some((entry) => entry.state === 'stale')
+    ? 'stale'
+    : reasons.length > 0
+      ? 'unverified'
+      : 'fresh';
+  const affectedRecordIds = Array.from(new Set(
+    reasons.flatMap((entry) => entry.recordId === undefined ? [] : [entry.recordId]),
+  ));
+  return { state, reasons, affectedRecordIds };
+}
+
+/** Hash current sequences once, then reuse this Map for any number of results. */
+export function createScientificFreshnessRecordIndex(
+  records: readonly ScientificFreshnessRecord[],
+): Map<string, ScientificFreshnessRecordSnapshot> {
+  const index = new Map<string, ScientificFreshnessRecordSnapshot>();
+  for (const record of records) {
+    index.set(record.id, {
+      id: record.id,
+      sequenceSha256: sha256HexSync(record.sequence),
+      topology: record.topology,
+      ...(record.overhang5 === undefined ? {} : { overhang5: normalizedEndSequence(record.overhang5) }),
+      ...(record.overhang3 === undefined ? {} : { overhang3: normalizedEndSequence(record.overhang3) }),
+      ...(record.overhang5Type === undefined ? {} : { overhang5Type: record.overhang5Type }),
+      ...(record.overhang3Type === undefined ? {} : { overhang3Type: record.overhang3Type }),
+      ...(record.sangerEvidenceSha256 !== undefined && SHA256_HEX_PATTERN.test(record.sangerEvidenceSha256)
+        ? { sangerEvidenceSha256: record.sangerEvidenceSha256.toLowerCase() }
+        : {}),
+    });
+  }
+  return index;
+}
+
+function evaluateConstructVerificationReadEvidence(
+  result: Extract<ArtifactAnalysisResult, { kind: 'construct_verification' }>,
+  records: ScientificFreshnessRecordIndex,
+): ScientificFreshnessReason[] {
+  const readRecordIds = result.data.readRecordIds;
+  const rawEvidence = result.parameters.readEvidence;
+  const reasons: ScientificFreshnessReason[] = [];
+
+  if (rawEvidence === undefined) {
+    return readRecordIds.map((recordId) => reason(
+      'sanger_evidence_attestation_missing',
+      'unverified',
+      `Sequencing read "${recordId}" has no saved Sanger-evidence SHA-256 attestation.`,
+      { recordId, field: 'sanger_evidence' },
+    ));
+  }
+
+  if (!isPlainObject(rawEvidence)
+    || rawEvidence.schema !== CONSTRUCT_READ_EVIDENCE_SCHEMA
+    || !Array.isArray(rawEvidence.sha256s)) {
+    return readRecordIds.map((recordId) => reason(
+      'sanger_evidence_attestation_invalid',
+      'unverified',
+      `Sequencing read "${recordId}" has a malformed saved Sanger-evidence SHA-256 attestation.`,
+      { recordId, field: 'sanger_evidence' },
+    ));
+  }
+
+  const rawAttestations = rawEvidence.sha256s;
+  if (rawAttestations.length !== readRecordIds.length) {
+    return readRecordIds.map((recordId) => reason(
+      'sanger_evidence_attestation_misaligned',
+      'unverified',
+      `Saved Sanger-evidence SHA-256 attestations do not align with sequencing read "${recordId}".`,
+      { recordId, field: 'sanger_evidence' },
+    ));
+  }
+
+  for (let index = 0; index < readRecordIds.length; index += 1) {
+    const recordId = readRecordIds[index];
+    const attestedSha256 = rawAttestations[index];
+    const shared = { recordId, field: 'sanger_evidence' as const };
+    if (typeof attestedSha256 !== 'string' || !SHA256_HEX_PATTERN.test(attestedSha256)) {
+      reasons.push(reason(
+        'sanger_evidence_attestation_invalid',
+        'unverified',
+        `Sequencing read "${recordId}" has a malformed saved Sanger-evidence SHA-256 attestation.`,
+        {
+          ...shared,
+          ...(typeof attestedSha256 === 'string' ? { expected: attestedSha256 } : {}),
+        },
+      ));
+      continue;
+    }
+
+    const current = records.get(recordId);
+    if (!current) continue;
+    if (current.sangerEvidenceSha256 === undefined) {
+      reasons.push(reason(
+        'sanger_evidence_missing',
+        'stale',
+        `Sequencing read "${recordId}" no longer has a current Sanger-evidence SHA-256 digest.`,
+        { ...shared, expected: attestedSha256.toLowerCase() },
+      ));
+      continue;
+    }
+    if (current.sangerEvidenceSha256 !== attestedSha256.toLowerCase()) {
+      reasons.push(reason(
+        'sanger_evidence_hash_mismatch',
+        'stale',
+        `Sequencing read "${recordId}" no longer matches its saved Sanger-evidence SHA-256.`,
+        {
+          ...shared,
+          expected: attestedSha256.toLowerCase(),
+          actual: current.sangerEvidenceSha256,
+        },
+      ));
+    }
+  }
+
+  return reasons;
+}
+
+function evaluateInputSequences(
+  inputRecordIds: readonly string[],
+  inputSha256s: readonly string[] | undefined,
+  records: ScientificFreshnessRecordIndex,
+  rowIds?: readonly (string | undefined)[],
+): ScientificFreshnessReason[] {
+  const reasons: ScientificFreshnessReason[] = [];
+
+  for (let index = 0; index < inputRecordIds.length; index += 1) {
+    const recordId = inputRecordIds[index];
+    const rowId = rowIds?.[index];
+    const current = records.get(recordId);
+    const shared = {
+      recordId,
+      ...(rowId === undefined ? {} : { rowId }),
+      field: 'sequence' as const,
+    };
+    if (!current) {
+      reasons.push(reason(
+        'record_missing',
+        'stale',
+        `Input record "${recordId}" is no longer in the workspace.`,
+        shared,
+      ));
+    }
+
+    const attestedSha256 = inputSha256s?.[index];
+    if (attestedSha256 === undefined) {
+      reasons.push(reason(
+        'sequence_attestation_missing',
+        'unverified',
+        `Input record "${recordId}" has no saved sequence SHA-256 attestation.`,
+        shared,
+      ));
+      continue;
+    }
+    if (!SHA256_HEX_PATTERN.test(attestedSha256)) {
+      reasons.push(reason(
+        'sequence_attestation_invalid',
+        'unverified',
+        `Input record "${recordId}" has a malformed saved sequence SHA-256 attestation.`,
+        { ...shared, expected: attestedSha256 },
+      ));
+      continue;
+    }
+    if (current && attestedSha256.toLowerCase() !== current.sequenceSha256) {
+      reasons.push(reason(
+        'sequence_hash_mismatch',
+        'stale',
+        `Input record "${recordId}" no longer matches its saved sequence SHA-256.`,
+        { ...shared, expected: attestedSha256.toLowerCase(), actual: current.sequenceSha256 },
+      ));
+    }
+  }
+
+  return reasons;
+}
+
+function evaluateTopology(
+  recordId: string | undefined,
+  attestedTopology: unknown,
+  records: ScientificFreshnessRecordIndex,
+  options: { required: boolean },
+): ScientificFreshnessReason[] {
+  if (!recordId) return [];
+  if (attestedTopology === undefined) {
+    return options.required ? [reason(
+      'topology_attestation_missing',
+      'unverified',
+      `Input record "${recordId}" has no saved topology attestation.`,
+      { recordId, field: 'topology' },
+    )] : [];
+  }
+  if (!isTopology(attestedTopology)) {
+    return [reason(
+      'topology_attestation_invalid',
+      'unverified',
+      `Input record "${recordId}" has a malformed saved topology attestation.`,
+      { recordId, field: 'topology', expected: String(attestedTopology) },
+    )];
+  }
+  const current = records.get(recordId);
+  if (!current || current.topology === attestedTopology) return [];
+  return [reason(
+    'topology_mismatch',
+    'stale',
+    `Input record "${recordId}" is now ${current.topology}, but the saved result used ${attestedTopology} topology.`,
+    { recordId, field: 'topology', expected: attestedTopology, actual: current.topology },
+  )];
+}
+
+function setSavedEnd(
+  attestations: Map<string, SavedEndAttestations>,
+  recordId: string,
+  side: 'left' | 'right',
+  rawEnd: unknown,
+): void {
+  const current = attestations.get(recordId) ?? {};
+  const parsed = savedEnd(rawEnd);
+  const valueKey = side;
+  const invalidKey = side === 'left' ? 'invalidLeft' : 'invalidRight';
+  if (!parsed) {
+    attestations.set(recordId, { ...current, [invalidKey]: true });
+    return;
+  }
+  const existing = current[valueKey];
+  const conflicts = existing !== undefined && formatEnd(existing) !== formatEnd(parsed);
+  attestations.set(recordId, {
+    ...current,
+    [valueKey]: parsed,
+    ...(conflicts ? { [invalidKey]: true } : {}),
+  });
+}
+
+function ligationEndAttestations(parameters: ArtifactWorkflowResult['parameters']): Map<string, SavedEndAttestations> {
+  const attestations = new Map<string, SavedEndAttestations>();
+  const junctions = parameters.junctions;
+  if (Array.isArray(junctions)) {
+    for (const junction of junctions) {
+      if (!isPlainObject(junction)) continue;
+      if (typeof junction.leftRecordId === 'string') {
+        setSavedEnd(attestations, junction.leftRecordId, 'right', junction.leftEnd);
+      }
+      if (typeof junction.rightRecordId === 'string') {
+        setSavedEnd(attestations, junction.rightRecordId, 'left', junction.rightEnd);
+      }
+    }
+  }
+
+  const orderedIds = Array.isArray(parameters.orderedInputRecordIds)
+    ? parameters.orderedInputRecordIds.filter((value): value is string => typeof value === 'string')
+    : [];
+  const terminalEnds = parameters.terminalEnds;
+  if (orderedIds.length > 0 && isPlainObject(terminalEnds)) {
+    setSavedEnd(attestations, orderedIds[0], 'left', terminalEnds.left);
+    setSavedEnd(attestations, orderedIds[orderedIds.length - 1], 'right', terminalEnds.right);
+  }
+  return attestations;
+}
+
+function currentEnd(
+  record: ScientificFreshnessRecordSnapshot,
+  side: 'left' | 'right',
+): SavedEnd | null {
+  const sequence = side === 'left' ? record.overhang5 : record.overhang3;
+  const type = side === 'left' ? record.overhang5Type : record.overhang3Type;
+  if (sequence === undefined || type === undefined) return null;
+  return savedEnd({ sequence, type });
+}
+
+function evaluateLigationEnds(
+  result: ArtifactWorkflowResult,
+  records: ScientificFreshnessRecordIndex,
+): ScientificFreshnessReason[] {
+  const reasons: ScientificFreshnessReason[] = [];
+  const attestations = ligationEndAttestations(result.parameters);
+
+  for (const recordId of result.inputRecordIds) {
+    const current = records.get(recordId);
+    const saved = attestations.get(recordId);
+    for (const side of ['left', 'right'] as const) {
+      const field = side === 'left' ? 'left_end' as const : 'right_end' as const;
+      const invalid = side === 'left' ? saved?.invalidLeft : saved?.invalidRight;
+      const attested = saved?.[side];
+      if (invalid) {
+        reasons.push(reason(
+          'end_chemistry_attestation_invalid',
+          'unverified',
+          `Input record "${recordId}" has conflicting or malformed saved ${side}-end chemistry.`,
+          { recordId, field },
+        ));
+        continue;
+      }
+      if (!attested) {
+        reasons.push(reason(
+          'end_chemistry_attestation_missing',
+          'unverified',
+          `Input record "${recordId}" has no saved ${side}-end chemistry attestation.`,
+          { recordId, field },
+        ));
+        continue;
+      }
+      if (!current) continue;
+      const actual = currentEnd(current, side);
+      if (!actual) {
+        reasons.push(reason(
+          'end_chemistry_missing',
+          'stale',
+          `Input record "${recordId}" no longer has complete ${side}-end chemistry.`,
+          { recordId, field, expected: formatEnd(attested) },
+        ));
+        continue;
+      }
+      if (formatEnd(attested) !== formatEnd(actual)) {
+        reasons.push(reason(
+          'end_chemistry_mismatch',
+          'stale',
+          `Input record "${recordId}" no longer matches its saved ${side}-end chemistry.`,
+          { recordId, field, expected: formatEnd(attested), actual: formatEnd(actual) },
+        ));
+      }
+    }
+  }
+  return reasons;
+}
+
+/** Evaluate one saved digest, gel, Golden Gate, or ligation result. */
+export function evaluateWorkflowResultFreshness(
+  result: ArtifactWorkflowResult,
+  records: ScientificFreshnessRecordIndex,
+): ScientificFreshnessEvaluation {
+  const reasons = evaluateInputSequences(result.inputRecordIds, result.inputSha256s, records);
+  if (result.kind === 'digest') {
+    reasons.push(...evaluateTopology(result.inputRecordIds[0], result.parameters.topology, records, { required: true }));
+  }
+  if (result.kind === 'ligation') {
+    reasons.push(...evaluateLigationEnds(result, records));
+  }
+  return finishEvaluation(reasons);
+}
+
+/** Evaluate one typed analysis result and any topology that changes its interpretation. */
+export function evaluateAnalysisResultFreshness(
+  result: ArtifactAnalysisResult,
+  records: ScientificFreshnessRecordIndex,
+): ScientificFreshnessEvaluation {
+  const reasons = evaluateInputSequences(result.inputRecordIds, result.inputSha256s, records);
+  if (result.kind === 'pcr' && Object.prototype.hasOwnProperty.call(result.parameters, 'topology')) {
+    reasons.push(...evaluateTopology(result.data.templateRecordId, result.parameters.topology, records, { required: false }));
+  }
+  if (result.kind === 'construct_verification') {
+    reasons.push(...evaluateTopology(result.data.referenceRecordId, result.parameters.topology, records, { required: true }));
+    reasons.push(...evaluateConstructVerificationReadEvidence(result, records));
+  }
+  return finishEvaluation(reasons);
+}
+
+/** Evaluate linked alignment rows independently, then aggregate with stale dominance. */
+export function evaluateAlignmentFreshness(
+  alignment: ArtifactAlignment,
+  records: ScientificFreshnessRecordIndex,
+): ScientificFreshnessEvaluation {
+  const reasons: ScientificFreshnessReason[] = [];
+  for (const row of alignment.rows) {
+    if (!row.sourceRecordId) {
+      reasons.push(reason(
+        'alignment_row_source_unattested',
+        'unverified',
+        `Alignment row "${row.name}" has no source-record attestation.`,
+        { rowId: row.id, field: 'source_record' },
+      ));
+      continue;
+    }
+    reasons.push(...evaluateInputSequences(
+      [row.sourceRecordId],
+      row.inputSha256 === undefined ? undefined : [row.inputSha256],
+      records,
+      [row.id],
+    ));
+  }
+  return finishEvaluation(reasons);
+}
+
+export function evaluateWorkflowResultsFreshness(
+  results: readonly ArtifactWorkflowResult[],
+  records: ScientificFreshnessRecordIndex,
+): Map<string, ScientificFreshnessEvaluation> {
+  return new Map(results.map((result) => [result.id, evaluateWorkflowResultFreshness(result, records)]));
+}
+
+export function evaluateAnalysisResultsFreshness(
+  results: readonly ArtifactAnalysisResult[],
+  records: ScientificFreshnessRecordIndex,
+): Map<string, ScientificFreshnessEvaluation> {
+  return new Map(results.map((result) => [result.id, evaluateAnalysisResultFreshness(result, records)]));
+}
+
+export function evaluateAlignmentsFreshness(
+  alignments: readonly ArtifactAlignment[],
+  records: ScientificFreshnessRecordIndex,
+): Map<string, ScientificFreshnessEvaluation> {
+  return new Map(alignments.map((alignment) => [alignment.id, evaluateAlignmentFreshness(alignment, records)]));
+}

--- a/src/artifacts/claude-science-msa-view-preferences.ts
+++ b/src/artifacts/claude-science-msa-view-preferences.ts
@@ -1,57 +1,105 @@
+import {
+  MSA_COLOR_SCHEMES,
+  MSA_SHADE_MODES,
+  type MsaColorScheme,
+  type MsaShadeMode,
+} from './claude-science-msa';
+
 export type ClaudeScienceMsaTextFormat = 'fasta' | 'clustal' | 'consensus' | 'json';
 export type ClaudeScienceMsaDisplayMode = 'viewer' | 'trace' | 'text';
 export type ClaudeScienceMsaEmphasisMode = 'differences' | 'letters';
 export type ClaudeScienceMsaColorMode = 'mono' | 'residue';
 export type ClaudeScienceMsaRowSortMode = 'original' | 'name' | 'identity' | 'mismatches';
+export type ClaudeScienceMsaColorScheme = MsaColorScheme;
+export type ClaudeScienceMsaShadeMode = MsaShadeMode;
+
+/** Column-density zoom bounds. 1 = the font-derived cell width; below ~0.65 the
+ * viewer drops letters for a birdseye "blocks" rendering. Decoupled from font
+ * size so users can compress wide alignments without shrinking readable text. */
+export const MSA_ZOOM_MIN = 0.2;
+export const MSA_ZOOM_MAX = 2;
 
 export type ClaudeScienceMsaViewPreferences = {
   displayMode: ClaudeScienceMsaDisplayMode;
   emphasis: ClaudeScienceMsaEmphasisMode;
   colorMode: ClaudeScienceMsaColorMode;
+  colorScheme: ClaudeScienceMsaColorScheme;
+  shadeMode: ClaudeScienceMsaShadeMode;
   sortMode: ClaudeScienceMsaRowSortMode;
   fontSize: number;
+  zoom: number;
+  translationFrame: 0 | 1 | 2;
   textFormat: ClaudeScienceMsaTextFormat;
   showOverview: boolean;
   showAlignmentAxis: boolean;
   showTemplateAxis: boolean;
   showRowStats: boolean;
   showConservation: boolean;
+  showConservationHistogram: boolean;
+  showOccupancy: boolean;
   showConsensus: boolean;
+  showTranslation: boolean;
+  showAminoAcidIndices: boolean;
 };
 
 export const DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES: ClaudeScienceMsaViewPreferences = {
   displayMode: 'viewer',
   emphasis: 'differences',
   colorMode: 'mono',
+  colorScheme: 'auto',
+  shadeMode: 'none',
   sortMode: 'original',
   fontSize: 11,
+  zoom: 1,
+  translationFrame: 0,
   textFormat: 'fasta',
   showOverview: true,
   showAlignmentAxis: true,
   showTemplateAxis: true,
   showRowStats: true,
   showConservation: true,
+  showConservationHistogram: true,
+  showOccupancy: false,
   showConsensus: true,
+  showTranslation: false,
+  showAminoAcidIndices: true,
 };
 
 export function normalizeClaudeScienceMsaViewPreferences(value: unknown): ClaudeScienceMsaViewPreferences {
   const source = value && typeof value === 'object'
     ? value as Partial<Record<keyof ClaudeScienceMsaViewPreferences, unknown>>
     : {};
+  // Track toggles that default to visible: a malformed value keeps the track on
+  // rather than silently hiding evidence.
   const visible = (key: keyof Pick<ClaudeScienceMsaViewPreferences,
-    'showOverview' | 'showAlignmentAxis' | 'showTemplateAxis' | 'showRowStats' | 'showConservation' | 'showConsensus'>) => (
-    typeof source[key] === 'boolean' ? source[key] : true
+    'showOverview' | 'showAlignmentAxis' | 'showTemplateAxis' | 'showRowStats'
+    | 'showConservation' | 'showConservationHistogram' | 'showConsensus' | 'showAminoAcidIndices'>) => (
+    typeof source[key] === 'boolean' ? source[key] as boolean : true
+  );
+  // Toggles that default to off unless explicitly enabled.
+  const optional = (key: keyof Pick<ClaudeScienceMsaViewPreferences, 'showOccupancy' | 'showTranslation'>) => (
+    source[key] === true
   );
   return {
     displayMode: source.displayMode === 'trace' || source.displayMode === 'text' ? source.displayMode : 'viewer',
     emphasis: source.emphasis === 'letters' ? 'letters' : 'differences',
     colorMode: source.colorMode === 'residue' ? 'residue' : 'mono',
+    colorScheme: MSA_COLOR_SCHEMES.includes(source.colorScheme as MsaColorScheme)
+      ? source.colorScheme as MsaColorScheme
+      : 'auto',
+    shadeMode: MSA_SHADE_MODES.includes(source.shadeMode as MsaShadeMode)
+      ? source.shadeMode as MsaShadeMode
+      : 'none',
     sortMode: source.sortMode === 'name' || source.sortMode === 'identity' || source.sortMode === 'mismatches'
       ? source.sortMode
       : 'original',
     fontSize: Number.isFinite(source.fontSize)
       ? Math.max(9, Math.min(16, Math.round(source.fontSize as number)))
       : DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES.fontSize,
+    zoom: Number.isFinite(source.zoom)
+      ? Math.max(MSA_ZOOM_MIN, Math.min(MSA_ZOOM_MAX, Math.round((source.zoom as number) * 100) / 100))
+      : DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES.zoom,
+    translationFrame: source.translationFrame === 1 || source.translationFrame === 2 ? source.translationFrame : 0,
     textFormat: source.textFormat === 'clustal' || source.textFormat === 'consensus' || source.textFormat === 'json'
       ? source.textFormat
       : 'fasta',
@@ -60,6 +108,10 @@ export function normalizeClaudeScienceMsaViewPreferences(value: unknown): Claude
     showTemplateAxis: visible('showTemplateAxis'),
     showRowStats: visible('showRowStats'),
     showConservation: visible('showConservation'),
+    showConservationHistogram: visible('showConservationHistogram'),
+    showOccupancy: optional('showOccupancy'),
     showConsensus: visible('showConsensus'),
+    showTranslation: optional('showTranslation'),
+    showAminoAcidIndices: visible('showAminoAcidIndices'),
   };
 }

--- a/src/artifacts/claude-science-msa.css
+++ b/src/artifacts/claude-science-msa.css
@@ -1,0 +1,493 @@
+/*
+ * Motif — Claude Science MSA viewer enhancements.
+ *
+ * New styles only. The base `.motif-cs-msa-*` rules live in motif-artifact.css
+ * and are intentionally left untouched here; this sheet layers selection,
+ * hover, histogram, colour-scheme, and shading affordances on top and is
+ * imported by ClaudeScienceMsaViewer.tsx. Palette fills use color-mix against
+ * --bg-primary so every scheme stays legible in both light and dark themes.
+ */
+
+/* The matrix hosts absolutely-positioned selection/hover overlays. */
+.motif-cs-msa-matrix {
+  position: relative;
+}
+
+/* ===== Selection band + row emphasis ===== */
+.motif-cs-msa-selection-band {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 3;
+  pointer-events: none;
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  border-left: 2px solid var(--accent);
+  border-right: 2px solid var(--accent);
+  box-sizing: border-box;
+}
+.motif-cs-msa-selection-band::before,
+.motif-cs-msa-selection-band::after {
+  content: '';
+  position: absolute;
+  top: -1px;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid var(--accent);
+}
+.motif-cs-msa-selection-band::before { left: -6px; }
+.motif-cs-msa-selection-band::after { right: -6px; }
+
+.motif-cs-msa-matrix-row[data-selected='true'] {
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+}
+.motif-cs-msa-matrix-row[data-hover='true'] {
+  background: color-mix(in srgb, var(--accent) 9%, transparent);
+}
+
+/* ===== Hover crosshair + floating readout ===== */
+.motif-cs-msa-hover-column {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 2;
+  pointer-events: none;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  outline: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+}
+.motif-cs-msa-matrix-scroll[data-selecting='true'] {
+  cursor: crosshair;
+  user-select: none;
+}
+
+.motif-cs-msa-hover-readout {
+  position: fixed;
+  z-index: 60;
+  pointer-events: none;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  line-height: 1.3;
+  white-space: nowrap;
+  background: var(--bg-elevated, var(--bg-primary, #fff));
+  color: var(--text-primary, #16130f);
+  border: 1px solid var(--border, color-mix(in srgb, currentColor 18%, transparent));
+  box-shadow: 0 6px 20px color-mix(in srgb, var(--shadow-ink, #000) 22%, transparent);
+}
+.motif-cs-msa-hover-readout b {
+  font-size: 13px;
+  font-variant-ligatures: none;
+}
+.motif-cs-msa-hover-readout span { color: var(--text-secondary, color-mix(in srgb, currentColor 65%, transparent)); }
+.motif-cs-msa-hover-readout-name {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ===== Selection readout bar ===== */
+.motif-cs-msa-selection-readout {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 10px;
+  margin-top: 6px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  font-size: 12px;
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-primary));
+  border: 1px solid color-mix(in srgb, var(--accent) 26%, transparent);
+  color: var(--text-primary, inherit);
+}
+.motif-cs-msa-selection-readout strong { color: var(--accent); }
+.motif-cs-msa-selection-readout span { color: var(--text-secondary, inherit); }
+.motif-cs-msa-selection-readout .motif-cs-mini-button { margin-left: auto; }
+
+/* ===== Right-click context menu ===== */
+.motif-cs-msa-context-menu {
+  position: fixed;
+  z-index: 70;
+  min-width: 200px;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  border-radius: 8px;
+  background: var(--bg-elevated, var(--bg-primary, #fff));
+  border: 1px solid var(--border, color-mix(in srgb, currentColor 18%, transparent));
+  box-shadow: 0 10px 30px color-mix(in srgb, var(--shadow-ink, #000) 28%, transparent);
+}
+.motif-cs-msa-context-menu button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  padding: 7px 10px;
+  border-radius: 6px;
+  font-size: 12.5px;
+  color: var(--text-primary, inherit);
+  cursor: pointer;
+}
+.motif-cs-msa-context-menu button:hover,
+.motif-cs-msa-context-menu button:focus-visible {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  outline: none;
+}
+
+/* ===== Histogram tracks (conservation + occupancy) ===== */
+.motif-cs-msa-hist-row {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  height: 30px;
+}
+.motif-cs-msa-hist-label {
+  align-items: center;
+  color: var(--text-secondary, inherit);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.motif-cs-msa-hist-window {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: flex-end;
+}
+.motif-cs-msa-hist-cell {
+  width: var(--motif-cs-msa-cell-width, 10px);
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 2px;
+}
+.motif-cs-msa-hist-bar {
+  width: 68%;
+  min-height: 1px;
+  border-radius: 1px 1px 0 0;
+  background: color-mix(in srgb, var(--accent) 55%, transparent);
+}
+.motif-cs-msa-hist-cell[data-jump='true'] {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+/* Conservation: greener as it climbs; occupancy: neutral accent. */
+.motif-cs-msa-hist-bar-conservation[data-bucket='0'] { background: color-mix(in srgb, #d64545 60%, transparent); }
+.motif-cs-msa-hist-bar-conservation[data-bucket='1'] { background: color-mix(in srgb, #e08a3c 60%, transparent); }
+.motif-cs-msa-hist-bar-conservation[data-bucket='2'] { background: color-mix(in srgb, #d6c23c 62%, transparent); }
+.motif-cs-msa-hist-bar-conservation[data-bucket='3'] { background: color-mix(in srgb, #79b155 66%, transparent); }
+.motif-cs-msa-hist-bar-conservation[data-bucket='4'] { background: color-mix(in srgb, #2ea043 72%, transparent); }
+.motif-cs-msa-hist-bar-occupancy { background: color-mix(in srgb, var(--accent) 50%, transparent); }
+
+/* ===== Residue colour schemes (letter-cell backgrounds) ===== */
+.motif-cs-msa-matrix[data-color-scheme] .motif-cs-msa-symbol[data-color-key] {
+  border-radius: 2px;
+}
+/* Nucleotide */
+.motif-cs-msa-symbol[data-color-key='nt-a'] { background: color-mix(in srgb, #2ea043 34%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='nt-c'] { background: color-mix(in srgb, #4c8dff 34%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='nt-g'] { background: color-mix(in srgb, #f0a020 36%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='nt-t'] { background: color-mix(in srgb, #f0553f 34%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='nt-other'] { background: color-mix(in srgb, #8b93a1 30%, var(--bg-primary)); }
+/* ClustalX chemistry groups */
+.motif-cs-msa-symbol[data-color-key='cl-hydrophobic'] { background: color-mix(in srgb, #5b8def 34%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='cl-positive'] { background: color-mix(in srgb, #e0533f 34%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='cl-negative'] { background: color-mix(in srgb, #b657c4 34%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='cl-polar'] { background: color-mix(in srgb, #3fae6b 34%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='cl-cysteine'] { background: color-mix(in srgb, #e58fa8 36%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='cl-glycine'] { background: color-mix(in srgb, #e08a3c 36%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='cl-proline'] { background: color-mix(in srgb, #cdbb3a 40%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='cl-aromatic'] { background: color-mix(in srgb, #2fb0b8 34%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='cl-other'] { background: color-mix(in srgb, #8b93a1 26%, var(--bg-primary)); }
+/* Hydrophobicity diverging (0 hydrophilic .. 4 hydrophobic) */
+.motif-cs-msa-symbol[data-color-key='hyd-0'] { background: color-mix(in srgb, #4c8dff 34%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='hyd-1'] { background: color-mix(in srgb, #86b6f0 32%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='hyd-2'] { background: color-mix(in srgb, #cfd3da 28%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='hyd-3'] { background: color-mix(in srgb, #f0a86a 34%, var(--bg-primary)); }
+.motif-cs-msa-symbol[data-color-key='hyd-4'] { background: color-mix(in srgb, #f0553f 36%, var(--bg-primary)); }
+/* Taylor per-residue wheel */
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='A'] { background: color-mix(in srgb, #ccff00 40%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='R'] { background: color-mix(in srgb, #0000ff 34%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='N'] { background: color-mix(in srgb, #cc00ff 34%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='D'] { background: color-mix(in srgb, #ff0000 34%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='C'] { background: color-mix(in srgb, #ffff00 40%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='Q'] { background: color-mix(in srgb, #ff00cc 34%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='E'] { background: color-mix(in srgb, #ff0066 34%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='G'] { background: color-mix(in srgb, #ff9900 38%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='H'] { background: color-mix(in srgb, #0066ff 34%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='I'] { background: color-mix(in srgb, #66ff00 40%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='L'] { background: color-mix(in srgb, #33ff00 40%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='K'] { background: color-mix(in srgb, #6600ff 34%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='M'] { background: color-mix(in srgb, #00ff00 40%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='F'] { background: color-mix(in srgb, #00ff66 40%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='P'] { background: color-mix(in srgb, #ffcc00 40%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='S'] { background: color-mix(in srgb, #ff3300 36%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='T'] { background: color-mix(in srgb, #ff6600 38%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='W'] { background: color-mix(in srgb, #00ccff 36%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='Y'] { background: color-mix(in srgb, #00ffcc 40%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-color-scheme='taylor'] .motif-cs-msa-symbol[data-residue='V'] { background: color-mix(in srgb, #99ff00 40%, var(--bg-primary)); }
+
+/* ===== Column shading modes ===== */
+.motif-cs-msa-matrix[data-shade='mismatch'] .motif-cs-msa-symbol[data-difference] {
+  background: color-mix(in srgb, #ff7a6b 30%, var(--bg-primary));
+}
+.motif-cs-msa-matrix[data-shade='identity'] .motif-cs-msa-symbol[data-shade-bucket='4'],
+.motif-cs-msa-matrix[data-shade='conservation'] .motif-cs-msa-symbol[data-shade-bucket='4'] {
+  background: color-mix(in srgb, var(--accent) 30%, var(--bg-primary));
+}
+.motif-cs-msa-matrix[data-shade='identity'] .motif-cs-msa-symbol[data-shade-bucket='3'],
+.motif-cs-msa-matrix[data-shade='conservation'] .motif-cs-msa-symbol[data-shade-bucket='3'] {
+  background: color-mix(in srgb, var(--accent) 21%, var(--bg-primary));
+}
+.motif-cs-msa-matrix[data-shade='identity'] .motif-cs-msa-symbol[data-shade-bucket='2'],
+.motif-cs-msa-matrix[data-shade='conservation'] .motif-cs-msa-symbol[data-shade-bucket='2'] {
+  background: color-mix(in srgb, var(--accent) 13%, var(--bg-primary));
+}
+.motif-cs-msa-matrix[data-shade='identity'] .motif-cs-msa-symbol[data-shade-bucket='1'],
+.motif-cs-msa-matrix[data-shade='conservation'] .motif-cs-msa-symbol[data-shade-bucket='1'] {
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg-primary));
+}
+
+/* ===== View-menu select rows ===== */
+.motif-cs-msa-view-select {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 12px;
+}
+.motif-cs-msa-view-select select {
+  flex: 0 1 148px;
+  min-width: 0;
+}
+.motif-cs-msa-view-select select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.motif-cs-msa-ruler-window-clickable .motif-cs-msa-ruler-cell { cursor: pointer; }
+.motif-cs-msa-ruler-window-clickable:hover .motif-cs-msa-ruler-cell {
+  color: var(--accent);
+}
+
+/* ===== Row drag-reorder (grip handle, drop indicator, custom-order note) ===== */
+/* Reserve a left gutter for the grip so it never overlaps the row name. The
+   grip anchors to the sticky label (position: sticky) and so stays pinned at
+   the left edge while the alignment scrolls horizontally. */
+.motif-cs-msa-matrix-row .motif-cs-msa-row-label-draggable {
+  padding-left: 18px;
+}
+.motif-cs-msa-row-grip {
+  position: absolute;
+  left: 1px;
+  top: 0;
+  bottom: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  padding: 0;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-muted, color-mix(in srgb, currentColor 55%, transparent));
+  opacity: 0;
+  cursor: grab;
+  touch-action: none;
+  transition: opacity 120ms ease, color 120ms ease;
+}
+.motif-cs-msa-matrix-row:hover .motif-cs-msa-row-grip,
+.motif-cs-msa-row-grip:focus-visible {
+  opacity: 0.72;
+}
+.motif-cs-msa-row-grip:hover { opacity: 1; color: var(--accent); }
+.motif-cs-msa-row-grip:focus-visible { outline: 2px solid var(--accent); outline-offset: -1px; opacity: 1; }
+.motif-cs-msa-row-grip:active { cursor: grabbing; }
+
+/* The dragged row is dimmed; drop target draws an accent rule on the near edge.
+   The row is already position: relative, so these pseudo-elements need no extra
+   positioning context and span the full alignment width. */
+.motif-cs-msa-matrix-row[data-dragging='true'] {
+  opacity: 0.55;
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+.motif-cs-msa-matrix-row[data-drop-before='true']::before,
+.motif-cs-msa-matrix-row[data-drop-after='true']::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  z-index: 6;
+  background: var(--accent);
+  pointer-events: none;
+}
+.motif-cs-msa-matrix-row[data-drop-before='true']::before { top: -1px; }
+.motif-cs-msa-matrix-row[data-drop-after='true']::after { bottom: -1px; }
+.motif-cs-msa-matrix[data-reordering='true'] { cursor: grabbing; }
+
+.motif-cs-msa-order-note {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--text-secondary, inherit);
+}
+.motif-cs-msa-order-note > svg { color: var(--text-muted, inherit); }
+.motif-cs-msa-order-note .motif-cs-mini-button { margin-left: 2px; }
+
+/* ===== Zoom control + birdseye blocks ===== */
+.motif-cs-msa-zoom-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--text-secondary, inherit);
+}
+.motif-cs-msa-zoom-label {
+  font-weight: 600;
+  color: var(--text-muted, inherit);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10.5px;
+}
+.motif-cs-msa-zoom-range {
+  flex: 0 1 220px;
+  min-width: 120px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+.motif-cs-msa-zoom-value {
+  min-width: 40px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary, inherit);
+}
+.motif-cs-msa-blocks-chip {
+  background: color-mix(in srgb, var(--accent) 16%, var(--bg-primary));
+  border: 1px solid color-mix(in srgb, var(--accent) 34%, transparent);
+  color: var(--accent);
+}
+
+/* Birdseye blocks: past the legibility floor, hide glyphs and render each
+   residue as a solid tile so wide alignments read as a conservation mosaic.
+   Gaps stay empty; an explicit colour scheme keeps its own data-color-key
+   fills, otherwise the auto residue tone becomes the tile colour. */
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol {
+  color: transparent;
+  font-size: 0;
+}
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol[data-tone='gap'] { background: transparent; }
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol[data-tone='a'],
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol[data-tone='polar'] { background: color-mix(in srgb, var(--green) 52%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol[data-tone='c'],
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol[data-tone='hydrophobic'] { background: color-mix(in srgb, var(--accent) 52%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol[data-tone='g'],
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol[data-tone='special'] { background: color-mix(in srgb, var(--amber) 55%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol[data-tone='t'],
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol[data-tone='negative'] { background: color-mix(in srgb, var(--red) 52%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol[data-tone='positive'] { background: color-mix(in srgb, var(--purple) 50%, var(--bg-primary)); }
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol[data-tone='ambiguous'] { background: color-mix(in srgb, var(--text-secondary) 34%, var(--bg-primary)); }
+/* Keep a jumped column findable even as a tile. */
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol[data-jump='true'] { outline: 1px solid var(--accent); outline-offset: -1px; }
+
+/* ===== Amino-acid translation track ===== */
+.motif-cs-msa-translation-row {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  height: 28px;
+}
+.motif-cs-msa-translation-label small {
+  color: var(--text-muted, inherit);
+  font: 8px/1 var(--font-mono, monospace);
+  letter-spacing: 0;
+  text-transform: none;
+}
+.motif-cs-msa-translation-window {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+}
+.motif-cs-msa-aa {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  border-right: 1px solid var(--bg-primary);
+  font: 600 11px/1 var(--font-mono, monospace);
+  color: var(--text-primary, inherit);
+  overflow: hidden;
+  background: color-mix(in srgb, var(--text-secondary) 12%, var(--bg-primary));
+}
+.motif-cs-msa-aa-letter { pointer-events: none; }
+.motif-cs-msa-aa-index {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  font: 7px/1 var(--font-mono, monospace);
+  color: var(--text-muted, inherit);
+  pointer-events: none;
+}
+/* Clustal chemistry fills, matching the residue colour scheme. */
+.motif-cs-msa-aa[data-color-key='cl-hydrophobic'] { background: color-mix(in srgb, #5b8def 34%, var(--bg-primary)); }
+.motif-cs-msa-aa[data-color-key='cl-positive'] { background: color-mix(in srgb, #e0533f 34%, var(--bg-primary)); }
+.motif-cs-msa-aa[data-color-key='cl-negative'] { background: color-mix(in srgb, #b657c4 34%, var(--bg-primary)); }
+.motif-cs-msa-aa[data-color-key='cl-polar'] { background: color-mix(in srgb, #3fae6b 34%, var(--bg-primary)); }
+.motif-cs-msa-aa[data-color-key='cl-cysteine'] { background: color-mix(in srgb, #e58fa8 36%, var(--bg-primary)); }
+.motif-cs-msa-aa[data-color-key='cl-glycine'] { background: color-mix(in srgb, #e08a3c 36%, var(--bg-primary)); }
+.motif-cs-msa-aa[data-color-key='cl-proline'] { background: color-mix(in srgb, #cdbb3a 40%, var(--bg-primary)); }
+.motif-cs-msa-aa[data-color-key='cl-aromatic'] { background: color-mix(in srgb, #2fb0b8 34%, var(--bg-primary)); }
+.motif-cs-msa-aa[data-color-key='cl-other'] { background: color-mix(in srgb, #8b93a1 26%, var(--bg-primary)); }
+/* State overrides (after fills so they win). */
+.motif-cs-msa-aa[data-stop='true'] {
+  background: color-mix(in srgb, var(--red, #d64545) 42%, var(--bg-primary));
+  color: var(--text-primary, inherit);
+  font-weight: 800;
+}
+.motif-cs-msa-aa[data-unknown='true'] { color: var(--text-muted, inherit); }
+.motif-cs-msa-aa[data-gap-spanning='true'] { border-left: 1px dashed color-mix(in srgb, var(--text-muted, currentColor) 55%, transparent); }
+.motif-cs-msa-aa[data-jump='true'] { outline: 2px solid var(--accent); outline-offset: -2px; }
+
+/* ===== Sequence search ===== */
+.motif-cs-msa-search {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.motif-cs-msa-search-icon { color: var(--text-muted, inherit); flex: 0 0 auto; }
+.motif-cs-msa-search-input { width: 150px; min-width: 90px; }
+.motif-cs-msa-search-count {
+  min-width: 52px;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary, inherit);
+  white-space: nowrap;
+}
+/* Match highlight via an inset fill so it reads over residue/shade/blocks
+   backgrounds without a specificity fight; the letter stays on top. */
+.motif-cs-msa-symbol[data-search-match] {
+  box-shadow: inset 0 0 0 100px color-mix(in srgb, #f2c14e 55%, transparent);
+  color: var(--text-primary, inherit);
+}
+.motif-cs-msa-symbol[data-search-active] {
+  box-shadow: inset 0 0 0 100px color-mix(in srgb, #f2a10a 62%, transparent);
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .motif-cs-msa-hover-column,
+  .motif-cs-msa-selection-band { transition: none; }
+  .motif-cs-msa-row-grip { transition: none; }
+}

--- a/src/artifacts/claude-science-msa.ts
+++ b/src/artifacts/claude-science-msa.ts
@@ -1,4 +1,5 @@
 import { computeMSA, isMSAError, MSA_MAX_SEQ_LEN, type MSAResult } from '../bio/msa';
+import { STANDARD_CODE } from '../bio/codon-tables';
 import type { SequenceType } from '../bio/types';
 
 export const ARTIFACT_MSA_MAX_ALIGNMENTS = 50;
@@ -620,4 +621,406 @@ export function formatClustal(alignment: ArtifactAlignment, blockWidth = 60): st
 export function safeAlignmentFilename(alignment: ArtifactAlignment, extension: string): string {
   const slug = alignment.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 80) || 'alignment';
   return `${slug}.${extension.replace(/^\./, '')}`;
+}
+
+// ===== Viewer analytics: per-column statistics (pure, derived) =====
+//
+// These read only the aligned rows already stored on an ArtifactAlignment, so
+// they add no persisted state and never touch the alignment engine. The viewer
+// uses them to draw conservation/occupancy histograms, shade columns, and
+// summarize a selection.
+
+export type MsaColumnStats = {
+  /** Non-gap fraction of rows at this column (0..1). */
+  occupancy: number;
+  /** Majority non-gap residue; '-' when the whole column is gaps. */
+  consensusResidue: string;
+  /** Count of the majority residue among non-gap rows. */
+  consensusCount: number;
+  /** consensusCount / non-gap rows (0..1); 0 when the column is all gaps. */
+  consensusFraction: number;
+  /** consensusCount / total rows (0..1) — identity gated by occupancy. */
+  identity: number;
+  /** Blended 0..1 conservation score (majority dominance × occupancy). */
+  conservation: number;
+  /** Shannon entropy in bits over non-gap residues (0 = single residue). */
+  entropy: number;
+  /** True when every row carries the same non-gap residue here. */
+  fullyConserved: boolean;
+};
+
+const LOG2 = Math.log(2);
+
+/** Per-column statistics for an alignment's rows. O(rows × columns), single pass. */
+export function computeMsaColumnStats(rows: ReadonlyArray<{ aligned: string }>): MsaColumnStats[] {
+  const rowCount = rows.length;
+  const length = rows[0]?.aligned.length ?? 0;
+  const stats: MsaColumnStats[] = new Array(length);
+  for (let column = 0; column < length; column += 1) {
+    const counts = new Map<string, number>();
+    let nonGap = 0;
+    for (let row = 0; row < rowCount; row += 1) {
+      const symbol = rows[row].aligned[column] ?? '-';
+      if (symbol === '-') continue;
+      nonGap += 1;
+      counts.set(symbol, (counts.get(symbol) ?? 0) + 1);
+    }
+    if (nonGap === 0) {
+      stats[column] = {
+        occupancy: 0, consensusResidue: '-', consensusCount: 0,
+        consensusFraction: 0, identity: 0, conservation: 0, entropy: 0, fullyConserved: false,
+      };
+      continue;
+    }
+    let winner = '';
+    let winnerCount = 0;
+    let entropy = 0;
+    for (const [symbol, count] of counts) {
+      if (count > winnerCount || (count === winnerCount && (winner === '' || symbol < winner))) {
+        winner = symbol;
+        winnerCount = count;
+      }
+      const probability = count / nonGap;
+      entropy -= probability * (Math.log(probability) / LOG2);
+    }
+    const occupancy = nonGap / rowCount;
+    const consensusFraction = winnerCount / nonGap;
+    stats[column] = {
+      occupancy,
+      consensusResidue: winner,
+      consensusCount: winnerCount,
+      consensusFraction,
+      identity: winnerCount / rowCount,
+      conservation: consensusFraction * occupancy,
+      entropy,
+      fullyConserved: winnerCount === rowCount,
+    };
+  }
+  return stats;
+}
+
+/** Bucket a 0..1 score into 0..4 for CSS-driven shading intensity. */
+export function msaShadeBucket(value: number): 0 | 1 | 2 | 3 | 4 {
+  if (!(value > 0)) return 0;
+  if (value >= 0.999) return 4;
+  if (value >= 0.8) return 3;
+  if (value >= 0.6) return 2;
+  if (value >= 0.4) return 1;
+  return 0;
+}
+
+// ===== Residue colour schemes =====
+//
+// residueColorKey returns a stable class-like token consumed as a data-attribute
+// and coloured in claude-science-msa.css (so palettes stay theme-aware in light
+// and dark). 'auto' keeps the viewer's existing residueTone behaviour and is
+// handled there, so this function is only called for explicit schemes.
+
+export type MsaColorScheme = 'auto' | 'nucleotide' | 'clustal' | 'hydrophobicity' | 'taylor';
+export type MsaShadeMode = 'none' | 'mismatch' | 'identity' | 'conservation';
+
+export const MSA_COLOR_SCHEMES: readonly MsaColorScheme[] = ['auto', 'nucleotide', 'clustal', 'hydrophobicity', 'taylor'];
+export const MSA_SHADE_MODES: readonly MsaShadeMode[] = ['none', 'mismatch', 'identity', 'conservation'];
+
+// ClustalX-style amino-acid chemistry groups.
+const CLUSTAL_GROUP: Record<string, string> = {
+  A: 'hydrophobic', I: 'hydrophobic', L: 'hydrophobic', M: 'hydrophobic', F: 'hydrophobic', W: 'hydrophobic', V: 'hydrophobic',
+  K: 'positive', R: 'positive',
+  E: 'negative', D: 'negative',
+  N: 'polar', Q: 'polar', S: 'polar', T: 'polar',
+  C: 'cysteine', G: 'glycine', P: 'proline', H: 'aromatic', Y: 'aromatic',
+};
+
+// Kyte-Doolittle hydropathy, bucketed 0 (hydrophilic) .. 4 (hydrophobic).
+const KYTE_DOOLITTLE: Record<string, number> = {
+  I: 4.5, V: 4.2, L: 3.8, F: 2.8, C: 2.5, M: 1.9, A: 1.8, G: -0.4, T: -0.7, S: -0.8,
+  W: -0.9, Y: -1.3, P: -1.6, H: -3.2, E: -3.5, Q: -3.5, D: -3.5, N: -3.5, K: -3.9, R: -4.5,
+};
+
+function hydropathyBucket(symbol: string): 0 | 1 | 2 | 3 | 4 {
+  const value = KYTE_DOOLITTLE[symbol];
+  if (value === undefined) return 2;
+  if (value >= 3) return 4;
+  if (value >= 1) return 3;
+  if (value >= -1) return 2;
+  if (value >= -3.4) return 1;
+  return 0;
+}
+
+/** Palette token for a residue under a given scheme; '' means "no colour". */
+export function residueColorKey(symbol: string, molecule: SequenceType, scheme: MsaColorScheme): string {
+  const residue = symbol.toUpperCase();
+  if (residue === '-' || residue === '.' || residue === '' || residue === '?') return '';
+  if (scheme === 'nucleotide' || (scheme === 'auto' && molecule !== 'protein')) {
+    if (residue === 'A') return 'nt-a';
+    if (residue === 'C') return 'nt-c';
+    if (residue === 'G') return 'nt-g';
+    if (residue === 'T' || residue === 'U') return 'nt-t';
+    return 'nt-other';
+  }
+  if (scheme === 'taylor') return 'taylor';
+  if (scheme === 'hydrophobicity') return `hyd-${hydropathyBucket(residue)}`;
+  const group = CLUSTAL_GROUP[residue];
+  return group ? `cl-${group}` : 'cl-other';
+}
+
+// ===== Selection helpers =====
+//
+// A selection is an inclusive column range plus an optional row-id subset (all
+// rows when omitted). These produce copy payloads for the viewer's context menu
+// without mutating the workspace.
+
+export type MsaColumnRange = { start: number; end: number };
+
+export type MsaSelection = {
+  columns: MsaColumnRange;
+  rowIds?: readonly string[];
+};
+
+function selectionRows(alignment: ArtifactAlignment, selection: MsaSelection): ArtifactAlignmentRow[] {
+  if (!selection.rowIds || selection.rowIds.length === 0) return alignment.rows;
+  // Resolve ids in the order the caller supplied them (the displayed/sorted/
+  // reordered order), not the alignment's stored order.
+  const byId = new Map(alignment.rows.map((row) => [row.id, row]));
+  return selection.rowIds
+    .map((id) => byId.get(id))
+    .filter((row): row is ArtifactAlignmentRow => row !== undefined);
+}
+
+function clampRange(range: MsaColumnRange, length: number): MsaColumnRange {
+  const start = Math.max(0, Math.min(length - 1, Math.min(range.start, range.end)));
+  const end = Math.max(0, Math.min(length - 1, Math.max(range.start, range.end)));
+  return { start, end };
+}
+
+/** Aligned (gapped) slice of the selected block, one entry per selected row. */
+export function sliceSelectionRows(
+  alignment: ArtifactAlignment,
+  selection: MsaSelection,
+): Array<{ id: string; name: string; aligned: string }> {
+  const { start, end } = clampRange(selection.columns, alignment.alignmentLength);
+  return selectionRows(alignment, selection).map((row) => ({
+    id: row.id,
+    name: row.name,
+    aligned: row.aligned.slice(start, end + 1),
+  }));
+}
+
+/** Selected block as aligned (gap-preserving) FASTA. */
+export function selectionToFasta(alignment: ArtifactAlignment, selection: MsaSelection): string {
+  return `${sliceSelectionRows(alignment, selection)
+    .map((row) => `>${row.name}\n${wrapSequence(row.aligned)}`)
+    .join('\n')}\n`;
+}
+
+/** Selected block as ungapped (residues-only) FASTA, dropping rows left empty. */
+export function selectionToUngappedFasta(alignment: ArtifactAlignment, selection: MsaSelection): string {
+  const rows = sliceSelectionRows(alignment, selection)
+    .map((row) => ({ ...row, residues: row.aligned.replace(/-/g, '') }))
+    .filter((row) => row.residues.length > 0);
+  return `${rows.map((row) => `>${row.name}\n${wrapSequence(row.residues)}`).join('\n')}\n`;
+}
+
+/** Selected block as plain aligned rows (one line per row, no headers). */
+export function selectionToColumnsText(alignment: ArtifactAlignment, selection: MsaSelection): string {
+  return sliceSelectionRows(alignment, selection).map((row) => row.aligned).join('\n');
+}
+
+/** Aggregate stats over a column range, for the selection readout. */
+export function summarizeSelectionColumns(
+  columnStats: readonly MsaColumnStats[],
+  range: MsaColumnRange,
+): { columns: number; variableColumns: number; fullyConserved: number; meanIdentity: number; meanConservation: number; gapColumns: number } {
+  const length = columnStats.length;
+  const { start, end } = clampRange(range, length);
+  let variableColumns = 0;
+  let fullyConserved = 0;
+  let gapColumns = 0;
+  let identitySum = 0;
+  let conservationSum = 0;
+  const columns = length > 0 ? end - start + 1 : 0;
+  for (let column = start; column <= end && column < length; column += 1) {
+    const stat = columnStats[column];
+    if (!stat) continue;
+    identitySum += stat.identity;
+    conservationSum += stat.conservation;
+    // An all-gap column has no residues to agree or disagree, so it is neither
+    // conserved nor variable — only a gap column.
+    if (stat.occupancy === 0) { gapColumns += 1; continue; }
+    if (stat.fullyConserved) fullyConserved += 1;
+    else if (stat.consensusFraction < 1) variableColumns += 1;
+  }
+  return {
+    columns,
+    variableColumns,
+    fullyConserved,
+    gapColumns,
+    meanIdentity: columns > 0 ? identitySum / columns : 0,
+    meanConservation: columns > 0 ? conservationSum / columns : 0,
+  };
+}
+
+/**
+ * Return a new ordering with `id` moved to `targetIndex`. The item is removed
+ * first, then reinserted, so `targetIndex` is interpreted against the array
+ * without the moved id and clamped to its bounds. Used by the viewer's manual
+ * row drag-reorder (pointer drop and keyboard step both funnel through here so
+ * the reorder logic stays pure and unit-testable). Ids absent from `order`, or
+ * a target equal to the current slot, yield an equivalent order.
+ */
+export function moveRowId(order: readonly string[], id: string, targetIndex: number): string[] {
+  const from = order.indexOf(id);
+  if (from < 0) return order.slice();
+  const without = order.filter((value) => value !== id);
+  const clamped = Math.max(0, Math.min(without.length, targetIndex));
+  without.splice(clamped, 0, id);
+  return without;
+}
+
+/** One translated amino-acid cell, positioned against alignment columns. */
+export type MsaTranslationCodon = {
+  aminoAcid: string;      // single-letter AA; 'X' unknown/ambiguous, '*' stop
+  position: number;       // 1-based amino-acid index within this row's frame
+  codon: string;          // 3-letter DNA codon (U normalized to T), uppercase
+  startColumn: number;    // alignment column of the codon's first nucleotide
+  endColumn: number;      // alignment column of the codon's third nucleotide
+  gapSpanning: boolean;   // alignment gaps fall between the codon's nucleotides
+};
+
+/**
+ * Translate a gapped, aligned nucleotide row into amino-acid cells positioned
+ * against the alignment columns. Ungapped nucleotides are read starting at
+ * `frame`, grouped into codons; each returned cell spans the columns of its
+ * codon's first and third nucleotide (wider than three columns when alignment
+ * gaps interrupt the codon — flagged via `gapSpanning`). The `frame` offset and
+ * any trailing 1-2 nucleotide remainder produce no cell. Unknown/ambiguous
+ * codons yield 'X'; stop codons yield '*'. Gaps never consume the reading frame,
+ * so a gap alone is not treated as a frameshift. Callers should restrict this to
+ * nucleotide molecules (DNA/RNA).
+ */
+export function translateAlignedRow(aligned: string, frame: 0 | 1 | 2 = 0): MsaTranslationCodon[] {
+  const codons: MsaTranslationCodon[] = [];
+  let seenNonGap = 0;
+  let bases = '';
+  let columns: number[] = [];
+  let position = 0;
+  for (let column = 0; column < aligned.length; column += 1) {
+    const raw = aligned[column];
+    if (raw === '-' || raw === '.') continue;
+    seenNonGap += 1;
+    if (seenNonGap <= frame) continue;
+    const upper = raw.toUpperCase();
+    bases += upper === 'U' ? 'T' : upper;
+    columns.push(column);
+    if (bases.length === 3) {
+      position += 1;
+      codons.push({
+        aminoAcid: STANDARD_CODE.codons[bases] ?? 'X',
+        position,
+        codon: bases,
+        startColumn: columns[0],
+        endColumn: columns[2],
+        gapSpanning: columns[2] - columns[0] !== 2,
+      });
+      bases = '';
+      columns = [];
+    }
+  }
+  return codons;
+}
+
+/** A motif hit within one row, mapped back to alignment columns. */
+export type MsaMotifMatch = {
+  rowId: string;
+  rowName: string;
+  startColumn: number;      // alignment column of the first matched residue
+  endColumn: number;        // alignment column of the last matched residue
+  columns: number[];        // alignment columns of every matched residue (gaps skipped)
+};
+
+export type MsaMotifSearchResult = { matches: MsaMotifMatch[]; truncated: boolean };
+
+export const MSA_MOTIF_SEARCH_MAX_MATCHES = 5_000;
+
+// IUPAC nucleotide ambiguity → the concrete bases each code covers.
+const IUPAC_NUCLEOTIDES: Record<string, string> = {
+  A: 'A', C: 'C', G: 'G', T: 'T', U: 'T',
+  R: 'AG', Y: 'CT', S: 'CG', W: 'AT', K: 'GT', M: 'AC',
+  B: 'CGT', D: 'AGT', H: 'ACT', V: 'ACG', N: 'ACGT',
+};
+
+function nucleotidesMatch(query: string, target: string): boolean {
+  const querySet = IUPAC_NUCLEOTIDES[query] ?? query;
+  const targetSet = IUPAC_NUCLEOTIDES[target] ?? target;
+  for (const base of querySet) if (targetSet.includes(base)) return true;
+  return false;
+}
+
+function residueMatch(query: string, target: string, molecule: SequenceType): boolean {
+  if (molecule === 'protein') return query === target || query === 'X' || target === 'X';
+  return nucleotidesMatch(query, target);
+}
+
+function normalizeMotifResidue(symbol: string, molecule: SequenceType): string {
+  const upper = symbol.toUpperCase();
+  return molecule !== 'protein' && upper === 'U' ? 'T' : upper;
+}
+
+/**
+ * Find every occurrence of `query` across the ungapped residues of each row,
+ * mapping each hit back to the alignment columns it covers (gap columns between
+ * matched residues are skipped, never counted as part of the motif). Matching is
+ * case-insensitive, treats U/T as equivalent for nucleotides, and honours IUPAC
+ * ambiguity in both the query and the target (protein uses X as a wildcard).
+ * Overlapping hits are returned. A query containing a gap, or empty, yields no
+ * matches. Results are capped at `maxMatches` (sorted by column then row) with a
+ * `truncated` flag so a low-complexity query stays bounded.
+ */
+export function findMsaMotifMatches(
+  rows: readonly { id: string; name: string; aligned: string }[],
+  query: string,
+  options: { molecule: SequenceType; maxMatches?: number },
+): MsaMotifSearchResult {
+  const trimmed = query.trim();
+  if (!trimmed || /[-.]/.test(trimmed)) return { matches: [], truncated: false };
+  const { molecule } = options;
+  const maxMatches = Math.max(0, Math.floor(options.maxMatches ?? MSA_MOTIF_SEARCH_MAX_MATCHES));
+  const needle = Array.from(trimmed, (symbol) => normalizeMotifResidue(symbol, molecule));
+  const matches: MsaMotifMatch[] = [];
+  let truncated = false;
+
+  outer: for (const row of rows) {
+    const residues: string[] = [];
+    const columns: number[] = [];
+    for (let column = 0; column < row.aligned.length; column += 1) {
+      const symbol = row.aligned[column];
+      if (symbol === '-' || symbol === '.') continue;
+      residues.push(normalizeMotifResidue(symbol, molecule));
+      columns.push(column);
+    }
+    const limit = residues.length - needle.length;
+    for (let start = 0; start <= limit; start += 1) {
+      let ok = true;
+      for (let offset = 0; offset < needle.length; offset += 1) {
+        if (!residueMatch(needle[offset], residues[start + offset], molecule)) { ok = false; break; }
+      }
+      if (!ok) continue;
+      if (matches.length >= maxMatches) { truncated = true; break outer; }
+      const matchColumns = columns.slice(start, start + needle.length);
+      matches.push({
+        rowId: row.id,
+        rowName: row.name,
+        startColumn: matchColumns[0],
+        endColumn: matchColumns[matchColumns.length - 1],
+        columns: matchColumns,
+      });
+    }
+  }
+
+  matches.sort((left, right) => (
+    left.startColumn - right.startColumn
+    || left.endColumn - right.endColumn
+    || left.rowName.localeCompare(right.rowName, undefined, { numeric: true })
+  ));
+  return { matches, truncated };
 }

--- a/src/artifacts/claude-science-pcr-materialization.ts
+++ b/src/artifacts/claude-science-pcr-materialization.ts
@@ -1,0 +1,420 @@
+import {
+  primerToFeature,
+  type PrimerCandidate,
+  type PrimerDesignParams,
+  type PrimerPair,
+} from '../bio/primer-design';
+import { simulatePCR, type PCRResult } from '../bio/pcr';
+import { reverseComplement } from '../bio/reverse-complement';
+import type { Feature, Topology } from '../bio/types';
+import type { ArtifactAnalysisResult } from './claude-science-analysis-results';
+import { sha256HexSync } from './claude-science-sha256';
+import type { ArtifactJsonObject } from './claude-science-workspace-collections';
+
+const DNA_ALPHABET = /^[ACGT]+$/i;
+const PCR_ENGINE_VERSION = '1';
+
+export class PcrMaterializationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PcrMaterializationError';
+  }
+}
+
+/** Structural subset of the standalone artifact's private record type. */
+export type PcrMaterializationSourceRecord = {
+  id: string;
+  name: string;
+  sequence: string;
+  type: 'dna';
+  topology: Topology;
+  active: boolean;
+  features?: readonly Feature[];
+  description?: string;
+  organism?: string;
+  source?: string;
+  group?: string;
+  tags?: readonly string[];
+};
+
+export type PcrMaterializationSelection = {
+  pair: PrimerPair;
+  pairNumber: number;
+  target: { start: number; end: number };
+  parameters?: PrimerDesignParams;
+};
+
+export type PcrMaterializationIdentity = {
+  recordId: string;
+  resultId: string;
+  productId: string;
+  createdAt: string;
+  recordName?: string;
+};
+
+export type PcrMaterializationPreparation = {
+  requestSha256: string;
+  actionId: string;
+  actionKind: string;
+  method: 'golden_gate' | 'gibson';
+  orientation: 'forward' | 'reverse';
+};
+
+export type PcrDerivedRecordProvenance = ArtifactJsonObject & {
+  source: 'motif-for-claude-science-artifact';
+  operation: 'pcr_materialization';
+  actor: 'user';
+  engine: 'motif-pcr';
+  engineVersion: typeof PCR_ENGINE_VERSION;
+  parentRecordId: string;
+  primerDesignResultId: string;
+  templateSha256: string;
+  productSha256: string;
+  primerDesignSha256: string;
+  materializationKey: string;
+  wrapsOrigin: boolean;
+};
+
+/** Compatible with the artifact's private ArtifactRecordInput contract. */
+export type PcrDerivedRecordInput = {
+  id: string;
+  name: string;
+  description: string;
+  molecule: 'dna';
+  topology: 'linear';
+  seq: string;
+  length: number;
+  annotations: Feature[];
+  organism?: string;
+  source: string;
+  group?: string;
+  dateAdded: string;
+  tags?: string[];
+  active: true;
+  provenance: PcrDerivedRecordProvenance;
+};
+
+export type MaterializedPcrAmplicon = {
+  record: PcrDerivedRecordInput;
+  analysisResult: ArtifactAnalysisResult & { kind: 'pcr' };
+  simulation: PCRResult;
+  templateSha256: string;
+  productSha256: string;
+  primerDesignSha256: string;
+  materializationKey: string;
+};
+
+export type ExistingPcrMaterializationRecord = {
+  id: string;
+  name: string;
+  sequence: string;
+  provenance?: Record<string, unknown>;
+};
+
+function validateExactPrimerCandidate(
+  primer: PrimerCandidate,
+  role: 'forward' | 'reverse',
+): void {
+  const label = role === 'forward' ? 'Forward' : 'Reverse';
+  if (primer.direction !== role) {
+    throw new PcrMaterializationError(`${label} primer direction does not match its selected-pair role.`);
+  }
+  if (
+    !DNA_ALPHABET.test(primer.sequence)
+    || !DNA_ALPHABET.test(primer.fullSequence)
+    || (primer.tail.length > 0 && !DNA_ALPHABET.test(primer.tail))
+  ) {
+    throw new PcrMaterializationError(
+      `${label} primer materialization requires unambiguous A/C/G/T binding and full sequences.`,
+    );
+  }
+  if (primer.fullSequence.toUpperCase() !== `${primer.tail}${primer.sequence}`.toUpperCase()) {
+    throw new PcrMaterializationError(
+      `${label} primer fullSequence must equal its 5′ tail followed by its binding sequence.`,
+    );
+  }
+  if (
+    primer.length !== primer.sequence.length
+    || primer.fullLength !== primer.fullSequence.length
+    || primer.end - primer.start !== primer.sequence.length
+  ) {
+    throw new PcrMaterializationError(`${label} primer lengths do not match its sequence fields and binding range.`);
+  }
+}
+
+function primerDesignIdentity(selection: PcrMaterializationSelection): string {
+  const { forward, reverse } = selection.pair;
+  return JSON.stringify([
+    forward.fullSequence.toUpperCase(),
+    forward.start,
+    forward.end,
+    reverse.fullSequence.toUpperCase(),
+    reverse.start,
+    reverse.end,
+    selection.target.start,
+    selection.target.end,
+  ]);
+}
+
+export function createPcrMaterializationKey(
+  templateSha256: string,
+  primerDesignSha256: string,
+  productSha256: string,
+): string {
+  return sha256HexSync(JSON.stringify([templateSha256, primerDesignSha256, productSha256]));
+}
+
+export function findPcrMaterializationDuplicate(
+  records: readonly ExistingPcrMaterializationRecord[],
+  materializationKey: string,
+): ExistingPcrMaterializationRecord | null {
+  return records.find((record) => {
+    const provenance = record.provenance;
+    if (
+      provenance?.operation !== 'pcr_materialization'
+      || provenance.materializationKey !== materializationKey
+      || typeof provenance.templateSha256 !== 'string'
+      || typeof provenance.primerDesignSha256 !== 'string'
+      || typeof provenance.productSha256 !== 'string'
+      || sha256HexSync(record.sequence) !== provenance.productSha256
+    ) return false;
+    return createPcrMaterializationKey(
+      provenance.templateSha256,
+      provenance.primerDesignSha256,
+      provenance.productSha256,
+    ) === materializationKey;
+  }) ?? null;
+}
+
+export function simulateSelectedPrimerPair(
+  sourceRecord: PcrMaterializationSourceRecord,
+  selection: PcrMaterializationSelection,
+): PCRResult {
+  if (!sourceRecord.active) throw new PcrMaterializationError('PCR requires an active template record.');
+  if (!sourceRecord.sequence || !DNA_ALPHABET.test(sourceRecord.sequence)) {
+    throw new PcrMaterializationError('Exact PCR materialization requires an unambiguous A/C/G/T DNA template.');
+  }
+  validateExactPrimerCandidate(selection.pair.forward, 'forward');
+  validateExactPrimerCandidate(selection.pair.reverse, 'reverse');
+  const simulation = simulatePCR(
+    sourceRecord.sequence,
+    selection.pair.forward.fullSequence,
+    selection.pair.reverse.fullSequence,
+    [...(sourceRecord.features ?? [])],
+    sourceRecord.topology,
+    {
+      forward: { start: selection.pair.forward.start, end: selection.pair.forward.end },
+      reverse: { start: selection.pair.reverse.start, end: selection.pair.reverse.end },
+    },
+  );
+  if (!simulation) {
+    throw new PcrMaterializationError('The selected primer pair does not produce an exact amplicon on this template.');
+  }
+  return simulation;
+}
+
+function primerFeature(
+  id: string,
+  name: string,
+  start: number,
+  end: number,
+  strand: 1 | -1,
+  primer: PrimerCandidate,
+  bindingSequence: string,
+  tail: string,
+  sourceStart: number,
+  sourceEnd: number,
+): Feature {
+  const base = primerToFeature(primer, name);
+  return {
+    ...base,
+    id,
+    start,
+    end,
+    strand,
+    metadata: {
+      ...base.metadata,
+      generatedBy: 'motif-pcr',
+      primerSequence5to3: primer.fullSequence,
+      productPlusStrandSequence: strand === 1
+        ? primer.fullSequence
+        : reverseComplement(primer.fullSequence),
+      bindingSequence5to3: bindingSequence,
+      tail5: tail,
+      sourceBindStart: sourceStart,
+      sourceBindEnd: sourceEnd,
+    },
+  };
+}
+
+function uniqueTags(tags: readonly string[] | undefined): string[] {
+  const normalized = [...new Set(tags ?? [])];
+  if (normalized.length < 100 && !normalized.includes('PCR amplicon')) normalized.push('PCR amplicon');
+  return normalized;
+}
+
+export function materializePcrAmplicon(input: {
+  sourceRecord: PcrMaterializationSourceRecord;
+  selection: PcrMaterializationSelection;
+  identity: PcrMaterializationIdentity;
+  primerDesignResultId: string;
+  preparation?: PcrMaterializationPreparation;
+}): MaterializedPcrAmplicon {
+  const { sourceRecord, selection, identity, primerDesignResultId, preparation } = input;
+  const simulation = simulateSelectedPrimerPair(sourceRecord, selection);
+  const templateSha256 = sha256HexSync(sourceRecord.sequence.toUpperCase());
+  const productSha256 = sha256HexSync(simulation.product);
+  const primerDesignSha256 = sha256HexSync(primerDesignIdentity(selection));
+  const materializationKey = createPcrMaterializationKey(
+    templateSha256,
+    primerDesignSha256,
+    productSha256,
+  );
+  const forwardEnd = selection.pair.forward.fullSequence.length;
+  const reverseStart = simulation.product.length - selection.pair.reverse.fullSequence.length;
+  if (reverseStart < 0 || forwardEnd > simulation.product.length) {
+    throw new PcrMaterializationError('Primer annotations do not fit inside the simulated amplicon.');
+  }
+  const annotations = [
+    ...simulation.features,
+    primerFeature(
+      `${identity.recordId}-primer-forward`,
+      `PCR forward primer · pair ${selection.pairNumber}`,
+      0,
+      forwardEnd,
+      1,
+      selection.pair.forward,
+      simulation.forward.bindingSequence,
+      simulation.forward.tail,
+      simulation.forward.bindStart,
+      simulation.forward.bindEnd,
+    ),
+    primerFeature(
+      `${identity.recordId}-primer-reverse`,
+      `PCR reverse primer · pair ${selection.pairNumber}`,
+      reverseStart,
+      simulation.product.length,
+      -1,
+      selection.pair.reverse,
+      simulation.reverse.bindingSequence,
+      simulation.reverse.tail,
+      simulation.reverse.bindStart,
+      simulation.reverse.bindEnd,
+    ),
+  ];
+
+  const recordName = (identity.recordName?.trim() || `${sourceRecord.name} · PCR amplicon`).slice(0, 1_024);
+  const preparationMetadata: ArtifactJsonObject = {};
+  if (preparation) {
+    preparationMetadata.cloningPreparation = {
+      requestSha256: preparation.requestSha256,
+      actionId: preparation.actionId,
+      actionKind: preparation.actionKind,
+      method: preparation.method,
+      orientation: preparation.orientation,
+    };
+  }
+  const provenance: PcrDerivedRecordProvenance = {
+    source: 'motif-for-claude-science-artifact',
+    operation: 'pcr_materialization',
+    actor: 'user',
+    engine: 'motif-pcr',
+    engineVersion: PCR_ENGINE_VERSION,
+    parentRecordId: sourceRecord.id,
+    primerDesignResultId,
+    templateSha256,
+    productSha256,
+    primerDesignSha256,
+    materializationKey,
+    wrapsOrigin: simulation.wrapsOrigin,
+    forwardPrimer5to3: selection.pair.forward.fullSequence,
+    reversePrimer5to3: selection.pair.reverse.fullSequence,
+    forwardBindStart: simulation.forward.bindStart,
+    forwardBindEnd: simulation.forward.bindEnd,
+    reverseBindStart: simulation.reverse.bindStart,
+    reverseBindEnd: simulation.reverse.bindEnd,
+    ...preparationMetadata,
+  };
+  const record: PcrDerivedRecordInput = {
+    id: identity.recordId,
+    name: recordName,
+    description: `Exact in-silico PCR product from ${sourceRecord.name}; includes both 5′ primer tails.`,
+    molecule: 'dna',
+    topology: 'linear',
+    seq: simulation.product,
+    length: simulation.product.length,
+    annotations,
+    ...(sourceRecord.organism ? { organism: sourceRecord.organism } : {}),
+    source: 'Motif PCR materialization',
+    ...(sourceRecord.group ? { group: sourceRecord.group } : {}),
+    dateAdded: identity.createdAt,
+    tags: uniqueTags(sourceRecord.tags),
+    active: true,
+    provenance,
+  };
+
+  const analysisResult: ArtifactAnalysisResult & { kind: 'pcr' } = {
+    id: identity.resultId,
+    kind: 'pcr',
+    name: `${sourceRecord.name} · PCR product`,
+    status: 'complete',
+    summary: `Created one exact ${simulation.product.length.toLocaleString()} bp linear amplicon record, including primer tails.`,
+    inputRecordIds: [sourceRecord.id],
+    inputSha256s: [templateSha256],
+    dependsOnResultIds: [primerDesignResultId],
+    assetIds: [],
+    parameters: {
+      forwardPrimer: selection.pair.forward.fullSequence,
+      reversePrimer: selection.pair.reverse.fullSequence,
+      forwardBindingStart: simulation.forward.bindStart,
+      forwardBindingEnd: simulation.forward.bindEnd,
+      reverseBindingStart: simulation.reverse.bindStart,
+      reverseBindingEnd: simulation.reverse.bindEnd,
+      topology: sourceRecord.topology,
+      primerDesignSha256,
+      materializationKey,
+    },
+    data: {
+      templateRecordId: sourceRecord.id,
+      primerDesignResultId,
+      products: [{
+        id: identity.productId,
+        lengthBp: simulation.product.length,
+        recordId: identity.recordId,
+        ...(!simulation.wrapsOrigin ? {
+          templateRange: {
+            start: simulation.forward.bindStart,
+            end: simulation.reverse.bindEnd,
+          },
+        } : {}),
+      }],
+    },
+    createdAt: identity.createdAt,
+    provenance: {
+      source: 'motif-for-claude-science-artifact',
+      operation: 'pcr_materialization',
+      actor: 'user',
+      engine: 'motif-pcr',
+      engineVersion: PCR_ENGINE_VERSION,
+      parentIds: [sourceRecord.id, primerDesignResultId],
+      metadata: {
+        templateSha256,
+        productSha256,
+        primerDesignSha256,
+        materializationKey,
+        wrapsOrigin: simulation.wrapsOrigin,
+        ...preparationMetadata,
+      },
+    },
+  };
+
+  return {
+    record,
+    analysisResult,
+    simulation,
+    templateSha256,
+    productSha256,
+    primerDesignSha256,
+    materializationKey,
+  };
+}

--- a/src/artifacts/claude-science-workspace-envelope.ts
+++ b/src/artifacts/claude-science-workspace-envelope.ts
@@ -1,0 +1,107 @@
+import {
+  normalizeArtifactDurableState,
+  type ArtifactDurableState,
+} from './claude-science-session';
+import {
+  normalizeArtifactWorkspaceCollections,
+  type ArtifactNote,
+  type ArtifactWorkflowResult,
+} from './claude-science-workspace-collections';
+
+export type NormalizedArtifactWorkspaceEnvelope = {
+  notes: ArtifactNote[];
+  workflowResults: ArtifactWorkflowResult[];
+  artifactState: ArtifactDurableState;
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+const RECORD_KEYED_ARTIFACT_STATE_FIELDS = [
+  'translationLayersByRecord',
+  'enzymeSourcesByRecord',
+  'hiddenEnzymesByRecord',
+  'hiddenFeatureTranslationsByRecord',
+  'restrictionLabelsByRecord',
+  'motifsByRecord',
+] as const;
+
+function assertArtifactStateRecordKeys(
+  artifactState: unknown,
+  recordLengths: ReadonlyMap<string, number>,
+): void {
+  if (!isPlainObject(artifactState)) return;
+  for (const field of RECORD_KEYED_ARTIFACT_STATE_FIELDS) {
+    const recordMap = artifactState[field];
+    if (!isPlainObject(recordMap)) continue;
+    const unknownRecordIds = Object.keys(recordMap).filter((recordId) => !recordLengths.has(recordId));
+    if (unknownRecordIds.length > 0) {
+      throw new Error(
+        `artifactState.${field} references unknown record id${unknownRecordIds.length === 1 ? '' : 's'}: `
+        + unknownRecordIds.join(', '),
+      );
+    }
+  }
+}
+
+function assertAlignmentRecordKeys(
+  workspace: Record<string, unknown>,
+  recordLengths: ReadonlyMap<string, number>,
+): void {
+  if (workspace.alignments !== undefined && !Array.isArray(workspace.alignments)) {
+    throw new Error('Workspace alignments must be an array when provided.');
+  }
+  if (workspace.alignment !== undefined && !isPlainObject(workspace.alignment)) {
+    throw new Error('Workspace alignment must be a plain object when provided.');
+  }
+  if (workspace.alignment !== undefined && workspace.alignments !== undefined) {
+    throw new Error('Workspace must provide either alignment or alignments, not both.');
+  }
+  const alignments = Array.isArray(workspace.alignments)
+    ? workspace.alignments
+    : isPlainObject(workspace.alignment)
+      ? [workspace.alignment]
+      : [];
+  const missingRecordIds = new Set<string>();
+  for (const alignment of alignments) {
+    if (!isPlainObject(alignment) || typeof alignment.alignedFasta === 'string') continue;
+    const rows = Array.isArray(alignment.rows)
+      ? alignment.rows
+      : Array.isArray(alignment.sequences)
+        ? alignment.sequences
+        : [];
+    for (const row of rows) {
+      if (!isPlainObject(row) || typeof row.sourceRecordId !== 'string') continue;
+      const recordId = row.sourceRecordId.trim();
+      if (recordId && !recordLengths.has(recordId)) missingRecordIds.add(recordId);
+    }
+  }
+  if (missingRecordIds.size > 0) {
+    const ids = Array.from(missingRecordIds);
+    throw new Error(
+      `Alignment rows reference unknown record id${ids.length === 1 ? '' : 's'}: ${ids.join(', ')}`,
+    );
+  }
+}
+
+/**
+ * Canonical validation seam shared by portable producers and the workbench.
+ * It deliberately returns normalized clones without mutating or widening the
+ * caller's payload; producers can use it for validation-only acceptance parity.
+ */
+export function normalizeArtifactWorkspaceEnvelope(
+  value: unknown,
+  recordLengths: ReadonlyMap<string, number>,
+): NormalizedArtifactWorkspaceEnvelope {
+  if (!isPlainObject(value)) throw new Error('Workspace payload must be a plain object.');
+  const collections = normalizeArtifactWorkspaceCollections(value, { recordLengths });
+  assertAlignmentRecordKeys(value, recordLengths);
+  assertArtifactStateRecordKeys(value.artifactState, recordLengths);
+  return {
+    ...collections,
+    artifactState: normalizeArtifactDurableState(value.artifactState, recordLengths),
+  };
+}

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -2267,6 +2267,19 @@ summary.motif-cs-panel-head {
   container-type: inline-size;
 }
 
+.motif-cs-alignment-freshness-summary {
+  display: grid;
+  gap: 4px;
+  margin: 0 12px 10px;
+  padding: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--panel-bg);
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
 .motif-cs-workflow-history {
   min-width: 0;
 }
@@ -2331,6 +2344,18 @@ summary.motif-cs-panel-head {
   color: var(--text-muted);
   font-size: 10px;
   line-height: 1.35;
+}
+
+.motif-cs-workflow-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
+  min-width: 0;
+}
+
+.motif-cs-workflow-row-copy .motif-cs-workflow-meta > small {
+  min-width: 0;
 }
 
 .motif-cs-workflow-record-label {
@@ -9514,6 +9539,18 @@ summary.motif-cs-panel-head:focus-visible {
     border-left-color: var(--border-strong);
     background: var(--panel-bg);
     box-shadow: 0 10px 28px color-mix(in srgb, var(--shadow-ink) 20%, transparent);
+  }
+
+  /* The collapsed 48 px tool rail intentionally sits above floating windows.
+     Reserve its hit area so window actions and scientific content remain
+     reachable instead of being painted underneath the rail. */
+  .motif-cs-shell:has(.motif-cs-inspector[data-tools-pinned="false"]) .motif-cs-window-head,
+  .motif-cs-shell:has(.motif-cs-inspector[data-tools-pinned="false"]) .motif-cs-window-body {
+    padding-right: 58px;
+  }
+
+  .motif-cs-shell:has(.motif-cs-inspector[data-tools-pinned="false"]) .motif-cs-window-resize {
+    right: 58px;
   }
 
   .motif-cs-resize-handle[data-pane="tools"] {

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-refresh/only-export-components -- artifact entry exports pure runtime test seams */
 import { Component, useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState, type ClipboardEvent as ReactClipboardEvent, type CSSProperties, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type RefObject } from 'react';
 import { createRoot } from 'react-dom/client';
-import { Activity, AlignCenter, Beaker, ChevronDown, ChevronLeft, ChevronRight, Crosshair, Dna, FileText, History, Info, Languages, LayoutGrid, List, Map as MapIcon, Maximize2, Minimize2, NotebookPen, Plus, Redo2, Search, Settings, Tag, Trash2, Undo2, Workflow, Wrench, X, type LucideIcon } from 'lucide-react';
+import { Activity, AlignCenter, Beaker, ChevronDown, ChevronLeft, ChevronRight, Crosshair, Dna, FileText, History, Info, Languages, LayoutGrid, List, Map as MapIcon, Maximize2, Minimize2, NotebookPen, Plus, Redo2, Search, Settings, ShieldCheck, Tag, Trash2, Undo2, Workflow, Wrench, X, type LucideIcon } from 'lucide-react';
 import vectorsRaw from '../../public/data/vectors.json?raw';
 import type { Feature, FeatureStrand, FeatureType, ORF, RestrictionEnzyme, RestrictionSite, SequenceType, Topology } from '../bio/types';
 import { extractEmbeddedFastaContent, parseFasta } from '../bio/fasta-parser';
@@ -40,6 +40,7 @@ import {
 import ClaudeScienceDataSettings from './ClaudeScienceDataSettings';
 import { ClaudeScienceWorkflowHistoryPanel } from './ClaudeScienceWorkflowHistoryPanel';
 import { ClaudeScienceAgentResultsPanel } from './ClaudeScienceAgentResultsPanel';
+import { ClaudeScienceFreshnessBadge } from './ClaudeScienceFreshnessBadge';
 import { ClaudeSciencePrimerWorkspace, type ClaudeSciencePrimerExport, type ClaudeSciencePrimerHandoff } from './ClaudeSciencePrimerWorkspace';
 import ClaudeScienceGelWorkspace, {
   createClaudeScienceGelLaneCandidates,
@@ -49,9 +50,32 @@ import { type ArtifactGelLadderPreset, type ArtifactGelPreview } from './claude-
 import { ClaudeScienceAssemblyWorkspace, type ClaudeScienceAssemblySavePayload } from './ClaudeScienceAssemblyWorkspace';
 import {
   ClaudeScienceCloningDesignWorkspace,
+  type ClaudeScienceCloningDesignWorkspaceHandle,
   type ClaudeScienceCloningPrimerRequest,
   type ClaudeScienceCloningSavePayload,
 } from './ClaudeScienceCloningDesignWorkspace';
+import {
+  ClaudeScienceConstructVerificationWorkspace,
+  type ClaudeScienceConstructVerificationRecord,
+  type ClaudeScienceConstructVerificationRequest,
+  type ClaudeScienceConstructVerificationSavePayload,
+} from './ClaudeScienceConstructVerificationWorkspace';
+import {
+  artifactConstructReadEvidenceSha256,
+  buildArtifactConstructVerificationArtifacts,
+  findDuplicateArtifactConstructVerificationResult,
+} from './claude-science-construct-verification-artifacts';
+import {
+  ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS,
+  ARTIFACT_CONSTRUCT_VERIFICATION_TEXT_LIMITS,
+  verifyArtifactConstruct,
+} from './claude-science-construct-verification';
+import {
+  findPcrMaterializationDuplicate,
+  materializePcrAmplicon,
+  simulateSelectedPrimerPair,
+  type PcrMaterializationSourceRecord,
+} from './claude-science-pcr-materialization';
 import {
   planArtifactGibsonDesign,
   planArtifactGoldenGateDesign,
@@ -83,11 +107,19 @@ import { buildDigestRecipe, type DigestRecipe } from './claude-science-digest-re
 import { materializeDigestWorkflow } from './claude-science-digest-workflow';
 import { sha256HexSync } from './claude-science-sha256';
 import {
+  createScientificFreshnessRecordIndex,
+  evaluateAlignmentsFreshness,
+  evaluateAnalysisResultsFreshness,
+  evaluateWorkflowResultsFreshness,
+} from './claude-science-freshness';
+import {
   appendArtifactAnalysisAsset,
   appendArtifactAnalysisWorkspaceResult,
+  artifactAnalysisResultRecordIds,
   cloneArtifactAnalysisWorkspace,
   normalizeArtifactAnalysisWorkspace,
-  removeArtifactAnalysisResult,
+  removeArtifactAnalysisAsset,
+  removeArtifactAnalysisWorkspaceResult,
   removeArtifactAnalysisResultsForRecord,
   serializeArtifactAnalysisWorkspace,
   type ArtifactAnalysisAsset,
@@ -108,6 +140,7 @@ import {
   type ArtifactNote,
   type ArtifactWorkflowResult,
 } from './claude-science-workspace-collections';
+import { normalizeArtifactWorkspaceEnvelope } from './claude-science-workspace-envelope';
 import {
   MOTIF_INVENTORY_SCHEMA,
   MOTIF_INVENTORY_SCHEMA_V1,
@@ -222,6 +255,38 @@ type ArtifactVector = {
   sangerTrace?: SangerTraceData;
 };
 
+type ArtifactConstructTraceEvidence = {
+  baseCalls: string;
+  qualityScores?: readonly number[];
+  sha256: string;
+};
+
+/** The digest follows exactly the bounded calls and qualities sent to verification. */
+function artifactConstructTraceEvidence(record: ArtifactVector): ArtifactConstructTraceEvidence | null {
+  const trace = record.sangerTrace;
+  if (!trace || trace.baseCalls.length > ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReadLength) return null;
+  // Malformed imported quality arrays are not repaired. The engine receives the
+  // calls without qualities and will surface that limitation as review evidence.
+  const qualityScores = trace.qualityScores.length > 0 && trace.qualityScores.length === trace.baseCalls.length
+    ? trace.qualityScores
+    : undefined;
+  const evidence = {
+    baseCalls: trace.baseCalls,
+    ...(qualityScores ? { qualityScores } : {}),
+  };
+  return {
+    ...evidence,
+    sha256: artifactConstructReadEvidenceSha256(evidence),
+  };
+}
+
+function boundedArtifactConstructName(value: string): string {
+  const maximumLength = ARTIFACT_CONSTRUCT_VERIFICATION_TEXT_LIMITS.maxNameLength;
+  return value.length <= maximumLength
+    ? value
+    : `${value.slice(0, Math.max(0, maximumLength - 1))}…`;
+}
+
 type ArtifactOverhangType = 'blunt' | '5prime' | '3prime';
 
 type ArtifactPayload = {
@@ -267,6 +332,15 @@ type LoadedPayload = {
   analysisResults: ArtifactAnalysisResult[];
   analysisAssets: ArtifactAnalysisAsset[];
 };
+
+type PreparedArtifactWorkspace = {
+  payload: LoadedPayload;
+  artifactState: ArtifactDurableState;
+};
+
+type InitialArtifactSource =
+  | { kind: 'sample' }
+  | { kind: 'payload'; value: unknown; origin: 'script' | 'window' };
 
 type RuntimeRecoveryPayload = {
   schema: string;
@@ -347,7 +421,8 @@ type MotifArtifactErrorCode =
   | 'MOTIF_RECORD_TOO_LARGE'
   | 'MOTIF_INPUT_LIMIT_EXCEEDED'
   | 'MOTIF_INVALID_ALIGNMENT_INPUT'
-  | 'MOTIF_INVALID_WORKSPACE_INPUT';
+  | 'MOTIF_INVALID_WORKSPACE_INPUT'
+  | 'MOTIF_INVALID_PRELOAD';
 type MotifArtifactErrorDetails = Record<string, unknown>;
 
 export class MotifArtifactRuntimeError extends Error {
@@ -774,6 +849,19 @@ function defaultCloningDesignWindowRect(): WindowRect {
   }, viewportWidth, viewportHeight);
 }
 
+function defaultConstructVerificationWindowRect(): WindowRect {
+  const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1280;
+  const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 800;
+  const width = Math.min(1180, Math.max(360, viewportWidth - 32));
+  const height = Math.min(760, Math.max(380, viewportHeight - 72));
+  return clampWindowRect({
+    x: Math.max(12, Math.round((viewportWidth - width) / 2)),
+    y: Math.max(34, Math.round((viewportHeight - height) / 2)),
+    w: width,
+    h: height,
+  }, viewportWidth, viewportHeight);
+}
+
 function createGelResultIdentity(): ClaudeScienceGelResultIdentity {
   return {
     workflowResultId: `gel-${crypto.randomUUID()}`,
@@ -853,7 +941,7 @@ const builtInRecords = JSON.parse(vectorsRaw) as ArtifactRecordInput[];
 
 const MOTIF_HELP_API: Record<string, string> = {
   'motifAddRecords(recordOrRecords)': 'Append one record or an array; returns number added; focuses the first new record.',
-  'motifRenderInventory(recordsOrPayload)': 'Transactionally replace the inventory. Passing [] intentionally clears; invalid non-empty input throws MotifArtifactRuntimeError and preserves the current inventory.',
+  'motifRenderInventory(recordsOrPayload)': 'Replace records while preserving compatible alignments, notes, results, and durable settings. Workspace fields or orphaning replacements are rejected transactionally; use motifReplaceWorkspace for intentional full replacement.',
   'motifGetInventory()': 'Return all current records (serialized, round-trippable into motifAddRecords/motifRenderInventory).',
   'motifGetActiveRecord()': 'Return the currently selected record, or null.',
   'motifAddAlignments(alignmentOrAlignments)': 'Validate and append one precomputed gapped alignment or an array; returns number added.',
@@ -866,7 +954,7 @@ const MOTIF_HELP_API: Record<string, string> = {
   'motifGetWorkflowResults()': 'Return a defensive snapshot of saved workflow results.',
   'motifRemoveWorkflowResults(resultIdOrIds)': 'Remove saved workflow-result ids transactionally; returns number removed.',
   'motifAddAnalysisAssets(assetOrAssets)': 'Append bounded inert text/JSON assets for typed analyses; returns number added.',
-  'motifAddAnalysisResults(resultOrResults)': 'Append validated primer, PCR, assembly, BLAST, structure, report, or table results; returns number added and reveals Results.',
+  'motifAddAnalysisResults(resultOrResults)': 'Append validated primer, PCR, assembly, construct-verification, BLAST, structure, report, or table results; returns number added and reveals Results.',
   'motifGetAnalysisWorkspace()': 'Return defensive snapshots of typed analysis results and their inert assets.',
   'motifRemoveAnalysisResults(resultIdOrIds)': 'Remove analysis results only when no other result depends on them; returns number removed.',
   'motifGetWorkspace()': 'Return a complete defensive workspace snapshot suitable for motifReplaceWorkspace or JSON backup.',
@@ -889,7 +977,8 @@ const MOTIF_HELP: MotifHelp = {
   howToAddSequences:
     'Call window.motifAddRecords(recordOrRecords) to APPEND without disturbing existing records ' +
     '(returns the count added and focuses the first). Use window.motifRenderInventory(records) only ' +
-    'to REPLACE the whole inventory. Read the current inventory with window.motifGetInventory().',
+    'to REPLACE the record inventory; linked workspace data is preserved or the call is rejected. ' +
+    'Read the current inventory with window.motifGetInventory().',
   capabilities: {
     addSequences: 'Append DNA, RNA, or protein records at runtime with motifAddRecords(...).',
     groupSequences: "Put records into compact collapsible groups using record.group, project, folder, collection, or tags like 'project:Design queue'.",
@@ -901,7 +990,7 @@ const MOTIF_HELP: MotifHelp = {
     multipleSequenceAlignment: 'Open Alignment from Tools to compare 2–10 same-type records locally, or inspect/import precomputed MAFFT, MUSCLE, or Clustal Omega aligned FASTA.',
     notes: 'Save workspace, record, or selected-range notes in the Tools pane or with motifAddNotes(...). Markdown is stored as inert text.',
     workflowHistory: 'Store digest, gel, Golden Gate, and ligation result summaries with explicit input/output record ids and engine provenance.',
-    analysisResults: 'Store typed primer, PCR, assembly, BLAST, structure, report, or table results. The UI renders supplied content as inert text/data only.',
+    analysisResults: 'Store typed primer, PCR, assembly, construct-verification, BLAST, structure, report, or table results. The UI renders supplied content as inert text/data only.',
     backupRecovery: 'motifGetWorkspace() and Settings → Data & recovery produce a complete v2 JSON snapshot; motifReplaceWorkspace(...) restores it transactionally.',
     exportInventory: 'The export panel can produce database JSON, CSV, FASTA, multi-FASTA, basic GenBank, HTML/Markdown report, PDF via print, and ZIP. Workspace data lives in this artifact session, so export JSON or ZIP before reloading.',
   },
@@ -980,7 +1069,7 @@ const MOTIF_HELP: MotifHelp = {
     provenance: 'required { source, operation?, actor?, engine?, engineVersion?, parentIds?, metadata? }.',
   },
   analysisResultSchema: {
-    kind: "'primer_design' | 'pcr' | 'assembly_plan' | 'blast_search' | 'structure_model' | 'report' | 'table'.",
+    kind: "'primer_design' | 'pcr' | 'assembly_plan' | 'construct_verification' | 'blast_search' | 'structure_model' | 'report' | 'table'.",
     status: "'complete' | 'partial' | 'failed'.",
     inputRecordIds: 'string[] — ordered existing workspace records used by the analysis.',
     inputSha256s: 'optional string[] — exact sequence SHA-256 values aligned to inputRecordIds.',
@@ -1018,6 +1107,7 @@ const MOTIF_HELP: MotifHelp = {
 
 const enzymeByLowerName = new Map(RESTRICTION_ENZYMES.map((enzyme) => [enzyme.name.toLowerCase(), enzyme]));
 const fullEnzymeByLowerName = new Map(RESTRICTION_ENZYMES_FULL.map((enzyme) => [enzyme.name.toLowerCase(), enzyme]));
+const ALLOWED_SEQUENCE_TYPES = new Set<SequenceType>(['dna', 'rna', 'protein', 'misc', 'unknown', 'mixed']);
 const emptyFeatures: readonly Feature[] = [];
 const emptySites: readonly RestrictionSite[] = [];
 const emptyTracks: readonly InlineTranslationTrack[] = [];
@@ -2600,20 +2690,43 @@ async function writeTextToClipboard(text: string): Promise<boolean> {
   }
 }
 
-function readJsonPayloadFromDom(): unknown | null {
-  const scriptPayload = document.getElementById('motif-artifact-data')?.textContent?.trim();
-  if (scriptPayload && !DATA_PLACEHOLDERS.some((placeholder) => scriptPayload.includes(placeholder))) {
-    try {
-      if (scriptPayload.length > MOTIF_MAX_PAYLOAD_JSON_BYTES
-        || utf8Encoder.encode(scriptPayload).byteLength > MOTIF_MAX_PAYLOAD_JSON_BYTES) {
-        throw new Error('Embedded artifact payload exceeds the 32 MiB input limit.');
+export function readInitialArtifactSourceFromDom(): InitialArtifactSource {
+  const scriptElement = document.getElementById('motif-artifact-data');
+  if (scriptElement) {
+    const scriptPayload = scriptElement.textContent?.trim() ?? '';
+    const isBuildPlaceholder = DATA_PLACEHOLDERS.includes(scriptPayload);
+    if (!scriptPayload && !isBuildPlaceholder) {
+      throw new MotifArtifactRuntimeError(
+        'MOTIF_INVALID_PRELOAD',
+        'Preloaded workspace could not be opened: the embedded payload is blank. No bundled sample data was substituted.',
+        { operation: 'initialHydration', origin: 'script', mutated: false },
+      );
+    }
+    if (!isBuildPlaceholder && (scriptPayload.length > MOTIF_MAX_PAYLOAD_JSON_BYTES
+      || utf8Encoder.encode(scriptPayload).byteLength > MOTIF_MAX_PAYLOAD_JSON_BYTES)) {
+      throw new MotifArtifactRuntimeError(
+        'MOTIF_INVALID_PRELOAD',
+        'Preloaded workspace could not be opened: the embedded payload exceeds the 32 MiB input limit. No bundled sample data was substituted.',
+        { operation: 'initialHydration', origin: 'script', mutated: false },
+      );
+    }
+    if (!isBuildPlaceholder) {
+      try {
+        return { kind: 'payload', value: JSON.parse(scriptPayload), origin: 'script' };
+      } catch (cause) {
+        const detail = cause instanceof Error ? cause.message : String(cause);
+        throw new MotifArtifactRuntimeError(
+          'MOTIF_INVALID_PRELOAD',
+          `Preloaded workspace could not be opened: embedded JSON is malformed (${detail}). No bundled sample data was substituted.`,
+          { operation: 'initialHydration', origin: 'script', mutated: false },
+        );
       }
-      return JSON.parse(scriptPayload);
-    } catch {
-      // Keep the artifact usable if an edited payload is malformed.
     }
   }
-  return window.MOTIF_ARTIFACT_DATA ?? null;
+  if (window.MOTIF_ARTIFACT_DATA !== undefined) {
+    return { kind: 'payload', value: window.MOTIF_ARTIFACT_DATA, origin: 'window' };
+  }
+  return { kind: 'sample' };
 }
 
 function coercePayload(raw: unknown): ArtifactPayload {
@@ -2621,12 +2734,14 @@ function coercePayload(raw: unknown): ArtifactPayload {
   if (!isObject(raw)) return {};
 
   const payload = raw as ArtifactPayload;
-  if (Array.isArray(payload.records) || Array.isArray(payload.entries) || Array.isArray(payload.vectors) || payload.record) {
+  if (['records', 'entries', 'vectors', 'record'].some((field) => (
+    Object.prototype.hasOwnProperty.call(payload, field)
+  ))) {
     return payload;
   }
 
   const maybeRecord = raw as ArtifactRecordInput;
-  if (typeof maybeRecord.seq === 'string' || typeof maybeRecord.sequence === 'string' || typeof maybeRecord.name === 'string') {
+  if (typeof maybeRecord.seq === 'string' || typeof maybeRecord.sequence === 'string') {
     return { ...payload, records: [maybeRecord] };
   }
 
@@ -2643,6 +2758,9 @@ function payloadRecords(payload: ArtifactPayload): ArtifactRecordInput[] {
 
 function payloadHasExplicitRecords(rawPayload: unknown, payload: ArtifactPayload): boolean {
   return Array.isArray(rawPayload)
+    || (isObject(rawPayload) && ['records', 'entries', 'vectors', 'record'].some((field) => (
+      Object.prototype.hasOwnProperty.call(rawPayload, field)
+    )))
     || Array.isArray(payload.records)
     || Array.isArray(payload.entries)
     || Array.isArray(payload.vectors)
@@ -2677,7 +2795,7 @@ function resolveSelectedRecordId(
   return records[0]?.id ?? 'record-1';
 }
 
-function loadArtifactPayload(rawPayload = readJsonPayloadFromDom(), fallbackSelectedRecordId?: string): LoadedPayload {
+function loadArtifactPayload(rawPayload: unknown = null, fallbackSelectedRecordId?: string): LoadedPayload {
   const fallbackRecords = normalizeRecords(builtInRecords).filter((record) => record.active);
   const fallbackPayload: LoadedPayload = {
     schema: DEFAULT_SCHEMA,
@@ -2704,7 +2822,6 @@ function loadArtifactPayload(rawPayload = readJsonPayloadFromDom(), fallbackSele
   validateRuntimePayloadEnvelope(rawPayload);
   const records = normalizeRecords(rawRecords as ArtifactRecordInput[]).filter((record) => record.active);
   const hasExplicitRecords = payloadHasExplicitRecords(rawPayload, payload);
-  const hasInjectedRecords = records.length > 0;
   const usableRecords = hasExplicitRecords ? records : records.length > 0 ? records : fallbackRecords;
   const inventory = isPlainObject(payload.inventory) ? payload.inventory : undefined;
   const alignments = normalizeArtifactAlignments(payload.alignments ?? payload.alignment);
@@ -2723,7 +2840,7 @@ function loadArtifactPayload(rawPayload = readJsonPayloadFromDom(), fallbackSele
       ? DEFAULT_SCHEMA
       : normalizeOptionalText(payload.schema) ?? DEFAULT_SCHEMA,
     inventory: {
-      id: normalizeOptionalText(inventory?.id) ?? (hasInjectedRecords ? 'motif-sequence-inventory' : fallbackPayload.inventory.id),
+      id: normalizeOptionalText(inventory?.id) ?? (hasExplicitRecords ? 'motif-sequence-inventory' : fallbackPayload.inventory.id),
       title: normalizeOptionalText(inventory?.title) ?? (hasExplicitRecords ? 'Motif sequence inventory' : fallbackPayload.inventory.title),
       description: normalizeOptionalText(inventory?.description) ?? (
         hasExplicitRecords
@@ -2743,31 +2860,41 @@ function loadArtifactPayload(rawPayload = readJsonPayloadFromDom(), fallbackSele
   };
 }
 
-function loadInitialArtifactPayload(): LoadedPayload {
+export function prepareInitialArtifactWorkspace(
+  rawWorkspace: unknown,
+  origin: 'script' | 'window' = 'script',
+): PreparedArtifactWorkspace {
   try {
-    const payload = loadArtifactPayload();
-    rememberLastGoodRuntimePayload(
-      payload,
-      normalizeArtifactDurableState(
-        undefined,
-        new Map(payload.records.map((record) => [record.id, record.sequence.length])),
-      ),
+    return prepareArtifactDatabaseRestore(rawWorkspace);
+  } catch (cause) {
+    if (cause instanceof MotifArtifactRuntimeError && cause.code === 'MOTIF_INVALID_PRELOAD') throw cause;
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    throw new MotifArtifactRuntimeError(
+      'MOTIF_INVALID_PRELOAD',
+      `Preloaded workspace could not be opened: ${detail} No bundled sample data was substituted.`,
+      { operation: 'initialHydration', origin, mutated: false },
     );
-    return payload;
-  } catch {
-    // A hand-edited or externally injected payload must never blank the shell.
-    // Runtime replacement APIs still throw the structured error transactionally;
-    // initial boot falls back to the vetted built-in inventory.
-    const payload = loadArtifactPayload(null);
-    rememberLastGoodRuntimePayload(
-      payload,
-      normalizeArtifactDurableState(
-        undefined,
-        new Map(payload.records.map((record) => [record.id, record.sequence.length])),
-      ),
-    );
-    return payload;
   }
+}
+
+export function loadInitialArtifactWorkspace(): PreparedArtifactWorkspace {
+  const source = readInitialArtifactSourceFromDom();
+  if (source.kind === 'sample') {
+    const payload = loadArtifactPayload(null);
+    const artifactState = normalizeArtifactDurableState(
+      undefined,
+      new Map(payload.records.map((record) => [record.id, record.sequence.length])),
+    );
+    rememberLastGoodRuntimePayload(
+      payload,
+      artifactState,
+    );
+    return { payload, artifactState };
+  }
+
+  const prepared = prepareInitialArtifactWorkspace(source.value, source.origin);
+  rememberLastGoodRuntimePayload(prepared.payload, prepared.artifactState);
+  return prepared;
 }
 
 type RuntimeRecordIssue = {
@@ -2790,6 +2917,13 @@ function omitTraceArraysForGenericJsonValidation(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(stripRecord);
   if (!isPlainObject(value)) return value;
   const projected = { ...value };
+  const hasRecordContainer = ['records', 'entries', 'vectors', 'record'].some((field) => (
+    Object.prototype.hasOwnProperty.call(projected, field)
+  ));
+  if (!hasRecordContainer
+    && (typeof projected.seq === 'string' || typeof projected.sequence === 'string')) {
+    return stripRecord(projected);
+  }
   for (const field of ['records', 'entries', 'vectors'] as const) {
     if (Array.isArray(projected[field])) projected[field] = projected[field].map(stripRecord);
   }
@@ -2829,6 +2963,14 @@ function collectMalformedRecordIssues(
     if (record[field] !== undefined && typeof record[field] !== 'boolean') {
       add(`${basePath}.${field}`, `${field} must be a boolean when provided`);
     }
+  }
+  for (const field of ['type', 'molecule'] as const) {
+    if (record[field] !== undefined && !ALLOWED_SEQUENCE_TYPES.has(record[field] as SequenceType)) {
+      add(`${basePath}.${field}`, `${field} is not a supported sequence type`);
+    }
+  }
+  if (record.topology !== undefined && record.topology !== 'linear' && record.topology !== 'circular') {
+    add(`${basePath}.topology`, 'topology must be linear or circular');
   }
   const normalizedRecordSequence = normalizeSequence(record.seq ?? record.sequence ?? '', record.molecule ?? record.type);
   const normalizedRecordType = normalizeSequenceType(record.molecule ?? record.type, normalizedRecordSequence);
@@ -3226,6 +3368,22 @@ function validateRuntimePayloadEnvelope(rawPayload: unknown): void {
   };
   const payload = coercePayload(rawPayload);
   const recordCount = payloadRecords(payload).length;
+  if (isPlainObject(rawPayload)) {
+    for (const field of ['records', 'entries', 'vectors'] as const) {
+      if (Object.prototype.hasOwnProperty.call(rawPayload, field) && !Array.isArray(rawPayload[field])) {
+        add(`payload.${field}`, `${field} must be an array when provided`);
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(rawPayload, 'record') && !isPlainObject(rawPayload.record)) {
+      add('payload.record', 'record must be a plain object when provided');
+    }
+    const recordContainers = ['records', 'entries', 'vectors', 'record'].filter((field) => (
+      Object.prototype.hasOwnProperty.call(rawPayload, field)
+    ));
+    if (recordContainers.length > 1) {
+      add('payload', `payload has ambiguous record containers: ${recordContainers.join(', ')}`);
+    }
+  }
   if (recordCount > MOTIF_MAX_RECORDS) {
     add(
       'payload.records',
@@ -3253,6 +3411,12 @@ function validateRuntimePayloadEnvelope(rawPayload: unknown): void {
         'resource_limit',
       );
     }
+  }
+  if (typeof payload.schema === 'string'
+    && payload.schema.startsWith('motif.claude-science.inventory.')
+    && payload.schema !== MOTIF_INVENTORY_SCHEMA_V1
+    && payload.schema !== DEFAULT_SCHEMA) {
+    add('payload.schema', `Unsupported Motif inventory schema: ${payload.schema}`);
   }
   if (payload.selectedIndex !== undefined && !Number.isInteger(payload.selectedIndex)) {
     add('payload.selectedIndex', 'selectedIndex must be an integer when provided');
@@ -3318,16 +3482,245 @@ export function prepareInventoryReplacement(
   return nextPayload;
 }
 
-export function prepareArtifactDatabaseRestore(
-  rawDatabase: Record<string, unknown>,
+const RECORDS_ONLY_FORBIDDEN_FIELDS = [
+  'alignment',
+  'alignments',
+  'artifactState',
+  'notes',
+  'workflowResults',
+  'analysisResults',
+  'analysisAssets',
+] as const;
+
+type RecordsOnlyCompatibilityIssue = {
+  category: 'alignment' | 'note' | 'workflowResult' | 'analysisResult' | 'artifactState';
+  message: string;
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function artifactRecordBiologyChanged(previous: ArtifactVector, next: ArtifactVector): boolean {
+  return previous.sequence !== next.sequence
+    || previous.type !== next.type
+    || previous.topology !== next.topology
+    || previous.overhang5 !== next.overhang5
+    || previous.overhang3 !== next.overhang3
+    || previous.overhang5Type !== next.overhang5Type
+    || previous.overhang3Type !== next.overhang3Type;
+}
+
+/**
+ * Prepare the records-only page API as one transaction. Existing workspace
+ * sidecars are cloned and revalidated against the prospective record set; a
+ * caller must use motifReplaceWorkspace when a replacement would orphan any
+ * linked result or durable record setting.
+ */
+export function prepareRecordsOnlyWorkspaceReplacement(
+  currentPayload: LoadedPayload,
+  currentArtifactState: ArtifactDurableState,
+  rawPayload: ArtifactPayload | ArtifactRecordInput | ArtifactRecordInput[],
   fallbackSelectedRecordId?: string,
-): { payload: LoadedPayload; artifactState: ArtifactDurableState } {
+): PreparedArtifactWorkspace {
+  if (isPlainObject(rawPayload)) {
+    const forbiddenFields = RECORDS_ONLY_FORBIDDEN_FIELDS.filter((field) => (
+      Object.prototype.hasOwnProperty.call(rawPayload, field)
+    ));
+    if (forbiddenFields.length > 0) {
+      throw new MotifArtifactRuntimeError(
+        'MOTIF_INVALID_WORKSPACE_INPUT',
+        'motifRenderInventory is records-only and will not discard workspace state silently. Use motifReplaceWorkspace for a complete backup payload.',
+        { operation: 'motifRenderInventory', forbiddenFields, mutated: false },
+      );
+    }
+  }
+
+  const replacement = prepareInventoryReplacement(rawPayload, fallbackSelectedRecordId);
+  const recordLengths = new Map(replacement.records.map((record) => [record.id, record.sequence.length]));
+  const previousRecordsById = new Map(currentPayload.records.map((record) => [record.id, record]));
+  const biologicallyChangedRecordIds = new Set(replacement.records.flatMap((record) => {
+    const previous = previousRecordsById.get(record.id);
+    return previous && artifactRecordBiologyChanged(previous, record) ? [record.id] : [];
+  }));
+  const issues: RecordsOnlyCompatibilityIssue[] = [];
+  const capture = <T,>(
+    category: RecordsOnlyCompatibilityIssue['category'],
+    operation: () => T,
+  ): T | null => {
+    try {
+      return operation();
+    } catch (error) {
+      issues.push({ category, message: errorMessage(error) });
+      return null;
+    }
+  };
+  const addBiologicalIdentityIssue = (
+    category: RecordsOnlyCompatibilityIssue['category'],
+    recordIds: Iterable<string | undefined>,
+  ) => {
+    const changedIds = Array.from(new Set(Array.from(recordIds).flatMap((recordId) => (
+      recordId && biologicallyChangedRecordIds.has(recordId) ? [recordId] : []
+    ))));
+    if (changedIds.length > 0) {
+      issues.push({
+        category,
+        message: `Preserved ${category} data is linked to biologically changed record${changedIds.length === 1 ? '' : 's'}: ${changedIds.join(', ')}.`,
+      });
+    }
+  };
+
+  const missingAlignmentRecordIds = Array.from(new Set(currentPayload.alignments.flatMap((alignment) => (
+    alignment.rows.flatMap((row) => (
+      row.sourceRecordId && !recordLengths.has(row.sourceRecordId) ? [row.sourceRecordId] : []
+    ))
+  ))));
+  if (missingAlignmentRecordIds.length > 0) {
+    issues.push({
+      category: 'alignment',
+      message: `Alignment rows reference records absent from the replacement: ${missingAlignmentRecordIds.join(', ')}.`,
+    });
+  }
+  addBiologicalIdentityIssue('alignment', currentPayload.alignments.flatMap((alignment) => (
+    alignment.rows.map((row) => row.sourceRecordId)
+  )));
+  const alignments = capture('alignment', () => normalizeArtifactAlignments(
+    currentPayload.alignments.map(serializeArtifactAlignment),
+  ));
+  addBiologicalIdentityIssue('note', currentPayload.notes.map((note) => note.recordId));
+  const noteCollections = capture('note', () => normalizeArtifactWorkspaceCollections({
+    notes: currentPayload.notes,
+    workflowResults: [],
+  }, { recordLengths }));
+  addBiologicalIdentityIssue('workflowResult', currentPayload.workflowResults.flatMap((result) => (
+    [...result.inputRecordIds, ...result.outputRecordIds]
+  )));
+  const previousRecordIds = new Set(currentPayload.records.map((record) => record.id));
+  const newlyMissingWorkflowOutputIds = Array.from(new Set(currentPayload.workflowResults.flatMap((result) => (
+    result.outputRecordIds.filter((recordId) => previousRecordIds.has(recordId) && !recordLengths.has(recordId))
+  ))));
+  if (newlyMissingWorkflowOutputIds.length > 0) {
+    issues.push({
+      category: 'workflowResult',
+      message: `Workflow outputs would become newly orphaned: ${newlyMissingWorkflowOutputIds.join(', ')}.`,
+    });
+  }
+  const workflowCollections = capture('workflowResult', () => normalizeArtifactWorkspaceCollections({
+    notes: [],
+    workflowResults: currentPayload.workflowResults,
+  }, { recordLengths, allowMissingWorkflowOutputRecords: true }));
+  addBiologicalIdentityIssue(
+    'analysisResult',
+    currentPayload.analysisResults.flatMap(artifactAnalysisResultRecordIds),
+  );
+  const analysisWorkspace = capture('analysisResult', () => normalizeArtifactAnalysisWorkspace({
+    analysisResults: currentPayload.analysisResults,
+    analysisAssets: currentPayload.analysisAssets,
+  }, { recordLengths }));
+
+  const artifactStateRecordIds = new Set<string>();
+  for (const field of [
+    'translationLayersByRecord',
+    'enzymeSourcesByRecord',
+    'hiddenEnzymesByRecord',
+    'hiddenFeatureTranslationsByRecord',
+    'restrictionLabelsByRecord',
+    'motifsByRecord',
+  ] as const) {
+    Object.keys(currentArtifactState[field]).forEach((recordId) => artifactStateRecordIds.add(recordId));
+    const missingIds = Object.keys(currentArtifactState[field]).filter((recordId) => !recordLengths.has(recordId));
+    if (missingIds.length > 0) {
+      issues.push({
+        category: 'artifactState',
+        message: `artifactState.${field} references records absent from the replacement: ${missingIds.join(', ')}.`,
+      });
+    }
+  }
+  for (const [recordId, hiddenIds] of Object.entries(currentArtifactState.hiddenFeatureTranslationsByRecord)) {
+    const previous = previousRecordsById.get(recordId);
+    const next = replacement.records.find((record) => record.id === recordId);
+    if (!previous || !next) continue;
+    const previousFeatureIds = new Set(previous.features.map((feature) => `feat:${feature.id}`));
+    const nextFeatureIds = new Set(next.features.map((feature) => `feat:${feature.id}`));
+    const newlyMissingFeatureIds = hiddenIds.filter((id) => previousFeatureIds.has(id) && !nextFeatureIds.has(id));
+    if (newlyMissingFeatureIds.length > 0) {
+      issues.push({
+        category: 'artifactState',
+        message: `artifactState.hiddenFeatureTranslationsByRecord.${recordId} would reference removed feature${newlyMissingFeatureIds.length === 1 ? '' : 's'}: ${newlyMissingFeatureIds.join(', ')}.`,
+      });
+    }
+  }
+  addBiologicalIdentityIssue('artifactState', artifactStateRecordIds);
+  const artifactState = capture('artifactState', () => (
+    normalizeArtifactDurableState(currentArtifactState, recordLengths)
+  ));
+
+  if (issues.length > 0 || !alignments || !noteCollections || !workflowCollections || !analysisWorkspace || !artifactState) {
+    throw new MotifArtifactRuntimeError(
+      'MOTIF_INVALID_INVENTORY_REPLACEMENT',
+      'motifRenderInventory would orphan existing workspace data. The existing workspace was preserved; use motifReplaceWorkspace for an intentional complete replacement.',
+      { operation: 'motifRenderInventory', issues, mutated: false },
+    );
+  }
+
+  const rawPayloadObject = isPlainObject(rawPayload) ? rawPayload : null;
+  const suppliesInventory = Boolean(rawPayloadObject
+    && Object.prototype.hasOwnProperty.call(rawPayloadObject, 'inventory'));
+  const suppliesSchema = Boolean(rawPayloadObject
+    && Object.prototype.hasOwnProperty.call(rawPayloadObject, 'schema'));
+  const suppliesDefaultMotif = Boolean(rawPayloadObject && (
+    Object.prototype.hasOwnProperty.call(rawPayloadObject, 'defaultMotif')
+    || Object.prototype.hasOwnProperty.call(rawPayloadObject, 'motif')
+  ));
+
+  return {
+    payload: {
+      ...replacement,
+      schema: suppliesSchema ? replacement.schema : currentPayload.schema,
+      inventory: suppliesInventory ? replacement.inventory : { ...currentPayload.inventory },
+      defaultMotif: suppliesDefaultMotif ? replacement.defaultMotif : currentPayload.defaultMotif,
+      alignments,
+      notes: noteCollections.notes,
+      workflowResults: workflowCollections.workflowResults,
+      analysisResults: analysisWorkspace.analysisResults,
+      analysisAssets: analysisWorkspace.analysisAssets,
+    },
+    artifactState,
+  };
+}
+
+export function prepareArtifactDatabaseRestore(
+  rawDatabase: unknown,
+  fallbackSelectedRecordId?: string,
+): PreparedArtifactWorkspace {
   // Validate both halves before returning either one. Callers can therefore
   // replace the current workspace in one commit without leaving a partially
   // imported inventory behind when nested session state is malformed.
-  const payload = prepareInventoryReplacement(rawDatabase as ArtifactPayload, fallbackSelectedRecordId);
-  const recordLengths = new Map(payload.records.map((record) => [record.id, record.sequence.length]));
-  const artifactState = normalizeArtifactDurableState(rawDatabase.artifactState, recordLengths);
+  const coercedDatabase = coercePayload(rawDatabase);
+  const isSidecarOnlyWorkspace = isPlainObject(rawDatabase)
+    && !payloadHasExplicitRecords(rawDatabase, coercedDatabase)
+    && RECORDS_ONLY_FORBIDDEN_FIELDS.some((field) => Object.prototype.hasOwnProperty.call(rawDatabase, field));
+  const restoreInput = isSidecarOnlyWorkspace
+    ? { ...rawDatabase, records: [] }
+    : rawDatabase;
+  const preparedPayload = prepareInventoryReplacement(
+    restoreInput as ArtifactPayload | ArtifactRecordInput | ArtifactRecordInput[],
+    fallbackSelectedRecordId,
+  );
+  const recordLengths = new Map(preparedPayload.records.map((record) => [record.id, record.sequence.length]));
+  if (!isPlainObject(rawDatabase)) {
+    return {
+      payload: preparedPayload,
+      artifactState: normalizeArtifactDurableState(undefined, recordLengths),
+    };
+  }
+  const envelope = normalizeArtifactWorkspaceEnvelope(rawDatabase, recordLengths);
+  const payload: LoadedPayload = {
+    ...preparedPayload,
+    notes: envelope.notes,
+    workflowResults: envelope.workflowResults,
+  };
+  const artifactState = envelope.artifactState;
   return { payload, artifactState };
 }
 
@@ -3694,15 +4087,17 @@ function compactMapFeatureLabel(name: string): string {
 
 type ArtifactRuntimeErrorBoundaryState = {
   errorMessage: string | null;
+  errorCode: MotifArtifactErrorCode | null;
   recoveryStatus: string | null;
 };
 
 export class ArtifactRuntimeErrorBoundary extends Component<{ children: ReactNode }, ArtifactRuntimeErrorBoundaryState> {
-  state: ArtifactRuntimeErrorBoundaryState = { errorMessage: null, recoveryStatus: null };
+  state: ArtifactRuntimeErrorBoundaryState = { errorMessage: null, errorCode: null, recoveryStatus: null };
 
   static getDerivedStateFromError(error: unknown): Partial<ArtifactRuntimeErrorBoundaryState> {
     return {
       errorMessage: error instanceof Error ? error.message : 'An unexpected render error occurred.',
+      errorCode: error instanceof MotifArtifactRuntimeError ? error.code : null,
       recoveryStatus: null,
     };
   }
@@ -3723,7 +4118,8 @@ export class ArtifactRuntimeErrorBoundary extends Component<{ children: ReactNod
 
   render() {
     if (!this.state.errorMessage) return this.props.children;
-    const hasRecoverySnapshot = Boolean(lastGoodRuntimeRecoveryPayload);
+    const isPreloadFailure = this.state.errorCode === 'MOTIF_INVALID_PRELOAD';
+    const hasRecoverySnapshot = !isPreloadFailure && Boolean(lastGoodRuntimeRecoveryPayload);
     return (
       <main
         className="motif-cs-shell"
@@ -3732,21 +4128,30 @@ export class ArtifactRuntimeErrorBoundary extends Component<{ children: ReactNod
       >
         <section className="motif-cs-panel" role="alert" style={{ width: 'min(560px, 100%)', padding: 24 }}>
           <div className="motif-cs-kicker">Motif recovery</div>
-          <h1>Workspace rendering stopped safely</h1>
-          <p>
-            The artifact kept the last accepted inventory separate from this failed render. Copy its recovery JSON before
-            reloading, then use Add Entry to restore the database JSON.
-          </p>
+          <h1>{isPreloadFailure ? 'Preloaded workspace could not be opened' : 'Workspace rendering stopped safely'}</h1>
+          {isPreloadFailure ? (
+            <p>
+              Motif rejected the embedded data before initialization. No bundled sample data was substituted. Fix or
+              regenerate the payload, then reload the artifact.
+            </p>
+          ) : (
+            <p>
+              The artifact kept the last accepted inventory separate from this failed render. Copy its recovery JSON before
+              reloading, then use Add Entry to restore the database JSON.
+            </p>
+          )}
           <p className="motif-cs-muted">{this.state.errorMessage}</p>
           <div className="motif-cs-inline-actions">
-            <button
-              className="motif-cs-mini-button motif-cs-mini-button-accent"
-              type="button"
-              disabled={!hasRecoverySnapshot}
-              onClick={() => { void this.copyRecoveryJson(); }}
-            >
-              Copy recovery JSON
-            </button>
+            {!isPreloadFailure ? (
+              <button
+                className="motif-cs-mini-button motif-cs-mini-button-accent"
+                type="button"
+                disabled={!hasRecoverySnapshot}
+                onClick={() => { void this.copyRecoveryJson(); }}
+              >
+                Copy recovery JSON
+              </button>
+            ) : null}
             <button className="motif-cs-mini-button" type="button" onClick={() => window.location.reload()}>
               Reload artifact
             </button>
@@ -3754,7 +4159,9 @@ export class ArtifactRuntimeErrorBoundary extends Component<{ children: ReactNod
           <p className="motif-cs-muted" role="status" aria-live="polite">
             {this.state.recoveryStatus ?? (hasRecoverySnapshot
               ? 'A last-good recovery snapshot is ready.'
-              : 'Reload to return to the bundled starting inventory.')}
+              : isPreloadFailure
+                ? 'No workspace was accepted. The embedded source remains unchanged.'
+                : 'No recovery snapshot is available yet.')}
           </p>
         </section>
       </main>
@@ -3765,15 +4172,24 @@ export class ArtifactRuntimeErrorBoundary extends Component<{ children: ReactNod
 function App() {
   const initialWorkspaceLayout = useMemo(() => loadWorkspaceLayoutPrefs(), []);
   const initialMsaViewPreferences = useMemo(() => loadMsaViewPreferences(), []);
-  const [payload, setPayload] = useState(loadInitialArtifactPayload);
+  const [initialWorkspace] = useState(loadInitialArtifactWorkspace);
+  const [payload, setPayload] = useState(initialWorkspace.payload);
   const [selectedRecordId, setSelectedRecordId] = useState(payload.selectedRecordId);
   const payloadRef = useRef(payload);
   const selectedRecordIdRef = useRef(selectedRecordId);
   const describeSnapshotRef = useRef<RecordSummary | null>(null);
-  const [hiddenEnzymesByRecord, setHiddenEnzymesByRecord] = useState<Record<string, readonly string[]>>({});
-  const [enzymeSourcesByRecord, setEnzymeSourcesByRecord] = useState<Record<string, readonly RestrictionEnzymeSourceId[]>>({});
-  const [restrictionLabelsByRecord, setRestrictionLabelsByRecord] = useState<Record<string, boolean>>({});
-  const [motifsByRecord, setMotifsByRecord] = useState<Record<string, string>>({});
+  const [hiddenEnzymesByRecord, setHiddenEnzymesByRecord] = useState<Record<string, readonly string[]>>(
+    initialWorkspace.artifactState.hiddenEnzymesByRecord,
+  );
+  const [enzymeSourcesByRecord, setEnzymeSourcesByRecord] = useState<Record<string, readonly RestrictionEnzymeSourceId[]>>(
+    initialWorkspace.artifactState.enzymeSourcesByRecord,
+  );
+  const [restrictionLabelsByRecord, setRestrictionLabelsByRecord] = useState<Record<string, boolean>>(
+    initialWorkspace.artifactState.restrictionLabelsByRecord,
+  );
+  const [motifsByRecord, setMotifsByRecord] = useState<Record<string, string>>(
+    initialWorkspace.artifactState.motifsByRecord,
+  );
   const [mapViewportsByRecord, setMapViewportsByRecord] = useState<Record<string, MapViewport>>({});
   const [mapRangesByRecord, setMapRangesByRecord] = useState<Record<string, MapSelectionRange | null>>({});
   const [selection, setSelection] = useState<Selection>(null);
@@ -3782,9 +4198,13 @@ function App() {
   // User-added inline translation layers (from a selection). Coding features
   // (CDS/gene/…) auto-translate; these are extra translated regions the user pins
   // to the sequence. Keyed by record.
-  const [translationLayersByRecord, setTranslationLayersByRecord] = useState<Record<string, InlineTranslationTrack[]>>({});
+  const [translationLayersByRecord, setTranslationLayersByRecord] = useState<Record<string, InlineTranslationTrack[]>>(
+    initialWorkspace.artifactState.translationLayersByRecord,
+  );
   const [selectedTranslationLayerByRecord, setSelectedTranslationLayerByRecord] = useState<Record<string, string | null>>({});
-  const [hiddenFeatureTranslationsByRecord, setHiddenFeatureTranslationsByRecord] = useState<Record<string, readonly string[]>>({});
+  const [hiddenFeatureTranslationsByRecord, setHiddenFeatureTranslationsByRecord] = useState<Record<string, readonly string[]>>(
+    initialWorkspace.artifactState.hiddenFeatureTranslationsByRecord,
+  );
   // Show the antiparallel complement strand under each line (dsDNA/RNA view).
   const [showComplement, setShowComplement] = useState(false);
   // Translate-window controls: strand + frame for the current target (a selection,
@@ -3792,7 +4212,9 @@ function App() {
   // changes (see effect below) so the panel updates in place instead of swapping UI.
   const [translateStrand, setTranslateStrand] = useState<'sense' | 'antisense'>('sense');
   const [translateFrame, setTranslateFrame] = useState<0 | 1 | 2>(0);
-  const [customEnzymes, setCustomEnzymes] = useState<RestrictionEnzyme[]>([]);
+  const [customEnzymes, setCustomEnzymes] = useState<RestrictionEnzyme[]>(
+    initialWorkspace.artifactState.customEnzymes,
+  );
   const [copyStatus, setCopyStatus] = useState<string | null>(null);
   const [dropState, setDropState] = useState<{ active: boolean; message: string }>({ active: false, message: '' });
   const [workbenchNotice, setWorkbenchNotice] = useState<WorkbenchNotice | null>(null);
@@ -3837,6 +4259,9 @@ function App() {
   const [showCloningDesign, setShowCloningDesign] = useState(false);
   const [cloningDesignWin, setCloningDesignWin] = useState<WindowRect>(defaultCloningDesignWindowRect);
   const [cloningDesignInitialRecordIds, setCloningDesignInitialRecordIds] = useState<string[]>([]);
+  const cloningDesignWorkspaceRef = useRef<ClaudeScienceCloningDesignWorkspaceHandle>(null);
+  const [showConstructVerification, setShowConstructVerification] = useState(false);
+  const [constructVerificationWin, setConstructVerificationWin] = useState<WindowRect>(defaultConstructVerificationWindowRect);
   const [activeAlignmentId, setActiveAlignmentId] = useState<string | null>(payload.alignments[0]?.id ?? null);
   const [msaViewPreferences, setMsaViewPreferences] = useState<ClaudeScienceMsaViewPreferences>(initialMsaViewPreferences);
   const [lockedTranslateTarget, setLockedTranslateTarget] = useState<{ recordId: string; target: TranslateTarget } | null>(null);
@@ -3908,6 +4333,7 @@ function App() {
   const translationsToggleRef = useRef<HTMLButtonElement | null>(null);
   const alignmentToggleRef = useRef<HTMLElement | null>(null);
   const cloningToggleRef = useRef<HTMLElement | null>(null);
+  const constructVerificationToggleRef = useRef<HTMLElement | null>(null);
   const primerToggleRef = useRef<HTMLElement | null>(null);
   const gelReturnFocusRef = useRef<HTMLElement | null>(null);
   const inventoryColumnRef = useRef<HTMLElement | null>(null);
@@ -3928,6 +4354,94 @@ function App() {
   const recordNamesById = useMemo(() => Object.fromEntries(
     payload.records.map((record) => [record.id, record.name]),
   ), [payload.records]);
+  const constructTraceEvidenceByRecordId = useMemo(() => {
+    const evidence = new Map<string, ArtifactConstructTraceEvidence>();
+    payload.records.forEach((record) => {
+      const current = artifactConstructTraceEvidence(record);
+      if (current) evidence.set(record.id, current);
+    });
+    return evidence;
+  }, [payload.records]);
+  const constructVerificationCandidates = useMemo(() => {
+    const records: ClaudeScienceConstructVerificationRecord[] = [];
+    let excludedCount = 0;
+    payload.records.forEach((record) => {
+      if (!record.active || record.type !== 'dna') return;
+      if (record.id.length > ARTIFACT_CONSTRUCT_VERIFICATION_TEXT_LIMITS.maxIdLength) {
+        excludedCount += 1;
+        return;
+      }
+      const evidence = constructTraceEvidenceByRecordId.get(record.id);
+      if (record.sangerTrace) {
+        if (!evidence || evidence.baseCalls.length > ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReadLength) {
+          excludedCount += 1;
+          return;
+        }
+      } else if (record.sequence.length > ARTIFACT_CONSTRUCT_VERIFICATION_LIMITS.maxReferenceLength) {
+        excludedCount += 1;
+        return;
+      }
+      records.push({
+        id: record.id,
+        name: boundedArtifactConstructName(record.name),
+        sequence: record.sequence,
+        topology: record.topology,
+        sha256: sha256HexSync(record.sequence),
+        ...(evidence ? {
+          sangerTrace: {
+            baseCalls: evidence.baseCalls,
+            ...(evidence.qualityScores ? { qualityScores: evidence.qualityScores } : {}),
+          },
+          sangerEvidenceSha256: evidence.sha256,
+        } : {}),
+      });
+    });
+    return { records, excludedCount };
+  }, [constructTraceEvidenceByRecordId, payload.records]);
+  const constructVerificationRecords = constructVerificationCandidates.records;
+  const constructVerificationExcludedCount = constructVerificationCandidates.excludedCount;
+  const constructVerificationInitialReferenceId = useMemo(() => {
+    const selected = constructVerificationRecords.find((record) => record.id === selectedRecordId);
+    if (selected && !selected.sangerTrace) return selected.id;
+    return constructVerificationRecords.find((record) => !record.sangerTrace)?.id
+      ?? selected?.id
+      ?? constructVerificationRecords[0]?.id;
+  }, [constructVerificationRecords, selectedRecordId]);
+  const constructVerificationReadCount = useMemo(() => constructVerificationRecords.filter(
+    (record) => Boolean(record.sangerTrace),
+  ).length, [constructVerificationRecords]);
+  const constructVerificationReferenceCount = constructVerificationRecords.length - constructVerificationReadCount;
+  const scientificFreshnessRecordIndex = useMemo(() => createScientificFreshnessRecordIndex(
+    payload.records.map((record) => ({
+      id: record.id,
+      sequence: record.sequence,
+      topology: record.topology,
+      overhang5: record.overhang5,
+      overhang3: record.overhang3,
+      overhang5Type: record.overhang5Type,
+      overhang3Type: record.overhang3Type,
+      ...(constructTraceEvidenceByRecordId.get(record.id)
+        ? { sangerEvidenceSha256: constructTraceEvidenceByRecordId.get(record.id)!.sha256 }
+        : {}),
+    })),
+  ), [constructTraceEvidenceByRecordId, payload.records]);
+  const workflowFreshnessByResultId = useMemo(() => evaluateWorkflowResultsFreshness(
+    payload.workflowResults,
+    scientificFreshnessRecordIndex,
+  ), [payload.workflowResults, scientificFreshnessRecordIndex]);
+  const analysisFreshnessByResultId = useMemo(() => evaluateAnalysisResultsFreshness(
+    payload.analysisResults,
+    scientificFreshnessRecordIndex,
+  ), [payload.analysisResults, scientificFreshnessRecordIndex]);
+  const alignmentFreshnessById = useMemo(() => evaluateAlignmentsFreshness(
+    payload.alignments,
+    scientificFreshnessRecordIndex,
+  ), [payload.alignments, scientificFreshnessRecordIndex]);
+  const alignmentsNeedingReview = useMemo(() => Array.from(alignmentFreshnessById.values()).filter(
+    (evaluation) => evaluation.state !== 'fresh',
+  ), [alignmentFreshnessById]);
+  const representativeAlignmentFreshness = alignmentsNeedingReview.find((evaluation) => evaluation.state === 'stale')
+    ?? alignmentsNeedingReview[0];
   const gelLaneCandidates = useMemo(() => createClaudeScienceGelLaneCandidates(
     payload.records.map((record) => ({
       id: record.id,
@@ -3937,7 +4451,8 @@ function App() {
       sequence: record.sequence,
     })),
     payload.workflowResults,
-  ), [payload.records, payload.workflowResults]);
+    workflowFreshnessByResultId,
+  ), [payload.records, payload.workflowResults, workflowFreshnessByResultId]);
   const assemblyRecords = useMemo(() => payload.records
     .filter((record) => record.active && record.type === 'dna')
     .map((record) => ({
@@ -4258,27 +4773,31 @@ function App() {
   const canUndo = (editHistoryRef.current[recordId]?.undo.length ?? 0) > 0;
   const canRedo = (editHistoryRef.current[recordId]?.redo.length ?? 0) > 0;
 
-  const resetRecordTransientState = useCallback(() => {
+  const resetWorkspaceViewState = useCallback(() => {
     setSelection(null);
     setCaret(null);
     setLockedTranslateTarget(null);
     setTranslateStrand('sense');
     setTranslateFrame(0);
+    setMapViewportsByRecord({});
+    setMapRangesByRecord({});
+    setSelectedTranslationLayerByRecord({});
+    sequenceScrollByRecordRef.current = {};
+    editHistoryRef.current = {};
+    bumpEditHistory();
+  }, []);
+
+  const resetRecordTransientState = useCallback(() => {
+    resetWorkspaceViewState();
     setHiddenEnzymesByRecord({});
     setEnzymeSourcesByRecord({});
     enzymeSourcesByRecordRef.current = {};
     setRestrictionLabelsByRecord({});
     setMotifsByRecord({});
-    setMapViewportsByRecord({});
-    setMapRangesByRecord({});
     setTranslationLayersByRecord({});
-    setSelectedTranslationLayerByRecord({});
     setHiddenFeatureTranslationsByRecord({});
     activeEnzymeSourcesRef.current = DEFAULT_ENZYME_SOURCES;
-    sequenceScrollByRecordRef.current = {};
-    editHistoryRef.current = {};
-    bumpEditHistory();
-  }, []);
+  }, [resetWorkspaceViewState]);
 
   const resetWorkflowWindowState = useCallback(() => {
     setShowPrimerDesign(false);
@@ -4295,6 +4814,7 @@ function App() {
     setAssemblyInitialRecordIds([]);
     setShowCloningDesign(false);
     setCloningDesignInitialRecordIds([]);
+    setShowConstructVerification(false);
   }, []);
 
   const clearWorkspaceData = useCallback(() => {
@@ -4580,25 +5100,28 @@ function App() {
 
   useEffect(() => {
     window.motifRenderInventory = (entriesOrPayload) => {
-      if (isPlainObject(entriesOrPayload) && (
-        Object.prototype.hasOwnProperty.call(entriesOrPayload, 'artifactState')
-        || Object.prototype.hasOwnProperty.call(entriesOrPayload, 'notes')
-        || Object.prototype.hasOwnProperty.call(entriesOrPayload, 'workflowResults')
-        || Object.prototype.hasOwnProperty.call(entriesOrPayload, 'analysisResults')
-        || Object.prototype.hasOwnProperty.call(entriesOrPayload, 'analysisAssets')
-      )) {
-        throw new MotifArtifactRuntimeError(
-          'MOTIF_INVALID_WORKSPACE_INPUT',
-          'motifRenderInventory is records-only and will not discard workspace state silently. Use motifReplaceWorkspace for a complete backup payload.',
-          { operation: 'motifRenderInventory', mutated: false },
-        );
-      }
-      const nextPayload = prepareInventoryReplacement(entriesOrPayload, selectedRecordIdRef.current);
+      const prepared = prepareRecordsOnlyWorkspaceReplacement(
+        payloadRef.current,
+        artifactStateRef.current,
+        entriesOrPayload,
+        selectedRecordIdRef.current,
+      );
+      const nextPayload = prepared.payload;
+      const nextSources = prepared.artifactState.enzymeSourcesByRecord[nextPayload.selectedRecordId]
+        ?? DEFAULT_ENZYME_SOURCES;
       rememberActiveSequenceScroll();
-      resetRecordTransientState();
+      resetWorkspaceViewState();
       payloadRef.current = nextPayload;
       selectedRecordIdRef.current = nextPayload.selectedRecordId;
-      describeSnapshotRef.current = describeRuntimePayloadSnapshot(nextPayload, nextPayload.selectedRecordId, DEFAULT_ENZYME_SOURCES);
+      artifactStateRef.current = prepared.artifactState;
+      enzymeSourcesByRecordRef.current = prepared.artifactState.enzymeSourcesByRecord;
+      customEnzymesRef.current = prepared.artifactState.customEnzymes;
+      activeEnzymeSourcesRef.current = nextSources;
+      describeSnapshotRef.current = describeRuntimePayloadSnapshot(
+        nextPayload,
+        nextPayload.selectedRecordId,
+        nextSources,
+      );
       setSelectedRecordId(nextPayload.selectedRecordId);
       setPayload(nextPayload);
       resetWorkflowWindowState();
@@ -4700,6 +5223,7 @@ function App() {
         payloadRef.current = nextPayload;
         setPayload(nextPayload);
         setShowTranslations(false);
+        setShowConstructVerification(false);
         setShowAlignment(true);
         return raw.length;
       } catch (caught) {
@@ -4902,13 +5426,26 @@ function App() {
       if (ids.length === 0) return 0;
       const current = payloadRef.current;
       try {
-        let nextResults = current.analysisResults;
         const context = {
-          analysisAssets: current.analysisAssets,
           recordLengths: new Map(current.records.map((record) => [record.id, record.sequence.length])),
         };
-        for (const id of ids) nextResults = removeArtifactAnalysisResult(nextResults, id, context);
-        const nextPayload: LoadedPayload = { ...current, analysisResults: nextResults };
+        let workspace = {
+          analysisResults: current.analysisResults,
+          analysisAssets: current.analysisAssets,
+        };
+        const candidateAssetIds = new Set<string>();
+        for (const id of ids) {
+          workspace.analysisResults.find((result) => result.id === id)?.assetIds.forEach((assetId) => {
+            candidateAssetIds.add(assetId);
+          });
+          workspace = removeArtifactAnalysisWorkspaceResult(workspace, id, context);
+        }
+        candidateAssetIds.forEach((assetId) => {
+          const stillUsed = workspace.analysisResults.some((result) => result.assetIds.includes(assetId));
+          const stillPresent = workspace.analysisAssets.some((asset) => asset.id === assetId);
+          if (!stillUsed && stillPresent) workspace = removeArtifactAnalysisAsset(workspace, assetId, context);
+        });
+        const nextPayload: LoadedPayload = { ...current, ...workspace };
         payloadRef.current = nextPayload;
         setPayload(nextPayload);
         return ids.length;
@@ -4964,7 +5501,7 @@ function App() {
       delete window.motifClearWorkspace;
       delete window.motifHelp;
     };
-  }, [applyArtifactDatabaseRestore, clearWorkspaceData, describeRuntimePayloadSnapshot, rememberActiveSequenceScroll, removeRecords, resetRecordTransientState, resetWorkflowWindowState]);
+  }, [applyArtifactDatabaseRestore, clearWorkspaceData, describeRuntimePayloadSnapshot, rememberActiveSequenceScroll, removeRecords, resetWorkflowWindowState, resetWorkspaceViewState]);
 
   useEffect(() => {
     setSelection((current) => {
@@ -5003,6 +5540,12 @@ function App() {
       const targetRecordId = selectedRecordIdRef.current ?? recordId;
       activeEnzymeSourcesRef.current = next;
       enzymeSourcesByRecordRef.current = { ...enzymeSourcesByRecordRef.current, [targetRecordId]: next };
+      artifactStateRef.current = {
+        ...artifactStateRef.current,
+        enzymeSourcesByRecord: Object.fromEntries(
+          Object.entries(enzymeSourcesByRecordRef.current).map(([id, sourcesForRecord]) => [id, [...sourcesForRecord]]),
+        ),
+      };
       setEnzymeSourcesByRecord((current) => ({ ...current, [targetRecordId]: next }));
       unhideRestrictionSourceEnzymes(next, targetRecordId);
       describeSnapshotRef.current = describeRuntimePayloadSnapshot(payloadRef.current, targetRecordId, next);
@@ -6627,11 +7170,20 @@ function App() {
   const removeWorkspaceAnalysisResult = useCallback((resultId: string) => {
     const current = payloadRef.current;
     try {
-      const analysisResults = removeArtifactAnalysisResult(current.analysisResults, resultId, {
-        analysisAssets: current.analysisAssets,
+      const removed = current.analysisResults.find((result) => result.id === resultId);
+      const context = {
         recordLengths: new Map(current.records.map((record) => [record.id, record.sequence.length])),
+      };
+      let workspace = removeArtifactAnalysisWorkspaceResult({
+        analysisResults: current.analysisResults,
+        analysisAssets: current.analysisAssets,
+      }, resultId, context);
+      removed?.assetIds.forEach((assetId) => {
+        const stillUsed = workspace.analysisResults.some((result) => result.assetIds.includes(assetId));
+        const stillPresent = workspace.analysisAssets.some((asset) => asset.id === assetId);
+        if (!stillUsed && stillPresent) workspace = removeArtifactAnalysisAsset(workspace, assetId, context);
       });
-      const nextPayload: LoadedPayload = { ...current, analysisResults };
+      const nextPayload: LoadedPayload = { ...current, ...workspace };
       payloadRef.current = nextPayload;
       setPayload(nextPayload);
       return true;
@@ -6766,27 +7318,60 @@ function App() {
   const simulatePrimerPcr = useCallback((handoff: ClaudeSciencePrimerHandoff) => {
     const primerResult = savePrimerDesignResult(handoff);
     const current = payloadRef.current;
+    const template = current.records.find((record) => record.id === handoff.recordId);
+    if (!template || !template.active || template.type !== 'dna') {
+      throw new Error('PCR simulation requires the active DNA template used for this primer design.');
+    }
+    const simulation = simulateSelectedPrimerPair({
+      id: template.id,
+      name: template.name,
+      sequence: template.sequence,
+      type: 'dna',
+      topology: template.topology,
+      active: template.active,
+      features: template.features,
+      description: template.description,
+      organism: template.organism,
+      source: template.source,
+      group: template.group,
+      tags: template.tags,
+    }, {
+      pair: handoff.pair,
+      pairNumber: handoff.pairNumber,
+      target: handoff.target,
+      parameters: handoff.parameters,
+    });
+    const templateSha256 = sha256HexSync(template.sequence);
+    const productSha256 = sha256HexSync(simulation.product);
     const pcrResult: ArtifactAnalysisResult = {
       id: `pcr-${crypto.randomUUID()}`,
       kind: 'pcr',
       name: `${handoff.recordName} · PCR simulation`,
       status: 'complete',
-      summary: `One ${handoff.pair.productLength.toLocaleString()} bp in-silico amplicon spans the selected primer pair.`,
+      summary: `Simulated one exact ${simulation.productLength.toLocaleString()} bp amplicon, including primer tails. No sequence record was created.`,
       inputRecordIds: [handoff.recordId],
-      inputSha256s: [sha256HexSync(current.records.find((record) => record.id === handoff.recordId)?.sequence ?? '')],
+      inputSha256s: [templateSha256],
       dependsOnResultIds: [primerResult.id],
       assetIds: [],
       parameters: {
         forwardPrimer: handoff.pair.forward.fullSequence,
         reversePrimer: handoff.pair.reverse.fullSequence,
+        forwardBindingStart: simulation.forward.bindStart,
+        forwardBindingEnd: simulation.forward.bindEnd,
+        reverseBindingStart: simulation.reverse.bindStart,
+        reverseBindingEnd: simulation.reverse.bindEnd,
+        topology: template.topology,
+        productSha256,
       },
       data: {
         templateRecordId: handoff.recordId,
         primerDesignResultId: primerResult.id,
         products: [{
           id: `amplicon-${crypto.randomUUID()}`,
-          lengthBp: handoff.pair.productLength,
-          templateRange: { start: handoff.pair.forward.start, end: handoff.pair.reverse.end },
+          lengthBp: simulation.productLength,
+          ...(!simulation.wrapsOrigin ? {
+            templateRange: { start: simulation.forward.bindStart, end: simulation.reverse.bindEnd },
+          } : {}),
         }],
       },
       createdAt: new Date().toISOString(),
@@ -6794,11 +7379,28 @@ function App() {
         source: 'motif-for-claude-science-artifact',
         operation: 'pcr_simulation',
         actor: 'user',
-        engine: 'motif-primer-design',
+        engine: 'motif-pcr',
         engineVersion: '1',
-        parentIds: [primerResult.id],
+        parentIds: [template.id, primerResult.id],
+        metadata: {
+          templateSha256,
+          productSha256,
+          wrapsOrigin: simulation.wrapsOrigin,
+          recordCreated: false,
+        },
       },
     };
+    const duplicate = current.analysisResults.find((result) => (
+      result.kind === 'pcr'
+      && result.inputSha256s?.[0] === templateSha256
+      && result.dependsOnResultIds.includes(primerResult.id)
+      && result.provenance.operation === 'pcr_simulation'
+      && result.provenance.metadata?.productSha256 === productSha256
+    ));
+    if (duplicate) {
+      showWorkbenchNotice(`This exact PCR simulation is already saved as “${duplicate.name}”. No sequence record was created.`);
+      return;
+    }
     const workspace = appendArtifactAnalysisWorkspaceResult({
       analysisResults: current.analysisResults,
       analysisAssets: current.analysisAssets,
@@ -6808,8 +7410,136 @@ function App() {
     const nextPayload: LoadedPayload = { ...current, ...workspace };
     payloadRef.current = nextPayload;
     setPayload(nextPayload);
-    showWorkbenchNotice('PCR simulation saved in Results.');
+    showWorkbenchNotice('PCR simulation saved in Results only. No sequence record was created.');
   }, [savePrimerDesignResult, showWorkbenchNotice]);
+
+  const materializePrimerAmplicon = useCallback((handoff: ClaudeSciencePrimerHandoff) => {
+    const primerResult = savePrimerDesignResult(handoff);
+    const current = payloadRef.current;
+    const template = current.records.find((record) => record.id === handoff.recordId);
+    if (!template || !template.active || template.type !== 'dna') {
+      throw new Error('Amplicon creation requires the active DNA template used for this primer design.');
+    }
+    const sourceRecord: PcrMaterializationSourceRecord = {
+      id: template.id,
+      name: template.name,
+      sequence: template.sequence,
+      type: 'dna',
+      topology: template.topology,
+      active: template.active,
+      features: template.features,
+      ...(template.description ? { description: template.description } : {}),
+      ...(template.organism ? { organism: template.organism } : {}),
+      ...(template.source ? { source: template.source } : {}),
+      ...(template.group ? { group: template.group } : {}),
+      ...(template.tags ? { tags: template.tags } : {}),
+    };
+    const baseName = `${template.name.slice(0, 1_000)} · PCR amplicon`;
+    const usedNames = new Set(current.records.map((record) => record.name.trim().toLocaleLowerCase()));
+    let recordName = baseName;
+    for (let suffix = 2; usedNames.has(recordName.toLocaleLowerCase()); suffix += 1) {
+      recordName = `${baseName} ${suffix}`;
+    }
+    const createdAt = new Date().toISOString();
+    const materialized = materializePcrAmplicon({
+      sourceRecord,
+      selection: {
+        pair: handoff.pair,
+        pairNumber: handoff.pairNumber,
+        target: handoff.target,
+        parameters: handoff.parameters,
+      },
+      identity: {
+        recordId: `pcr-record-${crypto.randomUUID()}`,
+        resultId: `pcr-${crypto.randomUUID()}`,
+        productId: `amplicon-${crypto.randomUUID()}`,
+        createdAt,
+        recordName,
+      },
+      primerDesignResultId: primerResult.id,
+      ...(handoff.preparationContext ? {
+        preparation: {
+          requestSha256: handoff.preparationContext.requestSha256,
+          actionId: handoff.preparationContext.actionId,
+          actionKind: handoff.preparationContext.actionKind,
+          method: handoff.preparationContext.method,
+          orientation: handoff.preparationContext.orientation,
+        },
+      } : {}),
+    });
+
+    const duplicate = findPcrMaterializationDuplicate(current.records, materialized.materializationKey);
+    const replaceInCloningDraft = (productId: string, productName: string): boolean => (
+      Boolean(handoff.preparationContext)
+      && cloningDesignWorkspaceRef.current?.replacePreparedPart({
+        expectedRequestSha256: handoff.preparationContext?.requestSha256 ?? '',
+        actionId: handoff.preparationContext?.actionId ?? '',
+        sourceRecordId: handoff.recordId,
+        productRecordId: productId,
+        productRecordName: productName,
+      }) === true
+    );
+    if (duplicate) {
+      const reusable = current.records.find((record) => (
+        record.id === duplicate.id && record.active && record.type === 'dna'
+      ));
+      const replaced = reusable
+        ? replaceInCloningDraft(reusable.id, reusable.name)
+        : false;
+      if (replaced) {
+        setShowPrimerDesign(false);
+        setCloningPrimerRequest(null);
+        setCompletedCloningPrimerActionIds([]);
+        showWorkbenchNotice(`Reused existing amplicon “${duplicate.name}”, replaced the prepared part, and rechecked the cloning draft.`);
+      } else {
+        showWorkbenchNotice(`This exact amplicon already exists as “${duplicate.name}”. No duplicate record was created.${reusable ? '' : ' Reactivate it before using it in cloning.'}`);
+      }
+      return;
+    }
+    if (current.records.length >= MOTIF_MAX_RECORDS) {
+      throw new Error(`Creating this amplicon would exceed the ${MOTIF_MAX_RECORDS}-record artifact limit.`);
+    }
+
+    const recordInput = omitUndefinedObjectProperties(materialized.record) as ArtifactRecordInput;
+    validateRuntimeRecordInputs([recordInput], 'motifAddRecords');
+    const normalized = normalizeRecord(recordInput, current.records.length);
+    if (!normalized) throw new Error('The exact PCR product could not be normalized.');
+    if (current.records.some((record) => record.id === normalized.id)) {
+      throw new Error(`PCR product id “${normalized.id}” already exists.`);
+    }
+    if (normalized.sequence !== materialized.simulation.product) {
+      throw new Error('PCR product normalization changed the simulated sequence; nothing was saved.');
+    }
+
+    const records = [...current.records, { ...normalized, default: false }];
+    const workspace = appendArtifactAnalysisWorkspaceResult({
+      analysisResults: current.analysisResults,
+      analysisAssets: current.analysisAssets,
+    }, materialized.analysisResult, {
+      recordLengths: new Map(records.map((record) => [record.id, record.sequence.length])),
+    });
+    const replaced = replaceInCloningDraft(normalized.id, normalized.name);
+    const nextPayload: LoadedPayload = { ...current, records, ...workspace };
+    payloadRef.current = nextPayload;
+    setPayload(nextPayload);
+
+    if (replaced) {
+      setShowPrimerDesign(false);
+      setCloningPrimerRequest(null);
+      setCompletedCloningPrimerActionIds([]);
+      showWorkbenchNotice(`Created “${normalized.name}”, replaced the prepared part, and rechecked the cloning draft. The source record is unchanged.`);
+      return;
+    }
+
+    rememberActiveSequenceScroll();
+    selectedRecordIdRef.current = normalized.id;
+    setSelectedRecordId(normalized.id);
+    setSelection(null);
+    setShowPrimerDesign(false);
+    showWorkbenchNotice(handoff.preparationContext
+      ? `Created “${normalized.name}”, but the cloning draft changed and was not replaced. Review the draft before using this record.`
+      : `Created and opened “${normalized.name}”. The source record is unchanged.`);
+  }, [rememberActiveSequenceScroll, savePrimerDesignResult, showWorkbenchNotice]);
 
   const selectTranslationCodonAndReveal = useCallback((start: number, end: number, strand?: 1 | -1) => {
     selectTranslationCodon(start, end, strand);
@@ -6860,6 +7590,7 @@ function App() {
     setShowAssembly(false);
     setShowCloningDesign(false);
     setShowPrimerDesign(false);
+    setShowConstructVerification(false);
     setGelSelectedCandidateIds([`digest:${digestWorkflowResultId}`]);
     setGelWorkflowName(`${result.name} · gel`);
     renewGelDraft();
@@ -6874,6 +7605,7 @@ function App() {
     setShowGel(false);
     setShowAssembly(false);
     setShowCloningDesign(false);
+    setShowConstructVerification(false);
     setCloningPrimerRequest(null);
     setShowPrimerDesign(true);
   }, [closeOpenToolDetails, isEditable]);
@@ -6893,6 +7625,7 @@ function App() {
     setShowAssembly(false);
     setShowCloningDesign(false);
     setShowPrimerDesign(false);
+    setShowConstructVerification(false);
     const firstCandidate = gelLaneCandidates.find((candidate) => candidate.id === `record:${recordId}`)
       ?? gelLaneCandidates[0];
     setGelSelectedCandidateIds(firstCandidate ? [firstCandidate.id] : []);
@@ -6925,6 +7658,7 @@ function App() {
     setShowGel(false);
     setShowCloningDesign(false);
     setShowPrimerDesign(false);
+    setShowConstructVerification(false);
     const active = assemblyRecords.find((record) => record.id === recordId)?.id;
     const preferred = active
       ? [active, ...assemblyRecords.filter((record) => record.id !== active).map((record) => record.id)]
@@ -6940,6 +7674,7 @@ function App() {
     setShowGel(false);
     setShowAssembly(false);
     setShowPrimerDesign(false);
+    setShowConstructVerification(false);
     const active = assemblyRecords.find((record) => record.id === preferredRecordId)?.id;
     setCloningDesignInitialRecordIds(active ? [active] : []);
     setShowCloningDesign(true);
@@ -7014,6 +7749,7 @@ function App() {
     setCloningPrimerRecordIndex(0);
     setCompletedCloningPrimerActionIds([]);
     setCloningPrimerRequest(request);
+    setShowConstructVerification(false);
     setShowPrimerDesign(true);
     showWorkbenchNotice(
       request.actionIds.length > 1
@@ -7302,6 +8038,126 @@ function App() {
     showWorkbenchNotice(shouldCreateProduct ? 'Design and product saved.' : 'Assembly plan saved in Results.');
   }, [showWorkbenchNotice]);
 
+  const runConstructVerification = useCallback((request: ClaudeScienceConstructVerificationRequest) => {
+    return verifyArtifactConstruct({
+      reference: {
+        id: request.reference.id,
+        name: request.reference.name,
+        sequence: request.reference.sequence,
+        topology: request.reference.topology,
+        sha256: request.reference.sha256,
+      },
+      reads: request.reads.map((read) => ({
+        id: read.id,
+        name: read.name,
+        baseCalls: read.sangerTrace.baseCalls,
+        ...(read.sangerTrace.qualityScores && read.sangerTrace.qualityScores.length > 0
+          ? { qualityScores: read.sangerTrace.qualityScores }
+          : {}),
+        sha256: read.sha256,
+      })),
+      requiredRegions: [{
+        id: 'full-reference',
+        name: 'Full predicted construct',
+        start: 0,
+        end: request.reference.sequence.length,
+        minDepth: request.minDepth,
+        requireBothStrands: request.requireBothStrands,
+      }],
+      expectedVariants: [],
+      thresholds: {
+        minCoverageFraction: 1,
+        minDepth: request.minDepth,
+        requireBothStrands: request.requireBothStrands,
+      },
+    });
+  }, []);
+
+  const saveConstructVerification = useCallback((saved: ClaudeScienceConstructVerificationSavePayload) => {
+    const current = payloadRef.current;
+    const reference = current.records.find((record) => record.id === saved.snapshot.reference.id);
+    if (!reference || reference.type !== 'dna') {
+      throw new Error('The predicted reference is no longer available as DNA. Run verification again.');
+    }
+    const referenceSha256 = sha256HexSync(reference.sequence);
+    if (
+      referenceSha256 !== saved.snapshot.reference.sequenceSha256
+      || reference.topology !== saved.snapshot.reference.topology
+      || saved.result.reference.id !== reference.id
+      || saved.result.reference.sha256 !== referenceSha256
+      || saved.result.reference.topology !== reference.topology
+    ) {
+      throw new Error('The predicted reference changed after verification. Run verification again before saving.');
+    }
+    if (
+      saved.result.thresholds.minDepth !== saved.snapshot.minDepth
+      || saved.result.thresholds.requireBothStrands !== saved.snapshot.requireBothStrands
+    ) {
+      throw new Error('The saved acceptance criteria no longer match the reviewed run. Run verification again.');
+    }
+    if (
+      saved.result.reads.length !== saved.snapshot.reads.length
+      || saved.result.reads.some((read, index) => read.id !== saved.snapshot.reads[index]?.id)
+    ) {
+      throw new Error('The reviewed read order no longer matches the verification result. Run verification again.');
+    }
+
+    const evidenceSha256s = saved.snapshot.reads.map((snapshotRead, index) => {
+      const record = current.records.find((candidate) => candidate.id === snapshotRead.id);
+      const evidence = record ? artifactConstructTraceEvidence(record) : null;
+      const sequenceSha256 = record ? sha256HexSync(record.sequence) : null;
+      if (
+        !record
+        || record.type !== 'dna'
+        || !evidence
+        || snapshotRead.sangerEvidenceSha256 === null
+        || sequenceSha256 !== snapshotRead.sequenceSha256
+        || evidence.sha256 !== snapshotRead.sangerEvidenceSha256
+        || saved.result.reads[index]?.sha256 !== sequenceSha256
+      ) {
+        throw new Error(`Sanger evidence “${snapshotRead.id}” changed after verification. Run verification again before saving.`);
+      }
+      return evidence.sha256;
+    });
+
+    const duplicate = findDuplicateArtifactConstructVerificationResult(current.analysisResults, {
+      engine: saved.result.provenance.engine,
+      engineVersion: saved.result.provenance.engineVersion,
+      requestSha256: saved.result.provenance.requestSha256,
+    });
+    if (duplicate) throw new Error(`This exact verification is already saved as “${duplicate.name}”.`);
+
+    const createdAt = new Date().toISOString();
+    const artifacts = buildArtifactConstructVerificationArtifacts(saved.result, evidenceSha256s, {
+      resultId: `construct-verification-${crypto.randomUUID()}`,
+      assetId: `construct-verification-report-${crypto.randomUUID()}`,
+      createdAt,
+    });
+    const context = {
+      recordLengths: new Map(current.records.map((record) => [record.id, record.sequence.length])),
+    };
+    let workspace = appendArtifactAnalysisAsset({
+      analysisResults: current.analysisResults,
+      analysisAssets: current.analysisAssets,
+    }, artifacts.asset, context);
+    workspace = appendArtifactAnalysisWorkspaceResult(workspace, artifacts.result, context);
+    const nextPayload: LoadedPayload = { ...current, ...workspace };
+    payloadRef.current = nextPayload;
+    setPayload(nextPayload);
+    showWorkbenchNotice('Construct verification saved in Results with its compact evidence report.');
+  }, [showWorkbenchNotice]);
+
+  const openConstructVerificationWorkspace = useCallback(() => {
+    closeOpenToolDetails();
+    setShowTranslations(false);
+    setShowAlignment(false);
+    setShowGel(false);
+    setShowAssembly(false);
+    setShowCloningDesign(false);
+    setShowPrimerDesign(false);
+    setShowConstructVerification(true);
+  }, [closeOpenToolDetails]);
+
   const openTranslationsWindow = useCallback(() => {
     closeOpenToolDetails();
     setShowAlignment(false);
@@ -7309,6 +8165,7 @@ function App() {
     setShowAssembly(false);
     setShowCloningDesign(false);
     setShowPrimerDesign(false);
+    setShowConstructVerification(false);
     setShowTranslations(true);
   }, [closeOpenToolDetails]);
 
@@ -7321,6 +8178,7 @@ function App() {
         setShowAssembly(false);
         setShowCloningDesign(false);
         setShowPrimerDesign(false);
+        setShowConstructVerification(false);
       }
       return !current;
     });
@@ -7333,6 +8191,7 @@ function App() {
     setShowAssembly(false);
     setShowCloningDesign(false);
     setShowPrimerDesign(false);
+    setShowConstructVerification(false);
     setShowAlignment(true);
   }, [closeOpenToolDetails]);
 
@@ -9059,6 +9918,33 @@ function App() {
             </div>
           </details>
 
+          <details className="motif-cs-panel" name="motif-cs-tools" data-rail-tool="construct-verification">
+            <summary ref={constructVerificationToggleRef} className="motif-cs-panel-head" data-rail-label="V" title="Construct verification">
+              <ShieldCheck className="motif-cs-panel-icon" size={14} strokeWidth={2.2} aria-hidden="true" />
+              <span>Construct Verification</span>
+              <span className="motif-cs-chip">{constructVerificationReadCount} read{constructVerificationReadCount === 1 ? '' : 's'}</span>
+            </summary>
+            <div className="motif-cs-tool-panel-body motif-cs-cloning-launcher">
+              <RailPopoverTitle title="Construct Verification" meta="predicted vs observed" />
+              <div className="motif-cs-cloning-launcher-copy">
+                <strong>Sanger evidence review</strong>
+                <span>Compare imported trace-backed reads with a predicted DNA construct, review coverage and variants, then save a provenance-linked report.</span>
+              </div>
+              <button
+                className="motif-cs-mini-button motif-cs-mini-button-accent"
+                type="button"
+                onClick={openConstructVerificationWorkspace}
+                disabled={constructVerificationReferenceCount === 0 || constructVerificationReadCount === 0}
+                data-testid="open-construct-verification"
+              >
+                Open verification workspace
+              </button>
+              <p className="motif-cs-form-note">
+                {constructVerificationReferenceCount} predicted reference{constructVerificationReferenceCount === 1 ? '' : 's'} · {constructVerificationReadCount} eligible Sanger read{constructVerificationReadCount === 1 ? '' : 's'}{constructVerificationExcludedCount > 0 ? ` · ${constructVerificationExcludedCount} excluded by verifier limits` : ''}. Verification only runs after explicit review.
+              </p>
+            </div>
+          </details>
+
           <details className="motif-cs-panel" name="motif-cs-tools" data-rail-tool="analysis-results">
             <summary className="motif-cs-panel-head" data-rail-label="R" title="Agent and analysis results">
               <Beaker className="motif-cs-panel-icon" size={14} strokeWidth={2.2} aria-hidden="true" />
@@ -9071,6 +9957,7 @@ function App() {
                 results={payload.analysisResults}
                 assets={payload.analysisAssets}
                 recordNames={recordNamesById}
+                freshnessByResultId={analysisFreshnessByResultId}
                 onRevealRecord={revealWorkspaceRecord}
                 onRemove={removeWorkspaceAnalysisResult}
               />
@@ -9088,6 +9975,7 @@ function App() {
               <ClaudeScienceWorkflowHistoryPanel
                 results={payload.workflowResults}
                 recordNames={recordNamesById}
+                freshnessByResultId={workflowFreshnessByResultId}
                 onRevealRecord={revealWorkspaceRecord}
                 onRemove={removeWorkspaceWorkflowResult}
               />
@@ -9101,10 +9989,25 @@ function App() {
               <span className="motif-cs-chip">{payload.alignments.length ? `${payload.alignments.length} MSA` : 'MSA'}</span>
             </summary>
             <div className="motif-cs-tool-panel-body motif-cs-alignment-tool-body">
-              <RailPopoverTitle title="Alignment" meta={payload.alignments.length ? `${payload.alignments.length} in session` : 'MSA'} />
+              <RailPopoverTitle
+                title="Alignment"
+                meta={payload.alignments.length
+                  ? `${payload.alignments.length} in session${alignmentsNeedingReview.length ? ` · ${alignmentsNeedingReview.length} review` : ''}`
+                  : 'MSA'}
+              />
               <p className="motif-cs-alignment-tool-intro">
                 Compare 2–10 compatible records locally, or review aligned output from MAFFT, MUSCLE, or Clustal Omega.
               </p>
+              {representativeAlignmentFreshness ? (
+                <div className="motif-cs-alignment-freshness-summary" data-testid="alignment-freshness-summary">
+                  <ClaudeScienceFreshnessBadge
+                    evaluation={representativeAlignmentFreshness}
+                    recordNames={recordNamesById}
+                    showReason
+                  />
+                  <span>{alignmentsNeedingReview.length.toLocaleString()} alignment{alignmentsNeedingReview.length === 1 ? '' : 's'} need lineage review.</span>
+                </div>
+              ) : null}
               <button className="motif-cs-mini-button motif-cs-alignment-launch" type="button" data-testid="msa-open-button" aria-label="Open alignment workspace" onClick={openAlignmentWindow}>
                 <AlignCenter size={17} strokeWidth={2.1} aria-hidden="true" />
                 <span className="motif-cs-alignment-launch-copy">
@@ -9315,6 +10218,7 @@ function App() {
               savePrimerDesignResult(handoff);
             }}
             onSimulatePcr={simulatePrimerPcr}
+            onCreateAmplicon={materializePrimerAmplicon}
             onUseForCloning={usePrimerDesignForCloning}
           />
         </FloatingWindow>
@@ -9350,12 +10254,33 @@ function App() {
           inactive={showPrimerDesign && cloningPrimerRequest !== null}
         >
           <ClaudeScienceCloningDesignWorkspace
+            ref={cloningDesignWorkspaceRef}
             embedded
             records={cloningDesignRecords}
             initialRecordIds={cloningDesignInitialRecordIds}
             onClose={() => setShowCloningDesign(false)}
             onDesignPrimers={designCloningPreparationPrimers}
             onSave={saveCloningDesign}
+          />
+        </FloatingWindow>
+      ) : null}
+      {showConstructVerification ? (
+        <FloatingWindow
+          title="Construct Verification"
+          subtitle={`${constructVerificationReadCount} eligible Sanger read${constructVerificationReadCount === 1 ? '' : 's'}`}
+          initial={constructVerificationWin}
+          onClose={() => setShowConstructVerification(false)}
+          onCommit={setConstructVerificationWin}
+          returnFocusRef={constructVerificationToggleRef}
+          maximizable
+        >
+          <ClaudeScienceConstructVerificationWorkspace
+            embedded
+            records={constructVerificationRecords}
+            initialReferenceId={constructVerificationInitialReferenceId}
+            onVerify={runConstructVerification}
+            onSave={saveConstructVerification}
+            onClose={() => setShowConstructVerification(false)}
           />
         </FloatingWindow>
       ) : null}

--- a/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/SKILL.md
+++ b/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/SKILL.md
@@ -217,11 +217,20 @@ alignment actually produced by an external executable.
 
 Use top-level `analysisResults` and `analysisAssets` when Claude has computed
 evidence that should remain visible beside the sequences. Supported result
-kinds are `primer_design`, `pcr`, `assembly_plan`, `blast_search`,
-`structure_model`, `report`, and `table`. Results require stable ids, ISO
+kinds are `primer_design`, `pcr`, `assembly_plan`, `construct_verification`,
+`blast_search`, `structure_model`, `report`, and `table`. Results require stable ids, ISO
 timestamps, explicit provenance, input record ids, dependency ids, asset ids,
 parameters, and kind-specific `data`. Any referenced record id must match an
 explicit record id in the same workspace.
+
+For `construct_verification`, list the predicted reference first in
+`inputRecordIds`, followed by the Sanger read records in the same order as
+`data.readRecordIds`; align `inputSha256s` to that order. The compact `data`
+summary records `referenceRecordId`, state, reference/coverage counts, mapped
+read and required-region counts, variant counts, stable `reasonCodes`, and an
+optional `verificationReportAssetId`. Put bounded read, reason, and variant
+detail in that inert `application/json` asset; do not persist raw AB1 bytes or
+unbounded per-base coordinate maps in the result.
 
 Assets are UTF-8 data, never executable content. Accepted media types are
 `application/json`, `text/plain`, `text/markdown`, `text/csv`,

--- a/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/analysis-validator.mjs
+++ b/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/analysis-validator.mjs
@@ -1,5 +1,142 @@
 // Generated from src/artifacts/claude-science-analysis-results.ts. Regenerate with the documented esbuild command; do not edit by hand.
 
+// src/artifacts/claude-science-sha256.ts
+var SHA256_ROUND_CONSTANTS = new Uint32Array([
+  1116352408,
+  1899447441,
+  3049323471,
+  3921009573,
+  961987163,
+  1508970993,
+  2453635748,
+  2870763221,
+  3624381080,
+  310598401,
+  607225278,
+  1426881987,
+  1925078388,
+  2162078206,
+  2614888103,
+  3248222580,
+  3835390401,
+  4022224774,
+  264347078,
+  604807628,
+  770255983,
+  1249150122,
+  1555081692,
+  1996064986,
+  2554220882,
+  2821834349,
+  2952996808,
+  3210313671,
+  3336571891,
+  3584528711,
+  113926993,
+  338241895,
+  666307205,
+  773529912,
+  1294757372,
+  1396182291,
+  1695183700,
+  1986661051,
+  2177026350,
+  2456956037,
+  2730485921,
+  2820302411,
+  3259730800,
+  3345764771,
+  3516065817,
+  3600352804,
+  4094571909,
+  275423344,
+  430227734,
+  506948616,
+  659060556,
+  883997877,
+  958139571,
+  1322822218,
+  1537002063,
+  1747873779,
+  1955562222,
+  2024104815,
+  2227730452,
+  2361852424,
+  2428436474,
+  2756734187,
+  3204031479,
+  3329325298
+]);
+function rotateRight(value, amount) {
+  return value >>> amount | value << 32 - amount;
+}
+function sha256HexSync(value) {
+  if (typeof value !== "string") throw new TypeError("SHA-256 input must be a string.");
+  const bytes = new TextEncoder().encode(value);
+  const paddingBytes = (64 + 56 - (bytes.length + 1) % 64) % 64;
+  const padded = new Uint8Array(bytes.length + 1 + paddingBytes + 8);
+  padded.set(bytes);
+  padded[bytes.length] = 128;
+  const bitLength = bytes.length * 8;
+  const view = new DataView(padded.buffer);
+  view.setUint32(padded.length - 8, Math.floor(bitLength / 4294967296), false);
+  view.setUint32(padded.length - 4, bitLength >>> 0, false);
+  let h0 = 1779033703;
+  let h1 = 3144134277;
+  let h2 = 1013904242;
+  let h3 = 2773480762;
+  let h4 = 1359893119;
+  let h5 = 2600822924;
+  let h6 = 528734635;
+  let h7 = 1541459225;
+  const schedule = new Uint32Array(64);
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    for (let index = 0; index < 16; index += 1) {
+      schedule[index] = view.getUint32(offset + index * 4, false);
+    }
+    for (let index = 16; index < 64; index += 1) {
+      const previous15 = schedule[index - 15];
+      const previous2 = schedule[index - 2];
+      const sigma0 = rotateRight(previous15, 7) ^ rotateRight(previous15, 18) ^ previous15 >>> 3;
+      const sigma1 = rotateRight(previous2, 17) ^ rotateRight(previous2, 19) ^ previous2 >>> 10;
+      schedule[index] = schedule[index - 16] + sigma0 + schedule[index - 7] + sigma1 >>> 0;
+    }
+    let a = h0;
+    let b = h1;
+    let c = h2;
+    let d = h3;
+    let e = h4;
+    let f = h5;
+    let g = h6;
+    let h = h7;
+    for (let index = 0; index < 64; index += 1) {
+      const upperSigma1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
+      const choose = e & f ^ ~e & g;
+      const temp1 = h + upperSigma1 + choose + SHA256_ROUND_CONSTANTS[index] + schedule[index] >>> 0;
+      const upperSigma0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
+      const majority = a & b ^ a & c ^ b & c;
+      const temp2 = upperSigma0 + majority >>> 0;
+      h = g;
+      g = f;
+      f = e;
+      e = d + temp1 >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = temp1 + temp2 >>> 0;
+    }
+    h0 = h0 + a >>> 0;
+    h1 = h1 + b >>> 0;
+    h2 = h2 + c >>> 0;
+    h3 = h3 + d >>> 0;
+    h4 = h4 + e >>> 0;
+    h5 = h5 + f >>> 0;
+    h6 = h6 + g >>> 0;
+    h7 = h7 + h >>> 0;
+  }
+  return [h0, h1, h2, h3, h4, h5, h6, h7].map((word) => word.toString(16).padStart(8, "0")).join("");
+}
+
 // src/artifacts/claude-science-analysis-results.ts
 var MAX_ARTIFACT_ANALYSIS_RESULTS = 1e3;
 var MAX_ARTIFACT_ANALYSIS_ASSETS = 2e3;
@@ -21,6 +158,7 @@ var ARTIFACT_ANALYSIS_KINDS = [
   "primer_design",
   "pcr",
   "assembly_plan",
+  "construct_verification",
   "blast_search",
   "structure_model",
   "report",
@@ -198,6 +336,9 @@ function normalizeAsset(value, index, budget) {
     normalizeJsonValue(parsed, `${path}.content JSON`, budget, /* @__PURE__ */ new WeakSet(), 0);
   }
   const sha256 = value.sha256 === void 0 ? void 0 : normalizeSha256(value.sha256, `${path}.sha256`, budget);
+  if (sha256 !== void 0 && sha256 !== sha256HexSync(content)) {
+    throw new Error(`${path}.sha256 must match the exact UTF-8 content.`);
+  }
   return {
     id,
     name,
@@ -332,6 +473,95 @@ function normalizeAssemblyData(value, path, budget) {
     ...junctions === void 0 ? {} : { junctions }
   };
 }
+function normalizeConstructVerificationData(value, path, budget, context) {
+  if (!isPlainObject(value)) throw new Error(`${path} must be an object.`);
+  assertKnownKeys(value, [
+    "referenceRecordId",
+    "readRecordIds",
+    "state",
+    "referenceLength",
+    "coveredBases",
+    "coverageFraction",
+    "mappedReadCount",
+    "requiredRegionCount",
+    "passingRegionCount",
+    "observedVariantCount",
+    "expectedVariantCount",
+    "unexpectedVariantCount",
+    "missingExpectedVariantCount",
+    "reasonCodes",
+    "verificationReportAssetId"
+  ], path);
+  const referenceRecordId = normalizeId(value.referenceRecordId, `${path}.referenceRecordId`, budget);
+  const readRecordIds = normalizeStringArray(
+    value.readRecordIds,
+    `${path}.readRecordIds`,
+    MAX_ARTIFACT_ANALYSIS_RECORD_IDS - 1,
+    budget,
+    { required: true, deduplicate: true }
+  );
+  if (readRecordIds.length === 0) throw new Error(`${path}.readRecordIds must contain at least one sequencing read.`);
+  if (readRecordIds.includes(referenceRecordId)) throw new Error(`${path}.readRecordIds cannot contain the reference record.`);
+  if (context.recordLengths) {
+    if (!context.recordLengths.has(referenceRecordId)) throw new Error(`${path}.referenceRecordId does not match a workspace record.`);
+    readRecordIds.forEach((recordId, index) => {
+      if (!context.recordLengths?.has(recordId)) throw new Error(`${path}.readRecordIds[${index}] does not match a workspace record.`);
+    });
+  }
+  if (value.state !== "consistent" && value.state !== "needs_review" && value.state !== "inconsistent") {
+    throw new Error(`${path}.state must be "consistent", "needs_review", or "inconsistent".`);
+  }
+  const referenceLength = finiteNumber(value.referenceLength, `${path}.referenceLength`, { min: 1, integer: true });
+  const coveredBases = finiteNumber(value.coveredBases, `${path}.coveredBases`, { min: 0, max: referenceLength, integer: true });
+  const coverageFraction = finiteNumber(value.coverageFraction, `${path}.coverageFraction`, { min: 0, max: 1 });
+  const expectedCoverageFraction = coveredBases / referenceLength;
+  if (Math.abs(coverageFraction - expectedCoverageFraction) > 1e-6) {
+    throw new Error(`${path}.coverageFraction must agree with coveredBases / referenceLength.`);
+  }
+  const mappedReadCount = finiteNumber(value.mappedReadCount, `${path}.mappedReadCount`, {
+    min: 0,
+    max: readRecordIds.length,
+    integer: true
+  });
+  const count = (field) => finiteNumber(value[field], `${path}.${field}`, { min: 0, integer: true });
+  const requiredRegionCount = count("requiredRegionCount");
+  const passingRegionCount = count("passingRegionCount");
+  if (passingRegionCount > requiredRegionCount) {
+    throw new Error(`${path}.passingRegionCount cannot exceed requiredRegionCount.`);
+  }
+  const observedVariantCount = count("observedVariantCount");
+  const expectedVariantCount = count("expectedVariantCount");
+  const unexpectedVariantCount = count("unexpectedVariantCount");
+  const missingExpectedVariantCount = count("missingExpectedVariantCount");
+  if (unexpectedVariantCount > observedVariantCount) {
+    throw new Error(`${path}.unexpectedVariantCount cannot exceed observedVariantCount.`);
+  }
+  if (missingExpectedVariantCount > expectedVariantCount) {
+    throw new Error(`${path}.missingExpectedVariantCount cannot exceed expectedVariantCount.`);
+  }
+  const reasonCodes = normalizeTextArray(value.reasonCodes, `${path}.reasonCodes`, 500, 128, budget);
+  reasonCodes.forEach((code, index) => {
+    if (!/^[a-z][a-z0-9_]*$/.test(code)) throw new Error(`${path}.reasonCodes[${index}] must be a stable lowercase code.`);
+  });
+  const verificationReportAssetId = value.verificationReportAssetId === void 0 ? void 0 : normalizeId(value.verificationReportAssetId, `${path}.verificationReportAssetId`, budget);
+  return {
+    referenceRecordId,
+    readRecordIds,
+    state: value.state,
+    referenceLength,
+    coveredBases,
+    coverageFraction,
+    mappedReadCount,
+    requiredRegionCount,
+    passingRegionCount,
+    observedVariantCount,
+    expectedVariantCount,
+    unexpectedVariantCount,
+    missingExpectedVariantCount,
+    reasonCodes,
+    ...verificationReportAssetId === void 0 ? {} : { verificationReportAssetId }
+  };
+}
 function normalizeBlastData(value, path, budget) {
   if (!isPlainObject(value)) throw new Error(`${path} must be an object.`);
   assertKnownKeys(value, ["program", "database", "databaseVersion", "queryRecordId", "hits"], path);
@@ -445,6 +675,7 @@ function normalizeData(kind, value, path, budget, context) {
   if (kind === "primer_design") return normalizePrimerDesignData(value, path, budget, context);
   if (kind === "pcr") return normalizePcrData(value, path, budget, context);
   if (kind === "assembly_plan") return normalizeAssemblyData(value, path, budget);
+  if (kind === "construct_verification") return normalizeConstructVerificationData(value, path, budget, context);
   if (kind === "blast_search") return normalizeBlastData(value, path, budget);
   if (kind === "structure_model") return normalizeStructureData(value, path, budget);
   if (kind === "report") return normalizeReportData(value, path, budget);
@@ -494,7 +725,7 @@ function assertUniqueIds(values, path) {
     ids.add(value.id);
   }
 }
-function resultRecordIds(result) {
+function artifactAnalysisResultRecordIds(result) {
   const ids = [...result.inputRecordIds];
   if (result.kind === "primer_design") ids.push(result.data.targetRecordId);
   if (result.kind === "pcr") {
@@ -509,6 +740,9 @@ function resultRecordIds(result) {
     if (result.data.productRecordId) ids.push(result.data.productRecordId);
     result.data.junctions?.forEach((junction) => ids.push(junction.leftRecordId, junction.rightRecordId));
   }
+  if (result.kind === "construct_verification") {
+    ids.push(result.data.referenceRecordId, ...result.data.readRecordIds);
+  }
   if (result.kind === "blast_search") ids.push(result.data.queryRecordId);
   if (result.kind === "structure_model") result.data.chains.forEach((chain) => {
     if (chain.recordId) ids.push(chain.recordId);
@@ -521,6 +755,9 @@ function resultAssetIds(result) {
     if (hit.alignmentAssetId) ids.push(hit.alignmentAssetId);
   });
   if (result.kind === "structure_model") ids.push(result.data.modelAssetId);
+  if (result.kind === "construct_verification" && result.data.verificationReportAssetId) {
+    ids.push(result.data.verificationReportAssetId);
+  }
   if (result.kind === "report" && result.data.bodyAssetId) ids.push(result.data.bodyAssetId);
   return Array.from(new Set(ids));
 }
@@ -528,6 +765,1084 @@ function resultDependencyIds(result) {
   const ids = [...result.dependsOnResultIds];
   if (result.kind === "pcr" && result.data.primerDesignResultId) ids.push(result.data.primerDesignResultId);
   return Array.from(new Set(ids));
+}
+var CONSTRUCT_VERIFICATION_REPORT_SCHEMA = "motif.construct-verification-report.v1";
+var STABLE_REASON_CODE_PATTERN = /^[a-z][a-z0-9_]*$/;
+var CONSTRUCT_REPORT_READ_STATUS_SET = /* @__PURE__ */ new Set([
+  "mapped",
+  "trimmed_read_too_short",
+  "unmapped",
+  "ambiguous_mapping",
+  "low_mapping_identity",
+  "excessive_indel"
+]);
+var CONSTRUCT_REPORT_REGION_STATUS_SET = /* @__PURE__ */ new Set(["covered", "uncovered", "low_depth", "missing_strand"]);
+var CONSTRUCT_REPORT_VARIANT_TYPE_SET = /* @__PURE__ */ new Set(["substitution", "insertion", "deletion"]);
+var CONSTRUCT_REPORT_EXPECTED_VARIANT_STATUS_SET = /* @__PURE__ */ new Set([
+  "observed",
+  "low_confidence",
+  "not_observed",
+  "not_covered"
+]);
+var CONSTRUCT_REPORT_THRESHOLD_KEYS = [
+  "trimQuality",
+  "trimWindow",
+  "minTrimmedReadLength",
+  "minMappingIdentity",
+  "minMappingMargin",
+  "maxIndelFraction",
+  "minCoverageFraction",
+  "minDepth",
+  "requireBothStrands",
+  "minConsensusFraction",
+  "minVariantQuality",
+  "minVariantFraction"
+];
+var CONSTRUCT_REPORT_LIMITS = {
+  maxReferenceLength: 5e4,
+  maxReads: 96,
+  maxReadLength: 5e3,
+  maxRequiredRegions: 128,
+  maxRequiredRegionBases: 5e5,
+  maxExpectedVariants: 256,
+  maxObservedVariants: 2e3,
+  maxIndelLength: 24,
+  maxWorkUnits: 25e6
+};
+var CONSTRUCT_REPORT_REASON_LIMIT = 256;
+var CONSTRUCT_REPORT_SUPPORTING_READ_LIMIT = 8;
+var CONSTRUCT_REPORT_OBSERVED_VARIANT_LIMIT = 192;
+var CONSTRUCT_REPORT_IUPAC_CONSENSUS_PATTERN = /^[ACGTN]*$/;
+var CONSTRUCT_REPORT_CANONICAL_DNA_PATTERN = /^[ACGT]*$/;
+function reportObject(value, path) {
+  if (!isPlainObject(value)) throw new Error(`${path} must be an object.`);
+  return value;
+}
+function reportArray(value, path) {
+  if (!Array.isArray(value)) throw new Error(`${path} must be an array.`);
+  return value;
+}
+function reportString(value, path) {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${path} must be a nonempty string.`);
+  return value;
+}
+function reportSha256(value, path) {
+  const sha256 = reportString(value, path).toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(sha256)) throw new Error(`${path} must be a 64-character SHA-256 value.`);
+  return sha256;
+}
+function reportInteger(value, path) {
+  if (!Number.isInteger(value) || value < 0) throw new Error(`${path} must be a non-negative integer.`);
+  return value;
+}
+function reportSignedInteger(value, path) {
+  if (!Number.isInteger(value)) throw new Error(`${path} must be an integer.`);
+  return value;
+}
+function reportFiniteNumber(value, path) {
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${path} must be a finite number.`);
+  return value;
+}
+function reportBoolean(value, path) {
+  if (typeof value !== "boolean") throw new Error(`${path} must be a boolean.`);
+  return value;
+}
+function reportIntegerBetween(value, path, minimum, maximum) {
+  const integer = reportInteger(value, path);
+  if (integer < minimum || integer > maximum) {
+    throw new Error(`${path} must be an integer from ${minimum.toLocaleString()} through ${maximum.toLocaleString()}.`);
+  }
+  return integer;
+}
+function reportNumberBetween(value, path, minimum, maximum) {
+  const number = reportFiniteNumber(value, path);
+  if (number < minimum || number > maximum) {
+    throw new Error(`${path} must be from ${minimum} through ${maximum}.`);
+  }
+  return number;
+}
+function reportNullableNumber(value, path, minimum, maximum) {
+  if (value === null) return null;
+  const number = reportFiniteNumber(value, path);
+  if (minimum !== void 0 && number < minimum) throw new Error(`${path} must be at least ${minimum}.`);
+  if (maximum !== void 0 && number > maximum) throw new Error(`${path} must be no greater than ${maximum}.`);
+  return number;
+}
+function reportIdentityText(value, path, maximumLength) {
+  const text = reportString(value, path);
+  if (text.trim() !== text || text.length > maximumLength) {
+    throw new Error(`${path} must contain 1\u2013${maximumLength.toLocaleString()} unpadded characters.`);
+  }
+  return text;
+}
+function reportOptionalIdentityText(value, path, maximumLength) {
+  return value === void 0 ? void 0 : reportIdentityText(value, path, maximumLength);
+}
+function reportNumbersAgree(actual, expected) {
+  return Object.is(actual, expected) || Math.abs(actual - expected) <= 1e-12;
+}
+function assertReportNumber(result, field, actual, expected) {
+  if (!reportNumbersAgree(actual, expected)) reportMismatch(result, field);
+}
+function reportMismatch(result, field) {
+  throw new Error(`Analysis result "${result.id}" verification report ${field} must match the saved result.`);
+}
+function assertReportValue(result, field, actual, expected) {
+  if (!Object.is(actual, expected)) reportMismatch(result, field);
+}
+function assertReportArray(result, field, actual, expected) {
+  if (actual.length !== expected.length || actual.some((value, index) => value !== expected[index])) {
+    reportMismatch(result, field);
+  }
+}
+function assertReportThresholds(result, reportThresholds) {
+  const savedThresholds = result.parameters.thresholds;
+  if (!isPlainObject(savedThresholds)) reportMismatch(result, "thresholds");
+  const reportKeys = Object.keys(reportThresholds).sort();
+  const savedKeys = Object.keys(savedThresholds).sort();
+  const expectedKeys = [...CONSTRUCT_REPORT_THRESHOLD_KEYS].sort();
+  assertReportArray(result, "thresholds schema", reportKeys, expectedKeys);
+  assertReportArray(result, "thresholds keys", reportKeys, savedKeys);
+  reportKeys.forEach((key) => {
+    const reportValue = reportThresholds[key];
+    const savedValue = savedThresholds[key];
+    if (typeof reportValue !== "number" && typeof reportValue !== "boolean" || !Object.is(reportValue, savedValue)) {
+      reportMismatch(result, `thresholds.${key}`);
+    }
+  });
+  reportIntegerBetween(reportThresholds.trimQuality, "verification report thresholds.trimQuality", 0, 255);
+  reportIntegerBetween(reportThresholds.trimWindow, "verification report thresholds.trimWindow", 1, 100);
+  reportIntegerBetween(
+    reportThresholds.minTrimmedReadLength,
+    "verification report thresholds.minTrimmedReadLength",
+    1,
+    CONSTRUCT_REPORT_LIMITS.maxReadLength
+  );
+  reportNumberBetween(reportThresholds.minMappingIdentity, "verification report thresholds.minMappingIdentity", 0, 1);
+  reportNumberBetween(reportThresholds.minMappingMargin, "verification report thresholds.minMappingMargin", 0, 1);
+  reportNumberBetween(reportThresholds.maxIndelFraction, "verification report thresholds.maxIndelFraction", 0, 1);
+  reportNumberBetween(reportThresholds.minCoverageFraction, "verification report thresholds.minCoverageFraction", 0, 1);
+  reportIntegerBetween(reportThresholds.minDepth, "verification report thresholds.minDepth", 1, CONSTRUCT_REPORT_LIMITS.maxReads);
+  reportBoolean(reportThresholds.requireBothStrands, "verification report thresholds.requireBothStrands");
+  reportNumberBetween(reportThresholds.minConsensusFraction, "verification report thresholds.minConsensusFraction", 0, 1);
+  reportNumberBetween(reportThresholds.minVariantQuality, "verification report thresholds.minVariantQuality", 0, 255);
+  reportNumberBetween(reportThresholds.minVariantFraction, "verification report thresholds.minVariantFraction", 0, 1);
+}
+function validateConstructReportMapping(value, path, topology, referenceLength, trimmedLength, status, thresholds) {
+  const mapping = reportObject(value, path);
+  assertKnownKeys(mapping, [
+    "orientation",
+    "referenceStart",
+    "referenceEnd",
+    "wraps",
+    "referenceSpan",
+    "score",
+    "secondBestScore",
+    "mappingMargin",
+    "identity",
+    "alignedLength",
+    "matches",
+    "substitutions",
+    "insertions",
+    "deletions",
+    "indelFraction"
+  ], path);
+  if (mapping.orientation !== "forward" && mapping.orientation !== "reverse") {
+    throw new Error(`${path}.orientation must be forward or reverse.`);
+  }
+  const referenceStart = reportIntegerBetween(mapping.referenceStart, `${path}.referenceStart`, 0, referenceLength - 1);
+  const referenceEnd = reportIntegerBetween(mapping.referenceEnd, `${path}.referenceEnd`, 0, referenceLength);
+  const wraps = reportBoolean(mapping.wraps, `${path}.wraps`);
+  const referenceSpan = reportIntegerBetween(
+    mapping.referenceSpan,
+    `${path}.referenceSpan`,
+    1,
+    CONSTRUCT_REPORT_LIMITS.maxReadLength + CONSTRUCT_REPORT_LIMITS.maxIndelLength * CONSTRUCT_REPORT_LIMITS.maxReadLength
+  );
+  const score = reportSignedInteger(mapping.score, `${path}.score`);
+  const secondBestScore = mapping.secondBestScore === null ? null : reportSignedInteger(mapping.secondBestScore, `${path}.secondBestScore`);
+  const mappingMargin = reportNullableNumber(mapping.mappingMargin, `${path}.mappingMargin`, 0);
+  if (secondBestScore === null !== (mappingMargin === null)) {
+    throw new Error(`${path}.secondBestScore and mappingMargin must either both be null or both be numbers.`);
+  }
+  if (secondBestScore !== null) {
+    if (secondBestScore > score) throw new Error(`${path}.secondBestScore cannot exceed score.`);
+    const expectedMargin = (score - secondBestScore) / Math.max(1, 3 * trimmedLength);
+    if (!reportNumbersAgree(mappingMargin, expectedMargin)) {
+      throw new Error(`${path}.mappingMargin must agree with score, secondBestScore, and trimmedLength.`);
+    }
+  }
+  const alignedLength = reportIntegerBetween(
+    mapping.alignedLength,
+    `${path}.alignedLength`,
+    1,
+    trimmedLength + CONSTRUCT_REPORT_LIMITS.maxIndelLength * CONSTRUCT_REPORT_LIMITS.maxReadLength
+  );
+  const matches = reportIntegerBetween(mapping.matches, `${path}.matches`, 0, alignedLength);
+  const substitutions = reportIntegerBetween(mapping.substitutions, `${path}.substitutions`, 0, alignedLength);
+  const insertions = reportIntegerBetween(mapping.insertions, `${path}.insertions`, 0, alignedLength);
+  const deletions = reportIntegerBetween(mapping.deletions, `${path}.deletions`, 0, alignedLength);
+  if (matches + substitutions + insertions + deletions !== alignedLength) {
+    throw new Error(`${path}.alignedLength must equal matches + substitutions + insertions + deletions.`);
+  }
+  if (matches + substitutions + insertions !== trimmedLength) {
+    throw new Error(`${path} operation counts must consume exactly trimmedLength read calls.`);
+  }
+  if (matches + substitutions + deletions !== referenceSpan) {
+    throw new Error(`${path}.referenceSpan must equal matches + substitutions + deletions.`);
+  }
+  const identity = reportNumberBetween(mapping.identity, `${path}.identity`, 0, 1);
+  const indelFraction = reportNumberBetween(mapping.indelFraction, `${path}.indelFraction`, 0, 1);
+  if (!reportNumbersAgree(identity, matches / alignedLength)) {
+    throw new Error(`${path}.identity must equal matches / alignedLength.`);
+  }
+  if (!reportNumbersAgree(indelFraction, (insertions + deletions) / alignedLength)) {
+    throw new Error(`${path}.indelFraction must agree with the insertion and deletion counts.`);
+  }
+  const minimumIdentity = reportFiniteNumber(
+    thresholds.minMappingIdentity,
+    "verification report thresholds.minMappingIdentity"
+  );
+  const maximumIndelFraction = reportFiniteNumber(
+    thresholds.maxIndelFraction,
+    "verification report thresholds.maxIndelFraction"
+  );
+  const minimumMargin = reportFiniteNumber(
+    thresholds.minMappingMargin,
+    "verification report thresholds.minMappingMargin"
+  );
+  if (status === "low_mapping_identity" !== identity < minimumIdentity || (status === "mapped" || status === "ambiguous_mapping") && indelFraction > maximumIndelFraction) {
+    throw new Error(`${path} identity or indel evidence is inconsistent with status ${status}.`);
+  }
+  if (status === "excessive_indel" && indelFraction <= maximumIndelFraction && insertions + deletions <= CONSTRUCT_REPORT_LIMITS.maxIndelLength) {
+    throw new Error(`${path} cannot support excessive_indel status.`);
+  }
+  if (status === "mapped" && secondBestScore !== null) {
+    if (secondBestScore >= score || mappingMargin < minimumMargin) {
+      throw new Error(`${path} runner-up evidence is inconsistent with mapped status.`);
+    }
+  }
+  if (status === "ambiguous_mapping" && secondBestScore !== null && secondBestScore !== score && mappingMargin >= minimumMargin) {
+    throw new Error(`${path} runner-up evidence is inconsistent with ambiguous_mapping status.`);
+  }
+  if (topology === "linear") {
+    if (wraps || referenceEnd !== referenceStart + referenceSpan || referenceEnd > referenceLength) {
+      throw new Error(`${path} linear coordinates must be nonwrapping and agree with referenceSpan.`);
+    }
+  } else {
+    const expectedWraps = referenceStart + referenceSpan > referenceLength;
+    const expectedEnd = expectedWraps ? (referenceStart + referenceSpan) % referenceLength : referenceStart + referenceSpan;
+    if (wraps !== expectedWraps || referenceEnd !== expectedEnd) {
+      throw new Error(`${path} circular coordinates must agree with wraps and referenceSpan.`);
+    }
+    if (status === "mapped" && referenceSpan > referenceLength) {
+      throw new Error(`${path} mapped reads cannot traverse a circular reference position more than once.`);
+    }
+  }
+}
+function validateConstructReportRead(value, index, topology, referenceLength, thresholds) {
+  const path = `verification report reads[${index}]`;
+  const read = reportObject(value, path);
+  assertKnownKeys(read, [
+    "id",
+    "name",
+    "sha256",
+    "rawLength",
+    "qualityProvided",
+    "meanQuality",
+    "status",
+    "trim",
+    "mapping"
+  ], path);
+  const id = reportIdentityText(read.id, `${path}.id`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+  reportOptionalIdentityText(read.name, `${path}.name`, MAX_ARTIFACT_ANALYSIS_NAME_LENGTH);
+  const sha256 = reportSha256(read.sha256, `${path}.sha256`);
+  const rawLength = reportIntegerBetween(read.rawLength, `${path}.rawLength`, 1, CONSTRUCT_REPORT_LIMITS.maxReadLength);
+  const qualityProvided = reportBoolean(read.qualityProvided, `${path}.qualityProvided`);
+  const meanQuality = reportNullableNumber(read.meanQuality, `${path}.meanQuality`, 0, 255);
+  const status = reportString(read.status, `${path}.status`);
+  if (!CONSTRUCT_REPORT_READ_STATUS_SET.has(status)) throw new Error(`${path}.status is not supported.`);
+  const trim = reportObject(read.trim, `${path}.trim`);
+  assertKnownKeys(trim, [
+    "method",
+    "rawStart",
+    "rawEnd",
+    "trimmedLength",
+    "removedFromStart",
+    "removedFromEnd"
+  ], `${path}.trim`);
+  if (trim.method !== "quality_window" && trim.method !== "none_missing_quality") {
+    throw new Error(`${path}.trim.method is not supported.`);
+  }
+  const rawStart = reportIntegerBetween(trim.rawStart, `${path}.trim.rawStart`, 0, rawLength);
+  const rawEnd = reportIntegerBetween(trim.rawEnd, `${path}.trim.rawEnd`, rawStart, rawLength);
+  const trimmedLength = reportIntegerBetween(trim.trimmedLength, `${path}.trim.trimmedLength`, 0, rawLength);
+  const removedFromStart = reportIntegerBetween(trim.removedFromStart, `${path}.trim.removedFromStart`, 0, rawLength);
+  const removedFromEnd = reportIntegerBetween(trim.removedFromEnd, `${path}.trim.removedFromEnd`, 0, rawLength);
+  if (trimmedLength !== rawEnd - rawStart || removedFromStart !== rawStart || removedFromEnd !== rawLength - rawEnd) {
+    throw new Error(`${path}.trim ranges and derived lengths are inconsistent.`);
+  }
+  if (trim.method === "none_missing_quality") {
+    if (qualityProvided || rawStart !== 0 || rawEnd !== rawLength || trimmedLength !== rawLength || meanQuality !== null) {
+      throw new Error(`${path}.trim none_missing_quality must retain the full read and omit quality evidence.`);
+    }
+  } else if (!qualityProvided || trimmedLength > 0 && meanQuality === null) {
+    throw new Error(`${path}.trim quality_window must agree with qualityProvided and meanQuality.`);
+  }
+  const minimumTrimmedLength = reportInteger(
+    thresholds.minTrimmedReadLength,
+    "verification report thresholds.minTrimmedReadLength"
+  );
+  if (status === "trimmed_read_too_short" !== trimmedLength < minimumTrimmedLength) {
+    throw new Error(`${path}.trimmedLength is inconsistent with status ${status}.`);
+  }
+  const requiresMapping = status !== "trimmed_read_too_short" && status !== "unmapped";
+  if (requiresMapping !== (read.mapping !== null)) {
+    throw new Error(`${path}.mapping presence is inconsistent with status ${status}.`);
+  }
+  if (read.mapping !== null) {
+    validateConstructReportMapping(
+      read.mapping,
+      `${path}.mapping`,
+      topology,
+      referenceLength,
+      trimmedLength,
+      status,
+      thresholds
+    );
+  }
+  return { id, sha256, status, mapped: status === "mapped", qualityProvided };
+}
+function validateConstructReportRegion(value, index, topology, referenceLength, mappedReadCount) {
+  const path = `verification report coverage.requiredRegions[${index}]`;
+  const region = reportObject(value, path);
+  assertKnownKeys(region, [
+    "id",
+    "name",
+    "start",
+    "end",
+    "wraps",
+    "length",
+    "minDepth",
+    "requireBothStrands",
+    "coveredBases",
+    "basesMeetingMinDepth",
+    "coveredFraction",
+    "minimumDepth",
+    "maximumDepth",
+    "meanDepth",
+    "forwardCoveredBases",
+    "reverseCoveredBases",
+    "bothStrandsCoveredBases",
+    "status"
+  ], path);
+  const id = reportIdentityText(region.id, `${path}.id`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+  reportOptionalIdentityText(region.name, `${path}.name`, MAX_ARTIFACT_ANALYSIS_NAME_LENGTH);
+  const start = reportIntegerBetween(region.start, `${path}.start`, 0, referenceLength - 1);
+  const end = reportIntegerBetween(region.end, `${path}.end`, 0, referenceLength);
+  if (start === end) throw new Error(`${path} must span at least one reference base.`);
+  const wraps = reportBoolean(region.wraps, `${path}.wraps`);
+  const expectedWraps = start > end;
+  if (wraps !== expectedWraps || wraps && topology !== "circular") {
+    throw new Error(`${path}.wraps is inconsistent with its topology and coordinates.`);
+  }
+  const expectedLength = wraps ? referenceLength - start + end : end - start;
+  const length = reportIntegerBetween(region.length, `${path}.length`, 1, referenceLength);
+  if (length !== expectedLength) throw new Error(`${path}.length must agree with its coordinates.`);
+  const minDepth = reportIntegerBetween(
+    region.minDepth,
+    `${path}.minDepth`,
+    1,
+    CONSTRUCT_REPORT_LIMITS.maxReads
+  );
+  const requireBothStrands = reportBoolean(region.requireBothStrands, `${path}.requireBothStrands`);
+  const coveredBases = reportIntegerBetween(region.coveredBases, `${path}.coveredBases`, 0, length);
+  const basesMeetingMinDepth = reportIntegerBetween(
+    region.basesMeetingMinDepth,
+    `${path}.basesMeetingMinDepth`,
+    0,
+    coveredBases
+  );
+  const coveredFraction = reportNumberBetween(region.coveredFraction, `${path}.coveredFraction`, 0, 1);
+  if (!reportNumbersAgree(coveredFraction, basesMeetingMinDepth / length)) {
+    throw new Error(`${path}.coveredFraction must equal basesMeetingMinDepth / length.`);
+  }
+  const minimumDepth = reportIntegerBetween(region.minimumDepth, `${path}.minimumDepth`, 0, mappedReadCount);
+  const maximumDepth = reportIntegerBetween(region.maximumDepth, `${path}.maximumDepth`, minimumDepth, mappedReadCount);
+  const meanDepth = reportNumberBetween(region.meanDepth, `${path}.meanDepth`, minimumDepth, maximumDepth);
+  if (length > 0 && (meanDepth < minimumDepth || meanDepth > maximumDepth)) {
+    throw new Error(`${path}.meanDepth must lie between minimumDepth and maximumDepth.`);
+  }
+  if (coveredBases === 0 !== (maximumDepth === 0) || coveredBases === length !== minimumDepth > 0 || basesMeetingMinDepth === 0 !== maximumDepth < minDepth || basesMeetingMinDepth === length !== minimumDepth >= minDepth) {
+    throw new Error(`${path} depth extrema, thresholds, and covered-base counts are inconsistent.`);
+  }
+  const forwardCoveredBases = reportIntegerBetween(
+    region.forwardCoveredBases,
+    `${path}.forwardCoveredBases`,
+    0,
+    coveredBases
+  );
+  const reverseCoveredBases = reportIntegerBetween(
+    region.reverseCoveredBases,
+    `${path}.reverseCoveredBases`,
+    0,
+    coveredBases
+  );
+  const bothStrandsCoveredBases = reportIntegerBetween(
+    region.bothStrandsCoveredBases,
+    `${path}.bothStrandsCoveredBases`,
+    0,
+    Math.min(forwardCoveredBases, reverseCoveredBases)
+  );
+  if (bothStrandsCoveredBases !== forwardCoveredBases + reverseCoveredBases - coveredBases) {
+    throw new Error(`${path} strand coverage counts violate inclusion-exclusion.`);
+  }
+  const status = reportString(region.status, `${path}.status`);
+  if (!CONSTRUCT_REPORT_REGION_STATUS_SET.has(status)) throw new Error(`${path}.status is not supported.`);
+  const expectedStatus = coveredBases < length ? "uncovered" : basesMeetingMinDepth < length ? "low_depth" : requireBothStrands && bothStrandsCoveredBases < length ? "missing_strand" : "covered";
+  if (status !== expectedStatus) throw new Error(`${path}.status is inconsistent with its coverage evidence.`);
+  const reasonCodes = [];
+  if (coveredBases < length) {
+    reasonCodes.push("required_region_uncovered");
+  } else if (basesMeetingMinDepth < length) {
+    reasonCodes.push("required_region_low_depth");
+  }
+  if (requireBothStrands && coveredBases === length && bothStrandsCoveredBases < length) {
+    reasonCodes.push("required_region_missing_strand");
+  }
+  return { id, status, reasonCodes };
+}
+function validateConstructReportVariantAlleles(value, path, topology, referenceLength) {
+  const type = reportString(value.type, `${path}.type`);
+  if (!CONSTRUCT_REPORT_VARIANT_TYPE_SET.has(type)) throw new Error(`${path}.type is not supported.`);
+  const maximumStart = type === "insertion" && topology === "linear" ? referenceLength : referenceLength - 1;
+  const start = reportIntegerBetween(value.referenceStart, `${path}.referenceStart`, 0, maximumStart);
+  const end = reportIntegerBetween(value.referenceEnd, `${path}.referenceEnd`, 0, referenceLength);
+  if (typeof value.reference !== "string" || typeof value.alternate !== "string") {
+    throw new Error(`${path}.reference and alternate must be strings.`);
+  }
+  const reference = value.reference;
+  const alternate = value.alternate;
+  if (!CONSTRUCT_REPORT_CANONICAL_DNA_PATTERN.test(reference) || !CONSTRUCT_REPORT_CANONICAL_DNA_PATTERN.test(alternate)) {
+    throw new Error(`${path} alleles must contain canonical A/C/G/T bases only.`);
+  }
+  if (type === "substitution") {
+    if (end !== start + 1 || reference.length !== 1 || alternate.length !== 1 || reference === alternate) {
+      throw new Error(`${path} substitution alleles and coordinates are inconsistent.`);
+    }
+  } else if (type === "insertion") {
+    if (end !== start || reference !== "" || alternate.length < 1 || alternate.length > CONSTRUCT_REPORT_LIMITS.maxIndelLength) {
+      throw new Error(`${path} insertion alleles and coordinates are inconsistent.`);
+    }
+  } else if (end <= start || end - start > CONSTRUCT_REPORT_LIMITS.maxIndelLength || reference.length !== end - start || alternate !== "") {
+    throw new Error(`${path} deletion alleles and coordinates are inconsistent.`);
+  }
+  return { type, start, end, reference, alternate };
+}
+function validateConstructReportObservedVariant(value, path, topology, referenceLength, mappedReadCount, mappedReadIds, qualityMappedReadIds, thresholds) {
+  const variant = reportObject(value, path);
+  assertKnownKeys(variant, [
+    "id",
+    "type",
+    "referenceStart",
+    "referenceEnd",
+    "reference",
+    "alternate",
+    "depth",
+    "support",
+    "supportWeight",
+    "fraction",
+    "meanQuality",
+    "confidence",
+    "supportingReadIds",
+    "expectedVariantId",
+    "omittedSupportingReadIds"
+  ], path);
+  const id = reportIdentityText(variant.id, `${path}.id`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+  const alleles = validateConstructReportVariantAlleles(variant, path, topology, referenceLength);
+  const depth = reportIntegerBetween(variant.depth, `${path}.depth`, 0, mappedReadCount);
+  const support = reportIntegerBetween(variant.support, `${path}.support`, 0, depth);
+  const supportWeight = reportNumberBetween(variant.supportWeight, `${path}.supportWeight`, 0, support * 256);
+  const fraction = reportNumberBetween(variant.fraction, `${path}.fraction`, 0, 1);
+  const meanQuality = reportNullableNumber(variant.meanQuality, `${path}.meanQuality`, 0, 255);
+  if (variant.confidence !== "high" && variant.confidence !== "low") {
+    throw new Error(`${path}.confidence must be high or low.`);
+  }
+  if (variant.confidence === "high" && (meanQuality === null || meanQuality < reportFiniteNumber(thresholds.minVariantQuality, "verification report thresholds.minVariantQuality") || fraction < reportFiniteNumber(thresholds.minVariantFraction, "verification report thresholds.minVariantFraction"))) {
+    throw new Error(`${path}.confidence high is inconsistent with the saved variant thresholds.`);
+  }
+  const supportingReadIds = reportArray(variant.supportingReadIds, `${path}.supportingReadIds`).map((readId, index) => reportIdentityText(readId, `${path}.supportingReadIds[${index}]`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH));
+  if (supportingReadIds.length > CONSTRUCT_REPORT_SUPPORTING_READ_LIMIT || new Set(supportingReadIds).size !== supportingReadIds.length || supportingReadIds.some((readId) => !mappedReadIds.has(readId))) {
+    throw new Error(`${path}.supportingReadIds must be unique mapped reads within the compact-report limit.`);
+  }
+  const omittedSupportingReadIds = reportInteger(variant.omittedSupportingReadIds, `${path}.omittedSupportingReadIds`);
+  if (supportingReadIds.length + omittedSupportingReadIds !== support) {
+    throw new Error(`${path} included and omitted supporting read ids must equal support.`);
+  }
+  const canNameQualitySupport = supportingReadIds.some((readId) => qualityMappedReadIds.has(readId));
+  const canOmitQualitySupport = omittedSupportingReadIds > 0 && [...qualityMappedReadIds].some((readId) => !supportingReadIds.includes(readId));
+  if (variant.confidence === "high" && !canNameQualitySupport && !canOmitQualitySupport) {
+    throw new Error(`${path}.confidence high requires possible quality-bearing mapped-read support.`);
+  }
+  const expectedVariantId = reportOptionalIdentityText(
+    variant.expectedVariantId,
+    `${path}.expectedVariantId`,
+    MAX_ARTIFACT_ANALYSIS_ID_LENGTH
+  );
+  const signature = JSON.stringify([
+    id,
+    alleles.type,
+    alleles.start,
+    alleles.end,
+    alleles.reference,
+    alleles.alternate,
+    depth,
+    support,
+    supportWeight,
+    fraction,
+    meanQuality,
+    variant.confidence,
+    supportingReadIds,
+    expectedVariantId ?? null,
+    omittedSupportingReadIds
+  ]);
+  return {
+    id,
+    ...expectedVariantId === void 0 ? {} : { expectedVariantId },
+    confidence: variant.confidence,
+    depth,
+    alleleKey: JSON.stringify(alleles),
+    signature,
+    omittedSupportingReadIds
+  };
+}
+function validateConstructReportExpectedVariant(value, path, topology, referenceLength, qualityMappedReadCount) {
+  const variant = reportObject(value, path);
+  assertKnownKeys(variant, [
+    "id",
+    "type",
+    "referenceStart",
+    "referenceEnd",
+    "reference",
+    "alternate",
+    "status",
+    "depth",
+    "observedVariantId"
+  ], path);
+  const id = reportIdentityText(variant.id, `${path}.id`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+  const alleles = validateConstructReportVariantAlleles(variant, path, topology, referenceLength);
+  const status = reportString(variant.status, `${path}.status`);
+  if (!CONSTRUCT_REPORT_EXPECTED_VARIANT_STATUS_SET.has(status)) throw new Error(`${path}.status is not supported.`);
+  const depth = reportIntegerBetween(variant.depth, `${path}.depth`, 0, qualityMappedReadCount);
+  const observedVariantId = reportOptionalIdentityText(
+    variant.observedVariantId,
+    `${path}.observedVariantId`,
+    MAX_ARTIFACT_ANALYSIS_ID_LENGTH
+  );
+  if ((status === "observed" || status === "low_confidence") !== (observedVariantId !== void 0)) {
+    throw new Error(`${path}.observedVariantId presence is inconsistent with status ${status}.`);
+  }
+  if (status === "not_covered" && depth !== 0 || (status === "observed" || status === "not_observed") && depth === 0) {
+    throw new Error(`${path}.depth is inconsistent with status ${status}.`);
+  }
+  const signature = JSON.stringify([
+    id,
+    alleles.type,
+    alleles.start,
+    alleles.end,
+    alleles.reference,
+    alleles.alternate,
+    status,
+    depth,
+    observedVariantId ?? null
+  ]);
+  return {
+    id,
+    status,
+    ...observedVariantId === void 0 ? {} : { observedVariantId },
+    depth,
+    alleleKey: JSON.stringify(alleles),
+    signature
+  };
+}
+function validateConstructVerificationReport(result, asset) {
+  const path = `Analysis result "${result.id}" verification report`;
+  if (result.status !== "complete") throw new Error(`${path} requires a complete analysis result.`);
+  if (asset.sha256 === void 0) throw new Error(`${path} asset requires a content SHA-256.`);
+  if (asset.createdAt !== result.createdAt) throw new Error(`${path} asset and result timestamps must match.`);
+  let parsed;
+  try {
+    parsed = JSON.parse(asset.content);
+  } catch {
+    throw new Error(`${path} must contain valid JSON.`);
+  }
+  const report = reportObject(parsed, path);
+  assertKnownKeys(report, [
+    "schema",
+    "version",
+    "state",
+    "reasons",
+    "reference",
+    "thresholds",
+    "reads",
+    "coverage",
+    "consensus",
+    "variants",
+    "provenance",
+    "omitted"
+  ], path);
+  if (report.schema !== CONSTRUCT_VERIFICATION_REPORT_SCHEMA || report.version !== 1) {
+    throw new Error(`${path} must use ${CONSTRUCT_VERIFICATION_REPORT_SCHEMA} version 1.`);
+  }
+  assertReportValue(result, "state", report.state, result.data.state);
+  if (!result.assetIds.includes(asset.id)) {
+    throw new Error(`Analysis result "${result.id}" verification report asset must also appear in assetIds.`);
+  }
+  if (!result.inputSha256s || result.inputSha256s.length !== result.inputRecordIds.length) {
+    throw new Error(`Analysis result "${result.id}" with a verification report requires ordered inputSha256s.`);
+  }
+  const reference = reportObject(report.reference, `${path}.reference`);
+  assertKnownKeys(reference, ["id", "name", "length", "topology", "sha256"], `${path}.reference`);
+  assertReportValue(
+    result,
+    "reference.id",
+    reportIdentityText(reference.id, `${path}.reference.id`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH),
+    result.data.referenceRecordId
+  );
+  reportOptionalIdentityText(reference.name, `${path}.reference.name`, MAX_ARTIFACT_ANALYSIS_NAME_LENGTH);
+  const referenceLength = reportIntegerBetween(
+    reference.length,
+    `${path}.reference.length`,
+    1,
+    CONSTRUCT_REPORT_LIMITS.maxReferenceLength
+  );
+  assertReportValue(result, "reference.length", referenceLength, result.data.referenceLength);
+  const topology = reportString(reference.topology, `${path}.reference.topology`);
+  if (topology !== "linear" && topology !== "circular") throw new Error(`${path}.reference.topology is not supported.`);
+  assertReportValue(result, "reference.topology", topology, result.parameters.topology);
+  const referenceSha256 = reportSha256(reference.sha256, `${path}.reference.sha256`);
+  assertReportValue(result, "reference.sha256", referenceSha256, result.inputSha256s[0]);
+  const reportThresholds = reportObject(report.thresholds, `${path}.thresholds`);
+  assertReportThresholds(result, reportThresholds);
+  const reads = reportArray(report.reads, `${path}.reads`);
+  const omitted = reportObject(report.omitted, `${path}.omitted`);
+  assertKnownKeys(omitted, [
+    "reasons",
+    "reads",
+    "requiredRegions",
+    "observedVariants",
+    "expectedVariants",
+    "unexpectedVariants",
+    "missingExpectedVariants",
+    "supportingReadIds"
+  ], `${path}.omitted`);
+  if (reportInteger(omitted.reads, `${path}.omitted.reads`) !== 0) {
+    throw new Error(`${path} cannot omit read identities.`);
+  }
+  if (reads.length !== result.data.readRecordIds.length) reportMismatch(result, "reads length");
+  const validatedReads = reads.map((value, index) => validateConstructReportRead(
+    value,
+    index,
+    topology,
+    referenceLength,
+    reportThresholds
+  ));
+  const reportReadIds = validatedReads.map((read) => read.id);
+  const reportReadSha256s = validatedReads.map((read) => read.sha256);
+  const mappedReadCount = validatedReads.filter((read) => read.mapped).length;
+  if (new Set(reportReadIds).size !== reportReadIds.length) throw new Error(`${path}.reads cannot contain duplicate ids.`);
+  assertReportArray(result, "reads[].id", reportReadIds, result.data.readRecordIds);
+  assertReportArray(result, "reads[].sha256", reportReadSha256s, result.inputSha256s.slice(1));
+  assertReportValue(result, "mapped read count", mappedReadCount, result.data.mappedReadCount);
+  const provenance = reportObject(report.provenance, `${path}.provenance`);
+  assertKnownKeys(provenance, [
+    "engine",
+    "engineVersion",
+    "referenceSha256",
+    "readSha256s",
+    "requestSha256",
+    "workUnits",
+    "limits"
+  ], `${path}.provenance`);
+  const engine = reportString(provenance.engine, `${path}.provenance.engine`);
+  const engineVersion = reportString(provenance.engineVersion, `${path}.provenance.engineVersion`);
+  if (engine !== "motif-construct-verification" || engineVersion !== "1") {
+    throw new Error(`${path}.provenance must identify motif-construct-verification version 1.`);
+  }
+  assertReportValue(result, "provenance.engine", engine, result.provenance.engine);
+  assertReportValue(result, "provenance.engineVersion", engineVersion, result.provenance.engineVersion);
+  assertReportValue(result, "provenance.referenceSha256", reportSha256(provenance.referenceSha256, `${path}.provenance.referenceSha256`), referenceSha256);
+  const provenanceReadSha256s = reportArray(provenance.readSha256s, `${path}.provenance.readSha256s`).map((sha256, index) => reportSha256(sha256, `${path}.provenance.readSha256s[${index}]`));
+  assertReportArray(result, "provenance.readSha256s", provenanceReadSha256s, reportReadSha256s);
+  const requestSha256 = reportSha256(provenance.requestSha256, `${path}.provenance.requestSha256`);
+  const savedRequestSha256 = reportSha256(result.parameters.requestSha256, `Analysis result "${result.id}" parameters.requestSha256`);
+  assertReportValue(result, "provenance.requestSha256", requestSha256, savedRequestSha256);
+  const readEvidence = reportObject(
+    result.parameters.readEvidence,
+    `Analysis result "${result.id}" parameters.readEvidence`
+  );
+  assertKnownKeys(readEvidence, ["schema", "sha256s"], `Analysis result "${result.id}" parameters.readEvidence`);
+  if (readEvidence.schema !== "motif.construct-read-evidence.v1") {
+    throw new Error(`Analysis result "${result.id}" parameters.readEvidence schema is not supported.`);
+  }
+  const readEvidenceSha256s = reportArray(
+    readEvidence.sha256s,
+    `Analysis result "${result.id}" parameters.readEvidence.sha256s`
+  ).map((sha256, index) => reportSha256(
+    sha256,
+    `Analysis result "${result.id}" parameters.readEvidence.sha256s[${index}]`
+  ));
+  if (readEvidenceSha256s.length !== reportReadIds.length) {
+    throw new Error(`Analysis result "${result.id}" parameters.readEvidence must align one-to-one with reads.`);
+  }
+  const workUnits = reportIntegerBetween(
+    provenance.workUnits,
+    `${path}.provenance.workUnits`,
+    0,
+    CONSTRUCT_REPORT_LIMITS.maxWorkUnits
+  );
+  const provenanceLimits = reportObject(provenance.limits, `${path}.provenance.limits`);
+  assertKnownKeys(provenanceLimits, Object.keys(CONSTRUCT_REPORT_LIMITS), `${path}.provenance.limits`);
+  assertReportArray(
+    result,
+    "provenance.limits keys",
+    Object.keys(provenanceLimits).sort(),
+    Object.keys(CONSTRUCT_REPORT_LIMITS).sort()
+  );
+  Object.entries(CONSTRUCT_REPORT_LIMITS).forEach(([key, expected2]) => {
+    assertReportValue(
+      result,
+      `provenance.limits.${key}`,
+      reportInteger(provenanceLimits[key], `${path}.provenance.limits.${key}`),
+      expected2
+    );
+  });
+  const validateSavedProvenance = (saved, savedPath) => {
+    if (saved.source !== "motif-for-claude-science-artifact" || saved.operation !== "construct_verification" || saved.actor !== "user" || saved.engine !== engine || saved.engineVersion !== engineVersion) {
+      throw new Error(`${savedPath} must identify the Motif construct-verification engine and user action.`);
+    }
+    if (saved.parentIds === void 0) throw new Error(`${savedPath}.parentIds is required.`);
+    assertReportArray(result, `${savedPath}.parentIds`, saved.parentIds, result.inputRecordIds);
+    const metadata = reportObject(saved.metadata, `${savedPath}.metadata`);
+    assertKnownKeys(metadata, ["requestSha256", "workUnits"], `${savedPath}.metadata`);
+    assertReportValue(
+      result,
+      `${savedPath}.metadata.requestSha256`,
+      reportSha256(metadata.requestSha256, `${savedPath}.metadata.requestSha256`),
+      requestSha256
+    );
+    assertReportValue(
+      result,
+      `${savedPath}.metadata.workUnits`,
+      reportIntegerBetween(metadata.workUnits, `${savedPath}.metadata.workUnits`, 0, CONSTRUCT_REPORT_LIMITS.maxWorkUnits),
+      workUnits
+    );
+  };
+  validateSavedProvenance(result.provenance, `Analysis result "${result.id}" provenance`);
+  validateSavedProvenance(asset.provenance, `Analysis asset "${asset.id}" provenance`);
+  const consensus = reportObject(report.consensus, `${path}.consensus`);
+  assertKnownKeys(consensus, ["sequence"], `${path}.consensus`);
+  if (typeof consensus.sequence !== "string" || !CONSTRUCT_REPORT_IUPAC_CONSENSUS_PATTERN.test(consensus.sequence) || consensus.sequence.length > referenceLength + result.data.observedVariantCount * CONSTRUCT_REPORT_LIMITS.maxIndelLength) {
+    throw new Error(`${path}.consensus.sequence must be bounded A/C/G/T/N evidence.`);
+  }
+  const coverage = reportObject(report.coverage, `${path}.coverage`);
+  assertKnownKeys(coverage, [
+    "coveredBasesAtAnyDepth",
+    "basesMeetingMinDepth",
+    "coverageFraction",
+    "minimumDepth",
+    "maximumDepth",
+    "meanDepth",
+    "requiredRegions"
+  ], `${path}.coverage`);
+  const coveredBasesAtAnyDepth = reportIntegerBetween(
+    coverage.coveredBasesAtAnyDepth,
+    `${path}.coverage.coveredBasesAtAnyDepth`,
+    0,
+    referenceLength
+  );
+  const basesMeetingMinDepth = reportIntegerBetween(
+    coverage.basesMeetingMinDepth,
+    `${path}.coverage.basesMeetingMinDepth`,
+    0,
+    coveredBasesAtAnyDepth
+  );
+  assertReportValue(
+    result,
+    "coverage.basesMeetingMinDepth",
+    basesMeetingMinDepth,
+    result.data.coveredBases
+  );
+  const coverageFraction = reportNumberBetween(
+    coverage.coverageFraction,
+    `${path}.coverage.coverageFraction`,
+    0,
+    1
+  );
+  assertReportNumber(result, "coverage.coverageFraction", coverageFraction, result.data.coverageFraction);
+  assertReportNumber(result, "coverage.coverageFraction formula", coverageFraction, basesMeetingMinDepth / referenceLength);
+  const minimumDepth = reportIntegerBetween(
+    coverage.minimumDepth,
+    `${path}.coverage.minimumDepth`,
+    0,
+    mappedReadCount
+  );
+  const maximumDepth = reportIntegerBetween(
+    coverage.maximumDepth,
+    `${path}.coverage.maximumDepth`,
+    minimumDepth,
+    mappedReadCount
+  );
+  reportNumberBetween(coverage.meanDepth, `${path}.coverage.meanDepth`, minimumDepth, maximumDepth);
+  const globalMinDepth = reportInteger(
+    reportThresholds.minDepth,
+    `${path}.thresholds.minDepth`
+  );
+  if (coveredBasesAtAnyDepth === 0 !== (maximumDepth === 0) || coveredBasesAtAnyDepth === referenceLength !== minimumDepth > 0 || basesMeetingMinDepth === 0 !== maximumDepth < globalMinDepth || basesMeetingMinDepth === referenceLength !== minimumDepth >= globalMinDepth) {
+    throw new Error(`${path}.coverage depth extrema, thresholds, and covered-base counts are inconsistent.`);
+  }
+  const requiredRegions = reportArray(coverage.requiredRegions, `${path}.coverage.requiredRegions`);
+  const omittedRequiredRegions = reportInteger(omitted.requiredRegions, `${path}.omitted.requiredRegions`);
+  assertReportValue(result, "required region count", requiredRegions.length + omittedRequiredRegions, result.data.requiredRegionCount);
+  if (omittedRequiredRegions !== 0) throw new Error(`${path} cannot omit required-region acceptance states.`);
+  if (requiredRegions.length > CONSTRUCT_REPORT_LIMITS.maxRequiredRegions) {
+    throw new Error(`${path}.coverage.requiredRegions exceeds the v1 limit.`);
+  }
+  const validatedRegions = requiredRegions.map((value, index) => validateConstructReportRegion(
+    value,
+    index,
+    topology,
+    referenceLength,
+    mappedReadCount
+  ));
+  if (new Set(validatedRegions.map((region) => region.id)).size !== validatedRegions.length) {
+    throw new Error(`${path}.coverage.requiredRegions cannot contain duplicate ids.`);
+  }
+  const passingRegionCount = validatedRegions.filter((region) => region.status === "covered").length;
+  assertReportValue(result, "passing region count", passingRegionCount, result.data.passingRegionCount);
+  const variants = reportObject(report.variants, `${path}.variants`);
+  assertKnownKeys(variants, ["observed", "expected", "unexpected", "missingExpected"], `${path}.variants`);
+  const observedValues = reportArray(variants.observed, `${path}.variants.observed`);
+  const expectedValues = reportArray(variants.expected, `${path}.variants.expected`);
+  const unexpectedValues = reportArray(variants.unexpected, `${path}.variants.unexpected`);
+  const missingExpectedValues = reportArray(variants.missingExpected, `${path}.variants.missingExpected`);
+  const omittedObservedVariants = reportInteger(omitted.observedVariants, `${path}.omitted.observedVariants`);
+  const omittedUnexpectedVariants = reportInteger(omitted.unexpectedVariants, `${path}.omitted.unexpectedVariants`);
+  const omittedExpectedVariants = reportInteger(omitted.expectedVariants, `${path}.omitted.expectedVariants`);
+  const omittedMissingExpectedVariants = reportInteger(
+    omitted.missingExpectedVariants,
+    `${path}.omitted.missingExpectedVariants`
+  );
+  const assertCompactCount = (field, displayed, omittedCount, total, displayLimit) => {
+    assertReportValue(result, `variants.${field} displayed count`, displayed, Math.min(total, displayLimit));
+    assertReportValue(result, `variants.${field} omitted count`, omittedCount, Math.max(0, total - displayLimit));
+  };
+  assertCompactCount(
+    "observed",
+    observedValues.length,
+    omittedObservedVariants,
+    result.data.observedVariantCount,
+    CONSTRUCT_REPORT_OBSERVED_VARIANT_LIMIT
+  );
+  assertCompactCount(
+    "unexpected",
+    unexpectedValues.length,
+    omittedUnexpectedVariants,
+    result.data.unexpectedVariantCount,
+    CONSTRUCT_REPORT_OBSERVED_VARIANT_LIMIT
+  );
+  assertCompactCount(
+    "expected",
+    expectedValues.length,
+    omittedExpectedVariants,
+    result.data.expectedVariantCount,
+    CONSTRUCT_REPORT_LIMITS.maxExpectedVariants
+  );
+  assertCompactCount(
+    "missingExpected",
+    missingExpectedValues.length,
+    omittedMissingExpectedVariants,
+    result.data.missingExpectedVariantCount,
+    CONSTRUCT_REPORT_LIMITS.maxExpectedVariants
+  );
+  if (observedValues.length > CONSTRUCT_REPORT_OBSERVED_VARIANT_LIMIT || unexpectedValues.length > CONSTRUCT_REPORT_OBSERVED_VARIANT_LIMIT || expectedValues.length > CONSTRUCT_REPORT_LIMITS.maxExpectedVariants || missingExpectedValues.length > CONSTRUCT_REPORT_LIMITS.maxExpectedVariants) {
+    throw new Error(`${path}.variants exceeds the v1 limits.`);
+  }
+  const knownReadIds = new Set(reportReadIds);
+  const mappedReadIds = new Set(validatedReads.filter((read) => read.mapped).map((read) => read.id));
+  const qualityMappedReadIds = new Set(validatedReads.filter((read) => read.mapped && read.qualityProvided).map((read) => read.id));
+  const observed = observedValues.map((value, index) => validateConstructReportObservedVariant(
+    value,
+    `${path}.variants.observed[${index}]`,
+    topology,
+    referenceLength,
+    mappedReadCount,
+    mappedReadIds,
+    qualityMappedReadIds,
+    reportThresholds
+  ));
+  const unexpected = unexpectedValues.map((value, index) => validateConstructReportObservedVariant(
+    value,
+    `${path}.variants.unexpected[${index}]`,
+    topology,
+    referenceLength,
+    mappedReadCount,
+    mappedReadIds,
+    qualityMappedReadIds,
+    reportThresholds
+  ));
+  const expected = expectedValues.map((value, index) => validateConstructReportExpectedVariant(
+    value,
+    `${path}.variants.expected[${index}]`,
+    topology,
+    referenceLength,
+    qualityMappedReadIds.size
+  ));
+  const missingExpected = missingExpectedValues.map((value, index) => validateConstructReportExpectedVariant(
+    value,
+    `${path}.variants.missingExpected[${index}]`,
+    topology,
+    referenceLength,
+    qualityMappedReadIds.size
+  ));
+  const assertUniqueVariantIds = (entries, field) => {
+    if (new Set(entries.map((entry) => entry.id)).size !== entries.length) {
+      throw new Error(`${path}.variants.${field} cannot contain duplicate ids.`);
+    }
+  };
+  assertUniqueVariantIds(observed, "observed");
+  assertUniqueVariantIds(expected, "expected");
+  assertUniqueVariantIds(unexpected, "unexpected");
+  assertUniqueVariantIds(missingExpected, "missingExpected");
+  const observedById = new Map(observed.map((variant) => [variant.id, variant]));
+  const expectedById = new Map(expected.map((variant) => [variant.id, variant]));
+  observed.forEach((variant) => {
+    if (variant.expectedVariantId === void 0) return;
+    const linked = expectedById.get(variant.expectedVariantId);
+    if (!linked || linked.observedVariantId !== variant.id || linked.alleleKey !== variant.alleleKey || linked.depth > variant.depth) {
+      throw new Error(`${path}.variants observed/expected cross-links are inconsistent.`);
+    }
+  });
+  expected.forEach((variant) => {
+    if (variant.observedVariantId === void 0) return;
+    const linked = observedById.get(variant.observedVariantId);
+    if (linked !== void 0 && (linked.expectedVariantId !== variant.id || linked.alleleKey !== variant.alleleKey || variant.depth > linked.depth || (variant.status === "observed" ? linked.confidence !== "high" : linked.confidence !== "low"))) {
+      throw new Error(`${path}.variants expected/observed cross-links are inconsistent.`);
+    }
+    if (linked === void 0 && omittedObservedVariants === 0) {
+      throw new Error(`${path}.variants expected/observed cross-links are inconsistent.`);
+    }
+  });
+  const unexpectedById = new Map(unexpected.map((variant) => [variant.id, variant]));
+  observed.filter((variant) => variant.expectedVariantId === void 0).forEach((variant) => {
+    const matching = unexpectedById.get(variant.id);
+    if (!matching || matching.signature !== variant.signature) {
+      throw new Error(`${path}.variants.unexpected must retain every visible unexpected observed variant.`);
+    }
+  });
+  unexpected.forEach((variant) => {
+    if (variant.expectedVariantId !== void 0) {
+      throw new Error(`${path}.variants.unexpected cannot contain an expected variant link.`);
+    }
+    const matching = observedById.get(variant.id);
+    if (matching !== void 0 && matching.signature !== variant.signature) {
+      throw new Error(`${path}.variants.unexpected must exactly match observed evidence.`);
+    }
+    if (matching === void 0 && omittedObservedVariants === 0) {
+      throw new Error(`${path}.variants.unexpected references absent observed evidence.`);
+    }
+  });
+  const expectedMissingSignatures = expected.filter((variant) => variant.status !== "observed").map((variant) => variant.signature);
+  assertReportArray(
+    result,
+    "variants.missingExpected subset",
+    missingExpected.map((variant) => variant.signature),
+    expectedMissingSignatures
+  );
+  const expectedSupportingOmissions = [...observed, ...unexpected].reduce((total, variant) => total + variant.omittedSupportingReadIds, 0);
+  const reportedSupportingOmissions = reportInteger(
+    omitted.supportingReadIds,
+    `${path}.omitted.supportingReadIds`
+  );
+  if (omittedObservedVariants === 0 && omittedUnexpectedVariants === 0 && reportedSupportingOmissions !== expectedSupportingOmissions || reportedSupportingOmissions < expectedSupportingOmissions) {
+    throw new Error(`${path}.omitted.supportingReadIds is inconsistent with compact variant evidence.`);
+  }
+  const requiredReasonCodes = /* @__PURE__ */ new Set();
+  if (mappedReadCount === 0) requiredReasonCodes.add("no_usable_reads");
+  validatedReads.forEach((read) => {
+    if (!read.qualityProvided) requiredReasonCodes.add("missing_quality");
+    if (read.status === "trimmed_read_too_short") requiredReasonCodes.add("trimmed_read_too_short");
+    else if (read.status === "unmapped") requiredReasonCodes.add("unmapped_read");
+    else if (read.status !== "mapped") requiredReasonCodes.add(read.status);
+  });
+  if (coverageFraction < reportFiniteNumber(reportThresholds.minCoverageFraction, `${path}.thresholds.minCoverageFraction`)) requiredReasonCodes.add("partial_reference_coverage");
+  validatedRegions.forEach((region) => {
+    region.reasonCodes.forEach((code) => requiredReasonCodes.add(code));
+  });
+  observed.forEach((variant) => {
+    if (variant.confidence === "low") requiredReasonCodes.add("low_confidence_variant");
+  });
+  const visibleHighConfidenceUnexpected = unexpected.some((variant) => variant.confidence === "high");
+  if (visibleHighConfidenceUnexpected) requiredReasonCodes.add("unexpected_variant");
+  expected.forEach((variant) => {
+    if (variant.status === "not_covered") requiredReasonCodes.add("expected_variant_not_covered");
+    else if (variant.status === "not_observed") requiredReasonCodes.add("expected_variant_not_observed");
+  });
+  requiredReasonCodes.forEach((code) => {
+    if (!result.data.reasonCodes.includes(code)) {
+      throw new Error(`${path} is missing required reason code ${code}.`);
+    }
+  });
+  const visibleInconsistency = visibleHighConfidenceUnexpected || expected.some((variant) => variant.status === "not_observed");
+  if (visibleInconsistency && result.data.state !== "inconsistent") {
+    throw new Error(`${path}.state must be inconsistent for visible contradictory variant evidence.`);
+  }
+  if (requiredReasonCodes.size > 0 && result.data.state === "consistent") {
+    throw new Error(`${path}.state cannot be consistent while review or inconsistent evidence is present.`);
+  }
+  const reasons = reportArray(report.reasons, `${path}.reasons`);
+  if (reasons.length > CONSTRUCT_REPORT_REASON_LIMIT) throw new Error(`${path}.reasons exceeds the v1 limit.`);
+  const reportReasonCodes = [];
+  const seenReasonCodes = /* @__PURE__ */ new Set();
+  let hasReviewReason = false;
+  let hasInconsistentReason = false;
+  const knownRegionIds = new Set(validatedRegions.map((region) => region.id));
+  const knownVariantIds = new Set([...observed, ...expected].map((variant) => variant.id));
+  reasons.forEach((value, index) => {
+    const reason = reportObject(value, `${path}.reasons[${index}]`);
+    assertKnownKeys(reason, ["code", "severity", "message", "readId", "regionId", "variantId"], `${path}.reasons[${index}]`);
+    const code = reportIdentityText(reason.code, `${path}.reasons[${index}].code`, 128);
+    if (!STABLE_REASON_CODE_PATTERN.test(code)) throw new Error(`${path}.reasons[${index}].code is not stable.`);
+    if (reason.severity !== "review" && reason.severity !== "inconsistent") {
+      throw new Error(`${path}.reasons[${index}].severity is not supported.`);
+    }
+    if (reason.severity === "review") hasReviewReason = true;
+    else hasInconsistentReason = true;
+    if (typeof reason.message !== "string" || reason.message.length > 512) {
+      throw new Error(`${path}.reasons[${index}].message must be a string no longer than 512 characters.`);
+    }
+    const readId = reportOptionalIdentityText(reason.readId, `${path}.reasons[${index}].readId`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+    const regionId = reportOptionalIdentityText(reason.regionId, `${path}.reasons[${index}].regionId`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+    const variantId = reportOptionalIdentityText(reason.variantId, `${path}.reasons[${index}].variantId`, MAX_ARTIFACT_ANALYSIS_ID_LENGTH);
+    if (readId !== void 0 && !knownReadIds.has(readId)) throw new Error(`${path}.reasons[${index}].readId is unknown.`);
+    if (regionId !== void 0 && !knownRegionIds.has(regionId)) throw new Error(`${path}.reasons[${index}].regionId is unknown.`);
+    if (variantId !== void 0 && !knownVariantIds.has(variantId) && omittedObservedVariants === 0 && omittedUnexpectedVariants === 0) throw new Error(`${path}.reasons[${index}].variantId is unknown.`);
+    if (!seenReasonCodes.has(code)) {
+      seenReasonCodes.add(code);
+      reportReasonCodes.push(code);
+    }
+  });
+  assertReportArray(result, "reason code prefix", reportReasonCodes, result.data.reasonCodes.slice(0, reportReasonCodes.length));
+  const omittedReasons = reportInteger(omitted.reasons, `${path}.omitted.reasons`);
+  if (reasons.length < CONSTRUCT_REPORT_REASON_LIMIT && omittedReasons !== 0) {
+    throw new Error(`${path}.omitted.reasons cannot be nonzero below the report limit.`);
+  }
+  if (omittedReasons === 0) {
+    assertReportArray(result, "reason codes", reportReasonCodes, result.data.reasonCodes);
+  }
+  if (result.data.state === "consistent" && (hasReviewReason || hasInconsistentReason || omittedReasons > 0) || result.data.state === "needs_review" && (hasInconsistentReason || !hasReviewReason && omittedReasons === 0) || result.data.state === "inconsistent" && !hasInconsistentReason && omittedReasons === 0) {
+    throw new Error(`${path}.state is inconsistent with its reason severities.`);
+  }
 }
 function validateDependencies(workspace, context) {
   const resultIds = new Set(workspace.analysisResults.map((result) => result.id));
@@ -541,9 +1856,22 @@ function validateDependencies(workspace, context) {
       if (!assetIds.has(assetId)) throw new Error(`Analysis result "${result.id}" references missing asset "${assetId}".`);
     });
     if (context.recordLengths) {
-      resultRecordIds(result).forEach((recordId) => {
+      artifactAnalysisResultRecordIds(result).forEach((recordId) => {
         if (!context.recordLengths?.has(recordId)) throw new Error(`Analysis result "${result.id}" references missing record "${recordId}".`);
       });
+    }
+    if (result.kind === "construct_verification") {
+      const expectedInputRecordIds = [result.data.referenceRecordId, ...result.data.readRecordIds];
+      if (result.inputRecordIds.length !== expectedInputRecordIds.length || result.inputRecordIds.some((recordId, index) => recordId !== expectedInputRecordIds[index])) {
+        throw new Error(`Analysis result "${result.id}" inputRecordIds must list the construct reference first, followed by readRecordIds in saved order.`);
+      }
+      if (result.data.verificationReportAssetId) {
+        const reportAsset = workspace.analysisAssets.find((candidate) => candidate.id === result.data.verificationReportAssetId);
+        if (reportAsset && reportAsset.mediaType !== "application/json") {
+          throw new Error(`Analysis result "${result.id}" verification report asset must use application/json.`);
+        }
+        if (reportAsset) validateConstructVerificationReport(result, reportAsset);
+      }
     }
     if (result.kind === "structure_model") {
       const asset = workspace.analysisAssets.find((candidate) => candidate.id === result.data.modelAssetId);
@@ -618,7 +1946,7 @@ function getArtifactAnalysisAssetDependents(value, assetId) {
 }
 function getArtifactAnalysisRecordDependents(value, recordId) {
   const workspace = normalizeArtifactAnalysisWorkspace(value);
-  return workspace.analysisResults.filter((result) => resultRecordIds(result).includes(recordId)).map((result) => result.id);
+  return workspace.analysisResults.filter((result) => artifactAnalysisResultRecordIds(result).includes(recordId)).map((result) => result.id);
 }
 function removeArtifactAnalysisWorkspaceResult(value, resultId, context = {}) {
   const workspace = normalizeArtifactAnalysisWorkspace(value, context);
@@ -681,7 +2009,7 @@ function removeArtifactAnalysisResultCascade(value, resultId, options = {}, cont
 }
 function removeArtifactAnalysisResultsForRecord(value, recordId, options = {}) {
   const workspace = normalizeArtifactAnalysisWorkspace(value);
-  const directIds = workspace.analysisResults.filter((result) => resultRecordIds(result).includes(recordId)).map((result) => result.id);
+  const directIds = workspace.analysisResults.filter((result) => artifactAnalysisResultRecordIds(result).includes(recordId)).map((result) => result.id);
   if (directIds.length === 0) return workspace;
   const removedIds = collectResultCascade(workspace.analysisResults, directIds);
   const keptResults = workspace.analysisResults.filter((result) => !removedIds.has(result.id));
@@ -712,6 +2040,7 @@ export {
   appendArtifactAnalysisAsset,
   appendArtifactAnalysisResult,
   appendArtifactAnalysisWorkspaceResult,
+  artifactAnalysisResultRecordIds,
   cloneArtifactAnalysisWorkspace,
   getArtifactAnalysisAssetDependents,
   getArtifactAnalysisRecordDependents,

--- a/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/create-artifact.mjs
+++ b/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/create-artifact.mjs
@@ -19,6 +19,7 @@ import {
   MAX_ARTIFACT_ANALYSIS_TOTAL_ASSET_BYTES,
   normalizeArtifactAnalysisWorkspace,
 } from './analysis-validator.mjs';
+import { normalizeArtifactWorkspaceEnvelope } from './workspace-validator.mjs';
 
 const scriptPath = fileURLToPath(import.meta.url);
 const skillDirectory = resolve(dirname(scriptPath), '..');
@@ -38,6 +39,7 @@ export const MAX_TAGS_PER_RECORD = 100;
 export const MAX_SHORT_TEXT_LENGTH = 1_024;
 export const MAX_DESCRIPTION_LENGTH = 16_384;
 export const MAX_TAG_LENGTH = 256;
+export const MAX_OVERHANG_LENGTH = 64;
 export const MAX_RAW_SEQUENCE_CHARACTERS = 1_000_000;
 export const MAX_METADATA_JSON_DEPTH = 16;
 export const MAX_METADATA_JSON_NODES = 10_000;
@@ -72,6 +74,10 @@ const FEATURE_TYPES = new Set([
 const SAFE_FEATURE_COLOR = /^(?:#[0-9a-f]{3,8}|(?:rgb|hsl)a?\([\d\s.,%+\-/]+\)|[a-z]+)$/i;
 const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 const ALIGNMENT_MODES = new Set(['browser', 'local-command', 'imported']);
+const SUPPORTED_INVENTORY_SCHEMAS = new Set([
+  'motif.claude-science.inventory.v1',
+  'motif.claude-science.inventory.v2',
+]);
 
 function isPlainObject(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
@@ -143,6 +149,53 @@ function validateOptionalString(object, field, path, maxLength = MAX_SHORT_TEXT_
   }
   if (typeof object[field] === 'string' && object[field].length > maxLength) {
     throw new Error(`${path}.${field} cannot exceed ${maxLength.toLocaleString()} characters`);
+  }
+}
+
+function normalizedRecordType(value, sequence) {
+  if (['dna', 'rna', 'protein', 'misc', 'unknown', 'mixed'].includes(value)) return value;
+  const normalized = typeof sequence === 'string' ? sequence.toUpperCase().replace(/[^A-Z*]/g, '') : '';
+  if (normalized.includes('*')) return 'protein';
+  if (/^[ACGTUNRYSWKMBDHV]+$/.test(normalized)) {
+    return normalized.includes('U') && !normalized.includes('T') ? 'rna' : 'dna';
+  }
+  return 'protein';
+}
+
+function validateRecordOverhangs(record, path, recordType) {
+  for (const field of ['overhang5', 'overhang3']) {
+    const value = record[field];
+    if (value === undefined) continue;
+    if (typeof value !== 'string') throw new Error(`${path}.${field} must be a DNA string when provided`);
+    if (value.length > MAX_OVERHANG_LENGTH) {
+      throw new Error(`${path}.${field} cannot exceed ${MAX_OVERHANG_LENGTH.toLocaleString()} bases`);
+    }
+    if (!/^[ACGTRYSWKMBDHVN]*$/.test(value.toUpperCase().replace(/\s+/g, ''))) {
+      throw new Error(`${path}.${field} must contain DNA IUPAC bases only`);
+    }
+    if (recordType !== 'dna') throw new Error(`${path}.${field} is valid on DNA records only`);
+  }
+  for (const [sequenceField, typeField] of [
+    ['overhang5', 'overhang5Type'],
+    ['overhang3', 'overhang3Type'],
+  ]) {
+    const type = record[typeField];
+    if (type === undefined) continue;
+    if (!['blunt', '5prime', '3prime'].includes(type)) {
+      throw new Error(`${path}.${typeField} must be blunt, 5prime, or 3prime`);
+    }
+    if (recordType !== 'dna') throw new Error(`${path}.${typeField} is valid on DNA records only`);
+    const sequence = record[sequenceField];
+    if (typeof sequence !== 'string') {
+      throw new Error(`${path}.${typeField} requires a matching ${sequenceField} string`);
+    }
+    const compact = sequence.replace(/\s+/g, '');
+    if (type === 'blunt' && compact.length > 0) {
+      throw new Error(`${path}.${typeField} cannot be blunt when ${sequenceField} contains a sticky sequence`);
+    }
+    if (type !== 'blunt' && compact.length === 0) {
+      throw new Error(`${path}.${typeField} must be blunt when ${sequenceField} is empty`);
+    }
   }
 }
 
@@ -400,8 +453,36 @@ function isValidSequence(sequence, sequenceTypeHint) {
     && looksLikeImplicitProteinSequence(sequence);
 }
 
-function normalizedSequenceLength(sequence) {
-  return typeof sequence === 'string' ? sequence.toUpperCase().replace(/[^A-Z*]/g, '').length : 0;
+function normalizedSequenceLength(sequence, sequenceTypeHint) {
+  if (typeof sequence !== 'string') return 0;
+  const normalized = sequence.toUpperCase().replace(/[^A-Z*]/g, '');
+  return sequenceTypeHint === 'dna' || sequenceTypeHint === 'rna'
+    ? normalized.replace(/\*/g, '').length
+    : normalized.length;
+}
+
+function normalizedRecordIdText(value) {
+  if (typeof value !== 'string') return null;
+  const normalized = Array.from(value).filter((character) => {
+    const code = character.charCodeAt(0);
+    return code === 9 || code === 10 || code === 13 || (code >= 32 && code !== 127);
+  }).join('').trim();
+  return normalized || null;
+}
+
+function uniqueRuntimeRecordId(base, usedIds) {
+  if (!usedIds.has(base)) {
+    usedIds.add(base);
+    return base;
+  }
+  for (let suffix = 2; suffix < 100_000; suffix += 1) {
+    const candidate = `${base}-${suffix}`;
+    if (!usedIds.has(candidate)) {
+      usedIds.add(candidate);
+      return candidate;
+    }
+  }
+  throw new Error(`Payload record id ${base} has too many collisions`);
 }
 
 function payloadRecords(payload) {
@@ -409,6 +490,7 @@ function payloadRecords(payload) {
   if (Array.isArray(payload.entries)) return payload.entries;
   if (Array.isArray(payload.vectors)) return payload.vectors;
   if (payload.record && typeof payload.record === 'object' && !Array.isArray(payload.record)) return [payload.record];
+  if (typeof payload.seq === 'string' || typeof payload.sequence === 'string') return [payload];
   return [];
 }
 
@@ -423,6 +505,13 @@ function omitTraceArraysForGenericJsonValidation(payload) {
     };
   };
   const projected = { ...payload };
+  const hasRecordContainer = ['records', 'entries', 'vectors', 'record'].some((field) => (
+    Object.prototype.hasOwnProperty.call(projected, field)
+  ));
+  if (!hasRecordContainer
+    && (typeof projected.seq === 'string' || typeof projected.sequence === 'string')) {
+    return stripRecord(projected);
+  }
   for (const field of ['records', 'entries', 'vectors']) {
     if (Array.isArray(projected[field])) projected[field] = projected[field].map(stripRecord);
   }
@@ -648,16 +737,36 @@ function validateAlignments(payload) {
   });
 }
 
-function validateAnalysisCollections(payload) {
+function activeExplicitRecordLengths(payload) {
   const records = payloadRecords(payload);
-  const hasAnalysisResults = Array.isArray(payload.analysisResults) && payload.analysisResults.length > 0;
   const recordLengths = new Map();
+  const explicitIds = new Set();
+  const usedIds = new Set();
   records.forEach((record, index) => {
-    if (!isPlainObject(record) || typeof record.id !== 'string' || !record.id.trim()) return;
-    const id = record.id.trim();
-    if (hasAnalysisResults && recordLengths.has(id)) throw new Error(`Payload records contain duplicate id ${id}`);
-    recordLengths.set(id, normalizedSequenceLength(record.seq ?? record.sequence));
+    if (!isPlainObject(record)) return;
+    const explicitId = normalizedRecordIdText(record.id);
+    if (explicitId && explicitIds.has(explicitId)) throw new Error(`Payload records contain duplicate id ${explicitId}`);
+    if (explicitId) explicitIds.add(explicitId);
+    const id = uniqueRuntimeRecordId(
+      explicitId ?? normalizedRecordIdText(record.name) ?? `record-${index + 1}`,
+      usedIds,
+    );
+    if (record.active === false) return;
+    recordLengths.set(id, normalizedSequenceLength(record.seq ?? record.sequence, record.molecule ?? record.type));
   });
+  return recordLengths;
+}
+
+function validateWorkspaceEnvelope(payload, recordLengths) {
+  try {
+    normalizeArtifactWorkspaceEnvelope(payload, recordLengths);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Payload workspace is invalid: ${detail}`);
+  }
+}
+
+function validateAnalysisCollections(payload, recordLengths) {
   try {
     normalizeArtifactAnalysisWorkspace({
       analysisResults: payload.analysisResults ?? [],
@@ -682,8 +791,24 @@ export function validatePayload(payload) {
   if ('record' in payload && (!payload.record || typeof payload.record !== 'object' || Array.isArray(payload.record))) {
     throw new Error('Payload record must be an object');
   }
+  const recordContainers = ['records', 'entries', 'vectors', 'record'].filter((field) => field in payload);
+  const isBareRecord = recordContainers.length === 0
+    && (typeof payload.seq === 'string' || typeof payload.sequence === 'string');
+  const hasWorkspaceSidecar = ['alignment', 'alignments', 'notes', 'workflowResults', 'analysisResults', 'analysisAssets', 'artifactState']
+    .some((field) => field in payload);
+  if (recordContainers.length === 0 && !isBareRecord && !hasWorkspaceSidecar) {
+    throw new Error('Payload must contain records, a bare sequence record, or a supported workspace sidecar');
+  }
+  if (recordContainers.length > 1) {
+    throw new Error(`Payload has ambiguous record containers: ${recordContainers.join(', ')}`);
+  }
   for (const field of ['schema', 'selectedRecordId', 'selectedName', 'defaultMotif', 'motif']) {
     validateOptionalString(payload, field, 'Payload');
+  }
+  if (typeof payload.schema === 'string'
+    && payload.schema.startsWith('motif.claude-science.inventory.')
+    && !SUPPORTED_INVENTORY_SCHEMAS.has(payload.schema)) {
+    throw new Error(`Unsupported Motif inventory schema: ${payload.schema}`);
   }
   if (payload.selectedIndex !== undefined && !Number.isInteger(payload.selectedIndex)) {
     throw new Error('Payload.selectedIndex must be an integer when provided');
@@ -721,7 +846,7 @@ export function validatePayload(payload) {
     if (!isValidSequence(sequence, type)) {
       throw new Error(`Payload record ${index + 1} does not contain a valid DNA, RNA, or sequence-like protein value`);
     }
-    const length = normalizedSequenceLength(sequence);
+    const length = normalizedSequenceLength(sequence, type);
     if (length > MAX_RECORD_LENGTH) {
       throw new Error(`${recordPath} contains ${length.toLocaleString()} residues; the artifact supports at most ${MAX_RECORD_LENGTH.toLocaleString()} per record`);
     }
@@ -734,6 +859,7 @@ export function validatePayload(payload) {
     if (record.topology !== undefined && !['linear', 'circular'].includes(record.topology)) {
       throw new Error(`${recordPath}.topology must be linear or circular`);
     }
+    validateRecordOverhangs(record, recordPath, normalizedRecordType(type, sequence));
     for (const field of ['id', 'name', 'description', 'organism', 'source', 'group', 'project', 'folder', 'collection', 'dateAdded']) {
       validateOptionalString(
         record,
@@ -781,16 +907,21 @@ export function validatePayload(payload) {
         record.sangerTrace,
         `${recordPath}.sangerTrace`,
         sequence,
-        type,
+        normalizedRecordType(type, sequence),
       );
       if (totalSangerTraceSamples > MAX_SANGER_TRACE_SAMPLES_PER_WORKSPACE) {
         throw new Error(`Payload chromatograms cannot contain more than ${MAX_SANGER_TRACE_SAMPLES_PER_WORKSPACE.toLocaleString()} channel sample entries in total`);
       }
     }
   });
+  if (records.length > 0 && records.every((record) => record.active === false)) {
+    throw new Error('A non-empty payload must contain at least one active record');
+  }
 
+  const recordLengths = activeExplicitRecordLengths(payload);
   validateAlignments(payload);
-  validateAnalysisCollections(payload);
+  validateWorkspaceEnvelope(payload, recordLengths);
+  validateAnalysisCollections(payload, recordLengths);
 
   // Trace arrays have their own stricter cardinality/range validation above.
   // Exclude those already-bounded numeric leaves from the generic metadata node

--- a/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/workspace-validator.mjs
+++ b/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/workspace-validator.mjs
@@ -1,0 +1,612 @@
+// Generated from src/artifacts/claude-science-workspace-envelope.ts. Regenerate with the documented esbuild command; do not edit by hand.
+
+// src/artifacts/claude-science-session.ts
+var MAX_ARTIFACT_DATABASE_JSON_CHARACTERS = 128 * 1024 * 1024;
+var MAX_CUSTOM_ENZYMES = 100;
+var MAX_HIDDEN_ENZYMES_PER_RECORD = 512;
+var MAX_TRANSLATION_LAYERS_PER_RECORD = 200;
+var MAX_TRANSLATION_LAYER_TEXT_LENGTH = 160;
+var MAX_MOTIF_LENGTH = 256;
+var MAX_CUSTOM_ENZYME_NAME_LENGTH = 64;
+var MAX_CUSTOM_ENZYME_RECOGNITION_LENGTH = 64;
+var MAX_HIDDEN_FEATURE_TRANSLATIONS_PER_RECORD = 2e3;
+var VALID_SOURCE_IDS = /* @__PURE__ */ new Set([
+  "common",
+  "all",
+  "favorites",
+  "golden-gate-type-iis",
+  "common-mcs",
+  "classic-6-cutter",
+  "diagnostic-screening"
+]);
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function requiredString(value, path, maxLength = MAX_TRANSLATION_LAYER_TEXT_LENGTH) {
+  if (typeof value !== "string" || !value.trim() || value.length > maxLength) {
+    throw new Error(`${path} must be a non-empty string no longer than ${maxLength} characters.`);
+  }
+  return value.trim();
+}
+function requiredInteger(value, path) {
+  if (!Number.isInteger(value)) throw new Error(`${path} must be an integer.`);
+  return Number(value);
+}
+function uniqueId(base, used, maxLength = MAX_TRANSLATION_LAYER_TEXT_LENGTH) {
+  let candidate = base;
+  let suffix = 2;
+  while (used.has(candidate)) {
+    const suffixText = `-${suffix}`;
+    candidate = `${base.slice(0, Math.max(0, maxLength - suffixText.length))}${suffixText}`;
+    suffix += 1;
+  }
+  used.add(candidate);
+  return candidate;
+}
+function normalizeCustomEnzymes(value) {
+  if (value === void 0) return [];
+  if (!Array.isArray(value)) throw new Error("artifactState.customEnzymes must be an array.");
+  if (value.length > MAX_CUSTOM_ENZYMES) {
+    throw new Error(`artifactState.customEnzymes cannot contain more than ${MAX_CUSTOM_ENZYMES} entries.`);
+  }
+  const byName = /* @__PURE__ */ new Map();
+  value.forEach((raw, index) => {
+    const path = `artifactState.customEnzymes[${index}]`;
+    if (!isObject(raw)) throw new Error(`${path} must be an object.`);
+    const name = requiredString(raw.name, `${path}.name`, MAX_CUSTOM_ENZYME_NAME_LENGTH);
+    const recognitionSequence = requiredString(
+      raw.recognitionSequence,
+      `${path}.recognitionSequence`,
+      MAX_CUSTOM_ENZYME_RECOGNITION_LENGTH
+    ).toUpperCase();
+    if (!/^[ACGTRYSWKMBDHVN]+$/.test(recognitionSequence)) {
+      throw new Error(`${path}.recognitionSequence must contain only IUPAC DNA symbols.`);
+    }
+    const cutOffset = requiredInteger(raw.cutOffset, `${path}.cutOffset`);
+    const complementCutOffset = requiredInteger(raw.complementCutOffset, `${path}.complementCutOffset`);
+    if (Math.abs(cutOffset) > 100 || Math.abs(complementCutOffset) > 100) {
+      throw new Error(`${path} cut offsets must be between -100 and 100.`);
+    }
+    if (raw.overhang !== "blunt" && raw.overhang !== "5prime" && raw.overhang !== "3prime") {
+      throw new Error(`${path}.overhang must be "blunt", "5prime", or "3prime".`);
+    }
+    byName.set(name.toLowerCase(), { name, recognitionSequence, cutOffset, complementCutOffset, overhang: raw.overhang });
+  });
+  return Array.from(byName.values());
+}
+function normalizeTranslationLayers(value, recordLengths) {
+  if (value === void 0) return {};
+  if (!isObject(value)) throw new Error("artifactState.translationLayersByRecord must be an object.");
+  const result = {};
+  for (const [recordId, rawLayers] of Object.entries(value)) {
+    const sequenceLength = recordLengths.get(recordId);
+    if (sequenceLength === void 0) continue;
+    if (!Array.isArray(rawLayers)) {
+      throw new Error(`artifactState.translationLayersByRecord.${recordId} must be an array.`);
+    }
+    if (rawLayers.length > MAX_TRANSLATION_LAYERS_PER_RECORD) {
+      throw new Error(`Record ${recordId} cannot restore more than ${MAX_TRANSLATION_LAYERS_PER_RECORD} translation layers.`);
+    }
+    const usedIds = /* @__PURE__ */ new Set();
+    result[recordId] = rawLayers.map((raw, index) => {
+      const path = `artifactState.translationLayersByRecord.${recordId}[${index}]`;
+      if (!isObject(raw)) throw new Error(`${path} must be an object.`);
+      const baseId = requiredString(raw.id, `${path}.id`);
+      const label = requiredString(raw.label, `${path}.label`);
+      const start = requiredInteger(raw.start, `${path}.start`);
+      const end = requiredInteger(raw.end, `${path}.end`);
+      if (start < 0 || end <= start || end > sequenceLength) {
+        throw new Error(`${path} must use a valid 0-based [start,end) range within ${sequenceLength} residues.`);
+      }
+      const strand = raw.strand === -1 ? -1 : raw.strand === 1 ? 1 : null;
+      if (strand === null) throw new Error(`${path}.strand must be 1 or -1.`);
+      const frame = raw.frame === 0 || raw.frame === 1 || raw.frame === 2 ? raw.frame : null;
+      if (frame === null) throw new Error(`${path}.frame must be 0, 1, or 2.`);
+      const color = raw.color === void 0 ? void 0 : requiredString(raw.color, `${path}.color`, 32);
+      if (color && !/^#[0-9a-f]{6}$/i.test(color)) throw new Error(`${path}.color must be a 6-digit hex color.`);
+      return { id: uniqueId(baseId, usedIds), label, start, end, strand, frame, source: "layer", color };
+    });
+  }
+  return result;
+}
+function normalizeStringArraysByRecord(value, path, recordLengths, maxEntries) {
+  if (value === void 0) return {};
+  if (!isObject(value)) throw new Error(`${path} must be an object.`);
+  const result = {};
+  for (const [recordId, rawValues] of Object.entries(value)) {
+    if (!recordLengths.has(recordId)) continue;
+    if (!Array.isArray(rawValues) || rawValues.some((item) => typeof item !== "string")) {
+      throw new Error(`${path}.${recordId} must be a string array.`);
+    }
+    if (maxEntries !== void 0 && rawValues.length > maxEntries) {
+      throw new Error(`${path}.${recordId} cannot contain more than ${maxEntries} entries.`);
+    }
+    result[recordId] = Array.from(new Set(rawValues.map((item) => item.trim()).filter(Boolean)));
+  }
+  return result;
+}
+function normalizeRestrictionSources(value, recordLengths) {
+  const raw = normalizeStringArraysByRecord(value, "artifactState.enzymeSourcesByRecord", recordLengths);
+  const result = {};
+  for (const [recordId, sources] of Object.entries(raw)) {
+    const validated = sources.filter((source) => VALID_SOURCE_IDS.has(source));
+    if (validated.length !== sources.length) throw new Error(`artifactState.enzymeSourcesByRecord.${recordId} contains an unknown source.`);
+    result[recordId] = validated;
+  }
+  return result;
+}
+function normalizeBooleanByRecord(value, path, recordLengths) {
+  if (value === void 0) return {};
+  if (!isObject(value)) throw new Error(`${path} must be an object.`);
+  const result = {};
+  for (const [recordId, rawValue] of Object.entries(value)) {
+    if (!recordLengths.has(recordId)) continue;
+    if (typeof rawValue !== "boolean") throw new Error(`${path}.${recordId} must be a boolean.`);
+    result[recordId] = rawValue;
+  }
+  return result;
+}
+function normalizeMotifs(value, recordLengths) {
+  if (value === void 0) return {};
+  if (!isObject(value)) throw new Error("artifactState.motifsByRecord must be an object.");
+  const result = {};
+  for (const [recordId, rawValue] of Object.entries(value)) {
+    if (!recordLengths.has(recordId)) continue;
+    if (typeof rawValue !== "string" || rawValue.length > MAX_MOTIF_LENGTH) {
+      throw new Error(
+        `artifactState.motifsByRecord.${recordId} must be a string no longer than ${MAX_MOTIF_LENGTH} characters.`
+      );
+    }
+    result[recordId] = rawValue;
+  }
+  return result;
+}
+function normalizeArtifactDurableState(value, recordLengths) {
+  if (value === void 0) {
+    return {
+      customEnzymes: [],
+      translationLayersByRecord: {},
+      enzymeSourcesByRecord: {},
+      hiddenEnzymesByRecord: {},
+      hiddenFeatureTranslationsByRecord: {},
+      restrictionLabelsByRecord: {},
+      motifsByRecord: {}
+    };
+  }
+  if (!isObject(value)) throw new Error("artifactState must be an object.");
+  return {
+    customEnzymes: normalizeCustomEnzymes(value.customEnzymes),
+    translationLayersByRecord: normalizeTranslationLayers(value.translationLayersByRecord, recordLengths),
+    enzymeSourcesByRecord: normalizeRestrictionSources(value.enzymeSourcesByRecord, recordLengths),
+    hiddenEnzymesByRecord: normalizeStringArraysByRecord(
+      value.hiddenEnzymesByRecord,
+      "artifactState.hiddenEnzymesByRecord",
+      recordLengths,
+      MAX_HIDDEN_ENZYMES_PER_RECORD
+    ),
+    hiddenFeatureTranslationsByRecord: normalizeStringArraysByRecord(
+      value.hiddenFeatureTranslationsByRecord,
+      "artifactState.hiddenFeatureTranslationsByRecord",
+      recordLengths,
+      MAX_HIDDEN_FEATURE_TRANSLATIONS_PER_RECORD
+    ),
+    restrictionLabelsByRecord: normalizeBooleanByRecord(
+      value.restrictionLabelsByRecord,
+      "artifactState.restrictionLabelsByRecord",
+      recordLengths
+    ),
+    motifsByRecord: normalizeMotifs(value.motifsByRecord, recordLengths)
+  };
+}
+
+// src/artifacts/claude-science-workspace-collections.ts
+var MAX_ARTIFACT_NOTES = 1e3;
+var MAX_ARTIFACT_WORKFLOW_RESULTS = 1e3;
+var MAX_ARTIFACT_NOTE_BODY_LENGTH = 65536;
+var MAX_ARTIFACT_NOTE_TITLE_LENGTH = 256;
+var MAX_ARTIFACT_NOTE_TAGS = 50;
+var MAX_ARTIFACT_TAG_LENGTH = 128;
+var MAX_ARTIFACT_ID_LENGTH = 160;
+var MAX_ARTIFACT_WORKFLOW_NAME_LENGTH = 256;
+var MAX_ARTIFACT_WORKFLOW_RECORD_IDS = 250;
+var MAX_ARTIFACT_PROVENANCE_PARENT_IDS = 250;
+var MAX_ARTIFACT_PROVENANCE_TEXT_LENGTH = 256;
+var MAX_ARTIFACT_STRUCTURED_DEPTH = 12;
+var MAX_ARTIFACT_STRUCTURED_NODES = 5e4;
+var MAX_ARTIFACT_STRUCTURED_ENTRIES = 1e4;
+var MAX_ARTIFACT_STRUCTURED_KEY_LENGTH = 256;
+var MAX_ARTIFACT_STRUCTURED_STRING_LENGTH = 16384;
+var MAX_ARTIFACT_COLLECTION_TEXT_CHARACTERS = 8388608;
+var UNSAFE_OBJECT_KEYS = /* @__PURE__ */ new Set(["__proto__", "constructor", "prototype"]);
+var WORKFLOW_KINDS = /* @__PURE__ */ new Set(["digest", "gel", "golden_gate", "ligation"]);
+function isPlainObject(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+function consumeText(value, path, budget) {
+  budget.textCharacters += value.length;
+  if (budget.textCharacters > MAX_ARTIFACT_COLLECTION_TEXT_CHARACTERS) {
+    throw new Error(
+      `${path} makes workspace notes and workflow data exceed the maximum of ${MAX_ARTIFACT_COLLECTION_TEXT_CHARACTERS.toLocaleString()} text characters.`
+    );
+  }
+}
+function boundedString(value, path, maxLength, budget, options = {}) {
+  if (typeof value !== "string") throw new Error(`${path} must be a string.`);
+  const normalized = options.trim === false ? value.replace(/\r\n?/g, "\n") : value.trim();
+  if (!options.allowBlank && !normalized.trim()) throw new Error(`${path} must not be blank.`);
+  if (normalized.length > maxLength) {
+    throw new Error(`${path} cannot exceed ${maxLength.toLocaleString()} characters.`);
+  }
+  consumeText(normalized, path, budget);
+  return normalized;
+}
+function normalizeId(value, path, budget) {
+  return boundedString(value, path, MAX_ARTIFACT_ID_LENGTH, budget);
+}
+function normalizeTimestamp(value, path, budget) {
+  const raw = boundedString(value, path, 64, budget);
+  if (!/^\d{4}-\d{2}-\d{2}T/.test(raw)) {
+    throw new Error(`${path} must be an ISO 8601 date-time.`);
+  }
+  const milliseconds = Date.parse(raw);
+  if (!Number.isFinite(milliseconds)) throw new Error(`${path} must be a valid ISO 8601 date-time.`);
+  return new Date(milliseconds).toISOString();
+}
+function normalizeStringArray(value, path, maxEntries, maxLength, budget, options = {}) {
+  if (value === void 0 && !options.required) return [];
+  if (!Array.isArray(value)) throw new Error(`${path} must be an array.`);
+  if (value.length > maxEntries) {
+    throw new Error(`${path} cannot contain more than ${maxEntries.toLocaleString()} entries.`);
+  }
+  const normalized = value.map((item, index) => boundedString(
+    item,
+    `${path}[${index}]`,
+    maxLength,
+    budget
+  ));
+  return options.deduplicate ? Array.from(new Set(normalized)) : normalized;
+}
+function normalizeJsonValue(value, path, budget, ancestors, depth) {
+  budget.nodes += 1;
+  if (budget.nodes > MAX_ARTIFACT_STRUCTURED_NODES) {
+    throw new Error(`${path} exceeds the maximum of ${MAX_ARTIFACT_STRUCTURED_NODES.toLocaleString()} structured-data nodes.`);
+  }
+  if (depth > MAX_ARTIFACT_STRUCTURED_DEPTH) {
+    throw new Error(`${path} exceeds the maximum structured-data depth of ${MAX_ARTIFACT_STRUCTURED_DEPTH}.`);
+  }
+  if (value === null || typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    if (value.length > MAX_ARTIFACT_STRUCTURED_STRING_LENGTH) {
+      throw new Error(`${path} cannot exceed ${MAX_ARTIFACT_STRUCTURED_STRING_LENGTH.toLocaleString()} characters.`);
+    }
+    consumeText(value, path, budget);
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error(`${path} must not contain NaN or Infinity.`);
+    return value;
+  }
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`${path} must contain JSON-compatible values only.`);
+  }
+  if (ancestors.has(value)) throw new Error(`${path} must not contain circular references.`);
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      if (value.length > MAX_ARTIFACT_STRUCTURED_ENTRIES) {
+        throw new Error(`${path} cannot contain more than ${MAX_ARTIFACT_STRUCTURED_ENTRIES.toLocaleString()} entries.`);
+      }
+      return value.map((item, index) => normalizeJsonValue(
+        item,
+        `${path}[${index}]`,
+        budget,
+        ancestors,
+        depth + 1
+      ));
+    }
+    if (!isPlainObject(value)) throw new Error(`${path} must contain plain JSON objects only.`);
+    const entries = Object.entries(value);
+    if (entries.length > MAX_ARTIFACT_STRUCTURED_ENTRIES) {
+      throw new Error(`${path} cannot contain more than ${MAX_ARTIFACT_STRUCTURED_ENTRIES.toLocaleString()} properties.`);
+    }
+    const normalized = {};
+    for (const [key, item] of entries) {
+      if (UNSAFE_OBJECT_KEYS.has(key)) throw new Error(`${path}.${key} is not an allowed object key.`);
+      if (!key || key.length > MAX_ARTIFACT_STRUCTURED_KEY_LENGTH) {
+        throw new Error(`${path} contains an empty or overlong object key.`);
+      }
+      consumeText(key, `${path}.${key}`, budget);
+      normalized[key] = normalizeJsonValue(item, `${path}.${key}`, budget, ancestors, depth + 1);
+    }
+    return normalized;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+function normalizeJsonObject(value, path, budget) {
+  if (!isPlainObject(value)) throw new Error(`${path} must be a plain JSON object.`);
+  return normalizeJsonValue(value, path, budget, /* @__PURE__ */ new WeakSet(), 0);
+}
+function normalizeProvenance(value, path, budget, required) {
+  if (value === void 0) {
+    if (required) throw new Error(`${path} is required.`);
+    return void 0;
+  }
+  if (!isPlainObject(value)) throw new Error(`${path} must be an object.`);
+  const source = boundedString(value.source, `${path}.source`, MAX_ARTIFACT_PROVENANCE_TEXT_LENGTH, budget);
+  const optionalText = (field) => value[field] === void 0 ? void 0 : boundedString(value[field], `${path}.${field}`, MAX_ARTIFACT_PROVENANCE_TEXT_LENGTH, budget);
+  const operation = optionalText("operation");
+  const actor = optionalText("actor");
+  const engine = optionalText("engine");
+  const engineVersion = optionalText("engineVersion");
+  const parentIds = value.parentIds === void 0 ? void 0 : normalizeStringArray(
+    value.parentIds,
+    `${path}.parentIds`,
+    MAX_ARTIFACT_PROVENANCE_PARENT_IDS,
+    MAX_ARTIFACT_ID_LENGTH,
+    budget
+  );
+  const metadata = value.metadata === void 0 ? void 0 : normalizeJsonObject(value.metadata, `${path}.metadata`, budget);
+  return {
+    source,
+    ...operation === void 0 ? {} : { operation },
+    ...actor === void 0 ? {} : { actor },
+    ...engine === void 0 ? {} : { engine },
+    ...engineVersion === void 0 ? {} : { engineVersion },
+    ...parentIds === void 0 ? {} : { parentIds },
+    ...metadata === void 0 ? {} : { metadata }
+  };
+}
+function normalizeNote(value, index, context, budget) {
+  const path = `notes[${index}]`;
+  if (!isPlainObject(value)) throw new Error(`${path} must be an object.`);
+  const id = normalizeId(value.id, `${path}.id`, budget);
+  const title = value.title === void 0 ? void 0 : boundedString(value.title, `${path}.title`, MAX_ARTIFACT_NOTE_TITLE_LENGTH, budget);
+  const body = boundedString(
+    value.body,
+    `${path}.body`,
+    MAX_ARTIFACT_NOTE_BODY_LENGTH,
+    budget,
+    { trim: false }
+  );
+  const format = value.format === void 0 || value.format === "plain" ? "plain" : value.format === "markdown" ? "markdown" : (() => {
+    throw new Error(`${path}.format must be "plain" or "markdown".`);
+  })();
+  const scope = value.scope === "workspace" || value.scope === "record" || value.scope === "range" ? value.scope : (() => {
+    throw new Error(`${path}.scope must be "workspace", "record", or "range".`);
+  })();
+  const recordId = value.recordId === void 0 ? void 0 : normalizeId(value.recordId, `${path}.recordId`, budget);
+  let range;
+  if (value.range !== void 0) {
+    if (!isPlainObject(value.range)) throw new Error(`${path}.range must be an object.`);
+    const start = value.range.start;
+    const end = value.range.end;
+    if (!Number.isInteger(start) || !Number.isInteger(end) || Number(start) < 0 || Number(end) <= Number(start)) {
+      throw new Error(`${path}.range must be a valid 0-based [start,end) range.`);
+    }
+    range = { start: Number(start), end: Number(end) };
+  }
+  if (scope === "workspace" && (recordId !== void 0 || range !== void 0)) {
+    throw new Error(`${path} workspace notes cannot carry recordId or range.`);
+  }
+  if (scope === "record" && (recordId === void 0 || range !== void 0)) {
+    throw new Error(`${path} record notes require recordId and cannot carry range.`);
+  }
+  if (scope === "range" && (recordId === void 0 || range === void 0)) {
+    throw new Error(`${path} range notes require both recordId and range.`);
+  }
+  if (recordId !== void 0 && context.recordLengths) {
+    const recordLength = context.recordLengths.get(recordId);
+    if (recordLength === void 0) throw new Error(`${path}.recordId does not match a workspace record.`);
+    if (range && range.end > recordLength) {
+      throw new Error(`${path}.range must fit within the ${recordLength}-residue record.`);
+    }
+  }
+  const tags = value.tags === void 0 ? void 0 : normalizeStringArray(
+    value.tags,
+    `${path}.tags`,
+    MAX_ARTIFACT_NOTE_TAGS,
+    MAX_ARTIFACT_TAG_LENGTH,
+    budget,
+    { deduplicate: true }
+  );
+  const createdAt = normalizeTimestamp(value.createdAt, `${path}.createdAt`, budget);
+  const updatedAt = normalizeTimestamp(value.updatedAt, `${path}.updatedAt`, budget);
+  if (Date.parse(updatedAt) < Date.parse(createdAt)) {
+    throw new Error(`${path}.updatedAt cannot be earlier than createdAt.`);
+  }
+  const provenance = normalizeProvenance(value.provenance, `${path}.provenance`, budget, false);
+  return {
+    id,
+    ...title === void 0 ? {} : { title },
+    body,
+    format,
+    scope,
+    ...recordId === void 0 ? {} : { recordId },
+    ...range === void 0 ? {} : { range },
+    ...tags === void 0 ? {} : { tags },
+    createdAt,
+    updatedAt,
+    ...provenance === void 0 ? {} : { provenance }
+  };
+}
+function normalizeWorkflowResult(value, index, context, budget) {
+  const path = `workflowResults[${index}]`;
+  if (!isPlainObject(value)) throw new Error(`${path} must be an object.`);
+  const id = normalizeId(value.id, `${path}.id`, budget);
+  if (!WORKFLOW_KINDS.has(value.kind)) {
+    throw new Error(`${path}.kind must be "digest", "gel", "golden_gate", or "ligation".`);
+  }
+  const kind = value.kind;
+  const name = boundedString(value.name, `${path}.name`, MAX_ARTIFACT_WORKFLOW_NAME_LENGTH, budget);
+  const inputRecordIds = normalizeStringArray(
+    value.inputRecordIds,
+    `${path}.inputRecordIds`,
+    MAX_ARTIFACT_WORKFLOW_RECORD_IDS,
+    MAX_ARTIFACT_ID_LENGTH,
+    budget,
+    { required: true }
+  );
+  if (inputRecordIds.length === 0) throw new Error(`${path}.inputRecordIds must contain at least one record id.`);
+  const inputSha256s = value.inputSha256s === void 0 ? void 0 : normalizeStringArray(
+    value.inputSha256s,
+    `${path}.inputSha256s`,
+    MAX_ARTIFACT_WORKFLOW_RECORD_IDS,
+    64,
+    budget
+  );
+  if (inputSha256s && inputSha256s.length !== inputRecordIds.length) {
+    throw new Error(`${path}.inputSha256s must align one-to-one with inputRecordIds.`);
+  }
+  inputSha256s?.forEach((sha256, shaIndex) => {
+    if (!/^[0-9a-f]{64}$/i.test(sha256)) {
+      throw new Error(`${path}.inputSha256s[${shaIndex}] must be a 64-character SHA-256 value.`);
+    }
+  });
+  const normalizedInputSha256s = inputSha256s?.map((sha256) => sha256.toLowerCase());
+  const parameters = normalizeJsonObject(value.parameters ?? {}, `${path}.parameters`, budget);
+  const outputRecordIds = normalizeStringArray(
+    value.outputRecordIds,
+    `${path}.outputRecordIds`,
+    MAX_ARTIFACT_WORKFLOW_RECORD_IDS,
+    MAX_ARTIFACT_ID_LENGTH,
+    budget
+  );
+  if (context.recordLengths) {
+    inputRecordIds.forEach((recordId, recordIndex) => {
+      if (!context.recordLengths?.has(recordId)) {
+        throw new Error(`${path}.inputRecordIds[${recordIndex}] does not match a workspace record.`);
+      }
+    });
+    if (!context.allowMissingWorkflowOutputRecords) {
+      outputRecordIds.forEach((recordId, recordIndex) => {
+        if (!context.recordLengths?.has(recordId)) {
+          throw new Error(`${path}.outputRecordIds[${recordIndex}] does not match a workspace record.`);
+        }
+      });
+    }
+  }
+  const result = value.result === void 0 ? void 0 : normalizeJsonObject(value.result, `${path}.result`, budget);
+  const createdAt = normalizeTimestamp(value.createdAt, `${path}.createdAt`, budget);
+  const provenance = normalizeProvenance(value.provenance, `${path}.provenance`, budget, true);
+  if (!provenance) throw new Error(`${path}.provenance is required.`);
+  return {
+    id,
+    kind,
+    name,
+    inputRecordIds,
+    ...normalizedInputSha256s === void 0 ? {} : { inputSha256s: normalizedInputSha256s },
+    parameters,
+    outputRecordIds,
+    ...result === void 0 ? {} : { result },
+    createdAt,
+    provenance
+  };
+}
+function assertUniqueIds(values, path) {
+  const ids = /* @__PURE__ */ new Set();
+  for (const value of values) {
+    if (ids.has(value.id)) throw new Error(`${path} contains duplicate id "${value.id}".`);
+    ids.add(value.id);
+  }
+}
+function normalizeNotesWithBudget(value, context, budget) {
+  if (value === void 0) return [];
+  if (!Array.isArray(value)) throw new Error("notes must be an array when provided.");
+  if (value.length > MAX_ARTIFACT_NOTES) {
+    throw new Error(`notes cannot contain more than ${MAX_ARTIFACT_NOTES.toLocaleString()} entries.`);
+  }
+  const notes = value.map((note, index) => normalizeNote(note, index, context, budget));
+  assertUniqueIds(notes, "notes");
+  return notes;
+}
+function normalizeWorkflowResultsWithBudget(value, budget, context) {
+  if (value === void 0) return [];
+  if (!Array.isArray(value)) throw new Error("workflowResults must be an array when provided.");
+  if (value.length > MAX_ARTIFACT_WORKFLOW_RESULTS) {
+    throw new Error(`workflowResults cannot contain more than ${MAX_ARTIFACT_WORKFLOW_RESULTS.toLocaleString()} entries.`);
+  }
+  const results = value.map((result, index) => normalizeWorkflowResult(result, index, context, budget));
+  assertUniqueIds(results, "workflowResults");
+  return results;
+}
+function normalizeArtifactWorkspaceCollections(value, context = {}) {
+  if (value === void 0 || value === null) return { notes: [], workflowResults: [] };
+  if (!isPlainObject(value)) throw new Error("Workspace collections must be an object.");
+  const budget = { nodes: 0, textCharacters: 0 };
+  return {
+    notes: normalizeNotesWithBudget(value.notes, context, budget),
+    workflowResults: normalizeWorkflowResultsWithBudget(value.workflowResults, budget, context)
+  };
+}
+
+// src/artifacts/claude-science-workspace-envelope.ts
+function isPlainObject2(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+var RECORD_KEYED_ARTIFACT_STATE_FIELDS = [
+  "translationLayersByRecord",
+  "enzymeSourcesByRecord",
+  "hiddenEnzymesByRecord",
+  "hiddenFeatureTranslationsByRecord",
+  "restrictionLabelsByRecord",
+  "motifsByRecord"
+];
+function assertArtifactStateRecordKeys(artifactState, recordLengths) {
+  if (!isPlainObject2(artifactState)) return;
+  for (const field of RECORD_KEYED_ARTIFACT_STATE_FIELDS) {
+    const recordMap = artifactState[field];
+    if (!isPlainObject2(recordMap)) continue;
+    const unknownRecordIds = Object.keys(recordMap).filter((recordId) => !recordLengths.has(recordId));
+    if (unknownRecordIds.length > 0) {
+      throw new Error(
+        `artifactState.${field} references unknown record id${unknownRecordIds.length === 1 ? "" : "s"}: ` + unknownRecordIds.join(", ")
+      );
+    }
+  }
+}
+function assertAlignmentRecordKeys(workspace, recordLengths) {
+  if (workspace.alignments !== void 0 && !Array.isArray(workspace.alignments)) {
+    throw new Error("Workspace alignments must be an array when provided.");
+  }
+  if (workspace.alignment !== void 0 && !isPlainObject2(workspace.alignment)) {
+    throw new Error("Workspace alignment must be a plain object when provided.");
+  }
+  if (workspace.alignment !== void 0 && workspace.alignments !== void 0) {
+    throw new Error("Workspace must provide either alignment or alignments, not both.");
+  }
+  const alignments = Array.isArray(workspace.alignments) ? workspace.alignments : isPlainObject2(workspace.alignment) ? [workspace.alignment] : [];
+  const missingRecordIds = /* @__PURE__ */ new Set();
+  for (const alignment of alignments) {
+    if (!isPlainObject2(alignment) || typeof alignment.alignedFasta === "string") continue;
+    const rows = Array.isArray(alignment.rows) ? alignment.rows : Array.isArray(alignment.sequences) ? alignment.sequences : [];
+    for (const row of rows) {
+      if (!isPlainObject2(row) || typeof row.sourceRecordId !== "string") continue;
+      const recordId = row.sourceRecordId.trim();
+      if (recordId && !recordLengths.has(recordId)) missingRecordIds.add(recordId);
+    }
+  }
+  if (missingRecordIds.size > 0) {
+    const ids = Array.from(missingRecordIds);
+    throw new Error(
+      `Alignment rows reference unknown record id${ids.length === 1 ? "" : "s"}: ${ids.join(", ")}`
+    );
+  }
+}
+function normalizeArtifactWorkspaceEnvelope(value, recordLengths) {
+  if (!isPlainObject2(value)) throw new Error("Workspace payload must be a plain object.");
+  const collections = normalizeArtifactWorkspaceCollections(value, { recordLengths });
+  assertAlignmentRecordKeys(value, recordLengths);
+  assertArtifactStateRecordKeys(value.artifactState, recordLengths);
+  return {
+    ...collections,
+    artifactState: normalizeArtifactDurableState(value.artifactState, recordLengths)
+  };
+}
+export {
+  normalizeArtifactWorkspaceEnvelope
+};

--- a/src/bio/pcr.ts
+++ b/src/bio/pcr.ts
@@ -52,6 +52,37 @@ export interface PCRResult {
   gcPercent: number;
   /** Features from template that fall within the amplified region, offset to product coordinates */
   features: Feature[];
+  /** True when a circular-template amplicon crosses coordinate 0. */
+  wrapsOrigin: boolean;
+}
+
+/** Optional exact primer binding coordinates selected by a primer-design UI. */
+export interface PCRBindingSelection {
+  forward: { start: number; end: number };
+  reverse: { start: number; end: number };
+}
+
+function propagateFeature(feature: Feature, offset: number): Feature {
+  return {
+    ...feature,
+    id: crypto.randomUUID(),
+    start: feature.start + offset,
+    end: feature.end + offset,
+    ...(feature.subRanges ? {
+      subRanges: feature.subRanges.map((range) => ({
+        ...range,
+        start: range.start + offset,
+        end: range.end + offset,
+      })),
+    } : {}),
+    metadata: {
+      ...feature.metadata,
+      pcrSourceFeatureId: feature.id,
+      pcrSourceStart: feature.start,
+      pcrSourceEnd: feature.end,
+      generatedBy: 'motif-pcr',
+    },
+  };
 }
 
 /**
@@ -66,8 +97,23 @@ export interface PCRResult {
 function findPrimerOnStrand(
   template: string,
   primer: string,
+  preferredStart?: number,
+  preferredBindLength?: number,
 ): { pos: number; bindLength: number } | null {
   if (primer.length < MIN_BINDING) return null;
+
+  if (preferredStart !== undefined || preferredBindLength !== undefined) {
+    if (
+      preferredStart === undefined
+      || preferredBindLength === undefined
+      || preferredBindLength < MIN_BINDING
+      || preferredBindLength > primer.length
+    ) return null;
+    const binding = primer.slice(primer.length - preferredBindLength);
+    return template.startsWith(binding, preferredStart)
+      ? { pos: preferredStart, bindLength: preferredBindLength }
+      : null;
+  }
 
   // Try full primer first, then progressively remove from 5' end
   for (let trimmed = 0; trimmed <= primer.length - MIN_BINDING; trimmed++) {
@@ -100,6 +146,7 @@ function findPrimerOnStrand(
  * @param reversePrimer  - Reverse primer sequence 5'→3' (any case, non-ACGT stripped)
  * @param features       - Optional template features to propagate into the product
  * @param topology       - Template topology; 'circular' enables origin-wrapping products
+ * @param selectedBinding - Optional exact forward-strand coordinates selected by primer design
  * @returns PCRResult or null if no product would be amplified
  */
 export function simulatePCR(
@@ -108,6 +155,7 @@ export function simulatePCR(
   reversePrimer: string,
   features?: Feature[],
   topology: Topology = 'linear',
+  selectedBinding?: PCRBindingSelection,
 ): PCRResult | null {
   const tmpl = template.toUpperCase().replace(/[^ACGT]/g, '');
   const fwd = forwardPrimer.toUpperCase().replace(/[^ACGT]/g, '');
@@ -115,10 +163,26 @@ export function simulatePCR(
 
   if (fwd.length < MIN_BINDING || rev.length < MIN_BINDING) return null;
   if (tmpl.length === 0) return null;
+  if (selectedBinding) {
+    const validRange = ({ start, end }: { start: number; end: number }) => (
+      Number.isInteger(start)
+      && Number.isInteger(end)
+      && start >= 0
+      && end > start
+      && end <= tmpl.length
+    );
+    if (!validRange(selectedBinding.forward) || !validRange(selectedBinding.reverse)) return null;
+  }
 
   // ── Forward primer ──────────────────────────────────────────────
-  const fwdMatch = findPrimerOnStrand(tmpl, fwd);
+  const fwdMatch = findPrimerOnStrand(
+    tmpl,
+    fwd,
+    selectedBinding?.forward.start,
+    selectedBinding ? selectedBinding.forward.end - selectedBinding.forward.start : undefined,
+  );
   if (!fwdMatch) return null;
+  if (selectedBinding && fwdMatch.pos + fwdMatch.bindLength !== selectedBinding.forward.end) return null;
 
   const fwdTailLen = fwd.length - fwdMatch.bindLength;
   const fwdTail = fwd.slice(0, fwdTailLen);
@@ -126,14 +190,26 @@ export function simulatePCR(
 
   // ── Reverse primer (searches RC strand) ─────────────────────────
   const rcTmpl = reverseComplement(tmpl);
-  const revMatch = findPrimerOnStrand(rcTmpl, rev);
+  const N = tmpl.length;
+  const selectedReverseRcStart = selectedBinding
+    ? N - selectedBinding.reverse.end
+    : undefined;
+  const revMatch = findPrimerOnStrand(
+    rcTmpl,
+    rev,
+    selectedReverseRcStart,
+    selectedBinding ? selectedBinding.reverse.end - selectedBinding.reverse.start : undefined,
+  );
   if (!revMatch) return null;
 
   // Convert RC strand coordinates → template coordinates
   // RC position [pos, pos+len) → template [N-pos-len, N-pos)
-  const N = tmpl.length;
   const revBindEnd = N - revMatch.pos;          // exclusive end on template
   const revBindStart = N - revMatch.pos - revMatch.bindLength; // inclusive start on template
+  if (selectedBinding && (
+    revBindStart !== selectedBinding.reverse.start
+    || revBindEnd !== selectedBinding.reverse.end
+  )) return null;
 
   const revTailLen = rev.length - revMatch.bindLength;
   const revTail = rev.slice(0, revTailLen);
@@ -181,12 +257,7 @@ export function simulatePCR(
       const offset = fwdTailLen - regionStart; // shift: template coord → product coord
       for (const f of features) {
         if (f.start >= regionStart && f.end <= regionEnd) {
-          productFeatures.push({
-            ...f,
-            id: crypto.randomUUID(),
-            start: f.start + offset,
-            end: f.end + offset,
-          });
+          productFeatures.push(propagateFeature(f, offset));
         }
       }
     } else {
@@ -199,19 +270,9 @@ export function simulatePCR(
       const tailOffset = fwdTailLen + (N - fwdMatch.pos); // [0, revBindEnd)
       for (const f of features) {
         if (f.start >= fwdMatch.pos && f.end <= N) {
-          productFeatures.push({
-            ...f,
-            id: crypto.randomUUID(),
-            start: f.start + headOffset,
-            end: f.end + headOffset,
-          });
+          productFeatures.push(propagateFeature(f, headOffset));
         } else if (f.start >= 0 && f.end <= revBindEnd) {
-          productFeatures.push({
-            ...f,
-            id: crypto.randomUUID(),
-            start: f.start + tailOffset,
-            end: f.end + tailOffset,
-          });
+          productFeatures.push(propagateFeature(f, tailOffset));
         }
         // else: feature straddles the origin or lies outside the amplicon — skip.
       }
@@ -244,5 +305,6 @@ export function simulatePCR(
     tmDifference,
     gcPercent: gcContent(product) * 100,
     features: productFeatures,
+    wrapsOrigin: wraps,
   };
 }

--- a/src/mcp-app/__tests__/motif-connector.test.ts
+++ b/src/mcp-app/__tests__/motif-connector.test.ts
@@ -122,6 +122,77 @@ describe('Motif MCP payload boundary', () => {
     ]);
   });
 
+  it('preserves workspace sidecars when coercing a bare sequence record', () => {
+    const createdAt = '2026-07-12T12:00:00.000Z';
+    const validated = validateMotifPayload({
+      id: 'bare-record',
+      sequence: 'ATGC',
+      notes: [{
+        id: 'bare-note',
+        body: 'Keep this note.',
+        format: 'plain',
+        scope: 'record',
+        recordId: 'bare-record',
+        createdAt,
+        updatedAt: createdAt,
+      }],
+    });
+    expect(validated.payload.records).toEqual([
+      expect.objectContaining({ id: 'bare-record', sequence: 'ATGC' }),
+    ]);
+    expect(validated.payload.notes).toEqual([
+      expect.objectContaining({ id: 'bare-note', recordId: 'bare-record' }),
+    ]);
+
+    const explicitRecordsWin = validateMotifPayload({
+      sequence: 'TTTT',
+      records: [{ id: 'explicit-record', sequence: 'ATGC' }],
+      notes: [{
+        id: 'explicit-note',
+        body: 'Keep the explicit record container.',
+        format: 'plain',
+        scope: 'record',
+        recordId: 'explicit-record',
+        createdAt,
+        updatedAt: createdAt,
+      }],
+    });
+    expect(explicitRecordsWin.payload.records).toEqual([
+      expect.objectContaining({ id: 'explicit-record', sequence: 'ATGC' }),
+    ]);
+
+    const sidecarOnly = validateMotifPayload({ name: 'Workspace label', notes: [] });
+    expect(sidecarOnly.recordCount).toBe(0);
+    expect(sidecarOnly.payload).toMatchObject({ name: 'Workspace label', notes: [] });
+
+    const sangerTrace = {
+      schema: 'motif.sanger-trace.v1',
+      version: 1,
+      baseCalls: 'A',
+      sequence: 'A',
+      qualityScores: [],
+      peakPositions: [],
+      channels: { A: [1], C: [0], G: [0], T: [0] },
+      sampleCount: 1,
+      dyeOrder: null,
+      storedReverseComplement: null,
+      warnings: [],
+      metadata: {
+        format: 'ABIF',
+        abifVersion: 101,
+        baseCallsTag: 'PBAS2',
+        qualityScoresTag: null,
+        peakPositionsTag: null,
+        channelTags: {},
+      },
+    };
+    const bareTrace = validateMotifPayload({ id: 'bare-trace', type: 'dna', sequence: 'A', sangerTrace });
+    expect(bareTrace.payload.sangerTrace).toBeUndefined();
+    expect(bareTrace.payload.records).toEqual([
+      expect.objectContaining({ id: 'bare-trace', sangerTrace: expect.objectContaining({ baseCalls: 'A' }) }),
+    ]);
+  });
+
   it('rejects ambiguous inputs and out-of-range biological data transactionally', () => {
     expect(() => prepareMotifWorkbench({ payload: { records: [] }, content: '>x\nATGC' }))
       .toThrow(/either payload or content/i);
@@ -142,6 +213,84 @@ describe('Motif MCP payload boundary', () => {
     expect(() => validateMotifPayload({
       records: [{ name: 'bad active flag', sequence: 'ATGC', active: 'yes' }],
     })).toThrow(/active must be a boolean/i);
+    expect(() => validateMotifPayload({
+      records: [{ id: 'record-a', name: 'bad note', sequence: 'ATGC' }],
+      notes: { malformed: true },
+    })).toThrow(/payload workspace is invalid.*notes must be an array/i);
+    expect(() => validateMotifPayload({
+      records: [{ id: 'record-a', name: 'bad state', sequence: 'ATGC' }],
+      artifactState: { customEnzymes: { malformed: true } },
+    })).toThrow(/payload workspace is invalid.*customEnzymes must be an array/i);
+    expect(() => validateMotifPayload({
+      records: [{ id: 'record-a', name: 'bad color', sequence: 'ATGC', features: [{ start: 0, end: 2, color: 'url(javascript:alert(1))' }] }],
+    })).toThrow(/simple CSS color value/i);
+    expect(() => validateMotifPayload({
+      records: [
+        { name: 'record-a', sequence: 'ATGC', active: false },
+        { id: 'record-a', sequence: 'ATGC', active: true },
+      ],
+      notes: [{
+        id: 'note-a', body: 'Ambiguous link', format: 'plain', scope: 'record', recordId: 'record-a',
+        createdAt: '2026-07-12T12:00:00.000Z', updatedAt: '2026-07-12T12:00:00.000Z',
+      }],
+    })).toThrow(/payload workspace is invalid/i);
+    expect(() => validateMotifPayload({
+      records: [{ id: 'record-a', sequence: 'ATGC' }],
+      alignments: [{
+        id: 'orphaned', molecule: 'dna', rows: [
+          { id: 'a', name: 'A', aligned: 'ATGC', sourceRecordId: 'missing' },
+          { id: 'b', name: 'B', aligned: 'AT-C' },
+        ],
+      }],
+    })).toThrow(/alignment rows reference unknown record id: missing/i);
+  });
+
+  it('matches browser record validation for nested metadata and DNA end chemistry', () => {
+    const base = { id: 'record-a', molecule: 'dna' as const, sequence: 'ATGC' };
+    expect(() => validateMotifPayload({ records: [{ ...base, overhang5: 'AATT', overhang5Type: '5prime', overhang3: '', overhang3Type: 'blunt' }] }))
+      .not.toThrow();
+
+    for (const record of [
+      { ...base, dateAdded: 42 },
+      { ...base, provenance: [] },
+      { ...base, provenance: { blob: 'x'.repeat(MOTIF_MCP_LIMITS.maxTextLength + 1) } },
+      { ...base, sites: { enzyme: 'EcoRI' } },
+      { ...base, sangerTrace: {} },
+      { ...base, features: [{ start: 0, end: 2, metadata: [] }] },
+      { ...base, features: [{ start: 0, end: 2, metadata: { blob: 'x'.repeat(MOTIF_MCP_LIMITS.maxTextLength + 1) } }] },
+      { ...base, features: [{ start: 0, end: 2, subRanges: [{ start: 0, end: 1, strand: 2 }] }] },
+      { ...base, overhang5: 'AATT', overhang5Type: 'blunt' },
+      { ...base, overhang5Type: '5prime' },
+      { ...base, overhang3: 'AX' },
+      { ...base, molecule: 'protein', sequence: 'MPEPTIDE', overhang5: 'AATT', overhang5Type: '5prime' },
+      { ...base, type: 'plasmid' },
+    ]) {
+      expect(() => validateMotifPayload({ records: [record] })).toThrow();
+    }
+
+    expect(() => validateMotifPayload({
+      sequence: 'ATGC',
+      records: { malformed: true },
+    })).toThrow(/records must be an array/i);
+    expect(() => validateMotifPayload({
+      records: [{ ...base, sequence: 'AT*GC' }],
+      artifactState: {
+        translationLayersByRecord: {
+          'record-a': [{ id: 'too-long', label: 'Too long', start: 0, end: 5, strand: 1, frame: 0 }],
+        },
+      },
+    })).toThrow(/payload workspace is invalid/i);
+    expect(() => validateMotifPayload({
+      records: [{ id: 'dual-sequence', molecule: 'dna', seq: 'AT', sequence: 'ATGCGC' }],
+      artifactState: {
+        translationLayersByRecord: {
+          'dual-sequence': [{ id: 'too-long', label: 'Too long', start: 0, end: 6, strand: 1, frame: 0 }],
+        },
+      },
+    })).toThrow(/payload workspace is invalid/i);
+    expect(validateMotifPayload({
+      records: [{ id: 'dual-sequence', molecule: 'dna', seq: 'AT', sequence: 'ATGCGC' }],
+    }).residueCount).toBe(2);
   });
 
   it('rejects unsupported future schemas instead of silently downgrading', () => {


### PR DESCRIPTION
## Summary

- add typed construct-verification, freshness, PCR materialization, workspace-integrity, and analysis-result trust loops
- preserve provenance and transactional validation across artifact, plugin, and connector surfaces
- expand the MSA viewer with direct selection, rulers, hover/context inspection, conservation and occupancy analytics, colouring and mismatch modes, row reordering, zoom/fit, translation, search, and responsive interaction coverage
- align the existing MSA View-menu integration test with the new exact accessible labels and default track visibility

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` — 65 files, 773 tests passed
- `npm run test:plugin`
- `npm run check:css-tokens`
- `npm run check:aria-controls`
- `npm run build:motif` — repeated with identical output hashes
- `npm run validate:plugin` — strict validation passed
- `npm run test:e2e` — 112 passed; 16 fixture-gated skips
- dedicated MSA Playwright campaign — 14/14 passed
- Gitleaks — 3 outgoing commits scanned, no leaks

The two real-AB1 browser cases remain gated on external fidelity fixtures. The 14 MSA cases skipped by the shared runner were executed successfully through their isolated configuration.

## Deterministic output hashes

- artifact/template: `eb7a7a83eaae8c5c7c97c373a8c5aeb872173fc45ccc0eb4b7dec24d03f2e334`
- plugin ZIP: `09a9778109ca80a9d2f18d2f816b06f4a1fe762af12a2acb4a2224e0ecbbaa32`
- MCP App: `188f5010018189c111899c57654170b3a2770804982f7954dd9cac51dd92d268`
- MCP server: `144bff403234c91aeb6f2478c27e9a708e5a45228268d360d35f7ce834d8a95a`
- checksum manifest: `65e50c849413becd69191d460df743e35186173ce4efe2fa7e7f80dc772063f7`
