### PR TITLE
Preserve discontinuous feature semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- Made discontinuous feature locations authoritative across inspection,
+  translation, exports, maps, mutation, PCR, digestion, Gibson assembly, and
+  Golden Gate assembly instead of silently using their coordinate envelopes.
+- Preserved joined, ordered, reverse, origin-spanning, mixed-strand, and fuzzy
+  INSDC locations in Basic GenBank and emitted one GFF3 row per feature piece.
+- Quarantined unmarked reverse multipart checkpoints from sequence-derived
+  actions when their legacy text order cannot be distinguished safely from
+  biological order; conservative interchange marks them non-materializable,
+  while new and imported locations carry an explicit order marker.
+
 ## 0.2.1 — 2026-07-13
 
 - Added the Motif-owned Claude Science local connector, setup doctor, and

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -259,7 +259,7 @@ test.describe('Claude Science artifact campaign', () => {
     const featureStart = annotationsPanel.getByLabel('Start');
     const featureEnd = annotationsPanel.getByLabel('End');
     await featureStart.fill('600');
-    await featureEnd.fill('500');
+    await featureEnd.fill('0');
     await expect(featureStart).toHaveAttribute('aria-invalid', 'true');
     await expect(featureStart).toHaveAttribute('aria-describedby', 'motif-cs-feature-range-error');
     await expect(annotationsPanel.locator('#motif-cs-feature-range-error')).toBeVisible();

--- a/e2e/claude-science-feature-semantics.spec.ts
+++ b/e2e/claude-science-feature-semantics.spec.ts
@@ -1,0 +1,317 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const artifactUrl = process.env.MOTIF_ARTIFACT_URL;
+
+async function openAnnotationsEditor(page: Page, featureName?: string) {
+  const annotations = page.locator('details[data-rail-tool="annotations"]');
+  if ((await annotations.getAttribute('open')) === null) await annotations.locator(':scope > summary').click();
+  const drawer = annotations.locator('.motif-cs-annotation-editor-drawer');
+  if (featureName) {
+    await annotations.locator('.motif-cs-feature-annotation-list > .motif-cs-row').filter({ hasText: featureName }).click();
+  } else if ((await drawer.getAttribute('open')) === null) {
+    await drawer.locator(':scope > summary').click();
+  }
+  await expect(drawer).toHaveAttribute('open', '');
+  return annotations;
+}
+
+test.describe('Claude Science multipart feature semantics', () => {
+  test.skip(!artifactUrl, 'Set MOTIF_ARTIFACT_URL to run the standalone artifact audit.');
+
+  const pageDiagnostics = new WeakMap<Page, string[]>();
+
+  test.beforeEach(async ({ page }) => {
+    const diagnostics: string[] = [];
+    pageDiagnostics.set(page, diagnostics);
+    page.on('pageerror', (error) => diagnostics.push(`pageerror: ${error.message}`));
+    page.on('console', (message) => {
+      if (message.type() === 'error' || message.type() === 'warning') {
+        diagnostics.push(`console.${message.type()}: ${message.text()}`);
+      }
+    });
+    await page.setViewportSize({ width: 1180, height: 900 });
+    await page.addInitScript(() => {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    });
+    await page.goto(artifactUrl!);
+    await expect(page.locator('.motif-cs-shell')).toBeVisible();
+    const toolsToggle = page.getByRole('button', { name: /Tools/ }).first();
+    if ((await toolsToggle.getAttribute('aria-pressed')) !== 'true') await toolsToggle.click();
+    await expect(page.locator('details[data-rail-tool="annotations"]')).toBeVisible();
+  });
+
+  test.afterEach(async ({ page }) => {
+    expect(pageDiagnostics.get(page) ?? []).toEqual([]);
+  });
+
+  test('uses joined pieces for inspection, translation, editing, extraction, and export', async ({ page }) => {
+    await page.evaluate(() => window.motifRenderInventory([{
+      id: 'joined-record',
+      name: 'Joined record',
+      molecule: 'dna',
+      topology: 'linear',
+      seq: 'ATGCCCGGGCCATTTAAA',
+      annotations: [{
+        id: 'joined-cds',
+        name: 'joined CDS',
+        type: 'cds',
+        start: 0,
+        end: 12,
+        strand: 1,
+        color: '#888888',
+        subRanges: [
+          { start: 0, end: 3, strand: 1 },
+          { start: 9, end: 12, strand: 1 },
+        ],
+      }],
+    }]));
+
+    const detail = page.getByRole('button', { name: 'Detail' }).first();
+    if ((await detail.getAttribute('data-active')) !== 'true') await detail.click();
+
+    const featureBlocks = page.locator('.motif-cs-feature-block').filter({ hasText: 'joined CDS' });
+    await expect(featureBlocks).toHaveCount(2);
+    await featureBlocks.first().click();
+    await expect(page.locator('.motif-cs-seq-hl')).toHaveCount(2);
+    await expect(page.locator('.motif-cs-selection-bar')).toContainText('6 bp');
+
+    const inspector = page.locator('details[data-rail-tool="inspector"]');
+    if ((await inspector.getAttribute('open')) === null) await inspector.locator(':scope > summary').click();
+    await expect(inspector).toContainText('1-3 + 10-12');
+    await expect(inspector).toContainText('6 bp');
+    await expect(inspector).toContainText('GC 50.0%');
+    await expect.poll(() => page.evaluate(() => window.motifDescribe?.())).toMatchObject({
+      data: {
+        features: [{
+          location: 'join(1..3,10..12)',
+          length: 6,
+          subRanges: [
+            { start: 0, end: 3, strand: 1 },
+            { start: 9, end: 12, strand: 1 },
+          ],
+        }],
+        selection: { length: 6, sequence: 'ATGCCA', gcPercent: 50 },
+      },
+    });
+    await expect.poll(() => page.evaluate(() => window.motifDescribe?.()?.text ?? '')).toContain('join(1..3,10..12) · 6 bp');
+
+    const translation = page.locator('details[data-rail-tool="translation"]');
+    if ((await translation.getAttribute('open')) === null) await translation.locator(':scope > summary').click();
+    await expect(translation.locator('.motif-cs-protein-readout')).toHaveText('MP');
+    await expect(translation).toContainText('stitched in biological order');
+    await expect(translation.getByRole('button', { name: 'Add AA track' })).toBeDisabled();
+
+    const exportPanel = page.locator('.motif-cs-sequence-tools-panel');
+    if ((await exportPanel.getAttribute('open')) === null) await exportPanel.locator(':scope > summary').click();
+    const exportFormat = exportPanel.locator('select[name="export-format"]');
+    const exportPreview = exportPanel.getByLabel('Selected export preview');
+
+    await exportFormat.selectOption('record-genbank');
+    await expect(exportPreview).toHaveValue(/join\(1\.\.3,10\.\.12\)/);
+    await exportFormat.selectOption('record-gff3');
+    await expect(exportPreview).toHaveValue(/joined-record\tMotif\tcds\t1\t3/);
+    await expect(exportPreview).toHaveValue(/joined-record\tMotif\tcds\t10\t12/);
+    await exportFormat.selectOption('features-csv');
+    await expect(exportPreview).toHaveValue(/,6,"join\(1\.\.3,10\.\.12\)",2/);
+
+    const annotations = await openAnnotationsEditor(page, 'joined CDS');
+    await expect(annotations.getByLabel('Start')).toBeDisabled();
+    await expect(annotations.getByLabel('End')).toBeDisabled();
+    await expect(annotations).toContainText('Multipart location');
+    await annotations.locator('input[name="feature-name"]').fill('renamed joined CDS');
+    await annotations.getByRole('button', { name: 'Update', exact: true }).first().click();
+    expect(await page.evaluate(() => window.motifGetInventory()[0].annotations?.[0].subRanges)).toEqual([
+      { start: 0, end: 3, strand: 1 },
+      { start: 9, end: 12, strand: 1 },
+    ]);
+
+    const countBefore = await page.evaluate(() => window.motifGetInventory().length);
+    await annotations.getByRole('button', { name: 'New record' }).click();
+    expect(await page.evaluate(() => window.motifGetInventory().length)).toBe(countBefore + 1);
+    await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('renamed joined CDS');
+    await expect.poll(() => page.evaluate(() => window.motifGetActiveRecord?.()?.seq)).toBe('ATGCCA');
+  });
+
+  test('honors imported codon_start when translating a joined CDS', async ({ page }) => {
+    await page.evaluate(() => window.motifRenderInventory([{
+      id: 'frame-record',
+      name: 'Frame record',
+      molecule: 'dna',
+      topology: 'linear',
+      seq: 'ATGCCCGGGCCATTTAAA',
+      annotations: [{
+        id: 'frame-cds',
+        name: 'frame two CDS',
+        type: 'cds',
+        start: 0,
+        end: 12,
+        strand: 1,
+        color: '#888888',
+        metadata: { codon_start: '2' },
+        subRanges: [
+          { start: 0, end: 3, strand: 1 },
+          { start: 9, end: 12, strand: 1 },
+        ],
+      }],
+    }]));
+
+    const detail = page.getByRole('button', { name: 'Detail' }).first();
+    if ((await detail.getAttribute('data-active')) !== 'true') await detail.click();
+    await page.locator('.motif-cs-feature-block').filter({ hasText: 'frame two CDS' }).first().click();
+
+    const translation = page.locator('details[data-rail-tool="translation"]');
+    if ((await translation.getAttribute('open')) === null) await translation.locator(':scope > summary').click();
+    await expect(translation.locator('.motif-cs-protein-readout')).toHaveText('C');
+    await expect(translation.getByRole('button', { name: '+2', exact: true })).toHaveAttribute('aria-pressed', 'true');
+
+    const annotations = await openAnnotationsEditor(page, 'frame two CDS');
+    await annotations.getByRole('button', { name: 'New protein' }).click();
+    await expect.poll(() => page.evaluate(() => window.motifGetActiveRecord?.()?.seq)).toBe('C');
+  });
+
+  test('keeps order locations visible but blocks implicit extraction and translation', async ({ page }) => {
+    await page.evaluate(() => window.motifRenderInventory([{
+      id: 'ordered-record',
+      name: 'Ordered record',
+      molecule: 'dna',
+      topology: 'linear',
+      seq: 'ATGCCCGGGCCATTTAAA',
+      annotations: [{
+        id: 'ordered-cds',
+        name: 'ordered CDS',
+        type: 'cds',
+        start: 0,
+        end: 12,
+        strand: 1,
+        color: '#888888',
+        metadata: { motifLocationOperator: 'order' },
+        subRanges: [
+          { start: 0, end: 3, strand: 1 },
+          { start: 9, end: 12, strand: 1 },
+        ],
+      }],
+    }]));
+
+    const detail = page.getByRole('button', { name: 'Detail' }).first();
+    if ((await detail.getAttribute('data-active')) !== 'true') await detail.click();
+    await page.locator('.motif-cs-feature-block').filter({ hasText: 'ordered CDS' }).first().click();
+    await expect.poll(() => page.evaluate(() => window.motifDescribe?.()?.data.selection ?? null)).toBeNull();
+    await expect(page.getByRole('group', { name: 'Selection actions' }).getByRole('button', { name: 'Reverse complement' })).toBeDisabled();
+
+    const translation = page.locator('details[data-rail-tool="translation"]');
+    if ((await translation.getAttribute('open')) === null) await translation.locator(':scope > summary').click();
+    await expect(translation).toContainText('does not assert one materializable sequence');
+    await expect(translation.getByRole('button', { name: 'New protein' })).toBeDisabled();
+
+    const annotations = await openAnnotationsEditor(page, 'ordered CDS');
+    await expect(annotations.getByRole('button', { name: 'New record' })).toBeDisabled();
+    await expect(annotations.getByRole('button', { name: 'New protein' })).toHaveCount(0);
+
+    const exportPanel = page.locator('.motif-cs-sequence-tools-panel');
+    if ((await exportPanel.getAttribute('open')) === null) await exportPanel.locator(':scope > summary').click();
+    const selectionActions = exportPanel.locator('.motif-cs-export-row').filter({ hasText: 'Selection' });
+    await expect(selectionActions.getByRole('button', { name: 'Copy', exact: true })).toBeDisabled();
+    await expect(exportPanel.getByRole('button', { name: 'Complement', exact: true })).toBeDisabled();
+    await expect(exportPanel.getByRole('button', { name: 'Copy rev comp' })).toBeDisabled();
+    await expect(exportPanel.getByRole('button', { name: 'New rev comp' })).toBeDisabled();
+    await expect(exportPanel).toContainText('does not assert that the pieces form one materializable sequence');
+    await exportPanel.locator('select[name="export-format"]').selectOption('record-genbank');
+    await expect(exportPanel.getByLabel('Selected export preview')).toHaveValue(/order\(1\.\.3,10\.\.12\)/);
+  });
+
+  test('quarantines a legacy unmarked reverse multipart location', async ({ page }) => {
+    await page.evaluate(() => window.motifRenderInventory([{
+      id: 'ambiguous-record',
+      name: 'Legacy reverse record',
+      molecule: 'dna',
+      topology: 'linear',
+      seq: 'ATGCCCGGGCCATTTAAA',
+      annotations: [{
+        id: 'ambiguous-cds',
+        name: 'legacy reverse CDS',
+        type: 'cds',
+        start: 0,
+        end: 12,
+        strand: -1,
+        color: '#888888',
+        subRanges: [
+          { start: 9, end: 12, strand: -1 },
+          { start: 0, end: 3, strand: -1 },
+        ],
+      }],
+    }]));
+
+    const detail = page.getByRole('button', { name: 'Detail' }).first();
+    if ((await detail.getAttribute('data-active')) !== 'true') await detail.click();
+    await page.locator('.motif-cs-feature-block').filter({ hasText: 'legacy reverse CDS' }).first().click();
+    await expect.poll(() => page.evaluate(() => window.motifDescribe?.()?.data.features?.[0])).toMatchObject({
+      locationOrder: 'ambiguous-unmarked',
+      materializable: false,
+    });
+    await expect.poll(() => page.evaluate(() => window.motifDescribe?.()?.data.selection ?? null)).toBeNull();
+
+    const inspector = page.locator('details[data-rail-tool="inspector"]');
+    if ((await inspector.getAttribute('open')) === null) await inspector.locator(':scope > summary').click();
+    await expect(inspector).toContainText('Segment order is ambiguous');
+
+    const translation = page.locator('details[data-rail-tool="translation"]');
+    if ((await translation.getAttribute('open')) === null) await translation.locator(':scope > summary').click();
+    await expect(translation).toContainText('ambiguous segment order');
+    await expect(translation.getByRole('button', { name: 'New protein' })).toBeDisabled();
+
+    const annotations = await openAnnotationsEditor(page, 'legacy reverse CDS');
+    await expect(annotations).toContainText('no reliable segment-order marker');
+    await expect(annotations.getByRole('button', { name: 'New record' })).toBeDisabled();
+
+    const exportPanel = page.locator('.motif-cs-sequence-tools-panel');
+    if ((await exportPanel.getAttribute('open')) === null) await exportPanel.locator(':scope > summary').click();
+    await expect(exportPanel.getByRole('button', { name: 'Complement', exact: true })).toBeDisabled();
+    await expect(exportPanel.getByRole('button', { name: 'Copy rev comp' })).toBeDisabled();
+    await expect(exportPanel.getByRole('button', { name: 'New rev comp' })).toBeDisabled();
+    await expect(exportPanel).toContainText('Basic GenBank and GFF3 label it non-materializable');
+    await exportPanel.locator('select[name="export-format"]').selectOption('record-genbank');
+    await expect(exportPanel.getByLabel('Selected export preview')).toHaveValue(/complement\(order\(1\.\.3,10\.\.12\)\)/);
+    await exportPanel.locator('select[name="export-format"]').selectOption('record-gff3');
+    await expect(exportPanel.getByLabel('Selected export preview')).toHaveValue(/motif_location_operator=ambiguous/);
+  });
+
+  test('stores reverse origin-wrap annotations in biological order', async ({ page }) => {
+    await page.evaluate(() => window.motifRenderInventory([{
+      id: 'circular-record',
+      name: 'Circular record',
+      molecule: 'dna',
+      topology: 'circular',
+      seq: 'ATGCCCGGGCCATTTAAA',
+    }]));
+
+    const detail = page.getByRole('button', { name: 'Detail' }).first();
+    if ((await detail.getAttribute('data-active')) !== 'true') await detail.click();
+    const annotations = await openAnnotationsEditor(page);
+    await annotations.locator('input[name="feature-name"]').fill('reverse wrap');
+    await annotations.locator('select[name="feature-strand"]').selectOption('-1');
+    await annotations.locator('input[name="feature-start"]').fill('16');
+    await annotations.locator('input[name="feature-end"]').fill('3');
+    await annotations.getByRole('button', { name: 'Add', exact: true }).click();
+
+    await expect.poll(() => page.evaluate(() => window.motifGetActiveRecord?.()?.annotations?.[0].subRanges)).toEqual([
+      { start: 0, end: 3, strand: -1 },
+      { start: 15, end: 18, strand: -1 },
+    ]);
+    await expect.poll(() => page.evaluate(() => window.motifGetActiveRecord?.()?.annotations?.[0].metadata)).toMatchObject({
+      motifSubRangeOrder: 'biological',
+    });
+    const featureBlocks = page.locator('.motif-cs-feature-block').filter({ hasText: 'reverse wrap' });
+    await expect(featureBlocks).toHaveCount(2);
+    await featureBlocks.first().click();
+    await expect.poll(() => page.evaluate(() => window.motifDescribe?.()?.data.selection ?? null)).toMatchObject({
+      length: 6,
+      sequence: 'CATTTT',
+    });
+
+    const exportPanel = page.locator('.motif-cs-sequence-tools-panel');
+    if ((await exportPanel.getAttribute('open')) === null) await exportPanel.locator(':scope > summary').click();
+    await exportPanel.locator('select[name="export-format"]').selectOption('record-genbank');
+    await expect(exportPanel.getByLabel('Selected export preview')).toHaveValue(/complement\(join\(16\.\.18,1\.\.3\)\)/);
+  });
+});

--- a/src/artifacts/__tests__/claude-science-digest-workflow.test.ts
+++ b/src/artifacts/__tests__/claude-science-digest-workflow.test.ts
@@ -313,7 +313,8 @@ describe('Claude Science digest workflow materialization', () => {
       id: 'digest-feature-1',
       name: 'contained feature',
       start: 1,
-      end: 4,
+      end: 3,
+      subRanges: [{ start: 1, end: 3, strand: 1 }],
       metadata: { nested: { source: 'fixture' } },
     }]);
     ((feature.metadata.nested as { source: string }).source) = 'mutated';
@@ -347,6 +348,20 @@ describe('Claude Science digest workflow materialization', () => {
         color: '#bbbbbb',
         metadata: {},
       },
+      {
+        id: 'origin-feature',
+        name: 'origin join',
+        type: 'cds',
+        start: 0,
+        end: 15,
+        strand: 1,
+        color: '#cccccc',
+        metadata: {},
+        subRanges: [
+          { start: 12, end: 15, strand: 1 },
+          { start: 0, end: 1, strand: 1 },
+        ],
+      },
     ];
     const source = sourceRecord('GAATTCAAAAGAATTC', 'circular', features);
     const result = materialize(source, recipeFor(source, 'EcoRI'));
@@ -361,6 +376,11 @@ describe('Claude Science digest workflow materialization', () => {
     }))).toEqual([
       { name: 'tail', start: 1, end: 4, sourceFeatureId: 'tail-feature' },
       { name: 'head', start: 5, end: 6, sourceFeatureId: 'head-feature' },
+      { name: 'origin join', start: 1, end: 6, sourceFeatureId: 'origin-feature' },
+    ]);
+    expect(result.records[1].annotations[2].subRanges).toEqual([
+      { start: 1, end: 4, strand: 1 },
+      { start: 5, end: 6, strand: 1 },
     ]);
   });
 

--- a/src/artifacts/__tests__/claude-science-feature-location-export.test.ts
+++ b/src/artifacts/__tests__/claude-science-feature-location-export.test.ts
@@ -1,0 +1,392 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractFeatureSequence,
+  featureLocationCoordinateSignature,
+  isAmbiguousFeatureLocation,
+  isMaterializableFeatureLocation,
+} from '../../bio/feature-location';
+import { parseFeatures, parseGenBank } from '../../bio/genbank-parser';
+import { reverseComplement, reverseComplementFeatures } from '../../bio/reverse-complement';
+import type { Feature } from '../../bio/types';
+import { featuresToCsv, normalizeRecord, toGenBankLite, toGff3Lite } from '../motif-artifact';
+
+const sequence = 'ATGCCCGGGCCATTTAAA';
+
+function joinedFeature(metadata: Record<string, unknown> = {}): Feature {
+  return {
+    id: 'joined-cds',
+    name: 'joined CDS',
+    type: 'cds',
+    start: 0,
+    end: 12,
+    strand: 1,
+    color: '#888888',
+    metadata,
+    subRanges: [
+      { start: 0, end: 3, strand: 1 },
+      { start: 9, end: 12, strand: 1 },
+    ],
+  };
+}
+
+function record(feature: Feature) {
+  return {
+    id: 'joined-record',
+    name: 'Joined record',
+    description: 'Multipart export fixture',
+    sequence,
+    topology: 'linear' as const,
+    type: 'dna' as const,
+    features: [feature],
+    sites: [],
+    active: true,
+    default: false,
+  };
+}
+
+describe('multipart feature interchange exports', () => {
+  it('quarantines unmarked reverse multipart arrays without guessing their order', () => {
+    const ambiguous = normalizeRecord({
+      id: 'current-reverse',
+      name: 'Current reverse',
+      molecule: 'dna',
+      topology: 'linear',
+      seq: sequence,
+      annotations: [{
+        id: 'current-cds',
+        name: 'current CDS',
+        type: 'cds',
+        start: 0,
+        end: 12,
+        strand: -1,
+        color: '#888888',
+        subRanges: [
+          { start: 9, end: 12, strand: -1 },
+          { start: 0, end: 3, strand: -1 },
+        ],
+      }],
+    }, 0);
+
+    expect(ambiguous?.features[0].subRanges).toEqual([
+      { start: 9, end: 12, strand: -1 },
+      { start: 0, end: 3, strand: -1 },
+    ]);
+    expect(ambiguous?.features[0].metadata).toMatchObject({ motifSubRangeOrderAmbiguous: true });
+    expect(ambiguous?.features[0].metadata.motifSubRangeOrder).toBeUndefined();
+    expect(isAmbiguousFeatureLocation(ambiguous!.features[0])).toBe(true);
+    expect(isMaterializableFeatureLocation(ambiguous!.features[0])).toBe(false);
+    expect(extractFeatureSequence(sequence, ambiguous!.features[0], 'dna')).toBe('');
+    expect(toGenBankLite(ambiguous!, 'linear')).toContain('complement(order(1..3,10..12))');
+    const ambiguousGffRows = toGff3Lite(ambiguous!).split('\n').filter((line) => line.includes('\tMotif\tcds\t'));
+    expect(ambiguousGffRows.map((row) => row.split('\t')[7])).toEqual(['.', '.']);
+    expect(ambiguousGffRows.every((row) => row.includes('motif_location_operator=ambiguous'))).toBe(true);
+
+    const reloaded = normalizeRecord({
+      ...ambiguous!,
+      seq: ambiguous!.sequence,
+      molecule: ambiguous!.type,
+      annotations: ambiguous!.features,
+    }, 0);
+    expect(reloaded?.features[0].subRanges).toEqual(ambiguous?.features[0].subRanges);
+    expect(isAmbiguousFeatureLocation(reloaded!.features[0])).toBe(true);
+
+    const marked = normalizeRecord({
+      id: 'marked-reverse',
+      name: 'Marked reverse',
+      molecule: 'dna',
+      topology: 'linear',
+      seq: sequence,
+      annotations: [{
+        ...ambiguous!.features[0],
+        metadata: { motifSubRangeOrder: 'biological' },
+      }],
+    }, 0);
+    expect(marked?.features[0].subRanges).toEqual(ambiguous?.features[0].subRanges);
+    expect(marked?.features[0].metadata).toMatchObject({ motifSubRangeOrder: 'biological' });
+    expect(isMaterializableFeatureLocation(marked!.features[0])).toBe(true);
+    expect(extractFeatureSequence(sequence, marked!.features[0], 'dna')).toBe('TGGCAT');
+  });
+
+  it('derives reverse ambiguity from piece strands when the top-level strand is omitted', () => {
+    const normalized = normalizeRecord({
+      id: 'piece-strand-reverse',
+      name: 'Piece-strand reverse',
+      molecule: 'dna',
+      topology: 'linear',
+      seq: sequence,
+      annotations: [{
+        id: 'piece-strand-cds',
+        name: 'piece-strand CDS',
+        type: 'cds',
+        start: 0,
+        end: 12,
+        color: '#888888',
+        subRanges: [
+          { start: 9, end: 12, strand: -1 },
+          { start: 0, end: 3, strand: -1 },
+        ],
+      }],
+    }, 0);
+
+    expect(normalized?.features[0].strand).toBe(-1);
+    expect(normalized?.features[0].metadata).toMatchObject({ motifSubRangeOrderAmbiguous: true });
+    expect(normalized?.features[0].metadata.motifSubRangeOrder).toBeUndefined();
+    expect(extractFeatureSequence(sequence, normalized!.features[0], 'dna')).toBe('');
+  });
+
+  it('quarantines a legacy outer-complemented mixed-strand location', () => {
+    const normalized = normalizeRecord({
+      id: 'legacy-mixed-complement',
+      name: 'Legacy mixed complement',
+      molecule: 'dna',
+      topology: 'linear',
+      seq: sequence,
+      annotations: [{
+        id: 'legacy-mixed-cds',
+        name: 'legacy mixed CDS',
+        type: 'cds',
+        start: 0,
+        end: 12,
+        strand: -1,
+        color: '#888888',
+        // Legacy outer-complement parsing flipped each piece but retained the
+        // GenBank text order, leaving a mixed effective strand.
+        subRanges: [
+          { start: 0, end: 3, strand: 1 },
+          { start: 9, end: 12, strand: -1 },
+        ],
+      }],
+    }, 0);
+
+    expect(normalized?.features[0].strand).toBe(0);
+    expect(normalized?.features[0].metadata).toMatchObject({ motifSubRangeOrderAmbiguous: true });
+    expect(normalized?.features[0].metadata.motifSubRangeOrder).toBeUndefined();
+    expect(extractFeatureSequence(sequence, normalized!.features[0], 'dna')).toBe('');
+  });
+
+  it('preserves an explicit ambiguity quarantine through whole-record reverse complement', () => {
+    const sourceFeature = joinedFeature({ motifSubRangeOrderAmbiguous: true });
+    sourceFeature.strand = -1;
+    sourceFeature.subRanges = [
+      { start: 9, end: 12, strand: -1 },
+      { start: 0, end: 3, strand: -1 },
+    ];
+    const transformedFeatures = reverseComplementFeatures([sourceFeature], sequence.length);
+    expect(transformedFeatures[0].strand).toBe(1);
+
+    const normalized = normalizeRecord({
+      id: 'reverse-complemented-ambiguous',
+      name: 'Reverse-complemented ambiguous',
+      molecule: 'dna',
+      topology: 'linear',
+      seq: reverseComplement(sequence),
+      annotations: transformedFeatures,
+    }, 0);
+
+    expect(normalized?.features[0].strand).toBe(1);
+    expect(normalized?.features[0].metadata).toMatchObject({ motifSubRangeOrderAmbiguous: true });
+    expect(normalized?.features[0].metadata.motifSubRangeOrder).toBeUndefined();
+    expect(extractFeatureSequence(normalized!.sequence, normalized!.features[0], 'dna')).toBe('');
+  });
+
+  it('round-trips a joined GenBank location without changing its product', () => {
+    const source = record(joinedFeature());
+    const genbank = toGenBankLite(source, source.topology);
+
+    expect(genbank).toContain('join(1..3,10..12)');
+    const reparsed = parseGenBank(genbank);
+    expect(reparsed).toHaveLength(1);
+    expect(extractFeatureSequence(reparsed[0].sequence, reparsed[0].features[0], 'dna').toUpperCase()).toBe('ATGCCA');
+  });
+
+  it('preserves codon_start in Basic GenBank', () => {
+    const source = record(joinedFeature({ codon_start: '2' }));
+    const genbank = toGenBankLite(source, source.topology);
+
+    expect(genbank).toContain('/codon_start=2');
+    const reparsed = parseGenBank(genbank)[0].features[0];
+    expect(reparsed.metadata.codon_start).toBe('2');
+  });
+
+  it('round-trips unchanged fuzzy bounds instead of silently making them exact', () => {
+    const fuzzy = parseFeatures([
+      '     CDS             <1..>3',
+      '                     /label="partial CDS"',
+    ].join('\n'))[0];
+    const genbank = toGenBankLite(record({ ...fuzzy, id: 'partial-cds' }), 'linear');
+
+    expect(genbank).toContain('<1..>3');
+    const reparsed = parseGenBank(genbank)[0].features[0];
+    expect(reparsed.metadata).toMatchObject({
+      motifOriginalLocation: '<1..>3',
+      motifLocationFuzzy: true,
+    });
+  });
+
+  it.each([
+    'order(<1..3,10..>12)',
+    '<2..>4',
+    '<1..>3\n                     /note="injected"',
+  ])('does not trust forged fuzzy-location metadata: %s', (forgedLocation) => {
+    const feature = joinedFeature({
+      motifLocationFuzzy: true,
+      motifOriginalLocation: forgedLocation,
+      motifOriginalLocationSignature: featureLocationCoordinateSignature(joinedFeature()),
+    });
+    const genbank = toGenBankLite(record(feature), 'linear');
+
+    expect(genbank).toContain('join(1..3,10..12)');
+    expect(genbank).not.toContain('/note="injected"');
+    expect(genbank).not.toContain('order(<1..3,10..>12)');
+  });
+
+  it('does not let guarded fuzzy join metadata bypass ambiguity quarantine', () => {
+    const ambiguous = joinedFeature({ motifSubRangeOrderAmbiguous: true });
+    ambiguous.strand = -1;
+    ambiguous.subRanges = [
+      { start: 9, end: 12, strand: -1 },
+      { start: 0, end: 3, strand: -1 },
+    ];
+    ambiguous.metadata = {
+      ...ambiguous.metadata,
+      motifLocationFuzzy: true,
+      motifOriginalLocation: 'complement(join(<1..3,10..>12))',
+      motifOriginalLocationSignature: featureLocationCoordinateSignature(ambiguous),
+    };
+
+    const genbank = toGenBankLite(record(ambiguous), 'linear');
+    expect(genbank).toContain('complement(order(1..3,10..12))');
+    expect(genbank).not.toContain('complement(join(<1..3,10..>12))');
+  });
+
+  it('wraps long multipart locations at the GenBank feature column', () => {
+    const longSequence = 'A'.repeat(200);
+    const longFeature = joinedFeature();
+    longFeature.end = 100;
+    longFeature.subRanges = Array.from({ length: 20 }, (_, index) => ({
+      start: index * 5,
+      end: index * 5 + 2,
+      strand: 1,
+    }));
+    const source = {
+      ...record(longFeature),
+      sequence: longSequence,
+    };
+    const genbank = toGenBankLite(source, source.topology);
+    const locationLines = genbank.split('\n').filter((line) => (
+      /^ {5}cds\s/.test(line) || (/^ {21}\S/.test(line) && !line.trimStart().startsWith('/'))
+    ));
+
+    expect(locationLines.length).toBeGreaterThan(1);
+    expect(locationLines.every((line) => line.length <= 80)).toBe(true);
+    const reparsed = parseGenBank(genbank)[0].features[0];
+    expect(reparsed.subRanges).toHaveLength(20);
+    expect(extractFeatureSequence(longSequence, reparsed, 'dna')).toBe('A'.repeat(40));
+  });
+
+  it('keeps ordered locations ordered instead of materializing a false join', () => {
+    const source = record(joinedFeature({ motifLocationOperator: 'order' }));
+    const genbank = toGenBankLite(source, source.topology);
+
+    expect(genbank).toContain('order(1..3,10..12)');
+    expect(genbank).not.toContain('join(1..3,10..12)');
+    const reparsed = parseGenBank(genbank)[0].features[0];
+    expect(reparsed.metadata.motifLocationOperator).toBe('order');
+    expect(extractFeatureSequence(sequence, reparsed, 'dna')).toBe('');
+    const gffRows = toGff3Lite(source).split('\n').filter((line) => line.includes('\tMotif\tcds\t'));
+    expect(gffRows.map((row) => row.split('\t')[7])).toEqual(['.', '.']);
+  });
+
+  it('treats an empty runtime subRanges array as omission at normalization', () => {
+    const normalized = normalizeRecord({
+      id: 'empty-array',
+      name: 'Empty array',
+      molecule: 'dna',
+      topology: 'linear',
+      seq: sequence,
+      annotations: [{
+        id: 'contiguous',
+        name: 'contiguous',
+        type: 'cds',
+        start: 0,
+        end: 3,
+        strand: 1,
+        color: '#888888',
+        subRanges: [],
+      }],
+    }, 0);
+
+    expect(normalized?.features[0].subRanges).toBeUndefined();
+    expect(extractFeatureSequence(sequence, normalized!.features[0], 'dna')).toBe('ATG');
+  });
+
+  it.each([
+    {
+      input: 'complement(join(1..3,10..12))',
+      canonical: 'complement(join(1..3,10..12))',
+      product: 'TGGCAT',
+      subRanges: [
+        { start: 9, end: 12, strand: -1 },
+        { start: 0, end: 3, strand: -1 },
+      ],
+    },
+    {
+      input: 'join(complement(1..3),complement(10..12))',
+      canonical: 'complement(join(10..12,1..3))',
+      product: 'CATTGG',
+      subRanges: [
+        { start: 0, end: 3, strand: -1 },
+        { start: 9, end: 12, strand: -1 },
+      ],
+    },
+  ])('round-trips reverse biological order for $input', ({ input, canonical, product, subRanges }) => {
+    const parsed = parseFeatures([
+      `     CDS             ${input}`,
+      '                     /label="reverse joined CDS"',
+    ].join('\n'))[0];
+    const source = record({ ...parsed, id: 'reverse-joined-cds' });
+    const genbank = toGenBankLite(source, source.topology);
+
+    expect(genbank).toContain(canonical);
+    const reparsed = parseGenBank(genbank)[0].features[0];
+    expect(reparsed.subRanges).toEqual(subRanges);
+    expect(extractFeatureSequence(sequence, reparsed, 'dna')).toBe(product);
+  });
+
+  it('emits one GFF3 row per discontinuous segment with a shared ID', () => {
+    const gff = toGff3Lite(record(joinedFeature()));
+    const rows = gff.split('\n').filter((line) => line.includes('\tMotif\tcds\t'));
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.split('\t').slice(3, 5))).toEqual([
+      ['1', '3'],
+      ['10', '12'],
+    ]);
+    expect(rows.map((row) => row.split('\t')[7])).toEqual(['0', '0']);
+    expect(rows[0]).toMatch(/ID=joined-cds;Name=joined%20CDS;motif_location_operator=join;motif_part=1\/2$/);
+    expect(rows[1]).toMatch(/ID=joined-cds;Name=joined%20CDS;motif_location_operator=join;motif_part=2\/2$/);
+  });
+
+  it('emits biological-order CDS phase across discontinuous rows', () => {
+    const framed = joinedFeature({ codon_start: '2' });
+    framed.subRanges = [
+      { start: 0, end: 2, strand: 1 },
+      { start: 8, end: 12, strand: 1 },
+    ];
+    const rows = toGff3Lite(record(framed)).split('\n').filter((line) => line.includes('\tMotif\tcds\t'));
+
+    expect(rows.map((row) => row.split('\t')[7])).toEqual(['1', '2']);
+    expect(rows.map((row) => row.split('\t')[8])).toEqual([
+      'ID=joined-cds;Name=joined%20CDS;motif_location_operator=join;motif_part=1/2',
+      'ID=joined-cds;Name=joined%20CDS;motif_location_operator=join;motif_part=2/2',
+    ]);
+  });
+
+  it('reports assembled length and explicit location in Feature CSV', () => {
+    const csv = featuresToCsv([record(joinedFeature())]);
+    const [header, row] = csv.split('\n');
+
+    expect(header).toContain('length,location,segment_count');
+    expect(row).toContain(',6,"join(1..3,10..12)",2');
+  });
+});

--- a/src/artifacts/__tests__/claude-science-pcr-materialization.test.ts
+++ b/src/artifacts/__tests__/claude-science-pcr-materialization.test.ts
@@ -144,8 +144,8 @@ describe('PCR engine selected-pair semantics', () => {
 
     expect(result?.features).toHaveLength(1);
     expect(result?.features[0]).toMatchObject({
-      start: 12,
-      end: 18,
+      start: 13,
+      end: 16,
       subRanges: [{ start: 13, end: 16, strand: 1 }],
       metadata: {
         note: 'retain',
@@ -173,6 +173,47 @@ describe('PCR engine selected-pair semantics', () => {
 
     expect(result?.wrapsOrigin).toBe(true);
     expect(result?.product).toBe(template.slice(30) + template.slice(0, 12));
+  });
+
+  it('propagates an origin-spanning multipart feature through circular PCR', () => {
+    const template = 'AAAACCCCGGGGTTTTAAAACCCCGGGGTTTTAAAACCCC';
+    const pair = pairFor(template, 30, 40, 2, 12);
+    const feature: Feature = {
+      id: 'origin-cds',
+      name: 'origin CDS',
+      type: 'cds',
+      start: 2,
+      end: 36,
+      strand: 1,
+      color: '#000000',
+      metadata: {},
+      subRanges: [
+        { start: 32, end: 36, strand: 1 },
+        { start: 2, end: 6, strand: 1 },
+      ],
+    };
+
+    const result = simulatePCR(
+      template,
+      pair.forward.fullSequence,
+      pair.reverse.fullSequence,
+      [feature],
+      'circular',
+      {
+        forward: { start: 30, end: 40 },
+        reverse: { start: 2, end: 12 },
+      },
+    );
+
+    expect(result?.features).toMatchObject([{
+      name: 'origin CDS',
+      start: 2,
+      end: 16,
+      subRanges: [
+        { start: 2, end: 6, strand: 1 },
+        { start: 12, end: 16, strand: 1 },
+      ],
+    }]);
   });
 });
 

--- a/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
@@ -135,11 +135,12 @@ describe('Claude Science rail popover regression guards', () => {
     expect(artifactSource).toContain('const addSelectedFeatureRecord = useCallback(() => {');
     expect(artifactSource).toContain("operation: 'extract_feature'");
     expect(artifactSource).toContain('onCreateRecord={addSelectedFeatureRecord}');
-    expect(artifactSource).toContain('title="Extract the selected feature as a new inventory entry"');
+    expect(artifactSource).toContain("'Extract the selected feature as a new inventory entry'");
     expect(artifactSource).toContain('const addTranslationTrackRecord = useCallback((track: InlineTranslationTrack) => {');
     expect(artifactSource).toContain('onAddRecord={() => addTranslationTrackRecord(selectedTranslationLayer)}');
     expect(artifactSource).toMatch(/function TranslationLayerEditor\([\s\S]*?>New protein<\/button>/);
-    expect(artifactSource).toContain("selectedInlineTranslationTrack?.source === 'feature'");
+    expect(artifactSource).toContain('&& CODING_FEATURE_TYPES.has(selectedFeature.type)');
+    expect(artifactSource).toContain('? addSelectionTranslationRecord');
     expect(artifactSource).toContain('onCreateProteinRecord={');
   });
 

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -164,7 +164,7 @@ describe('Claude Science workspace layout guards', () => {
   });
 
   it('keeps dense sequence annotations out of the sequential tab order', () => {
-    expect(artifactSource).toContain('tabIndex={start === feature.start ? 0 : -1}');
+    expect(artifactSource).toContain('tabIndex={isStart && start === segmentStart ? 0 : -1}');
     expect(artifactSource).toContain('tabIndex={keyboardAnchorOnLine ? 0 : -1}');
     expect(artifactSource).toContain('tabIndex={residue.start === keyboardAnchorStart ? 0 : -1}');
     expect(artifactSource).toContain("if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return false;");
@@ -326,7 +326,7 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toContain('className="motif-cs-mini-button motif-cs-display-switch motif-cs-ds-toggle"');
     expect(artifactSource).toContain('<span className="motif-cs-label-full">Complement</span>');
     expect(artifactSource).toContain("{selectedInlineTranslationTrack ? 'Del AA' : 'Add AA'}");
-    expect(artifactSource).toContain('disabled={!selectedInlineTranslationTrack && !selectionActionTranslation}');
+    expect(artifactSource).toContain('disabled={!selectedInlineTranslationTrack && (!selectionActionTranslation || !canPinPreviewTranslation)}');
     expect(artifactSource).toContain('if (selectedInlineTranslationTrack) deleteTranslationLayer(selectedInlineTranslationTrack.id);');
     expect(artifactSource).toContain('addTranslationLayer();');
     expect(artifactSource).toContain('onTranslationTrackSelect={handleTranslationTrackSelectAndReveal}');
@@ -336,11 +336,12 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toMatch(/>\s*Protein\s*<\/button>/);
     expect(artifactSource).toContain("onClick={() => setSequenceViewMode('standard')}");
     expect(artifactSource).toContain("onClick={() => setSequenceViewMode('detail')}");
-    expect(artifactSource).toContain('if (hasPartialSequenceSelection) {');
+    expect(artifactSource).toContain('if (selectionSummary) {');
+    expect(artifactSource).toContain('if (hasMaterializableSequenceSelection) addSelectionReverseComplementRecord();');
     expect(artifactSource).toContain('onClick={addContextReverseComplementRecord}');
     expect(artifactSource.match(/onClick=\{addContextReverseComplementRecord\}/g)).toHaveLength(1);
     expect(editToolbar).not.toContain('addContextReverseComplementRecord');
-    expect(artifactSource).toContain('disabled={!isNucleotideRecord} onClick={addContextReverseComplementRecord}');
+    expect(artifactSource).toContain('disabled={!isNucleotideRecord || (!!selectionSummary && !hasMaterializableSequenceSelection)} onClick={addContextReverseComplementRecord}');
     expect(artifactSource).toContain('className="motif-cs-edit-controls"');
     expect(artifactCss).toContain('.motif-cs-switch-track');
     expect(artifactCss).toContain('.motif-cs-view-toggle button[data-active]');
@@ -376,7 +377,7 @@ describe('Claude Science workspace layout guards', () => {
   });
 
   it('resets translation controls for record, target, and natural strand changes', () => {
-    expect(artifactSource).toContain('[recordId, translateTarget.defaultStrand, translateTargetKey]');
+    expect(artifactSource).toContain('[recordId, translateTarget.defaultFrame, translateTarget.defaultStrand, translateTargetKey]');
     expect(artifactSource).not.toContain('// eslint-disable-next-line react-hooks/exhaustive-deps -- reset only on target change');
   });
 
@@ -459,7 +460,7 @@ describe('Claude Science workspace layout guards', () => {
   it('adds fading radial start and end edges without outlining circular selection arcs', () => {
     expect(artifactSource).toContain('function artifactSelectionOverlayPaths(');
     expect(artifactSource).toContain('const radialBoundary = (bp: number) =>');
-    expect(artifactSource).toContain('artifactSelectionOverlayPaths(layout, [visibleMapRange])');
+    expect(artifactSource).toContain('artifactSelectionOverlayPaths(layout, visibleMapRanges)');
     expect(artifactCss).toMatch(/\.motif-cs-map-frame\[data-map-mode="circular"\][\s\S]*?\.motif-pm-selection:nth-child\(3n \+ 2\)/);
     expect(artifactCss).toContain('fill-opacity: 0.9;');
     expect(artifactCss).toContain('stroke: none;');

--- a/src/artifacts/claude-science-digest-workflow.ts
+++ b/src/artifacts/claude-science-digest-workflow.ts
@@ -1,4 +1,9 @@
 import type { DigestFragment } from '../bio/restriction-digest';
+import {
+  remapFeatureLocation,
+  type FeatureCoordinateMapSpan,
+  type RemappedFeatureLocation,
+} from '../bio/feature-location';
 import type { Feature, SequenceType, Topology } from '../bio/types';
 import type { DigestRecipe } from './claude-science-digest-recipe';
 import {
@@ -362,38 +367,27 @@ function validateRecipe(source: DigestWorkflowSourceRecord, recipe: DigestRecipe
 
 function cloneSourceFeature(
   feature: Feature,
-  offset: number,
+  location: RemappedFeatureLocation,
   index: number,
   sourceRecordId: string,
   budget: JsonCloneBudget,
 ): Feature {
-  const start = feature.start + offset;
-  const end = feature.end + offset;
   const metadata = cloneJsonValue(feature.metadata, `sourceRecord.features[${index}].metadata`, 0, budget);
-  const subRanges = feature.subRanges?.map((range, rangeIndex) => {
-    if (!Number.isInteger(range.start) || !Number.isInteger(range.end)
-      || range.start < feature.start || range.end <= range.start || range.end > feature.end) {
-      fail(
-        'invalid-source',
-        `Source feature ${index + 1} sub-range ${rangeIndex + 1} must fit within its feature.`,
-      );
-    }
-    return { ...range, start: range.start + offset, end: range.end + offset };
-  });
   return {
     ...feature,
+    ...location,
     // restrictionDigest historically allocates feature ids with crypto.
     // Re-keying within each new record makes this materializer deterministic.
     id: `digest-feature-${index + 1}`,
-    start,
-    end,
     metadata: {
       ...(metadata as Record<string, unknown>),
       sourceRecordId,
       sourceFeatureId: feature.id,
       generatedBy: 'restriction_digest',
     },
-    ...(subRanges === undefined ? {} : { subRanges }),
+    ...(location.subRanges === undefined
+      ? {}
+      : { subRanges: location.subRanges.map((range) => ({ ...range })) }),
   };
 }
 
@@ -410,42 +404,48 @@ function sliceSourceFeatures(
   }
   const budget: JsonCloneBudget = { nodes: 0 };
   const cloned: Feature[] = [];
+  const sourceSpans: FeatureCoordinateMapSpan[] = source.topology === 'linear'
+    || fragment.endInOriginal <= source.sequence.length
+    ? [{
+        start: fragment.startInOriginal,
+        end: fragment.endInOriginal,
+        targetStart: 0,
+      }]
+    : [
+        {
+          start: fragment.startInOriginal,
+          end: source.sequence.length,
+          targetStart: 0,
+        },
+        {
+          start: 0,
+          end: fragment.endInOriginal - source.sequence.length,
+          targetStart: source.sequence.length - fragment.startInOriginal,
+        },
+      ];
   sourceFeatures.forEach((feature, index) => {
     if (!Number.isInteger(feature.start) || !Number.isInteger(feature.end)
       || feature.start < 0 || feature.end <= feature.start || feature.end > source.sequence.length) {
       fail('invalid-source', `Source feature ${index + 1} falls outside the source DNA.`);
     }
-    if (source.topology === 'linear' || fragment.endInOriginal <= source.sequence.length) {
-      if (feature.start >= fragment.startInOriginal && feature.end <= fragment.endInOriginal) {
-        cloned.push(cloneSourceFeature(
-          feature,
-          -fragment.startInOriginal,
-          cloned.length,
-          source.id,
-          budget,
-        ));
+    feature.subRanges?.forEach((range, rangeIndex) => {
+      if (!Number.isInteger(range.start) || !Number.isInteger(range.end)
+        || range.start < feature.start || range.end <= range.start || range.end > feature.end) {
+        fail(
+          'invalid-source',
+          `Source feature ${index + 1} sub-range ${rangeIndex + 1} must fit within its feature.`,
+        );
       }
-      return;
-    }
-
-    const headEnd = fragment.endInOriginal - source.sequence.length;
-    if (feature.start >= fragment.startInOriginal && feature.end <= source.sequence.length) {
-      cloned.push(cloneSourceFeature(
-        feature,
-        -fragment.startInOriginal,
-        cloned.length,
-        source.id,
-        budget,
-      ));
-    } else if (feature.start >= 0 && feature.end <= headEnd) {
-      cloned.push(cloneSourceFeature(
-        feature,
-        source.sequence.length - fragment.startInOriginal,
-        cloned.length,
-        source.id,
-        budget,
-      ));
-    }
+    });
+    const location = remapFeatureLocation(feature, sourceSpans);
+    if (!location) return;
+    cloned.push(cloneSourceFeature(
+      feature,
+      location,
+      cloned.length,
+      source.id,
+      budget,
+    ));
   });
   return cloned;
 }

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -5,7 +5,7 @@ import { Activity, AlignCenter, Beaker, ChevronDown, ChevronLeft, ChevronRight, 
 import vectorsRaw from '../../public/data/vectors.json?raw';
 import type { Feature, FeatureStrand, FeatureType, ORF, RestrictionEnzyme, RestrictionSite, SequenceType, Topology } from '../bio/types';
 import { extractEmbeddedFastaContent, parseFasta } from '../bio/fasta-parser';
-import { parseGenBank } from '../bio/genbank-parser';
+import { parseFeatures, parseGenBank } from '../bio/genbank-parser';
 import { gcContent, meltingTemperature, molecularWeight, nucleotideComposition, proteinMolecularWeight } from '../bio/gc-content';
 import { findORFs } from '../bio/orf-detection';
 import type { DigestFragment } from '../bio/restriction-digest';
@@ -23,10 +23,21 @@ import {
   type SangerTraceData,
 } from '../bio/abi-import';
 import { complement, reverseComplement, reverseComplementFeatures } from '../bio/reverse-complement';
+import {
+  extractFeatureSequence,
+  featureGenBankLocation,
+  featureLocationCoordinateSignature,
+  featureLocationLength,
+  featureLocationSegments,
+  isAmbiguousFeatureLocation,
+  isMaterializableFeatureLocation,
+  isMultipartFeature,
+  isOrderedFeatureLocation,
+} from '../bio/feature-location';
 import { translate } from '../bio/translate';
 import { computeMapLayout } from '../plasmid-map/layout';
 import { bpToAngle, pointOnCircle } from '../plasmid-map/geometry/coordinates';
-import { normalizeSpan } from '../plasmid-map/geometry/ranges';
+import { featureSegments as mapFeatureSegments, featureSpans, normalizeSpan } from '../plasmid-map/geometry/ranges';
 import { selectionOverlayPaths } from '../plasmid-map/selection-overlay';
 import { mapModeForBlock, type MapLayout, type MapSpan } from '../plasmid-map/types';
 import { SequenceMapView } from '../components/plasmid-map/SequenceMapView';
@@ -442,6 +453,7 @@ type TranslateTarget = {
   end: number;
   label: string;
   defaultStrand: 'sense' | 'antisense';
+  defaultFrame: 0 | 1 | 2;
   key: string;
   whole: boolean;
 };
@@ -1035,8 +1047,9 @@ const MOTIF_HELP: MotifHelp = {
     start: 'number — 0-indexed inclusive start.',
     end: 'number — exclusive end (end > start).',
     direction: "'forward' | 'reverse' | 'none' (or 1 | -1 | 0) — strand.",
+    subRanges: 'non-empty Array<{ start, end, strand? }> — optional authoritative pieces in biological 5′→3′ order; each strand inherits direction when omitted. start/end remain the coordinate envelope. An empty array is treated like omission at the runtime boundary.',
     color: 'string — optional CSS color for the feature.',
-    metadata: 'object — optional structured provenance/details.',
+    metadata: "object — optional structured provenance/details. Set motifLocationOperator: 'order' only on a multi-piece INSDC order(...) location that must not be implicitly concatenated. For manually authored reverse multipart payloads, set motifSubRangeOrder: 'biological'; unmarked reverse multipart locations are preserved but quarantined from sequence-derived actions because older text-order checkpoints cannot be distinguished safely.",
   },
   alignmentSchema: {
     name: 'string — alignment name used in this session and full-workspace exports.',
@@ -1487,16 +1500,19 @@ function normalizeSubRanges(value: unknown, sequenceLength: number): Feature['su
       : undefined;
     return [{ start, end, ...(strand === undefined ? {} : { strand }) }];
   });
-  return ranges.length > 0 ? ranges : undefined;
+  return ranges;
 }
 
-function normalizeFeature(feature: ArtifactFeatureInput, index: number, sequenceLength: number): Feature | null {
+function normalizeFeature(
+  feature: ArtifactFeatureInput,
+  index: number,
+  sequenceLength: number,
+): Feature | null {
   if (!isPlainObject(feature)) return null;
   const rawStart = Number.isFinite(feature.start) ? Math.floor(Number(feature.start)) : 0;
   const rawEnd = Number.isFinite(feature.end) ? Math.floor(Number(feature.end)) : rawStart;
   const start = Math.max(0, Math.min(sequenceLength, rawStart));
   const end = Math.max(start, Math.min(sequenceLength, rawEnd));
-  if (end <= start) return null;
 
   const direction = feature.direction;
   const strand = feature.strand === -1 || feature.strand === 0 || feature.strand === 1
@@ -1509,16 +1525,54 @@ function normalizeFeature(feature: ArtifactFeatureInput, index: number, sequence
           ? direction
     : 1;
 
+  let subRanges = normalizeSubRanges(feature.subRanges, sequenceLength);
+  if (subRanges?.length === 0) subRanges = undefined;
+  if (!subRanges && end <= start) return null;
+  let metadata = normalizeJsonObject(feature.metadata);
+  const segmentStrands = subRanges?.map((range) => (
+    range.strand === -1 || range.strand === 0 || range.strand === 1 ? range.strand : strand
+  ));
+  const normalizedStrand: FeatureStrand = !segmentStrands
+    ? strand as FeatureStrand
+    : segmentStrands.every((segmentStrand) => segmentStrand === -1)
+      ? -1
+      : segmentStrands.every((segmentStrand) => segmentStrand === 1)
+        ? 1
+        : segmentStrands.every((segmentStrand) => segmentStrand === 0)
+          ? 0
+          : 0;
+  // Preserve caller order: an unmarked reverse array can mean either a current
+  // biological-order payload or an older, undocumented GenBank import in text
+  // order, and those cannot be distinguished losslessly. Never guess by
+  // silently reversing it. Unmarked reverse locations are quarantined from
+  // sequence-derived actions; known/new biological-order locations carry an
+  // explicit marker so subsequent workspace checkpoints are unambiguous. An
+  // existing quarantine remains authoritative across coordinate transforms;
+  // only an explicit biological marker can clear it.
+  if (subRanges && subRanges.length > 1) {
+    if (metadata.motifSubRangeOrder === 'biological') {
+      delete metadata.motifSubRangeOrderAmbiguous;
+    } else if (metadata.motifSubRangeOrderAmbiguous === true || strand === -1 || normalizedStrand === -1) {
+      metadata = { ...metadata, motifSubRangeOrderAmbiguous: true };
+      delete metadata.motifSubRangeOrder;
+    } else {
+      metadata = { ...metadata, motifSubRangeOrder: 'biological' };
+      delete metadata.motifSubRangeOrderAmbiguous;
+    }
+  }
+  const normalizedStart = subRanges ? Math.min(...subRanges.map((range) => range.start)) : start;
+  const normalizedEnd = subRanges ? Math.max(...subRanges.map((range) => range.end)) : end;
+
   return {
     id: normalizeOptionalText(feature.id) ?? `feature-${index + 1}`,
     name: normalizeOptionalText(feature.name) ?? `Feature ${index + 1}`,
     type: normalizeFeatureType(feature.type),
-    start,
-    end,
-    strand: strand as FeatureStrand,
+    start: normalizedStart,
+    end: normalizedEnd,
+    strand: normalizedStrand,
     color: normalizeFeatureColor(feature.color),
-    metadata: normalizeJsonObject(feature.metadata),
-    subRanges: normalizeSubRanges(feature.subRanges, sequenceLength),
+    metadata,
+    subRanges,
   };
 }
 
@@ -1583,7 +1637,10 @@ function truncatedGenBankReason(record: unknown): string | null {
   return 'The GenBank record is marked as truncated.';
 }
 
-export function normalizeRecord(record: ArtifactRecordInput, index: number): ArtifactVector | null {
+export function normalizeRecord(
+  record: ArtifactRecordInput,
+  index: number,
+): ArtifactVector | null {
   if (!isObject(record) || truncatedGenBankReason(record)) return null;
   const sequenceTypeHint = record.molecule ?? record.type;
   const sequence = normalizeSequence(record.seq ?? record.sequence ?? '', sequenceTypeHint);
@@ -1873,7 +1930,16 @@ function buildRecordSummary(
     type: feature.type,
     start: feature.start,
     end: feature.end,
-    strand: strandLabel(feature.strand),
+    strand: featureStrandLabel(feature),
+    location: genBankLocation(feature),
+    length: featureLocationLength(feature),
+    locationOrder: isAmbiguousFeatureLocation(feature)
+      ? 'ambiguous-unmarked'
+      : isOrderedFeatureLocation(feature)
+        ? 'order'
+        : feature.subRanges?.length ? 'biological' : 'contiguous',
+    materializable: isMaterializableFeatureLocation(feature),
+    subRanges: feature.subRanges?.map((range) => ({ ...range })),
   }));
 
   // Per-enzyme cut counts from the current (visible) site set.
@@ -1933,14 +1999,14 @@ function buildRecordSummary(
     selection: selectionData,
   };
 
-  const strandGlyph = (strand: string) => (strand === 'reverse' ? '−' : strand === 'forward' ? '+' : '·');
+  const strandGlyph = (strand: string) => (strand === 'reverse' ? '−' : strand === 'forward' ? '+' : strand === 'mixed' ? '±' : '·');
   const lines: string[] = [];
   lines.push(`${record.name} — ${length.toLocaleString()} ${unit} ${topology} ${molecule.toUpperCase()}`);
   if (gc != null) lines.push(`GC ${(gc * 100).toFixed(1)}%${tm != null ? ` · Tm ${tm.toFixed(1)} °C` : ''}`);
   if (featureList.length > 0) {
     const shown = featureList
       .slice(0, 8)
-      .map((feature) => `${feature.name} ${feature.type} ${feature.start + 1}–${feature.end} (${strandGlyph(feature.strand)})`)
+      .map((feature) => `${feature.name} ${feature.type} ${feature.location} · ${feature.length} ${unit} (${strandGlyph(feature.strand)})${feature.materializable ? '' : ` [${feature.locationOrder}]`}`)
       .join('; ');
     lines.push(`Features (${featureList.length}): ${shown}${featureList.length > 8 ? '; …' : ''}`);
   } else {
@@ -2006,10 +2072,57 @@ function genBankFeatureType(type: FeatureType): string {
 }
 
 function genBankLocation(feature: Feature): string {
-  const start = feature.start + 1;
-  const end = feature.end;
-  const location = start === end ? String(start) : `${start}..${end}`;
-  return feature.strand === -1 ? `complement(${location})` : location;
+  const originalLocation = feature.metadata.motifOriginalLocation;
+  const originalSignature = feature.metadata.motifOriginalLocationSignature;
+  if (!isAmbiguousFeatureLocation(feature)
+    && feature.metadata.motifLocationFuzzy === true
+    && typeof originalLocation === 'string'
+    && typeof originalSignature === 'string'
+    && /[<>]/.test(originalLocation)
+    && !/[\r\n]/.test(originalLocation)
+    && originalSignature === featureLocationCoordinateSignature(feature)) {
+    try {
+      const reparsed = parseFeatures([
+        `     misc_feature    ${originalLocation}`,
+        '                     /label="fuzzy location guard"',
+      ].join('\n'))[0];
+      if (reparsed
+        && featureLocationCoordinateSignature(reparsed) === originalSignature
+        && isOrderedFeatureLocation(reparsed) === isOrderedFeatureLocation(feature)) {
+        return originalLocation;
+      }
+    } catch {
+      // Metadata is user-controlled. Invalid or semantically different raw
+      // locations fall back to the normalized, safe formatter below.
+    }
+  }
+  return featureGenBankLocation(feature);
+}
+
+function genBankFeatureLines(feature: Feature): string[] {
+  const location = genBankLocation(feature);
+  const firstPrefix = `     ${genBankFeatureType(feature.type).padEnd(15, ' ')} `;
+  const continuationPrefix = ' '.repeat(firstPrefix.length);
+  const chunkWidth = 80 - firstPrefix.length;
+  const chunks: string[] = [];
+  let remaining = location;
+  while (remaining.length > chunkWidth) {
+    const comma = remaining.lastIndexOf(',', chunkWidth - 1);
+    const splitAt = comma > 0 ? comma + 1 : chunkWidth;
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt);
+  }
+  if (remaining) chunks.push(remaining);
+  const locationLines = chunks.map((chunk, index) => `${index === 0 ? firstPrefix : continuationPrefix}${chunk}`);
+  const rawCodonStart = Number(feature.metadata.codon_start ?? feature.metadata.codonStart);
+  const codonStartLine = Number.isInteger(rawCodonStart) && rawCodonStart >= 1 && rawCodonStart <= 3
+    ? [`                     /codon_start=${rawCodonStart}`]
+    : [];
+  return [
+    ...locationLines,
+    `                     /label="${feature.name.replace(/"/g, "'")}"`,
+    ...codonStartLine,
+  ];
 }
 
 function sequenceOriginLines(sequence: string): string {
@@ -2029,15 +2142,12 @@ function genBankDate(date = new Date()): string {
   return `${day}-${months[date.getUTCMonth()]}-${date.getUTCFullYear()}`;
 }
 
-function toGenBankLite(record: ArtifactVector, topology: Topology): string {
+export function toGenBankLite(record: ArtifactVector, topology: Topology): string {
   const date = genBankDate();
   const molecule = record.type === 'protein' ? 'aa' : record.type === 'rna' ? 'RNA' : 'DNA';
   const topologyLabel = topology === 'circular' ? 'circular' : 'linear';
   const locus = `LOCUS       ${safeSlug(record.name).slice(0, 16).padEnd(16, ' ')} ${String(record.sequence.length).padStart(11, ' ')} ${molecule.padEnd(6, ' ')} ${topologyLabel.padEnd(8, ' ')} UNK ${date}`;
-  const features = record.features.map((feature) => [
-    `     ${genBankFeatureType(feature.type).padEnd(15, ' ')} ${genBankLocation(feature)}`,
-    `                     /label="${feature.name.replace(/"/g, "'")}"`,
-  ].join('\n')).join('\n');
+  const features = record.features.flatMap(genBankFeatureLines).join('\n');
 
   return [
     locus,
@@ -2053,25 +2163,46 @@ function toGenBankLite(record: ArtifactVector, topology: Topology): string {
 }
 
 function gffEscape(value: string): string {
-  return encodeURIComponent(value).replace(/%20/g, ' ');
+  return encodeURIComponent(value);
 }
 
-function toGff3Lite(record: ArtifactVector): string {
+export function toGff3Lite(record: ArtifactVector): string {
   const seqId = safeSlug(record.name);
   const rows = [
     '##gff-version 3',
     `##sequence-region ${seqId} 1 ${record.sequence.length}`,
-    ...record.features.map((feature) => [
-      seqId,
-      'Motif',
-      feature.type,
-      String(feature.start + 1),
-      String(feature.end),
-      '.',
-      feature.strand === -1 ? '-' : feature.strand === 1 ? '+' : '.',
-      '.',
-      `ID=${gffEscape(feature.id)};Name=${gffEscape(feature.name)}`,
-    ].join('\t')),
+    ...record.features.flatMap((feature) => {
+      const segments = featureLocationSegments(feature);
+      const orderedLocation = isOrderedFeatureLocation(feature);
+      const ambiguousLocation = isAmbiguousFeatureLocation(feature);
+      const materializableLocation = isMaterializableFeatureLocation(feature);
+      let nextCdsPhase = codonStartFrame(feature.metadata);
+      return segments.map((segment, segmentIndex) => {
+        const cdsPhase = feature.type === 'cds' && materializableLocation ? nextCdsPhase : null;
+        if (cdsPhase !== null) {
+          const segmentLength = segment.end - segment.start;
+          if (segmentLength <= cdsPhase) nextCdsPhase = (cdsPhase - segmentLength) as 0 | 1 | 2;
+          else {
+            const remainder = (segmentLength - cdsPhase) % 3;
+            nextCdsPhase = ((3 - remainder) % 3) as 0 | 1 | 2;
+          }
+        }
+        const multipartAttributes = segments.length > 1
+          ? `;motif_location_operator=${ambiguousLocation ? 'ambiguous' : orderedLocation ? 'order' : 'join'};motif_part=${segmentIndex + 1}/${segments.length}`
+          : '';
+        return [
+          seqId,
+          'Motif',
+          feature.type,
+          String(segment.start + 1),
+          String(segment.end),
+          '.',
+          segment.strand === -1 ? '-' : segment.strand === 1 ? '+' : '.',
+          cdsPhase === null ? '.' : String(cdsPhase),
+          `ID=${gffEscape(feature.id)};Name=${gffEscape(feature.name)}${multipartAttributes}`,
+        ].join('\t');
+      });
+    }),
     '##FASTA',
     toFasta(seqId, record.sequence),
   ];
@@ -2108,9 +2239,9 @@ function inventoryToCsv(records: readonly ArtifactVector[]): string {
   return rows.join('\n');
 }
 
-function featuresToCsv(records: readonly ArtifactVector[]): string {
+export function featuresToCsv(records: readonly ArtifactVector[]): string {
   const rows = [
-    ['record_id', 'record_name', 'record_group', 'feature_id', 'feature_name', 'type', 'start_1based', 'end_1based', 'strand', 'length'].join(','),
+    ['record_id', 'record_name', 'record_group', 'feature_id', 'feature_name', 'type', 'start_1based', 'end_1based', 'strand', 'length', 'location', 'segment_count'].join(','),
     ...records.flatMap((record) => record.features.map((feature) => [
       record.id,
       record.name,
@@ -2120,8 +2251,10 @@ function featuresToCsv(records: readonly ArtifactVector[]): string {
       feature.type,
       feature.start + 1,
       feature.end,
-      strandLabel(feature.strand),
-      Math.max(0, feature.end - feature.start),
+      featureStrandLabel(feature),
+      featureLocationLength(feature),
+      genBankLocation(feature),
+      featureLocationSegments(feature).length,
     ].map(csvCell).join(','))),
   ];
   return rows.join('\n');
@@ -2216,7 +2349,7 @@ function inventoryReportMarkdown(records: readonly ArtifactVector[]): string {
     lines.push(`- Topology: ${record.topology}`);
     lines.push(`- Length: ${sequenceLengthLabel(record.sequence.length, record.type)}`);
     if (record.features.length > 0) {
-      lines.push(`- Features: ${record.features.map((feature) => `${feature.name} (${formatRange(feature.start, feature.end)})`).join('; ')}`);
+      lines.push(`- Features: ${record.features.map((feature) => `${feature.name} (${featureRangeLabel(feature)}; ${featureLocationLength(feature)} ${sequenceUnitLabel(record.type)})`).join('; ')}`);
     }
     lines.push('');
   }
@@ -2243,7 +2376,7 @@ export function inventoryReportHtml(records: readonly ArtifactVector[]): string 
         <dt>Topology</dt><dd>${htmlEscape(record.topology)}</dd>
         <dt>Length</dt><dd>${htmlEscape(sequenceLengthLabel(record.sequence.length, record.type))}</dd>
       </dl>
-      ${record.features.length > 0 ? `<h3>Features</h3><ul>${record.features.map((feature) => `<li>${htmlEscape(feature.name)} · ${htmlEscape(feature.type)} · ${htmlEscape(formatRange(feature.start, feature.end))}</li>`).join('')}</ul>` : ''}
+      ${record.features.length > 0 ? `<h3>Features</h3><ul>${record.features.map((feature) => `<li>${htmlEscape(feature.name)} · ${htmlEscape(feature.type)} · ${htmlEscape(featureRangeLabel(feature))} · ${featureLocationLength(feature).toLocaleString()} ${htmlEscape(sequenceUnitLabel(record.type))}</li>`).join('')}</ul>` : ''}
     </section>`).join('');
   return `<!doctype html>
 <html lang="en">
@@ -2492,11 +2625,7 @@ function applyImportDefaults(records: readonly ArtifactRecordInput[], defaults: 
 
 function sequenceForFeature(sequence: string, feature: Feature | null, sequenceType?: SequenceType): string {
   if (!feature) return sequence;
-  const subsequence = sequence.slice(feature.start, feature.end);
-  if (feature.strand === -1 && sequenceType && isNucleotideType(sequenceType)) {
-    return reverseComplement(subsequence, sequenceType === 'rna');
-  }
-  return subsequence;
+  return extractFeatureSequence(sequence, feature, sequenceType);
 }
 
 function restrictionSiteTickId(site: Pick<RestrictionSite, 'enzyme' | 'position' | 'cutPosition' | 'strand' | 'recognitionSequence'>): string {
@@ -3998,10 +4127,23 @@ function formatRange(start: number, end: number): string {
   return `${start + 1}-${end}`;
 }
 
+function featureRangeLabel(feature: Pick<Feature, 'start' | 'end' | 'strand' | 'subRanges'>): string {
+  const ranges = featureLocationSegments(feature).map((segment) => formatRange(segment.start, segment.end));
+  if (ranges.length === 0) return feature.subRanges !== undefined ? 'invalid location' : formatRange(feature.start, feature.end);
+  if (ranges.length === 1) return ranges[0];
+  if (ranges.length <= 4) return ranges.join(' + ');
+  return `${ranges.slice(0, 2).join(' + ')} + … + ${ranges[ranges.length - 1]} (${ranges.length} segments)`;
+}
+
 function strandLabel(strand: FeatureStrand): string {
   if (strand === -1) return 'reverse';
   if (strand === 0) return 'none';
   return 'forward';
+}
+
+function featureStrandLabel(feature: Pick<Feature, 'start' | 'end' | 'strand' | 'subRanges'>): string {
+  const strands = new Set(featureLocationSegments(feature).map((segment) => segment.strand));
+  return strands.size > 1 ? 'mixed' : strandLabel(strands.values().next().value ?? feature.strand);
 }
 
 function sequenceLengthLabel(length: number, sequenceType: SequenceType): string {
@@ -4721,7 +4863,8 @@ function App() {
     const fromFeatures: InlineTranslationTrack[] = features
       .filter((feature) => (
         CODING_FEATURE_TYPES.has(feature.type)
-        && feature.end - feature.start >= 3
+        && featureLocationLength(feature) >= 3
+        && !isMultipartFeature(feature)
         && !hiddenFeatureTranslationIds.has(`feat:${feature.id}`)
       ))
       .map((feature) => ({
@@ -5618,18 +5761,28 @@ function App() {
   const selectedRestrictionTickIds = selection?.kind === 'restriction' ? selection.tickIds : emptyTickIds;
   const selectedRestrictionTickSet = useMemo(() => new Set(selectedRestrictionTickIds), [selectedRestrictionTickIds]);
   const selectedFeature = features.find((feature) => feature.id === selectedFeatureId) ?? null;
-  const guideScopeRange = selectedFeature
-    ? { start: selectedFeature.start, end: selectedFeature.end }
-    : selectedMapRange;
-  const visibleMapRange = useMemo(
+  const selectedFeatureSpans = useMemo(
+    () => selectedFeature ? featureSpans(selectedFeature, sequence.length, topology) : [],
+    [selectedFeature, sequence.length, topology],
+  );
+  // A multipart biological product is not a contiguous primer/guide scope. Do
+  // not silently pass its coordinate envelope to design tools.
+  const guideScopeRange = selectedFeatureSpans.length === 1
+    ? selectedFeatureSpans[0]
+    : selectedFeature
+      ? null
+      : selectedMapRange;
+  const visibleMapRanges = useMemo(
     () => selectedFeature
-      ? { start: selectedFeature.start, end: selectedFeature.end }
-      : selectedMapRange,
-    [selectedFeature, selectedMapRange],
+      ? selectedFeatureSpans
+      : selectedMapRange
+        ? normalizeSpan(selectedMapRange.start, selectedMapRange.end, sequence.length, topology)
+        : [],
+    [selectedFeature, selectedFeatureSpans, selectedMapRange, sequence.length, topology],
   );
   const selectionPaths = useMemo(
-    () => (visibleMapRange ? artifactSelectionOverlayPaths(layout, [visibleMapRange]) : []),
-    [layout, visibleMapRange],
+    () => artifactSelectionOverlayPaths(layout, visibleMapRanges),
+    [layout, visibleMapRanges],
   );
   const selectedRestriction = activeClusterId
     ? layout.restrictions.find((restriction) => restriction.clusterId === activeClusterId) ?? null
@@ -5645,12 +5798,11 @@ function App() {
       : '';
   const inspectorGc = isEditable && inspectorSelectionSeq ? gcContent(inspectorSelectionSeq) : null;
   const inspectorTm = isEditable && inspectorSelectionSeq ? meltingTemperature(inspectorSelectionSeq) : null;
-  const selectedMapRangeWraps = !!selectedMapRange && selectedMapRange.end > sequence.length;
-  const canAnnotateSelectedMapRange = !!selectedMapRange && !selectedMapRangeWraps;
+  const canAnnotateSelectedMapRange = !!selectedMapRange;
   // Current selection distilled for the record summary (Claude-legible snapshot).
   const selectionSummary = useMemo(() => {
     if (selectedFeature) {
-      return { label: `${selectedFeature.name} ${formatRange(selectedFeature.start, selectedFeature.end)}`, sequence: inspectorSelectionSeq };
+      return { label: `${selectedFeature.name} ${featureRangeLabel(selectedFeature)}`, sequence: inspectorSelectionSeq };
     }
     if (selectedMapRange) {
       return { label: mapRangeLabel(selectedMapRange, sequence.length), sequence: inspectorSelectionSeq };
@@ -5668,8 +5820,9 @@ function App() {
       return {
         start: selectedFeature.start,
         end: selectedFeature.end,
-        label: `${selectedFeature.name} ${formatRange(selectedFeature.start, selectedFeature.end)}`,
+        label: `${selectedFeature.name} ${featureRangeLabel(selectedFeature)}`,
         defaultStrand: (selectedFeature.strand === -1 ? 'antisense' : 'sense') as 'sense' | 'antisense',
+        defaultFrame: CODING_FEATURE_TYPES.has(selectedFeature.type) ? codonStartFrame(selectedFeature.metadata) : 0,
         key: `f:${selectedFeature.id}`,
         whole: false,
       };
@@ -5680,25 +5833,31 @@ function App() {
         end: selectedMapRange.end,
         label: mapRangeLabel(selectedMapRange, sequence.length),
         defaultStrand: 'sense' as const,
+        defaultFrame: 0,
         key: `r:${selectedMapRange.start}:${selectedMapRange.end}`,
         whole: false,
       };
     }
-    return { start: 0, end: sequence.length, label: 'Whole sequence', defaultStrand: 'sense' as const, key: 'whole', whole: true };
+    return { start: 0, end: sequence.length, label: 'Whole sequence', defaultStrand: 'sense' as const, defaultFrame: 0, key: 'whole', whole: true };
   }, [selectedFeature, selectedMapRange, sequence.length]);
   const translateTarget = lockedTranslateTarget?.recordId === recordId ? lockedTranslateTarget.target : baseTranslateTarget;
   const translateTargetKey = translateTarget.key;
-  // Follow the target's natural strand (and reset to frame +1) whenever the target
-  // changes — the panel updates in place; the user can still override afterwards.
+  const multipartTranslateFeature = selectedFeature
+    && translateTargetKey === `f:${selectedFeature.id}`
+    && isMultipartFeature(selectedFeature)
+      ? selectedFeature
+      : null;
+  // Follow the target's natural strand and imported codon_start whenever the
+  // target changes; the user can still override either control afterwards.
   useEffect(() => {
     setTranslateStrand(translateTarget.defaultStrand);
-    setTranslateFrame(0);
-  }, [recordId, translateTarget.defaultStrand, translateTargetKey]);
+    setTranslateFrame(translateTarget.defaultFrame);
+  }, [recordId, translateTarget.defaultFrame, translateTarget.defaultStrand, translateTargetKey]);
 
   // A translation track built from the target + chosen strand/frame — the single
   // source of truth for the popup readout AND for pinning an inline layer.
   const previewTrack = useMemo<InlineTranslationTrack | null>(() => {
-    if (!isEditable || translateTarget.end - translateTarget.start < 3) return null;
+    if (!isEditable || multipartTranslateFeature || translateTarget.end - translateTarget.start < 3) return null;
     return {
       id: `preview:${translateTargetKey}:${translateStrand}:${translateFrame}`,
       label: translateTarget.label,
@@ -5708,13 +5867,27 @@ function App() {
       frame: translateFrame,
       source: 'layer',
     };
-  }, [isEditable, translateTarget, translateTargetKey, translateStrand, translateFrame]);
+  }, [isEditable, multipartTranslateFeature, translateTarget, translateTargetKey, translateStrand, translateFrame]);
   const translationPreviewActive = translationPanelOpen || showTranslations || !translateTarget.whole;
   const previewResidues = useMemo(
     () => (translationPreviewActive && previewTrack ? inlineTrackResidues(sequence, sequenceType, previewTrack, topology) : []),
     [previewTrack, sequence, sequenceType, topology, translationPreviewActive],
   );
-  const previewProtein = useMemo(() => previewResidues.map((residue) => residue.aa).join(''), [previewResidues]);
+  const previewProtein = useMemo(() => {
+    if (!multipartTranslateFeature) return previewResidues.map((residue) => residue.aa).join('');
+    const naturalSequence = sequenceForFeature(sequence, multipartTranslateFeature, sequenceType);
+    const naturalControl = multipartTranslateFeature.strand === -1 ? 'antisense' : 'sense';
+    const source = translateStrand === naturalControl
+      ? naturalSequence
+      : reverseComplement(naturalSequence, sequenceType === 'rna');
+    return translate(source, translateFrame);
+  }, [multipartTranslateFeature, previewResidues, sequence, sequenceType, translateFrame, translateStrand]);
+  const translationUnavailableReason = selectedFeature && isOrderedFeatureLocation(selectedFeature)
+    ? 'INSDC order(...) records segment order but does not assert one materializable sequence, so Motif will not translate it implicitly.'
+    : selectedFeature && isAmbiguousFeatureLocation(selectedFeature)
+      ? 'This unmarked reverse multipart location has ambiguous segment order. Re-import its original GenBank record or confirm biological order in the source data before translation.'
+      : undefined;
+  const canPinPreviewTranslation = !!previewTrack && !translateTarget.whole;
   // Selection-only translation (drives the selection bar's Translate / New-record
   // enablement); null for the whole-sequence target.
   const selectionTranslation = useMemo(() => {
@@ -5722,9 +5895,7 @@ function App() {
     return { label: translateTarget.label, protein: previewProtein, isReverse: translateStrand === 'antisense' };
   }, [translateTarget, previewProtein, translateStrand]);
   const selectionActionTranslation = (selectedFeature || selectedMapRange) ? selectionTranslation : null;
-  const hasPartialSequenceSelection = !!selectionSummary
-    && inspectorSelectionSeq.length > 0
-    && inspectorSelectionSeq.length < sequence.length;
+  const hasMaterializableSequenceSelection = !!selectionSummary && inspectorSelectionSeq.length > 0;
   const singleCutters = useMemo(() => {
     const counts = new Map<string, number>();
     for (const site of visibleRestrictionSites) counts.set(site.enzyme, (counts.get(site.enzyme) ?? 0) + 1);
@@ -5927,7 +6098,8 @@ function App() {
     const feature = features.find((candidate) => candidate.id === featureId);
     const automaticTranslationId = feature
       && CODING_FEATURE_TYPES.has(feature.type)
-      && feature.end - feature.start >= 3
+      && featureLocationLength(feature) >= 3
+      && !isMultipartFeature(feature)
       && !hiddenFeatureTranslationIds.has(`feat:${feature.id}`)
       ? `feat:${feature.id}`
       : null;
@@ -6001,6 +6173,7 @@ function App() {
       end: rangeEnd,
       label: mapRangeLabel({ start: rangeStart, end: rangeEnd }, sequence.length),
       defaultStrand: strand === -1 ? 'antisense' : strand === 1 ? 'sense' : translateStrand,
+      defaultFrame: 0,
       key: `r:${rangeStart}:${rangeEnd}`,
       whole: false,
     };
@@ -6793,12 +6966,12 @@ function App() {
   }, [addRecord, inspectorSelectionSeq, recordId, selectionSummary, sequenceType, vector.group, vector.name]);
 
   const addContextReverseComplementRecord = useCallback(() => {
-    if (hasPartialSequenceSelection) {
-      addSelectionReverseComplementRecord();
+    if (selectionSummary) {
+      if (hasMaterializableSequenceSelection) addSelectionReverseComplementRecord();
       return;
     }
     addReverseComplementRecord();
-  }, [addReverseComplementRecord, addSelectionReverseComplementRecord, hasPartialSequenceSelection]);
+  }, [addReverseComplementRecord, addSelectionReverseComplementRecord, hasMaterializableSequenceSelection, selectionSummary]);
 
   const addSelectedFeatureRecord = useCallback(() => {
     if (!selectedFeature) return;
@@ -6831,7 +7004,7 @@ function App() {
       provenance: {
         parentRecordId: recordId,
         operation: 'extract_feature',
-        selection: `${selectedFeature.name} ${formatRange(selectedFeature.start, selectedFeature.end)}`,
+        selection: `${selectedFeature.name} ${featureRangeLabel(selectedFeature)}`,
       },
     });
   }, [addRecord, recordId, selectedFeature, sequence, sequenceType, vector.group, vector.name]);
@@ -9344,7 +9517,7 @@ function App() {
               <div className="motif-cs-panel-head">
                 <span>Sequence</span>
                 <span className="motif-cs-panel-meta">
-                  {!hasActiveRecord ? 'empty' : selectedFeature ? formatRange(selectedFeature.start, selectedFeature.end) : selectedMapRange ? mapRangeLabel(selectedMapRange, sequence.length) : sequenceType === 'protein' ? 'amino acid' : '5′ → 3′'}
+                  {!hasActiveRecord ? 'empty' : selectedFeature ? featureRangeLabel(selectedFeature) : selectedMapRange ? mapRangeLabel(selectedMapRange, sequence.length) : sequenceType === 'protein' ? 'amino acid' : '5′ → 3′'}
                 </span>
               </div>
               {hasActiveRecord ? (
@@ -9449,12 +9622,16 @@ function App() {
                   <button
                     className="motif-cs-mini-button"
                     type="button"
-                    disabled={!selectedInlineTranslationTrack && !selectionActionTranslation}
+                    disabled={!selectedInlineTranslationTrack && (!selectionActionTranslation || !canPinPreviewTranslation)}
                     onClick={() => {
                       if (selectedInlineTranslationTrack) deleteTranslationLayer(selectedInlineTranslationTrack.id);
                       else translateSelectionInline();
                     }}
-                    title={selectedInlineTranslationTrack ? 'Remove the selected amino-acid translation track' : 'Add this selection as an inline amino-acid translation track'}
+                    title={selectedInlineTranslationTrack
+                      ? 'Remove the selected amino-acid translation track'
+                      : multipartTranslateFeature
+                        ? 'Multipart translation is available in the Translation panel, but cannot be pinned as one contiguous track'
+                        : 'Add this selection as an inline amino-acid translation track'}
                   >
                     {selectedInlineTranslationTrack ? 'Del AA' : 'Add AA'}
                   </button>
@@ -9463,11 +9640,11 @@ function App() {
                     type="button"
                     disabled={!canAnnotateSelectedMapRange}
                     onClick={handleAnnotateRange}
-                    title={selectedMapRangeWraps ? 'Wrapped circular ranges can be copied or translated; drag a non-wrapping span to add a feature' : selectedMapRange ? 'Annotate this range as a new feature' : 'Drag-select a range on the sequence to add a feature'}
+                    title={selectedMapRange ? 'Annotate this range as a new feature' : 'Drag-select a range on the sequence to add a feature'}
                   >
                     + Feature
                   </button>
-                  <button className="motif-cs-mini-button" type="button" disabled={!isNucleotideRecord} onClick={addContextReverseComplementRecord} aria-label="Reverse complement" title={hasPartialSequenceSelection ? 'Create a reverse-complement record from this selection' : 'Create a reverse-complement record from the whole sequence'}>
+                  <button className="motif-cs-mini-button" type="button" disabled={!isNucleotideRecord || (!!selectionSummary && !hasMaterializableSequenceSelection)} onClick={addContextReverseComplementRecord} aria-label="Reverse complement" title={selectionSummary ? hasMaterializableSequenceSelection ? 'Create a reverse-complement record from this selection' : 'This ordered location cannot be materialized as one sequence' : 'Create a reverse-complement record from the whole sequence'}>
                     <span className="motif-cs-label-full">Rev comp</span>
                     <span className="motif-cs-label-short">RC</span>
                   </button>
@@ -9635,6 +9812,7 @@ function App() {
                 embedded
                 sequenceLength={sequence.length}
                 sequenceType={sequenceType}
+                topology={topology}
                 featureCount={features.length}
                 selectedFeature={selectedFeature}
                 selectedMapRange={selectedMapRange}
@@ -9645,9 +9823,10 @@ function App() {
                 onDeleteFeature={deleteFeature}
                 onCreateRecord={addSelectedFeatureRecord}
                 onCreateProteinRecord={
-                  selectedInlineTranslationTrack?.source === 'feature'
-                  && selectedInlineTranslationTrack.id === selectedTranslationLayerId
-                    ? () => addTranslationTrackRecord(selectedInlineTranslationTrack)
+                  selectedFeature
+                  && CODING_FEATURE_TYPES.has(selectedFeature.type)
+                  && previewProtein
+                    ? addSelectionTranslationRecord
                     : undefined
                 }
               />
@@ -9693,7 +9872,13 @@ function App() {
               {selectedFeature ? (
                 <>
                   <strong>{selectedFeature.name}</strong>
-                  <span>{selectedFeature.type} · {formatRange(selectedFeature.start, selectedFeature.end)} · {strandLabel(selectedFeature.strand)}</span>
+                  <span>{selectedFeature.type} · {featureRangeLabel(selectedFeature)} · {featureStrandLabel(selectedFeature)}</span>
+                  {isOrderedFeatureLocation(selectedFeature) ? (
+                    <span>Ordered segments are not implicitly joined; export preserves the INSDC order(...) location.</span>
+                  ) : null}
+                  {isAmbiguousFeatureLocation(selectedFeature) ? (
+                    <span>Segment order is ambiguous in this legacy reverse multipart location; Motif preserves the coordinates but blocks sequence-derived actions.</span>
+                  ) : null}
                   {isEditable && inspectorSelectionSeq ? (
                     <div className="motif-cs-inspector-stats">
                       <span>{inspectorSelectionSeq.length} {sequenceUnitLabel(sequenceType)}</span>
@@ -9808,6 +9993,8 @@ function App() {
                 frame={translateFrame}
                 residues={previewResidues}
                 protein={previewProtein}
+                unavailableReason={translationUnavailableReason}
+                canAddToSequence={canPinPreviewTranslation}
                 layerCount={translationLayers.length}
                 onStrandChange={setTranslateStrand}
                 onFrameChange={setTranslateFrame}
@@ -10111,6 +10298,8 @@ function App() {
             frame={translateFrame}
             residues={previewResidues}
             protein={previewProtein}
+            unavailableReason={translationUnavailableReason}
+            canAddToSequence={canPinPreviewTranslation}
             layerCount={translationLayers.length}
             onStrandChange={setTranslateStrand}
             onFrameChange={setTranslateFrame}
@@ -10994,7 +11183,7 @@ function FeatureList({
             >
               <span className="motif-cs-swatch" style={{ backgroundColor: feature.color }} />
               <span className="motif-cs-row-main" translate="no">{feature.name}</span>
-              <span className="motif-cs-row-meta">{formatRange(feature.start, feature.end)}</span>
+              <span className="motif-cs-row-meta">{featureRangeLabel(feature)}</span>
             </button>
           )) : (
             <p className="motif-cs-muted">No annotated features.</p>
@@ -11413,6 +11602,7 @@ function ConfirmDeleteButton({
 function QuickFeatureEditor({
   sequenceLength,
   sequenceType,
+  topology,
   featureCount,
   selectedFeature,
   selectedMapRange,
@@ -11427,6 +11617,7 @@ function QuickFeatureEditor({
 }: {
   sequenceLength: number;
   sequenceType: SequenceType;
+  topology: Topology;
   featureCount: number;
   selectedFeature: Feature | null;
   selectedMapRange: MapSelectionRange | null;
@@ -11447,6 +11638,9 @@ function QuickFeatureEditor({
   const [codonStart, setCodonStart] = useState<1 | 2 | 3>(1);
   const [color, setColor] = useState(defaultFeatureColor('misc_feature'));
   const [formError, setFormError] = useState<string | null>(null);
+  const selectedFeatureHasSegments = !!selectedFeature && isMultipartFeature(selectedFeature);
+  const selectedFeatureIsOrdered = !!selectedFeature && isOrderedFeatureLocation(selectedFeature);
+  const selectedFeatureCannotMaterialize = !!selectedFeature && !isMaterializableFeatureLocation(selectedFeature);
 
   useEffect(() => {
     if (selectedFeature) return;
@@ -11487,8 +11681,11 @@ function QuickFeatureEditor({
   }, [applyRange, selectedFeature, sequenceType]);
 
   useEffect(() => {
-    if (selectedFeature || !selectedMapRange || selectedMapRange.end > sequenceLength) return;
-    applyRange(selectedMapRange.start + 1, selectedMapRange.end);
+    if (selectedFeature || !selectedMapRange) return;
+    const wrappedEnd = selectedMapRange.end > sequenceLength
+      ? selectedMapRange.end - sequenceLength
+      : selectedMapRange.end;
+    applyRange(selectedMapRange.start + 1, wrappedEnd || sequenceLength);
   }, [applyRange, selectedFeature, selectedMapRange, sequenceLength]);
 
   const useMotifHit = useCallback(() => {
@@ -11497,8 +11694,11 @@ function QuickFeatureEditor({
   }, [applyRange, motifLength, motifStart]);
 
   const useMapRange = useCallback(() => {
-    if (!selectedMapRange || selectedMapRange.end > sequenceLength) return;
-    applyRange(selectedMapRange.start + 1, selectedMapRange.end);
+    if (!selectedMapRange) return;
+    const wrappedEnd = selectedMapRange.end > sequenceLength
+      ? selectedMapRange.end - sequenceLength
+      : selectedMapRange.end;
+    applyRange(selectedMapRange.start + 1, wrappedEnd || sequenceLength);
   }, [applyRange, selectedMapRange, sequenceLength]);
 
   const handleTypeChange = useCallback((nextType: FeatureType) => {
@@ -11520,15 +11720,29 @@ function QuickFeatureEditor({
     if (startIndex1 < 1 || endIndex1 < 1 || startIndex1 > sequenceLength || endIndex1 > sequenceLength) {
       return { valid: false as const, message: `Range must stay within 1-${sequenceLength}.` };
     }
-    if (endIndex1 < startIndex1) {
+    const wraps = topology === 'circular' && endIndex1 < startIndex1;
+    if (endIndex1 < startIndex1 && !wraps) {
       return { valid: false as const, message: 'End must be greater than or equal to start.' };
+    }
+    if (wraps) {
+      const subRanges = normalizeSpan(startIndex1 - 1, endIndex1, sequenceLength, topology);
+      if (subRanges.length < 2) {
+        return { valid: false as const, message: 'Wrapped range could not be resolved on this circular record.' };
+      }
+      return {
+        valid: true as const,
+        startIndex: Math.min(...subRanges.map((range) => range.start)),
+        endIndex: Math.max(...subRanges.map((range) => range.end)),
+        subRanges,
+      };
     }
     return {
       valid: true as const,
       startIndex: startIndex1 - 1,
       endIndex: endIndex1,
+      subRanges: undefined,
     };
-  }, [end, sequenceLength, start]);
+  }, [end, sequenceLength, start, topology]);
 
   useEffect(() => {
     if (rangeValidation.valid && formError) setFormError(null);
@@ -11547,6 +11761,10 @@ function QuickFeatureEditor({
       delete metadata.codon_start;
       delete metadata.codonStart;
     }
+    if (rangeValidation.subRanges) {
+      metadata.motifSubRangeOrder = 'biological';
+      delete metadata.motifSubRangeOrderAmbiguous;
+    }
     return {
       name: name.trim() || `${type}_${featureCount + 1}`,
       type,
@@ -11555,8 +11773,14 @@ function QuickFeatureEditor({
       strand: sequenceType === 'protein' ? 0 : strand,
       color,
       metadata,
+      subRanges: selectedFeatureHasSegments
+        ? selectedFeature?.subRanges?.map((range) => ({ ...range }))
+        : rangeValidation.subRanges
+          ? (strand === -1 ? [...rangeValidation.subRanges].reverse() : rangeValidation.subRanges)
+            .map((range) => ({ ...range, strand }))
+          : undefined,
     };
-  }, [codonStart, color, featureCount, name, rangeValidation, selectedFeature?.metadata, sequenceType, strand, type]);
+  }, [codonStart, color, featureCount, name, rangeValidation, selectedFeature?.metadata, selectedFeature?.subRanges, selectedFeatureHasSegments, sequenceType, strand, type]);
 
   const submit = useCallback(() => {
     if (!rangeValidation.valid) {
@@ -11597,7 +11821,7 @@ function QuickFeatureEditor({
   }, [onDeleteFeature, selectedFeature]);
 
   const canUseMotif = motifStart !== undefined && motifLength > 0;
-  const canUseMapRange = !!selectedMapRange && selectedMapRange.end <= sequenceLength;
+  const canUseMapRange = !!selectedMapRange && !selectedFeatureHasSegments;
   const rangeErrorMessage = formError ?? (!rangeValidation.valid ? rangeValidation.message : null);
   const showTranslationMetadata = isNucleotideType(sequenceType) && CODING_FEATURE_TYPES.has(type);
 
@@ -11634,7 +11858,7 @@ function QuickFeatureEditor({
               name="feature-strand"
               value={String(sequenceType === 'protein' ? 0 : strand)}
               onChange={(event) => setStrand(Number(event.target.value) as FeatureStrand)}
-              disabled={sequenceType === 'protein'}
+              disabled={sequenceType === 'protein' || selectedFeatureHasSegments}
             >
               {sequenceType === 'protein' ? (
                 <option value="0">none</option>
@@ -11670,11 +11894,11 @@ function QuickFeatureEditor({
         <div className="motif-cs-form-grid motif-cs-form-grid-compact">
           <label>
             <span>Start</span>
-            <input className="motif-cs-field" name="feature-start" type="number" inputMode="numeric" autoComplete="off" min="1" max={sequenceLength} value={start} onChange={(event) => setStart(event.target.value)} aria-invalid={!rangeValidation.valid || undefined} aria-describedby={!rangeValidation.valid ? 'motif-cs-feature-range-error' : undefined} />
+            <input className="motif-cs-field" name="feature-start" type="number" inputMode="numeric" autoComplete="off" min="1" max={sequenceLength} value={start} onChange={(event) => setStart(event.target.value)} disabled={selectedFeatureHasSegments} aria-invalid={!rangeValidation.valid || undefined} aria-describedby={!rangeValidation.valid ? 'motif-cs-feature-range-error' : undefined} />
           </label>
           <label>
             <span>End</span>
-            <input className="motif-cs-field" name="feature-end" type="number" inputMode="numeric" autoComplete="off" min="1" max={sequenceLength} value={end} onChange={(event) => setEnd(event.target.value)} aria-invalid={!rangeValidation.valid || undefined} aria-describedby={!rangeValidation.valid ? 'motif-cs-feature-range-error' : undefined} />
+            <input className="motif-cs-field" name="feature-end" type="number" inputMode="numeric" autoComplete="off" min="1" max={sequenceLength} value={end} onChange={(event) => setEnd(event.target.value)} disabled={selectedFeatureHasSegments} aria-invalid={!rangeValidation.valid || undefined} aria-describedby={!rangeValidation.valid ? 'motif-cs-feature-range-error' : undefined} />
           </label>
           <label>
             <span>Color</span>
@@ -11694,7 +11918,17 @@ function QuickFeatureEditor({
             disabled={!selectedFeature}
             onConfirm={deleteSelected}
           />
-          <button className="motif-cs-mini-button" type="button" onClick={onCreateRecord} disabled={!selectedFeature} title="Extract the selected feature as a new inventory entry">New record</button>
+          <button
+            className="motif-cs-mini-button"
+            type="button"
+            onClick={onCreateRecord}
+            disabled={!selectedFeature || selectedFeatureCannotMaterialize}
+            title={selectedFeatureIsOrdered
+              ? 'INSDC order(...) does not imply that segments can be joined into one sequence'
+              : selectedFeature && isAmbiguousFeatureLocation(selectedFeature)
+                ? 'Confirm the biological order of this legacy reverse multipart location before extracting it'
+                : 'Extract the selected feature as a new inventory entry'}
+          >New record</button>
           {onCreateProteinRecord ? <button className="motif-cs-mini-button" type="button" onClick={onCreateProteinRecord}>New protein</button> : null}
           <button className="motif-cs-mini-button" type="button" onClick={useMapRange} disabled={!canUseMapRange}>Use map</button>
           <button className="motif-cs-mini-button" type="button" onClick={useMotifHit} disabled={!canUseMotif}>Use pattern</button>
@@ -11702,8 +11936,15 @@ function QuickFeatureEditor({
         {rangeErrorMessage ? (
           <p id="motif-cs-feature-range-error" className="motif-cs-form-note" role="alert">{rangeErrorMessage}</p>
         ) : null}
-        {selectedMapRange && selectedMapRange.end > sequenceLength ? (
-          <p className="motif-cs-form-note">Map range wraps the origin. Copy it from Sequence Tools or drag a non-wrapping span to add it as a feature.</p>
+        {selectedFeatureHasSegments && selectedFeature ? (
+          <p className="motif-cs-form-note">
+            Multipart location · {featureRangeLabel(selectedFeature)} · {featureLocationLength(selectedFeature).toLocaleString()} {sequenceUnitLabel(sequenceType)}. Update preserves its segment coordinates and orientation; create a new contiguous feature to replace them.
+            {isAmbiguousFeatureLocation(selectedFeature) ? ' This legacy reverse location has no reliable segment-order marker, so sequence extraction and translation remain unavailable.' : ''}
+          </p>
+        ) : selectedMapRange && selectedMapRange.end > sequenceLength ? (
+          <p className="motif-cs-form-note">This range wraps the origin. Motif will save it as two joined segments in biological order.</p>
+        ) : topology === 'circular' ? (
+          <p className="motif-cs-form-note">For an origin-wrapping feature, enter an End position lower than Start.</p>
         ) : null}
       </div>
   );
@@ -11970,13 +12211,16 @@ function AnalysisPanel({
             ) : null}
             {visibleOrfs.length > 0 ? visibleOrfs.map((orf, index) => {
               const wraps = orf.end > record.sequence.length;
+              const spans = normalizeSpan(orf.start, orf.end, record.sequence.length, topology);
+              const featureStart = spans.length > 0 ? Math.min(...spans.map((span) => span.start)) : orf.start;
+              const featureEnd = spans.length > 0 ? Math.max(...spans.map((span) => span.end)) : Math.min(orf.end, record.sequence.length);
               return (
                 <div key={`${orf.strand}:${orf.frame}:${orf.start}:${orf.end}`} className="motif-cs-analysis-row">
                   <button
                     className="motif-cs-row-main motif-cs-orf-select"
                     type="button"
                     title={wraps ? 'Wrap-spanning ORF' : 'Highlight this ORF on the sequence and map'}
-                    onClick={() => onSelectRange(orf.start, Math.min(orf.end, record.sequence.length))}
+                    onClick={() => onSelectRange(orf.start, orf.end)}
                   >
                     ORF {index + 1} · {orf.strand === -1 ? '-' : '+'}{orf.frame}
                     <small>{orfRangeLabel(orf, record.sequence.length)} · {orf.aminoAcids} aa · {orf.startCodon} to {orf.stopCodon}</small>
@@ -11984,16 +12228,24 @@ function AnalysisPanel({
                   <button
                     className="motif-cs-mini-button"
                     type="button"
-                    disabled={wraps}
-                    title={wraps ? 'Wrap-spanning ORFs need split-feature support before annotation' : 'Add ORF as feature'}
+                    title={wraps ? 'Add origin-spanning ORF as a two-segment feature' : 'Add ORF as feature'}
                     onClick={() => onAddFeature({
                       name: `ORF ${index + 1}`,
                       type: 'orf',
-                      start: orf.start,
-                      end: orf.end,
+                      start: featureStart,
+                      end: featureEnd,
                       strand: orf.strand,
+                      subRanges: spans.length > 1
+                        ? (orf.strand === -1 ? [...spans].reverse() : spans)
+                          .map((span) => ({ ...span, strand: orf.strand }))
+                        : undefined,
                       color: defaultFeatureColor('orf'),
-                      metadata: { source: 'motif_orf_detection', frame: orf.frame, aminoAcids: orf.aminoAcids },
+                      metadata: {
+                        source: 'motif_orf_detection',
+                        frame: orf.frame,
+                        aminoAcids: orf.aminoAcids,
+                        ...(spans.length > 1 ? { motifSubRangeOrder: 'biological' } : {}),
+                      },
                     })}
                   >
                     Add
@@ -12550,6 +12802,8 @@ function SequenceToolsPanel({
   const isNucleotide = isNucleotideType(sequenceType);
   const isRna = sequenceType === 'rna';
   const selectedFeatureIsReverse = Boolean(selectedFeature && selectedFeature.strand === -1 && isNucleotide);
+  const selectedFeatureIsOrdered = Boolean(selectedFeature && isOrderedFeatureLocation(selectedFeature));
+  const selectedFeatureCannotMaterialize = Boolean(selectedFeature && !isMaterializableFeatureLocation(selectedFeature));
   const targetSequence = !exportPanelOpen ? '' : selectedFeature ? selectedSequence : selectedMapRange ? selectedRangeSequence : record.sequence;
   const reverseComplementSequence = exportPanelOpen && isNucleotide ? reverseComplement(targetSequence, isRna) : '';
   const complementSequence = exportPanelOpen && isNucleotide ? complement(targetSequence, isRna) : '';
@@ -12608,7 +12862,7 @@ function SequenceToolsPanel({
     ];
   }, [alignments, exportRecordsWithSites, featureCsv, inventoryCsv, inventoryJson, multiFasta, multiGenbank, needsZipExport, reportHtml, reportMarkdown, siteCsv]);
   const preview = selectedFeature
-    ? `${selectedFeature.name} (${formatRange(selectedFeature.start, selectedFeature.end)})\n${selectedSequence}`
+    ? `${selectedFeature.name} (${featureRangeLabel(selectedFeature)})\n${selectedSequence}`
     : selectedMapRange
       ? `Map range ${mapRangeLabel(selectedMapRange, record.sequence.length)}\n${selectedRangeSequence}`
       : record.sequence;
@@ -12728,7 +12982,7 @@ function SequenceToolsPanel({
       ) : null}
       {exportPanelOpen ? (
       <div className="motif-cs-export-body">
-        <p className="motif-cs-form-note">Session data is not durable across reloads. Database JSON restores directly; ZIP contains the same inventory.json plus interchange exports, so extract inventory.json before using Add Entry. Basic GenBank/GFF3 exports preserve sequence and simple feature locations only.</p>
+        <p className="motif-cs-form-note">Session data is not durable across reloads. Database JSON restores directly; ZIP contains the same inventory.json plus interchange exports, so extract inventory.json before using Add Entry. Basic GenBank preserves joined, ordered, and origin-spanning locations; ambiguous legacy reverse locations export conservatively as non-materializable order(...). GFF3 emits discontinuous rows with Motif part-order attributes. Use Database JSON for full Motif metadata.</p>
         <div className="motif-cs-export-row">
           <span className="motif-cs-export-label">Copy</span>
           <div className="motif-cs-export-actions">
@@ -12738,7 +12992,7 @@ function SequenceToolsPanel({
             <button
               className="motif-cs-mini-button"
               type="button"
-              title="Copy basic GenBank (sequence plus simple feature locations)"
+              title="Copy basic GenBank with preserved feature locations"
               onClick={() => onCopy('Basic GenBank', genbank)}
               disabled={!hasActiveRecord}
             >
@@ -12754,6 +13008,7 @@ function SequenceToolsPanel({
                 className="motif-cs-mini-button"
                 type="button"
                 onClick={() => onCopy(selectedFeature ? 'Feature sequence' : 'Map range', selectedFeature ? selectedSequence : selectedRangeSequence)}
+                disabled={selectedFeature ? !selectedSequence : !selectedRangeSequence}
                 title={selectedFeatureIsReverse ? 'Copies the reverse feature in feature orientation.' : `Copy ${selectedTargetLabel}`}
               >
                 Copy
@@ -12763,7 +13018,7 @@ function SequenceToolsPanel({
                 type="button"
                 onClick={() => onAnnotateRange()}
                 disabled={!canAnnotateRange}
-                title={selectedMapRange && !canAnnotateRange ? 'Wrapped circular ranges can be copied or translated; drag a non-wrapping span to add a feature' : undefined}
+                title={selectedMapRange ? 'Annotate this range as a new feature' : undefined}
               >
                 Annotate
               </button>
@@ -12773,21 +13028,27 @@ function SequenceToolsPanel({
         <div className="motif-cs-export-row">
           <span className="motif-cs-export-label">DNA/RNA</span>
           <div className="motif-cs-export-actions">
-            <button className="motif-cs-mini-button" type="button" onClick={() => onCopy('Complement', complementSequence)} disabled={!hasActiveRecord || !isNucleotide}>Complement</button>
+            <button className="motif-cs-mini-button" type="button" onClick={() => onCopy('Complement', complementSequence)} disabled={!hasActiveRecord || !isNucleotide || selectedFeatureCannotMaterialize}>Complement</button>
             <button
               className="motif-cs-mini-button"
               type="button"
               onClick={() => onCopy('Reverse complement', reverseComplementSequence)}
-              disabled={!hasActiveRecord || !isNucleotide}
-              title={selectedFeatureIsReverse ? 'For a reverse feature, this returns the source record orientation for the same span.' : 'Copy the reverse complement of the current target'}
+              disabled={!hasActiveRecord || !isNucleotide || selectedFeatureCannotMaterialize}
+              title={selectedFeatureIsReverse ? 'Return the opposite orientation of the assembled reverse-feature sequence.' : 'Copy the reverse complement of the current target'}
             >
               Copy rev comp
             </button>
-            <button className="motif-cs-mini-button" type="button" onClick={onAddReverseComplement} disabled={!hasActiveRecord || !isNucleotide}>New rev comp</button>
+            <button className="motif-cs-mini-button" type="button" onClick={onAddReverseComplement} disabled={!hasActiveRecord || !isNucleotide || selectedFeatureCannotMaterialize}>New rev comp</button>
           </div>
         </div>
         {selectedFeatureIsReverse ? (
-          <p className="motif-cs-form-note">Reverse feature: Copy uses feature orientation; Copy rev comp returns the source record span.</p>
+          <p className="motif-cs-form-note">Reverse feature: Copy uses biological feature orientation; Copy rev comp returns the opposite orientation of the assembled feature sequence.</p>
+        ) : null}
+        {selectedFeatureIsOrdered ? (
+          <p className="motif-cs-form-note">INSDC order(...) records segment order but does not assert that the pieces form one materializable sequence. Sequence copy, complement, translation, and derived-record actions stay unavailable.</p>
+        ) : null}
+        {selectedFeature && isAmbiguousFeatureLocation(selectedFeature) ? (
+          <p className="motif-cs-form-note">This legacy reverse multipart location has no reliable biological-order marker. Database JSON preserves it exactly; Basic GenBank and GFF3 label it non-materializable. Sequence copy, complement, translation, and derived-record actions stay unavailable until the source order is confirmed.</p>
         ) : null}
         <div className="motif-cs-export-picker">
           <label>
@@ -13140,6 +13401,8 @@ function TranslationPanel({
   frame,
   residues,
   protein,
+  unavailableReason,
+  canAddToSequence,
   layerCount,
   onStrandChange,
   onFrameChange,
@@ -13157,6 +13420,8 @@ function TranslationPanel({
   frame: 0 | 1 | 2;
   residues: readonly TrackResidue[];
   protein: string;
+  unavailableReason?: string;
+  canAddToSequence: boolean;
   layerCount: number;
   onStrandChange: (strand: 'sense' | 'antisense') => void;
   onFrameChange: (frame: 0 | 1 | 2) => void;
@@ -13242,24 +13507,35 @@ function TranslationPanel({
 
       <div className="motif-cs-translate-controls">
         <div className="motif-cs-segmented" role="group" aria-label="Strand">
-          <button type="button" data-active={strand === 'sense' || undefined} aria-pressed={strand === 'sense'} onClick={() => onStrandChange('sense')}>Sense</button>
-          <button type="button" data-active={strand === 'antisense' || undefined} aria-pressed={strand === 'antisense'} onClick={() => onStrandChange('antisense')}>Antisense</button>
+          <button type="button" disabled={!!unavailableReason} data-active={strand === 'sense' || undefined} aria-pressed={strand === 'sense'} onClick={() => onStrandChange('sense')}>Sense</button>
+          <button type="button" disabled={!!unavailableReason} data-active={strand === 'antisense' || undefined} aria-pressed={strand === 'antisense'} onClick={() => onStrandChange('antisense')}>Antisense</button>
         </div>
         <div className="motif-cs-segmented" role="group" aria-label="Reading frame">
           {([0, 1, 2] as const).map((value) => (
-            <button key={value} type="button" data-active={frame === value || undefined} aria-pressed={frame === value} onClick={() => onFrameChange(value)}>+{value + 1}</button>
+            <button key={value} type="button" disabled={!!unavailableReason} data-active={frame === value || undefined} aria-pressed={frame === value} onClick={() => onFrameChange(value)}>+{value + 1}</button>
           ))}
         </div>
       </div>
 
       <div className="motif-cs-translate-actions">
         <button className="motif-cs-mini-button" type="button" disabled={!protein} onClick={handleCopyProtein}>Copy</button>
-        <button className="motif-cs-mini-button" type="button" disabled={isWhole || !protein} onClick={onAddToSequence} title={isWhole ? 'Select a region to pin its translation to the sequence' : 'Pin this translation to the sequence (above if sense, below if antisense)'}>Add AA track</button>
+        <button className="motif-cs-mini-button" type="button" disabled={!canAddToSequence || !protein} onClick={onAddToSequence} title={isWhole ? 'Select a region to pin its translation to the sequence' : !canAddToSequence ? 'Multipart translations cannot be represented as one contiguous amino-acid track' : 'Pin this translation to the sequence (above if sense, below if antisense)'}>Add AA track</button>
         <button className="motif-cs-mini-button motif-cs-mini-button-accent" type="button" disabled={!protein} onClick={onAddRecord}>New protein</button>
         {onOpenFloating ? <button className="motif-cs-mini-button" type="button" onClick={onOpenFloating}>Pop out</button> : null}
       </div>
 
-      {protein && residues.length > MAX_INTERACTIVE_TRANSLATION_RESIDUES ? (
+      {protein && residues.length === 0 ? (
+        <>
+          <div
+            className="motif-cs-protein-readout motif-cs-protein-readout-dense"
+            aria-label={`Multipart translation, ${protein.length.toLocaleString()} amino acids. Use native text selection or Copy.`}
+            translate="no"
+          >
+            {protein}
+          </div>
+          <p className="motif-cs-form-note">Multipart feature pieces were stitched in biological order before translation. Codon clicks and a contiguous AA track are unavailable across junctions.</p>
+        </>
+      ) : protein && residues.length > MAX_INTERACTIVE_TRANSLATION_RESIDUES ? (
         <>
           <div
             className="motif-cs-protein-readout motif-cs-protein-readout-dense"
@@ -13314,7 +13590,7 @@ function TranslationPanel({
           ))}
         </div>
       ) : (
-        <p className="motif-cs-muted">Region is shorter than one codon.</p>
+        <p className="motif-cs-muted">{unavailableReason ?? 'Region is shorter than one codon.'}</p>
       )}
 
       {layerCount > 0 ? (
@@ -13830,6 +14106,11 @@ type LineFeatureBlock = {
   feature: Feature;
   start: number;
   end: number;
+  segmentStart: number;
+  segmentEnd: number;
+  segmentIndex: number;
+  isStart: boolean;
+  isEnd: boolean;
 };
 
 type RestrictionCutGeometry = {
@@ -13920,13 +14201,20 @@ function featureLanesForLine(
   features: readonly Feature[],
   lineStart: number,
   lineEnd: number,
+  sequenceLength: number,
+  topology: Topology,
 ): LineFeatureBlock[][] {
   const blocks = features
-    .map((feature) => ({
+    .flatMap((feature) => mapFeatureSegments(feature, sequenceLength, topology).map((segment, segmentIndex) => ({
       feature,
-      start: Math.max(lineStart, feature.start),
-      end: Math.min(lineEnd, feature.end),
-    }))
+      start: Math.max(lineStart, segment.start),
+      end: Math.min(lineEnd, segment.end),
+      segmentStart: segment.start,
+      segmentEnd: segment.end,
+      segmentIndex,
+      isStart: segment.isStart,
+      isEnd: segment.isEnd,
+    })))
     .filter((block) => block.end > block.start)
     .sort((a, b) => a.start - b.start || b.end - a.end || a.feature.name.localeCompare(b.feature.name));
 
@@ -14413,7 +14701,7 @@ function SequenceText({
     if (rafRef.current !== null) window.cancelAnimationFrame(rafRef.current);
   }, []);
   const selectedRanges = selectedFeature
-    ? [{ start: selectedFeature.start, end: selectedFeature.end }]
+    ? featureSpans(selectedFeature, sequence.length, topology)
     : selectedMapRange
       ? normalizeSpan(selectedMapRange.start, selectedMapRange.end, sequence.length, topology)
       : [];
@@ -14534,7 +14822,7 @@ function SequenceText({
     const lineEnd = Math.min(sequence.length, lineStart + basesPerLine);
     const lineLen = lineEnd - lineStart;
     const lineSequence = sequence.slice(lineStart, lineEnd);
-    const lineFeatureLanes = detailMode ? featureLanesForLine(features, lineStart, lineEnd) : [];
+    const lineFeatureLanes = detailMode ? featureLanesForLine(features, lineStart, lineEnd, sequence.length, topology) : [];
     const lineRestrictionLabels = detailMode
       ? restrictionLabelLanesForLine(restrictionSites, lineStart, lineEnd)
       : { lanes: [], hidden: 0 };
@@ -14618,7 +14906,7 @@ function SequenceText({
           <div className="motif-cs-feature-tracks" aria-label={`Feature annotations for ${lineStart + 1}-${lineEnd}`}>
             {lineFeatureLanes.map((lane, laneIndex) => (
               <div className="motif-cs-feature-track-lane" key={laneIndex}>
-                {lane.map(({ feature, start, end }) => {
+                {lane.map(({ feature, start, end, segmentStart, segmentEnd, segmentIndex, isStart, isEnd }) => {
                   // Position ribbons in character (ch) units so they lock to the
                   // monospace bases below — one base == one ch. (A % of the full
                   // track width does NOT match, because the 60 bases only fill
@@ -14627,19 +14915,21 @@ function SequenceText({
                   const widthCh = Math.max(1, end - start);
                   // Only the segment holding the true 3' terminus gets the arrowhead,
                   // so a feature wrapping across lines doesn't look like many arrows.
-                  const showHead = (feature.strand === 1 && end === feature.end)
-                    || (feature.strand === -1 && start === feature.start);
+                  const showHead = isEnd && (
+                    (feature.strand === 1 && end === segmentEnd)
+                    || (feature.strand === -1 && start === segmentStart)
+                  );
                   return (
                     <button
-                      key={`${feature.id}:${start}:${end}`}
+                      key={`${feature.id}:${segmentIndex}:${start}:${end}`}
                       className="motif-cs-feature-block"
                       data-selected={selectedFeature?.id === feature.id || undefined}
                       aria-pressed={selectedFeature?.id === feature.id}
-                      aria-label={`${feature.name}, ${feature.type}, full range ${formatRange(feature.start, feature.end)}, segment ${formatRange(start, end)}, ${strandLabel(feature.strand)} strand`}
+                      aria-label={`${feature.name}, ${feature.type}, full location ${featureRangeLabel(feature)}, segment ${formatRange(start, end)}, ${featureStrandLabel(feature)} strand`}
                       data-strand={feature.strand}
                       data-head={showHead || undefined}
                       type="button"
-                      tabIndex={start === feature.start ? 0 : -1}
+                      tabIndex={isStart && start === segmentStart ? 0 : -1}
                       style={{ left: `${leftCh}ch`, width: `${widthCh}ch`, '--feature-color': feature.color } as CSSProperties}
                       onPointerDown={(event) => {
                         event.stopPropagation();
@@ -14649,7 +14939,7 @@ function SequenceText({
                         suppressNextFocusScrollRef.current = true;
                         onFeatureSelect(feature.id);
                       }}
-                      title={`${feature.name} · ${feature.type} · ${formatRange(feature.start, feature.end)}`}
+                      title={`${feature.name} · ${feature.type} · ${featureRangeLabel(feature)}`}
                     >
                       <span translate="no">{feature.name}</span>
                     </button>

--- a/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/SKILL.md
+++ b/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/SKILL.md
@@ -201,7 +201,17 @@ coordinates.
 Accepted record aliases include `seq` for `sequence`, `molecule` for `type`,
 and `annotations` for `features`. Group aliases include `project`, `folder`,
 and `collection`. Feature coordinates are zero-indexed: `start` is inclusive
-and `end` is exclusive.
+and `end` is exclusive. For a multipart feature, supply non-empty `subRanges` as
+`[{ start, end, strand? }, ...]` in biological 5′→3′ order; those pieces are
+authoritative, while the feature's `start`/`end` remain their coordinate
+envelope. A piece without `strand` inherits the feature direction. Set
+`metadata.motifLocationOperator` to `order` only when an INSDC multi-piece
+`order(...)` location must stay non-materializable; multipart locations
+otherwise behave as joins. For a manually authored reverse multipart payload,
+also set `metadata.motifSubRangeOrder` to `biological`. Motif preserves an
+unmarked reverse multipart checkpoint, but keeps sequence-derived actions
+unavailable because older text-order and current biological-order arrays cannot
+be distinguished safely without that marker.
 
 Alignment payloads accept either one top-level `alignment` object or an
 `alignments` array. Each alignment accepts `rows` (alias: `sequences`) with

--- a/src/artifacts/motif-for-claude-science-skill/SKILL.md
+++ b/src/artifacts/motif-for-claude-science-skill/SKILL.md
@@ -76,7 +76,17 @@ Minimal payload:
 Accepted record aliases include `seq` for `sequence`, `molecule` for `type`,
 and `annotations` for `features`. Group aliases include `project`, `folder`,
 and `collection`. Feature coordinates are zero-indexed: `start` is inclusive
-and `end` is exclusive.
+and `end` is exclusive. For a multipart feature, supply non-empty `subRanges` as
+`[{ start, end, strand? }, ...]` in biological 5′→3′ order; those pieces are
+authoritative, while the feature's `start`/`end` remain their coordinate
+envelope. A piece without `strand` inherits the feature direction. Set
+`metadata.motifLocationOperator` to `order` only when an INSDC multi-piece
+`order(...)` location must stay non-materializable; multipart locations
+otherwise behave as joins. For a manually authored reverse multipart payload,
+also set `metadata.motifSubRangeOrder` to `biological`. Motif preserves an
+unmarked reverse multipart checkpoint, but keeps sequence-derived actions
+unavailable because older text-order and current biological-order arrays cannot
+be distinguished safely without that marker.
 
 ## Add a precomputed alignment
 

--- a/src/bio/__tests__/feature-location.test.ts
+++ b/src/bio/__tests__/feature-location.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractFeatureSequence,
+  featureGenBankLocation,
+  featureLocationLength,
+  featureLocationSegments,
+  isAmbiguousFeatureLocation,
+  isMaterializableFeatureLocation,
+  isMultipartFeature,
+  remapFeatureLocation,
+} from '../feature-location';
+import { parseFeatures } from '../genbank-parser';
+import { reverseComplement, reverseComplementFeatures } from '../reverse-complement';
+import type { Feature } from '../types';
+
+const SEQUENCE = 'ATGCCCGGGCCATTTAAA';
+
+function feature(overrides: Partial<Feature> = {}): Feature {
+  return {
+    id: 'feature-1',
+    name: 'test feature',
+    type: 'cds',
+    start: 0,
+    end: 12,
+    strand: 1,
+    color: '#888888',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function parsedFeature(location: string): Feature {
+  const result = parseFeatures([
+    `     CDS             ${location}`,
+    '                     /label="joined CDS"',
+  ].join('\n'));
+  expect(result).toHaveLength(1);
+  return result[0];
+}
+
+describe('feature location semantics', () => {
+  it('concatenates forward join pieces and excludes intervening bases', () => {
+    const joined = parsedFeature('join(1..3,10..12)');
+
+    expect(featureLocationSegments(joined)).toEqual([
+      { start: 0, end: 3, strand: 1 },
+      { start: 9, end: 12, strand: 1 },
+    ]);
+    expect(featureLocationLength(joined)).toBe(6);
+    expect(isMultipartFeature(joined)).toBe(true);
+    expect(extractFeatureSequence(SEQUENCE, joined, 'dna')).toBe('ATGCCA');
+    expect(featureGenBankLocation(joined)).toBe('join(1..3,10..12)');
+  });
+
+  it('normalizes complement(join(...)) into biological order', () => {
+    const reverseJoined = parsedFeature('complement(join(1..3,10..12))');
+
+    expect(featureLocationSegments(reverseJoined)).toEqual([
+      { start: 9, end: 12, strand: -1 },
+      { start: 0, end: 3, strand: -1 },
+    ]);
+    expect(extractFeatureSequence(SEQUENCE, reverseJoined, 'dna')).toBe('TGGCAT');
+    expect(featureGenBankLocation(reverseJoined)).toBe('complement(join(1..3,10..12))');
+  });
+
+  it('keeps explicit per-piece complements distinct from an outer complement', () => {
+    const individuallyReversed = parsedFeature('join(complement(1..3),complement(10..12))');
+
+    expect(featureLocationSegments(individuallyReversed)).toEqual([
+      { start: 0, end: 3, strand: -1 },
+      { start: 9, end: 12, strand: -1 },
+    ]);
+    expect(extractFeatureSequence(SEQUENCE, individuallyReversed, 'dna')).toBe('CATTGG');
+    expect(featureGenBankLocation(individuallyReversed)).toBe('complement(join(10..12,1..3))');
+  });
+
+  it('preserves mixed segment orientation inside a join', () => {
+    const mixed = parsedFeature('join(complement(1..3),10..12)');
+
+    expect(mixed.strand).toBe(0);
+    expect(extractFeatureSequence(SEQUENCE, mixed, 'dna')).toBe('CATCCA');
+    expect(featureGenBankLocation(mixed)).toBe('join(complement(1..3),10..12)');
+  });
+
+  it('keeps an outer-complemented mixed location mixed while reversing its pieces', () => {
+    const mixed = parsedFeature('complement(join(complement(1..3),10..12))');
+
+    expect(mixed.strand).toBe(0);
+    expect(featureLocationSegments(mixed)).toEqual([
+      { start: 9, end: 12, strand: -1 },
+      { start: 0, end: 3, strand: 1 },
+    ]);
+  });
+
+  it('preserves order(...) without pretending its pieces form one sequence', () => {
+    const ordered = parsedFeature('order(1..3,10..12)');
+
+    expect(ordered.metadata.motifLocationOperator).toBe('order');
+    expect(featureLocationLength(ordered)).toBe(6);
+    expect(extractFeatureSequence(SEQUENCE, ordered, 'dna')).toBe('');
+    expect(featureGenBankLocation(ordered)).toBe('order(1..3,10..12)');
+  });
+
+  it('fails closed for an unmarked reverse multipart checkpoint', () => {
+    const ambiguous = feature({
+      strand: -1,
+      metadata: { motifSubRangeOrderAmbiguous: true },
+      subRanges: [
+        { start: 9, end: 12, strand: -1 },
+        { start: 0, end: 3, strand: -1 },
+      ],
+    });
+
+    expect(isAmbiguousFeatureLocation(ambiguous)).toBe(true);
+    expect(isMaterializableFeatureLocation(ambiguous)).toBe(false);
+    expect(extractFeatureSequence(SEQUENCE, ambiguous, 'dna')).toBe('');
+    expect(featureGenBankLocation(ambiguous)).toBe('complement(order(1..3,10..12))');
+  });
+
+  it('extracts an origin-spanning circular join in stored order', () => {
+    const wrapped = feature({
+      start: 0,
+      end: SEQUENCE.length,
+      subRanges: [
+        { start: 15, end: 18, strand: 1 },
+        { start: 0, end: 3, strand: 1 },
+      ],
+    });
+
+    expect(extractFeatureSequence(SEQUENCE, wrapped, 'dna')).toBe('AAAATG');
+    expect(featureLocationLength(wrapped)).toBe(6);
+    expect(featureGenBankLocation(wrapped)).toBe('join(16..18,1..3)');
+  });
+
+  it('preserves the feature product when a whole record is reverse-complemented', () => {
+    const sourceFeature = parsedFeature('join(1..3,10..12)');
+    const transformedSequence = reverseComplement(SEQUENCE);
+    const transformedFeature = reverseComplementFeatures([sourceFeature], SEQUENCE.length)[0];
+
+    expect(featureLocationSegments(transformedFeature)).toEqual([
+      { start: 15, end: 18, strand: -1 },
+      { start: 6, end: 9, strand: -1 },
+    ]);
+    expect(extractFeatureSequence(transformedSequence, transformedFeature, 'dna')).toBe(
+      extractFeatureSequence(SEQUENCE, sourceFeature, 'dna'),
+    );
+  });
+
+  it('lets legacy pieces inherit the feature strand', () => {
+    const legacy = feature({
+      strand: -1,
+      subRanges: [{ start: 9, end: 12 }, { start: 0, end: 3 }],
+    });
+
+    expect(extractFeatureSequence(SEQUENCE, legacy, 'dna')).toBe('TGGCAT');
+    expect(featureGenBankLocation(legacy)).toBe('complement(join(1..3,10..12))');
+  });
+
+  it('remaps all pieces through an origin-wrapping child sequence', () => {
+    const wrapped = feature({
+      start: 0,
+      end: 18,
+      subRanges: [
+        { start: 15, end: 18, strand: 1 },
+        { start: 0, end: 3, strand: 1 },
+      ],
+    });
+
+    expect(remapFeatureLocation(wrapped, [
+      { start: 12, end: 18, targetStart: 0 },
+      { start: 0, end: 6, targetStart: 6 },
+    ])).toEqual({
+      start: 3,
+      end: 9,
+      subRanges: [
+        { start: 3, end: 6, strand: 1 },
+        { start: 6, end: 9, strand: 1 },
+      ],
+    });
+  });
+
+  it('rejects a feature when any authoritative piece crosses a cut boundary', () => {
+    const joined = parsedFeature('join(1..3,10..12)');
+    expect(remapFeatureLocation(joined, [{ start: 0, end: 10, targetStart: 0 }])).toBeNull();
+  });
+
+  it('never resurrects an explicit empty location from its aggregate envelope', () => {
+    const empty = feature({ subRanges: [] });
+
+    expect(featureLocationSegments(empty)).toEqual([]);
+    expect(featureLocationLength(empty)).toBe(0);
+    expect(extractFeatureSequence(SEQUENCE, empty, 'dna')).toBe('');
+    expect(remapFeatureLocation(empty, [{ start: 0, end: SEQUENCE.length, targetStart: 0 }])).toBeNull();
+    expect(() => featureGenBankLocation(empty)).toThrow(/explicit empty location/i);
+  });
+
+  it('ignores a reserved order marker on a single contiguous segment', () => {
+    const contiguous = feature({ metadata: { motifLocationOperator: 'order' } });
+
+    expect(extractFeatureSequence(SEQUENCE, contiguous, 'dna')).toBe(SEQUENCE.slice(0, 12));
+    expect(featureGenBankLocation(contiguous)).toBe('1..12');
+  });
+
+  it.each(['100^101', '1.3', 'AB123:1..3', '1..3junk'])(
+    'surfaces unsupported location syntax %s instead of truncating it',
+    (location) => {
+      expect(() => parseFeatures([
+        `     CDS             ${location}`,
+        '                     /label="unsupported"',
+      ].join('\n'))).toThrow(/unsupported location/i);
+    },
+  );
+
+  it('retains valid INSDC fuzzy bounds as guarded round-trip metadata', () => {
+    const fuzzy = parsedFeature('<1..>3');
+
+    expect(featureLocationSegments(fuzzy)).toEqual([{ start: 0, end: 3, strand: 1 }]);
+    expect(fuzzy.metadata).toMatchObject({
+      motifOriginalLocation: '<1..>3',
+      motifLocationFuzzy: true,
+    });
+  });
+});

--- a/src/bio/__tests__/gibson-assembly-features.test.ts
+++ b/src/bio/__tests__/gibson-assembly-features.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { gibsonAssemble } from '../gibson-assembly';
+import type { Feature } from '../types';
+
+function feature(name: string, overrides: Partial<Feature>): Feature {
+  return {
+    id: `${name}-id`,
+    name,
+    type: 'cds',
+    start: 0,
+    end: 1,
+    strand: 1,
+    color: '#888888',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe('Gibson assembly feature locations', () => {
+  it('clips authoritative multipart pieces and rebuilds their product envelope', () => {
+    const result = gibsonAssemble([
+      {
+        name: 'A',
+        sequence: 'AAAACCC',
+        features: [feature('first multipart', {
+          start: 0,
+          end: 7,
+          strand: -1,
+          subRanges: [
+            { start: 4, end: 6, strand: -1 },
+            { start: 1, end: 2, strand: -1 },
+          ],
+        })],
+      },
+      {
+        name: 'B',
+        sequence: 'CCCGGGTTT',
+        features: [
+          feature('trimmed multipart', {
+            start: 0,
+            end: 8,
+            strand: -1,
+            subRanges: [
+              { start: 6, end: 8, strand: -1 },
+              { start: 0, end: 2, strand: -1 },
+              { start: 2, end: 5, strand: -1 },
+            ],
+          }),
+          feature('overlap-only multipart', {
+            start: 0,
+            end: 8,
+            subRanges: [{ start: 0, end: 2, strand: 1 }],
+          }),
+        ],
+      },
+    ], 3, 3, 'linear');
+
+    expect(result.success).toBe(true);
+    expect(result.sequence).toBe('AAAACCCGGGTTT');
+    expect(result.features.find(({ name }) => name === 'first multipart')).toMatchObject({
+      start: 1,
+      end: 6,
+      subRanges: [
+        { start: 4, end: 6, strand: -1 },
+        { start: 1, end: 2, strand: -1 },
+      ],
+    });
+    expect(result.features.find(({ name }) => name === 'trimmed multipart')).toMatchObject({
+      start: 7,
+      end: 12,
+      subRanges: [
+        { start: 10, end: 12, strand: -1 },
+        { start: 7, end: 9, strand: -1 },
+      ],
+    });
+    expect(result.features.some(({ name }) => name === 'overlap-only multipart')).toBe(false);
+  });
+
+  it('clips features after removing the duplicate closing overlap', () => {
+    const result = gibsonAssemble([
+      { name: 'A', sequence: 'TTTAAAACCC' },
+      {
+        name: 'B',
+        sequence: 'CCCGGGTTT',
+        features: [
+          feature('closing-tail multipart', {
+            start: 4,
+            end: 9,
+            strand: -1,
+            subRanges: [
+              { start: 6, end: 9, strand: -1 },
+              { start: 4, end: 6, strand: -1 },
+            ],
+          }),
+          feature('closing-tail crossing', { start: 5, end: 8 }),
+          feature('closing-tail only', {
+            start: 4,
+            end: 9,
+            subRanges: [{ start: 6, end: 9, strand: 1 }],
+          }),
+        ],
+      },
+    ], 3, 3, 'circular');
+
+    expect(result.success).toBe(true);
+    expect(result.sequence).toBe('TTTAAAACCCGGG');
+    expect(result.features.find(({ name }) => name === 'closing-tail multipart')).toMatchObject({
+      start: 11,
+      end: 13,
+      subRanges: [{ start: 11, end: 13, strand: -1 }],
+    });
+    expect(result.features.find(({ name }) => name === 'closing-tail crossing')).toMatchObject({
+      start: 12,
+      end: 13,
+    });
+    expect(result.features.some(({ name }) => name === 'closing-tail only')).toBe(false);
+    expect(result.features.every(({ start, end }) => start >= 0 && end <= result.sequence.length)).toBe(true);
+  });
+});

--- a/src/bio/__tests__/golden-gate-features.test.ts
+++ b/src/bio/__tests__/golden-gate-features.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSyntheticGoldenGateVector,
+  getGoldenGatePartBoundary,
+  goldenGateAssemble,
+} from '../golden-gate';
+import type { Feature } from '../types';
+
+function feature(name: string, overrides: Partial<Feature>): Feature {
+  return {
+    id: `${name}-id`,
+    name,
+    type: 'cds',
+    start: 0,
+    end: 1,
+    strand: 1,
+    color: '#888888',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function requiredInsertStart(part: { name: string; sequence: string }): number {
+  const boundary = getGoldenGatePartBoundary(part);
+  expect(boundary.valid).toBe(true);
+  if (boundary.insertStart === null) throw new Error(`Missing insert start for ${part.name}`);
+  return boundary.insertStart;
+}
+
+describe('Golden Gate assembly feature locations', () => {
+  it('preserves multipart order and rebuilds envelopes through digest, ligation, and circle closure', () => {
+    const aBase = buildSyntheticGoldenGateVector('ATGC', 'GCTA', {
+      name: 'A',
+      filler: 'AACCGGTT',
+    });
+    const bBase = buildSyntheticGoldenGateVector('GCTA', 'ATGC', {
+      name: 'B',
+      filler: 'TTCCAAGG',
+    });
+    const aStart = requiredInsertStart(aBase);
+    const bStart = requiredInsertStart(bBase);
+
+    const result = goldenGateAssemble([
+      {
+        ...aBase,
+        features: [
+          feature('A multipart', {
+            start: aStart - 2,
+            end: aStart + 7,
+            strand: -1,
+            subRanges: [
+              { start: aStart + 5, end: aStart + 7, strand: -1 },
+              { start: aStart - 2, end: aStart + 2, strand: -1 },
+            ],
+          }),
+          feature('A flank-only multipart', {
+            start: aStart - 2,
+            end: aStart + 7,
+            subRanges: [{ start: aStart - 2, end: aStart, strand: 1 }],
+          }),
+        ],
+      },
+      {
+        ...bBase,
+        features: [
+          feature('B multipart', {
+            start: bStart,
+            end: bStart + 10,
+            strand: -1,
+            subRanges: [
+              { start: bStart + 8, end: bStart + 10, strand: -1 },
+              { start: bStart, end: bStart + 2, strand: -1 },
+              { start: bStart + 3, end: bStart + 6, strand: -1 },
+            ],
+          }),
+          feature('B closing-tail crossing', {
+            start: bStart + 10,
+            end: bStart + 14,
+            subRanges: [{ start: bStart + 10, end: bStart + 14, strand: 1 }],
+          }),
+          feature('B closing-tail only', {
+            start: bStart + 8,
+            end: bStart + 16,
+            subRanges: [{ start: bStart + 12, end: bStart + 16, strand: 1 }],
+          }),
+        ],
+      },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.topology).toBe('circular');
+    expect(result.parts).toEqual(['A', 'B']);
+    expect(result.sequence).toHaveLength(24);
+    expect(result.features.find(({ name }) => name === 'A multipart')).toMatchObject({
+      start: 0,
+      end: 7,
+      subRanges: [
+        { start: 5, end: 7, strand: -1 },
+        { start: 0, end: 2, strand: -1 },
+      ],
+    });
+    expect(result.features.some(({ name }) => name === 'A flank-only multipart')).toBe(false);
+    expect(result.features.find(({ name }) => name === 'B multipart')).toMatchObject({
+      start: 16,
+      end: 22,
+      subRanges: [
+        { start: 20, end: 22, strand: -1 },
+        { start: 16, end: 18, strand: -1 },
+      ],
+    });
+    expect(result.features.find(({ name }) => name === 'B closing-tail crossing')).toMatchObject({
+      start: 22,
+      end: 24,
+      subRanges: [{ start: 22, end: 24, strand: 1 }],
+    });
+    expect(result.features.some(({ name }) => name === 'B closing-tail only')).toBe(false);
+    expect(result.features.every(({ start, end }) => start >= 0 && end <= result.sequence.length)).toBe(true);
+
+    const closingJunction = result.features.find((candidate) => (
+      candidate.metadata.kind === 'junction_overhang' && candidate.metadata.circular === true
+    ));
+    expect(closingJunction).toMatchObject({ start: 0, end: 4 });
+    expect(closingJunction?.subRanges).toBeUndefined();
+  });
+});

--- a/src/bio/__tests__/mutate-feature-locations.test.ts
+++ b/src/bio/__tests__/mutate-feature-locations.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { extractFeatureSequence, isMultipartFeature } from '../feature-location';
+import { applyDeletion, applyInsertion } from '../mutate';
+import type { Feature } from '../types';
+
+function joinedFeature(): Feature {
+  return {
+    id: 'joined-feature',
+    name: 'joined feature',
+    type: 'cds',
+    start: 0,
+    end: 12,
+    strand: 1,
+    subRanges: [
+      { start: 0, end: 3, strand: 1 },
+      { start: 9, end: 12, strand: 1 },
+    ],
+    color: '#888888',
+    metadata: {},
+  };
+}
+
+describe('mutation feature-location integrity', () => {
+  it('shifts authoritative pieces and recomputes their envelope after insertion', () => {
+    const result = applyInsertion('ATGCCCGGGCCA', [], [joinedFeature()], 5, 'AA');
+
+    expect(result.features[0]).toMatchObject({
+      start: 0,
+      end: 14,
+      subRanges: [
+        { start: 0, end: 3, strand: 1 },
+        { start: 11, end: 14, strand: 1 },
+      ],
+    });
+    expect(extractFeatureSequence(result.raw, result.features[0], 'dna')).toBe('ATGCCA');
+  });
+
+  it('drops a deleted piece and derives the envelope from the surviving piece', () => {
+    const result = applyDeletion('ATGCCCGGGCCA', [], [joinedFeature()], 0, 3);
+
+    expect(result.features).toHaveLength(1);
+    expect(result.features[0]).toMatchObject({
+      start: 6,
+      end: 9,
+      subRanges: [{ start: 6, end: 9, strand: 1 }],
+    });
+    expect(isMultipartFeature(result.features[0])).toBe(false);
+  });
+
+  it('removes an inter-segment gap without changing the assembled product', () => {
+    const result = applyDeletion('ATGCCCGGGCCA', [], [joinedFeature()], 3, 6);
+
+    expect(result.raw).toBe('ATGCCA');
+    expect(result.features[0]).toMatchObject({
+      start: 0,
+      end: 6,
+      subRanges: [
+        { start: 0, end: 3, strand: 1 },
+        { start: 3, end: 6, strand: 1 },
+      ],
+    });
+    expect(extractFeatureSequence(result.raw, result.features[0], 'dna')).toBe('ATGCCA');
+  });
+
+  it('removes a multipart feature when every authoritative piece is deleted', () => {
+    const result = applyDeletion('ATGCCCGGGCCA', [], [joinedFeature()], 0, 12);
+
+    expect(result.features).toEqual([]);
+  });
+});

--- a/src/bio/__tests__/restriction-digest-features.test.ts
+++ b/src/bio/__tests__/restriction-digest-features.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { restrictionDigest } from '../restriction-digest';
+import type { Feature } from '../types';
+
+describe('restriction digest feature propagation', () => {
+  it('carries a complete origin-spanning multipart feature onto the wrapping fragment', () => {
+    const sequence = 'GAATTCAAAAGAATTC';
+    const feature: Feature = {
+      id: 'origin-feature',
+      name: 'origin join',
+      type: 'cds',
+      start: 0,
+      end: 15,
+      strand: 1,
+      color: '#888888',
+      metadata: {},
+      subRanges: [
+        { start: 12, end: 15, strand: 1 },
+        { start: 0, end: 1, strand: 1 },
+      ],
+    };
+
+    const fragments = restrictionDigest(sequence, ['EcoRI'], 'circular', [feature]);
+    const wrapping = fragments.find((fragment) => fragment.endInOriginal > sequence.length);
+
+    expect(wrapping).toBeDefined();
+    expect(wrapping?.features).toHaveLength(1);
+    expect(wrapping?.features[0]).toMatchObject({
+      name: 'origin join',
+      start: 1,
+      end: 6,
+      subRanges: [
+        { start: 1, end: 4, strand: 1 },
+        { start: 5, end: 6, strand: 1 },
+      ],
+    });
+  });
+});

--- a/src/bio/feature-location.ts
+++ b/src/bio/feature-location.ts
@@ -1,0 +1,200 @@
+import { reverseComplement } from './reverse-complement';
+import type { Feature, FeatureStrand, SequenceType } from './types';
+
+export type FeatureLocation = Pick<Feature, 'start' | 'end' | 'strand' | 'subRanges'> & {
+  metadata?: Record<string, unknown>;
+};
+
+export type FeatureLocationSegment = {
+  start: number;
+  end: number;
+  strand: FeatureStrand;
+};
+
+export type FeatureCoordinateMapSpan = {
+  /** Inclusive start in the source sequence. */
+  start: number;
+  /** Exclusive end in the source sequence. */
+  end: number;
+  /** Coordinate in the destination sequence corresponding to `start`. */
+  targetStart: number;
+};
+
+export type RemappedFeatureLocation = Pick<Feature, 'start' | 'end' | 'subRanges'>;
+
+function effectiveStrand(value: unknown, fallback: FeatureStrand): FeatureStrand {
+  return value === -1 || value === 0 || value === 1 ? value : fallback;
+}
+
+/**
+ * Return the authoritative pieces of a feature in biological 5′→3′ order.
+ *
+ * `subRanges`, when present, are not merely drawing hints: they are the pieces
+ * that form the feature product. Their stored order is therefore significant.
+ * A range without its own strand inherits the feature strand for compatibility
+ * with older JSON payloads.
+ */
+export function featureLocationSegments(feature: FeatureLocation): FeatureLocationSegment[] {
+  const fallbackStrand = effectiveStrand(feature.strand, 1);
+  if (feature.subRanges !== undefined) {
+    return feature.subRanges.filter((range) => (
+      Number.isFinite(range.start)
+      && Number.isFinite(range.end)
+      && range.end > range.start
+    )).map((range) => ({
+      start: range.start,
+      end: range.end,
+      strand: effectiveStrand(range.strand, fallbackStrand),
+    }));
+  }
+
+  return feature.end > feature.start
+    ? [{ start: feature.start, end: feature.end, strand: fallbackStrand }]
+    : [];
+}
+
+/** Total annotated segment length, excluding gaps between pieces. */
+export function featureLocationLength(feature: FeatureLocation): number {
+  return featureLocationSegments(feature).reduce(
+    (length, segment) => length + Math.max(0, segment.end - segment.start),
+    0,
+  );
+}
+
+/** Stable coordinate/orientation fingerprint for guarded location metadata. */
+export function featureLocationCoordinateSignature(feature: FeatureLocation): string {
+  return JSON.stringify(featureLocationSegments(feature).map((segment) => [
+    segment.start,
+    segment.end,
+    segment.strand,
+  ]));
+}
+
+/** True when the feature product is assembled from more than one stored piece. */
+export function isMultipartFeature(feature: FeatureLocation): boolean {
+  return featureLocationSegments(feature).length > 1;
+}
+
+/** INSDC `order(...)` preserves order but does not authorize concatenation. */
+export function isOrderedFeatureLocation(feature: FeatureLocation): boolean {
+  return featureLocationSegments(feature).length > 1
+    && feature.metadata?.motifLocationOperator === 'order';
+}
+
+/** True when an older/unmarked reverse multipart array has no inferable order. */
+export function isAmbiguousFeatureLocation(feature: FeatureLocation): boolean {
+  return featureLocationSegments(feature).length > 1
+    && feature.metadata?.motifSubRangeOrderAmbiguous === true;
+}
+
+export function isMaterializableFeatureLocation(feature: FeatureLocation): boolean {
+  return !isOrderedFeatureLocation(feature) && !isAmbiguousFeatureLocation(feature);
+}
+
+/**
+ * Materialize the biological feature product.
+ *
+ * Each piece is oriented independently and then concatenated in stored
+ * biological order. This handles both `complement(join(...))` (normalized by
+ * the parser to reversed, negative-strand pieces) and explicit mixed locations
+ * such as `join(complement(...), ...)` without including intervening bases.
+ */
+export function extractFeatureSequence(
+  sequence: string,
+  feature: FeatureLocation,
+  sequenceType?: SequenceType,
+): string {
+  if (!isMaterializableFeatureLocation(feature)) return '';
+  const isNucleotide = sequenceType === 'dna' || sequenceType === 'rna';
+  const isRna = sequenceType === 'rna';
+
+  return featureLocationSegments(feature).map((segment) => {
+    const part = sequence.slice(segment.start, segment.end);
+    return isNucleotide && segment.strand === -1
+      ? reverseComplement(part, isRna)
+      : part;
+  }).join('');
+}
+
+/**
+ * Remap a complete feature through ordered source→destination spans.
+ *
+ * This is used when a digest/PCR product is assembled from one or more source
+ * intervals. Every authoritative feature piece must fit wholly inside one map
+ * span; otherwise the feature crosses a physical cut boundary and is omitted.
+ * Stored biological piece order and strand metadata are preserved.
+ */
+export function remapFeatureLocation(
+  feature: FeatureLocation,
+  sourceSpans: readonly FeatureCoordinateMapSpan[],
+): RemappedFeatureLocation | null {
+  const hasStoredSubRanges = feature.subRanges !== undefined;
+  const sourceSegments = hasStoredSubRanges
+    ? feature.subRanges!
+    : [{ start: feature.start, end: feature.end }];
+  const mapped = sourceSegments.map((segment) => {
+    const sourceSpan = sourceSpans.find((span) => (
+      segment.start >= span.start && segment.end <= span.end
+    ));
+    if (!sourceSpan) return null;
+    return {
+      ...segment,
+      start: sourceSpan.targetStart + segment.start - sourceSpan.start,
+      end: sourceSpan.targetStart + segment.end - sourceSpan.start,
+    };
+  });
+
+  if (mapped.some((segment) => segment === null)) return null;
+  const mappedSegments = mapped.filter((segment): segment is NonNullable<typeof segment> => segment !== null);
+  if (mappedSegments.length === 0) return null;
+
+  return {
+    start: Math.min(...mappedSegments.map((segment) => segment.start)),
+    end: Math.max(...mappedSegments.map((segment) => segment.end)),
+    ...(hasStoredSubRanges ? { subRanges: mappedSegments } : {}),
+  };
+}
+
+function genBankRange(start: number, end: number): string {
+  const start1 = start + 1;
+  return start1 === end ? String(start1) : `${start1}..${end}`;
+}
+
+/**
+ * Serialize a normalized feature location without collapsing multipart data.
+ * All-negative biological segments are emitted in canonical
+ * `complement(join(genomic-order...))` form; mixed-strand pieces retain their
+ * explicit per-piece orientation inside `join(...)`.
+ */
+export function featureGenBankLocation(feature: FeatureLocation): string {
+  const segments = featureLocationSegments(feature);
+  if (segments.length === 0) {
+    if (feature.subRanges !== undefined) {
+      throw new Error('Cannot serialize a feature with an explicit empty location.');
+    }
+    return genBankRange(feature.start, feature.end);
+  }
+
+  if (segments.length === 1) {
+    const segment = segments[0];
+    const location = genBankRange(segment.start, segment.end);
+    return segment.strand === -1 ? `complement(${location})` : location;
+  }
+
+  // An unmarked reverse multipart checkpoint can represent either legacy
+  // GenBank text order or current biological order. Serializing it as join
+  // would assert a product Motif cannot justify, so degrade safely to order.
+  const operator = isOrderedFeatureLocation(feature) || isAmbiguousFeatureLocation(feature)
+    ? 'order'
+    : 'join';
+  if (segments.every((segment) => segment.strand === -1)) {
+    const genomicOrder = [...segments].reverse();
+    return `complement(${operator}(${genomicOrder.map((segment) => genBankRange(segment.start, segment.end)).join(',')}))`;
+  }
+
+  const parts = segments.map((segment) => {
+    const location = genBankRange(segment.start, segment.end);
+    return segment.strand === -1 ? `complement(${location})` : location;
+  });
+  return `${operator}(${parts.join(',')})`;
+}

--- a/src/bio/genbank-parser.ts
+++ b/src/bio/genbank-parser.ts
@@ -1,4 +1,5 @@
-import type { Feature, FeatureType, Topology, Strand } from './types';
+import type { Feature, FeatureStrand, FeatureType, Topology } from './types';
+import { featureLocationCoordinateSignature } from './feature-location';
 
 // Phase 35 P-H (P2-E2): individual qualifier values larger than 1 MB are
 // truncated to this cap and tagged with a suffix so consumers can detect
@@ -169,7 +170,9 @@ const FEATURE_COLORS: Record<FeatureType, string> = {
  * "join(1..100,200..300)", or a single position "100".
  * Returns 0-indexed start (inclusive) and end (exclusive), plus strand.
  */
-type ParsedLocation = Pick<Feature, 'start' | 'end' | 'strand' | 'subRanges'>;
+type ParsedLocation = Pick<Feature, 'start' | 'end' | 'strand' | 'subRanges'> & {
+  locationOperator?: 'join' | 'order';
+};
 
 function splitTopLevel(expr: string): string[] {
   const parts: string[] = [];
@@ -199,11 +202,14 @@ function splitTopLevel(expr: string): string[] {
 function invertParsedLocation(location: ParsedLocation): ParsedLocation {
   return {
     ...location,
-    strand: location.strand === 1 ? -1 : 1,
-    subRanges: location.subRanges?.map((subRange) => ({
+    strand: location.strand === 1 ? -1 : location.strand === -1 ? 1 : 0,
+    // subRanges are stored in biological 5′→3′ order. Complementing a joined
+    // product reverses the order as well as each piece's strand:
+    // RC(a + b) = RC(b) + RC(a).
+    subRanges: location.subRanges ? [...location.subRanges].reverse().map((subRange) => ({
       ...subRange,
       strand: (subRange.strand ?? 1) === 1 ? -1 : 1,
-    })),
+    })) : undefined,
   };
 }
 
@@ -238,27 +244,33 @@ function parseLocation(loc: string, depth = 0): ParsedLocation {
   }
 
   if ((inner.startsWith('join(') || inner.startsWith('order(')) && inner.endsWith(')')) {
-    const offset = inner.startsWith('join(') ? 5 : 6;
+    const locationOperator = inner.startsWith('join(') ? 'join' : 'order';
+    const offset = locationOperator === 'join' ? 5 : 6;
     const parts = splitTopLevel(inner.slice(offset, -1)).map((p) => parseLocation(p, depth + 1));
     const subRanges = collectLeafRanges(parts);
     const start = Math.min(...subRanges.map((part) => part.start));
     const end = Math.max(...subRanges.map((part) => part.end));
-    const strand: Strand = subRanges.every((part) => (part.strand ?? 1) === -1) ? -1 : 1;
-    return assertValidLocation({ start, end, strand, subRanges }, loc);
+    const strand: FeatureStrand = subRanges.every((part) => (part.strand ?? 1) === -1)
+      ? -1
+      : subRanges.every((part) => (part.strand ?? 1) === 1)
+        ? 1
+        : 0;
+    return assertValidLocation({ start, end, strand, subRanges, locationOperator }, loc);
   }
 
-  const normalized = inner.replace(/[<>]/g, '');
-
-  if (normalized.includes('..')) {
-    const [startText, endText] = normalized.split('..');
+  const rangeMatch = inner.match(/^[<>]?(\d+)\.\.[<>]?(\d+)$/);
+  if (rangeMatch) {
     return assertValidLocation({
-      start: parseInt(startText, 10) - 1,
-      end: parseInt(endText, 10),
+      start: parseInt(rangeMatch[1], 10) - 1,
+      end: parseInt(rangeMatch[2], 10),
       strand: 1,
     }, loc);
   }
 
-  const pos = parseInt(normalized, 10);
+  if (!/^[<>]?\d+$/.test(inner)) {
+    throw new Error(`Unsupported GenBank location syntax: ${loc}`);
+  }
+  const pos = parseInt(inner.replace(/[<>]/g, ''), 10);
   return assertValidLocation({ start: pos - 1, end: pos, strand: 1 }, loc);
 }
 
@@ -439,10 +451,13 @@ export function parseFeatures(featuresText: string): Feature[] {
     let locationResult: ParsedLocation;
     try {
       locationResult = parseLocation(locationStr);
-    } catch {
-      continue;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unsupported syntax';
+      throw new Error(`GenBank feature ${featureKey} has an unsupported location "${locationStr}": ${message}`);
     }
-    const { start, end, strand, subRanges } = locationResult;
+    const { start, end, strand, subRanges, locationOperator } = locationResult;
+    const parsedLocationFeature = { start, end, strand, subRanges };
+    const fuzzyLocation = /[<>]/.test(locationStr);
 
     features.push({
       id: crypto.randomUUID(),
@@ -453,7 +468,16 @@ export function parseFeatures(featuresText: string): Feature[] {
       strand,
       subRanges,
       color: FEATURE_COLORS[mappedType],
-      metadata: qualifiers,
+      metadata: {
+        ...qualifiers,
+        ...(locationOperator ? { motifLocationOperator: locationOperator } : {}),
+        ...(subRanges ? { motifSubRangeOrder: 'biological' } : {}),
+        ...(fuzzyLocation ? {
+          motifOriginalLocation: locationStr,
+          motifOriginalLocationSignature: featureLocationCoordinateSignature(parsedLocationFeature),
+          motifLocationFuzzy: true,
+        } : {}),
+      },
     });
   }
 

--- a/src/bio/gibson-assembly.ts
+++ b/src/bio/gibson-assembly.ts
@@ -32,6 +32,47 @@ const DEFAULT_MAX_OVERLAP = 60;
 const IDEAL_OVERLAP_TM = 50; // °C minimum recommended Tm
 
 /**
+ * Keep the portions of a feature that fall inside one source span and place
+ * them in product coordinates. Multipart locations are authoritative: their
+ * stored biological order is preserved, empty pieces are removed, and the
+ * aggregate bounds are rebuilt from the surviving pieces.
+ */
+function clipFeatureToSpan(
+  feature: Feature,
+  sourceStart: number,
+  sourceEnd: number,
+  destinationStart: number,
+  rekey = false,
+): Feature | null {
+  if (sourceEnd <= sourceStart) return null;
+
+  const hasSubRanges = feature.subRanges !== undefined;
+  const sourceRanges = hasSubRanges
+    ? feature.subRanges!
+    : [{ start: feature.start, end: feature.end, strand: feature.strand }];
+  const mappedRanges = sourceRanges.flatMap((range) => {
+    const clippedStart = Math.max(range.start, sourceStart);
+    const clippedEnd = Math.min(range.end, sourceEnd);
+    if (clippedEnd <= clippedStart) return [];
+    return [{
+      ...range,
+      start: destinationStart + clippedStart - sourceStart,
+      end: destinationStart + clippedEnd - sourceStart,
+    }];
+  });
+  if (mappedRanges.length === 0) return null;
+
+  const { subRanges: _subRanges, ...featureWithoutSubRanges } = feature;
+  return {
+    ...featureWithoutSubRanges,
+    ...(rekey ? { id: crypto.randomUUID() } : {}),
+    start: Math.min(...mappedRanges.map((range) => range.start)),
+    end: Math.max(...mappedRanges.map((range) => range.end)),
+    ...(hasSubRanges ? { subRanges: mappedRanges } : {}),
+  };
+}
+
+/**
  * Find overlap between the 3' end of seq1 and the 5' end of seq2.
  * Scans from maxOverlap down to minOverlap for an exact match.
  */
@@ -179,21 +220,11 @@ export function gibsonAssemble(
   // trim the overlap from its beginning before appending
   let sequence = fragments[0].sequence.toUpperCase();
   const features: Feature[] = [];
-  let offset = 0;
 
   // Carry features from fragment 0
   for (const feat of fragments[0].features ?? []) {
-    features.push({
-      ...feat,
-      id: crypto.randomUUID(),
-      start: feat.start + offset,
-      end: feat.end + offset,
-      subRanges: feat.subRanges?.map((sr) => ({
-        ...sr,
-        start: sr.start + offset,
-        end: sr.end + offset,
-      })),
-    });
+    const copied = clipFeatureToSpan(feat, 0, fragments[0].sequence.length, 0, true);
+    if (copied) features.push(copied);
   }
 
   for (let i = 1; i < fragments.length; i++) {
@@ -223,7 +254,7 @@ export function gibsonAssemble(
       },
     });
 
-    offset = sequence.length;
+    const offset = sequence.length;
     sequence += trimmed;
 
     // Shift features: coordinates in frag are relative to frag.sequence[0].
@@ -231,28 +262,8 @@ export function gibsonAssemble(
     // and are skipped. Features spanning the overlap boundary are truncated.
     const overlapLength = overlap.length;
     for (const feat of frag.features ?? []) {
-      // Skip features entirely within the overlap (they belong to the previous fragment)
-      if (feat.end <= overlapLength) continue;
-
-      // Truncate features that span the overlap boundary
-      const newStart = Math.max(feat.start - overlapLength, 0);
-      const newEnd = feat.end - overlapLength;
-
-      if (newEnd > newStart) {
-        features.push({
-          ...feat,
-          id: crypto.randomUUID(),
-          start: newStart + offset,
-          end: newEnd + offset,
-          subRanges: feat.subRanges
-            ?.map((sr) => ({
-              ...sr,
-              start: Math.max(sr.start - overlapLength, 0) + offset,
-              end: sr.end - overlapLength + offset,
-            }))
-            .filter((sr) => sr.end > sr.start),
-        });
-      }
+      const copied = clipFeatureToSpan(feat, overlapLength, frag.sequence.length, offset, true);
+      if (copied) features.push(copied);
     }
   }
 
@@ -260,9 +271,14 @@ export function gibsonAssemble(
   // (head of fragment 0) and the end (tail of the last fragment) of the linear
   // accumulator. Trim the trailing copy so the overlap appears exactly once,
   // and annotate the seam (which physically sits at [0, len) on the product).
+  let productFeatures = features;
   if (topology === 'circular' && closingOverlap && closingOverlap.length > 0) {
     sequence = sequence.slice(0, sequence.length - closingOverlap.length);
-    features.push({
+    productFeatures = features.flatMap((feature) => {
+      const clipped = clipFeatureToSpan(feature, 0, sequence.length, 0);
+      return clipped ? [clipped] : [];
+    });
+    productFeatures.push({
       id: crypto.randomUUID(),
       name: `Junction: ${fragments[fragments.length - 1].name}×${fragments[0].name} (${closingOverlap.length} bp, closing)`,
       type: 'misc_feature',
@@ -280,7 +296,7 @@ export function gibsonAssemble(
     });
   }
 
-  return { sequence, features, overlaps, topology, success: true, errors: [], warnings };
+  return { sequence, features: productFeatures, overlaps, topology, success: true, errors: [], warnings };
 }
 
 /**

--- a/src/bio/golden-gate.ts
+++ b/src/bio/golden-gate.ts
@@ -225,6 +225,47 @@ function hammingDistance(a: string, b: string): number {
   return d;
 }
 
+/**
+ * Keep the portions of a feature that fall inside one source span and place
+ * them in product coordinates. Multipart locations are authoritative: their
+ * stored biological order is preserved, empty pieces are removed, and the
+ * aggregate bounds are rebuilt from the surviving pieces.
+ */
+function clipFeatureToSpan(
+  feature: Feature,
+  sourceStart: number,
+  sourceEnd: number,
+  destinationStart: number,
+  rekey = false,
+): Feature | null {
+  if (sourceEnd <= sourceStart) return null;
+
+  const hasSubRanges = feature.subRanges !== undefined;
+  const sourceRanges = hasSubRanges
+    ? feature.subRanges!
+    : [{ start: feature.start, end: feature.end, strand: feature.strand }];
+  const mappedRanges = sourceRanges.flatMap((range) => {
+    const clippedStart = Math.max(range.start, sourceStart);
+    const clippedEnd = Math.min(range.end, sourceEnd);
+    if (clippedEnd <= clippedStart) return [];
+    return [{
+      ...range,
+      start: destinationStart + clippedStart - sourceStart,
+      end: destinationStart + clippedEnd - sourceStart,
+    }];
+  });
+  if (mappedRanges.length === 0) return null;
+
+  const { subRanges: _subRanges, ...featureWithoutSubRanges } = feature;
+  return {
+    ...featureWithoutSubRanges,
+    ...(rekey ? { id: crypto.randomUUID() } : {}),
+    start: Math.min(...mappedRanges.map((range) => range.start)),
+    end: Math.max(...mappedRanges.map((range) => range.end)),
+    ...(hasSubRanges ? { subRanges: mappedRanges } : {}),
+  };
+}
+
 function createProductFeature(
   name: string,
   type: Feature['type'],
@@ -281,18 +322,29 @@ function createJunctionFeature(
   options: { circular?: boolean; sequenceLength?: number; overhangLength?: number } = {},
 ): Feature | null {
   const overhangLength = options.overhangLength ?? overhang.length;
-  const subRanges = options.circular && options.sequenceLength !== undefined
+  const circularRanges = options.circular && options.sequenceLength !== undefined
     ? [
       { start, end, strand: 1 },
       { start: 0, end: Math.min(overhangLength, options.sequenceLength), strand: 1 },
-    ].filter((range) => range.end > range.start)
-    : undefined;
+    ]
+      .filter((range) => range.end > range.start)
+      .filter((range, index, ranges) => ranges.findIndex((candidate) => (
+        candidate.start === range.start && candidate.end === range.end
+      )) === index)
+    : [];
+  const subRanges = circularRanges.length > 1 ? circularRanges : undefined;
+  const featureStart = subRanges
+    ? Math.min(...subRanges.map((range) => range.start))
+    : start;
+  const featureEnd = subRanges
+    ? Math.max(...subRanges.map((range) => range.end))
+    : end;
 
   return createProductFeature(
     `Junction ${leftPartName} -> ${rightPartName} (${overhang})`,
     'restriction_site',
-    start,
-    end,
+    featureStart,
+    featureEnd,
     PRODUCT_JUNCTION_COLOR,
     {
       source: 'golden_gate_assembly',
@@ -307,25 +359,7 @@ function createJunctionFeature(
 }
 
 function clampFeatureToLength(feature: Feature, length: number): Feature | null {
-  const start = Math.max(0, Math.min(feature.start, length));
-  const end = Math.max(start, Math.min(feature.end, length));
-  if (end <= start) return null;
-  const { subRanges: _subRanges, ...featureWithoutSubRanges } = feature;
-
-  const subRanges = feature.subRanges
-    ?.map((range) => ({
-      ...range,
-      start: Math.max(0, Math.min(range.start, length)),
-      end: Math.max(0, Math.min(range.end, length)),
-    }))
-    .filter((range) => range.end > range.start);
-
-  return {
-    ...featureWithoutSubRanges,
-    start,
-    end,
-    ...(subRanges && subRanges.length > 0 ? { subRanges } : {}),
-  };
+  return clipFeatureToSpan(feature, 0, length, 0);
 }
 
 function clampFeaturesToLength(features: Feature[], length: number): Feature[] {
@@ -414,23 +448,8 @@ function digestGoldenGateParts(
     const insertLength = insert.length;
     const shiftedFeatures: Feature[] = [];
     for (const feat of part.features ?? []) {
-      const clampedStart = Math.max(feat.start, leftCut);
-      const clampedEnd = Math.min(feat.end, leftCut + insertLength);
-      if (clampedEnd > clampedStart) {
-        shiftedFeatures.push({
-          ...feat,
-          id: crypto.randomUUID(),
-          start: clampedStart - leftCut,
-          end: clampedEnd - leftCut,
-          subRanges: feat.subRanges
-            ?.map((sr) => ({
-              ...sr,
-              start: Math.max(sr.start, leftCut) - leftCut,
-              end: Math.min(sr.end, leftCut + insertLength) - leftCut,
-            }))
-            .filter((sr) => sr.end > sr.start),
-        });
-      }
+      const shifted = clipFeatureToSpan(feat, leftCut, leftCut + insertLength, 0, true);
+      if (shifted) shiftedFeatures.push(shifted);
     }
 
     digested.push({ id: part.id, name: part.name, insert, oh5, oh3, rightOverhang, features: shiftedFeatures, insertStart: leftCut });
@@ -987,25 +1006,8 @@ export function goldenGateAssemble(
     if (partSpan) productFeatures.push(partSpan);
 
     for (const feat of curr.features) {
-      const shiftedStart = feat.start - overhangLength + offset;
-      const shiftedEnd = feat.end - overhangLength + offset;
-      const newStart = Math.max(offset, shiftedStart);
-      const newEnd = Math.min(sequence.length, shiftedEnd);
-      if (newEnd > newStart) {
-        features.push({
-          ...feat,
-          id: crypto.randomUUID(),
-          start: newStart,
-          end: newEnd,
-          subRanges: feat.subRanges
-            ?.map((sr) => ({
-              ...sr,
-              start: Math.max(offset, sr.start - overhangLength + offset),
-              end: Math.min(sequence.length, sr.end - overhangLength + offset),
-            }))
-            .filter((sr) => sr.end > sr.start),
-        });
-      }
+      const shifted = clipFeatureToSpan(feat, overhangLength, curr.insert.length, offset, true);
+      if (shifted) features.push(shifted);
     }
   }
 

--- a/src/bio/mutate.ts
+++ b/src/bio/mutate.ts
@@ -48,6 +48,14 @@ function shiftFeatures(
       start: range.start > editPos ? range.start + delta : range.start,
       end: range.end > editPos ? range.end + delta : range.end,
     }));
+    if (newSubRanges && newSubRanges.length > 0) {
+      return {
+        ...f,
+        start: Math.min(...newSubRanges.map((range) => range.start)),
+        end: Math.max(...newSubRanges.map((range) => range.end)),
+        subRanges: newSubRanges,
+      };
+    }
     return {
       ...f,
       start: newStart,
@@ -288,6 +296,16 @@ export function applyDeletion(
         }))
         .filter((range) => range.end > range.start);
 
+      if (f.subRanges && (!newSubRanges || newSubRanges.length === 0)) return null;
+      if (newSubRanges && newSubRanges.length > 0) {
+        return {
+          ...f,
+          start: Math.min(...newSubRanges.map((range) => range.start)),
+          end: Math.max(...newSubRanges.map((range) => range.end)),
+          subRanges: newSubRanges,
+        };
+      }
+
       return {
         ...f,
         start: newStart,
@@ -296,7 +314,7 @@ export function applyDeletion(
       };
     })
     // Filter out features that became zero-length or invalid
-    .filter((f) => f.end > f.start);
+    .filter((f): f is Feature => f !== null && f.end > f.start);
 
   return {
     raw: newRaw,

--- a/src/bio/pcr.ts
+++ b/src/bio/pcr.ts
@@ -3,6 +3,7 @@ import { gcContent } from './gc-content';
 import { calculateTm } from './tm-calculator';
 import { DEFAULT_TM_OPTIONS } from './primer-design';
 import type { Feature, Topology } from './types';
+import { remapFeatureLocation, type FeatureCoordinateMapSpan } from './feature-location';
 
 /**
  * Primer Tm for the PCR engine, computed with the SAME nearest-neighbor model +
@@ -62,19 +63,16 @@ export interface PCRBindingSelection {
   reverse: { start: number; end: number };
 }
 
-function propagateFeature(feature: Feature, offset: number): Feature {
+function propagateFeature(
+  feature: Feature,
+  sourceSpans: readonly FeatureCoordinateMapSpan[],
+): Feature | null {
+  const location = remapFeatureLocation(feature, sourceSpans);
+  if (!location) return null;
   return {
     ...feature,
     id: crypto.randomUUID(),
-    start: feature.start + offset,
-    end: feature.end + offset,
-    ...(feature.subRanges ? {
-      subRanges: feature.subRanges.map((range) => ({
-        ...range,
-        start: range.start + offset,
-        end: range.end + offset,
-      })),
-    } : {}),
+    ...location,
     metadata: {
       ...feature.metadata,
       pcrSourceFeatureId: feature.id,
@@ -250,32 +248,15 @@ export function simulatePCR(
   // into product coordinates by the forward tail length and template start.
   const productFeatures: Feature[] = [];
   if (features && features.length > 0) {
-    if (!wraps) {
-      // Linear / non-wrapping span [fwdMatch.pos, revBindEnd).
-      const regionStart = fwdMatch.pos;
-      const regionEnd = revBindEnd;
-      const offset = fwdTailLen - regionStart; // shift: template coord → product coord
-      for (const f of features) {
-        if (f.start >= regionStart && f.end <= regionEnd) {
-          productFeatures.push(propagateFeature(f, offset));
-        }
-      }
-    } else {
-      // Circular wrap: two contiguous template regions joined at the origin —
-      // [fwdMatch.pos, N) then [0, revBindEnd) — each with its own offset. A
-      // feature that straddles the origin would belong to both regions; it
-      // matches NEITHER "fully inside" test below and is skipped (we do not
-      // split features across the junction).
-      const headOffset = fwdTailLen - fwdMatch.pos;       // [fwdMatch.pos, N)
-      const tailOffset = fwdTailLen + (N - fwdMatch.pos); // [0, revBindEnd)
-      for (const f of features) {
-        if (f.start >= fwdMatch.pos && f.end <= N) {
-          productFeatures.push(propagateFeature(f, headOffset));
-        } else if (f.start >= 0 && f.end <= revBindEnd) {
-          productFeatures.push(propagateFeature(f, tailOffset));
-        }
-        // else: feature straddles the origin or lies outside the amplicon — skip.
-      }
+    const sourceSpans: FeatureCoordinateMapSpan[] = !wraps
+      ? [{ start: fwdMatch.pos, end: revBindEnd, targetStart: fwdTailLen }]
+      : [
+          { start: fwdMatch.pos, end: N, targetStart: fwdTailLen },
+          { start: 0, end: revBindEnd, targetStart: fwdTailLen + (N - fwdMatch.pos) },
+        ];
+    for (const feature of features) {
+      const propagated = propagateFeature(feature, sourceSpans);
+      if (propagated) productFeatures.push(propagated);
     }
   }
 

--- a/src/bio/restriction-digest.ts
+++ b/src/bio/restriction-digest.ts
@@ -2,6 +2,7 @@ import type { Topology, Feature, RestrictionEnzyme } from './types';
 import { findRestrictionSites } from './restriction-sites';
 import { RESTRICTION_ENZYMES_FULL } from './enzyme-data';
 import { reverseComplement } from './reverse-complement';
+import { remapFeatureLocation, type FeatureCoordinateMapSpan } from './feature-location';
 
 type RestrictionOverhangType = 'blunt' | '5prime' | '3prime';
 
@@ -79,45 +80,40 @@ export function restrictionDigest(
   features?: Feature[],
   enzymeCatalog: readonly RestrictionEnzyme[] = RESTRICTION_ENZYMES_FULL,
 ): DigestFragment[] {
+  /** Keep only complete feature products and remap every authoritative piece. */
+  function sliceFeaturesThroughSpans(sourceSpans: readonly FeatureCoordinateMapSpan[]): Feature[] {
+    if (!features || features.length === 0) return [];
+    return features.flatMap((feature) => {
+      const location = remapFeatureLocation(feature, sourceSpans);
+      return location ? [{
+        ...feature,
+        ...location,
+        id: crypto.randomUUID(),
+      }] : [];
+    });
+  }
+
   /** Filter parent features that fall entirely within [fragStart, fragEnd) and offset them. */
   function sliceFeatures(fragStart: number, fragEnd: number): Feature[] {
-    if (!features || features.length === 0) return [];
-    return features
-      .filter((f) => f.start >= fragStart && f.end <= fragEnd)
-      .map((f) => ({
-        ...f,
-        id: crypto.randomUUID(),
-        start: f.start - fragStart,
-        end: f.end - fragStart,
-      }));
+    return sliceFeaturesThroughSpans([{
+      start: fragStart,
+      end: fragEnd,
+      targetStart: 0,
+    }]);
   }
 
   /**
    * Wrap-aware feature slicer for a CIRCULAR fragment that straddles the origin:
    * the fragment sequence is the tail `[tailStart, seq.length)` followed by the
-   * head `[0, headEnd)`. (R11: the single-range `sliceFeatures(tailStart,
-   * headEnd + seq.length)` call dropped every feature on the HEAD/origin side of
-   * such a fragment — `f.start >= tailStart` is false for a head feature — so a
-   * circular digest silently lost those annotations and persisted the loss into
-   * the saved child block, while same-fragment tail features survived.)
+   * head `[0, headEnd)`. Multipart features can span both pieces as long as no
+   * individual authoritative segment crosses a physical cut boundary.
    */
   function sliceFeaturesWrap(tailStart: number, headEnd: number): Feature[] {
-    if (!features || features.length === 0) return [];
     const tailLen = seq.length - tailStart;
-    const out: Feature[] = [];
-    for (const f of features) {
-      if (f.start >= tailStart && f.end <= seq.length) {
-        // Fully within the tail [tailStart, seq.length).
-        out.push({ ...f, id: crypto.randomUUID(), start: f.start - tailStart, end: f.end - tailStart });
-      } else if (f.start >= 0 && f.end <= headEnd) {
-        // Fully within the head [0, headEnd) — placed after the tail in the
-        // fragment sequence, so shift by the tail length.
-        out.push({ ...f, id: crypto.randomUUID(), start: tailLen + f.start, end: tailLen + f.end });
-      }
-      // Else: the feature spans a cut boundary or crosses the origin seam —
-      // dropped, consistent with the linear cut-boundary-spanner rule.
-    }
-    return out;
+    return sliceFeaturesThroughSpans([
+      { start: tailStart, end: seq.length, targetStart: 0 },
+      { start: 0, end: headEnd, targetStart: tailLen },
+    ]);
   }
 
   const requestedNames = new Set(enzymeNames.map((name) => name.toLowerCase()));

--- a/src/plasmid-map/__tests__/geometry-core.test.ts
+++ b/src/plasmid-map/__tests__/geometry-core.test.ts
@@ -161,6 +161,16 @@ describe('ranges: featureSpans / featureSegments', () => {
       { start: 0, end: 5 },
     ]);
   });
+  it('orders a reverse aggregate origin wrap from biological 5′ to 3′', () => {
+    expect(featureSpans({ start: 95, end: 5, strand: -1 }, 100, 'circular')).toEqual([
+      { start: 0, end: 5 },
+      { start: 95, end: 100 },
+    ]);
+    expect(featureSegments({ start: 95, end: 5, strand: -1 }, 100, 'circular')).toEqual([
+      { start: 0, end: 5, isStart: true, isEnd: false },
+      { start: 95, end: 100, isStart: false, isEnd: true },
+    ]);
+  });
   it('marks first/last segments for arrowhead placement', () => {
     const segs = featureSegments({ start: 95, end: 5 }, 100, 'circular');
     expect(segs[0]).toMatchObject({ start: 95, end: 100, isStart: true, isEnd: false });
@@ -181,6 +191,14 @@ describe('ranges: featureSelectionRanges', () => {
     );
     expect(sel.ranges).toEqual([{ start: 2499, end: 2578 }, { start: 0, end: 100 }]);
     expect(sel.primary).toEqual({ start: 2499, end: 2578 });
+  });
+  it('uses the biological head span as primary for a reverse aggregate wrap', () => {
+    const sel = featureSelectionRanges({ start: 95, end: 5, strand: -1 }, 100, 'circular');
+    expect(sel.ranges).toEqual([
+      { start: 0, end: 5 },
+      { start: 95, end: 100 },
+    ]);
+    expect(sel.primary).toEqual({ start: 0, end: 5 });
   });
   it('single span -> primary equals the span', () => {
     const sel = featureSelectionRanges({ start: 10, end: 40 }, 100, 'linear');

--- a/src/plasmid-map/__tests__/layout.test.ts
+++ b/src/plasmid-map/__tests__/layout.test.ts
@@ -1344,6 +1344,43 @@ describe('computeMapLayout: segmentation', () => {
     const layout = computeMapLayout(circularInput({ features: [cds], restrictionSites: [] }));
     expect(layout.features[0].segmentPaths).toHaveLength(cds.subRanges!.length);
   });
+
+  it('puts a reverse multipart arrowhead on the biological terminal segment', () => {
+    const reverseCds = feat({
+      id: 'reverse-cds',
+      name: 'reverse split CDS',
+      type: 'cds',
+      start: 100,
+      end: 500,
+      strand: -1,
+      // Biological 5′→3′ order on the reverse strand is high to low.
+      subRanges: [
+        { start: 400, end: 500, strand: -1 },
+        { start: 100, end: 200, strand: -1 },
+      ],
+    });
+    const commandCount = (path: string, command: string) => (
+      path.match(new RegExp(`\\b${command}\\b`, 'g')) ?? []
+    ).length;
+
+    const circular = computeMapLayout(circularInput({ features: [reverseCds], restrictionSites: [] }));
+    expect(commandCount(circular.features[0].segmentPaths[0], 'L')).toBe(1);
+    expect(commandCount(circular.features[0].segmentPaths[1], 'L')).toBe(2);
+
+    const linear = computeMapLayout({
+      mode: 'linear',
+      name: 'reverse multipart',
+      length: 600,
+      topology: 'linear',
+      sequenceType: 'dna',
+      features: [reverseCds],
+      restrictionSites: [],
+      width: 800,
+      height: 260,
+    });
+    expect(linear.features[0].segmentPaths[0]).not.toContain(' L ');
+    expect(linear.features[0].segmentPaths[1]).toContain(' L ');
+  });
 });
 
 // ── protein / linear ──────────────────────────────────────────────────────────

--- a/src/plasmid-map/geometry/ranges.ts
+++ b/src/plasmid-map/geometry/ranges.ts
@@ -12,6 +12,9 @@
 import type { Feature, Topology } from '../../bio/types';
 import type { MapSpan, MapFeatureSegment, FeatureSelectionRanges } from '../types';
 
+type MapFeatureLocation = Pick<Feature, 'start' | 'end' | 'subRanges'>
+  & Partial<Pick<Feature, 'strand'>>;
+
 /**
  * Split a [start, end) range into non-wrapping spans clamped to [0, length).
  * - linear: clamp to bounds; drop if empty.
@@ -61,11 +64,11 @@ export function normalizeSpan(
 /**
  * All drawable segments of a feature in biological/import order, honoring
  * subRanges (authoritative when present) and origin wrap. `isStart`/`isEnd` mark
- * the biologically-first/last segments (layout folds the strand point into
- * `isEnd` for forward, `isStart` for reverse, none for directionless).
+ * the biologically-first/last segments (layout folds the 3′ strand point into
+ * `isEnd` for either direction, using strand to choose the pointed edge).
  */
 export function featureSegments(
-  feature: Pick<Feature, 'start' | 'end' | 'subRanges'>,
+  feature: MapFeatureLocation,
   length: number,
   topology: Topology,
 ): MapFeatureSegment[] {
@@ -79,16 +82,21 @@ export function featureSegments(
 
 /** Bare spans (no start/end flags) for a feature, biological/import order. */
 export function featureSpans(
-  feature: Pick<Feature, 'start' | 'end' | 'subRanges'>,
+  feature: MapFeatureLocation,
   length: number,
   topology: Topology,
 ): MapSpan[] {
-  const sub = feature.subRanges?.filter((r) => Number.isFinite(r.start) && Number.isFinite(r.end));
-  if (sub && sub.length > 0) {
+  if (feature.subRanges !== undefined) {
+    const sub = feature.subRanges.filter((r) => Number.isFinite(r.start) && Number.isFinite(r.end));
     // subRanges are authoritative and kept in stored (import/biological) order.
     return sub.flatMap((r) => normalizeSpan(r.start, r.end, length, topology));
   }
-  return normalizeSpan(feature.start, feature.end, length, topology);
+  const spans = normalizeSpan(feature.start, feature.end, length, topology);
+  // Aggregate origin wraps have no stored piece order. normalizeSpan emits
+  // genomic traversal order (tail then head), which is biological order only
+  // on the forward strand. Reverse features traverse head then tail so their
+  // first selection span and final 3′ arrow segment remain biologically honest.
+  return feature.strand === -1 && spans.length > 1 ? [...spans].reverse() : spans;
 }
 
 /**
@@ -97,7 +105,7 @@ export function featureSpans(
  * a wrapping range; callers pass this straight to the store setters.
  */
 export function featureSelectionRanges(
-  feature: Pick<Feature, 'start' | 'end' | 'subRanges'>,
+  feature: MapFeatureLocation,
   length: number,
   topology: Topology,
 ): FeatureSelectionRanges {

--- a/src/plasmid-map/layout.ts
+++ b/src/plasmid-map/layout.ts
@@ -625,7 +625,10 @@ function computeCircularLayout(input: MapInput): MapLayout {
     let terminalTipDeltaDeg = 0;
     if (displayStrand !== 0) {
       const forward = displayStrand === 1;
-      terminalIndex = forward ? segs.length - 1 : 0;
+      // Segments are stored in biological 5′→3′ order for both strands, so
+      // the 3′ arrowhead always belongs to the final segment. Strand chooses
+      // which edge of that terminal segment receives the point.
+      terminalIndex = segs.length - 1;
       const term = segs[terminalIndex];
       const termExtentPx = arcExtentPx(
         centerR,
@@ -1315,7 +1318,9 @@ function computeLinearLayout(input: MapInput): MapLayout {
     const yTop = band.top;
     const yMid = band.mid;
     const rowHeight = band.height;
-    const terminalIndex = displayStrand === 1 ? segs.length - 1 : displayStrand === -1 ? 0 : -1;
+    // Biological-order segments terminate at the final stored segment on both
+    // strands; reverse direction points from that segment's left edge.
+    const terminalIndex = displayStrand === 0 ? -1 : segs.length - 1;
     // How far the arrowhead TIP juts past the terminal segment body (0 when
     // directionless — no arrow is drawn). Shared by the glyph path below AND the
     // outside-label side choice, so the label gap clears the arrow tip, not just


### PR DESCRIPTION
## Summary

- treat joined feature subranges as authoritative biological products across inspection, translation, copy, reports, maps, and interchange
- preserve joined, ordered, reverse, origin-spanning, mixed-strand, fuzzy, and codon-start semantics in GenBank/GFF3 workflows
- remap every feature piece through mutation, PCR, digest, Gibson, and Golden Gate products
- fail closed for INSDC order locations and ambiguous legacy reverse multipart checkpoints
- keep reverse multipart and aggregate origin-wrap map arrows in biological order

## Validation

- typecheck and full-repo lint
- 823/823 unit tests
- plugin packaging, CSS-token, ARIA-control, deterministic build, and strict Claude plugin validation
- full browser campaign: 117 passed, 16 expected skips, 0 failed
- staged and committed Gitleaks scans: no leaks

No MSA implementation, MCP/connector source, package, lockfile, build-output, or generated-output files are changed.