### PR TITLE
Preserve workspace integrity and add bounded result viewers

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -64,6 +64,9 @@ backs it, so the list stays honest.
 - Database JSON restores directly. A workspace ZIP holds the same
   `inventory.json` plus interchange exports; restore it by extracting
   `inventory.json` and loading it from Settings.
+- Browser downloads are reported as requests, not verified saves. Confirm the
+  Database JSON or ZIP exists and can be reopened before treating it as a
+  durable checkpoint.
 - Source: `src/artifacts/claude-science-analysis-results.ts`, `src/artifacts/claude-science-session.ts`.
 
 ## Claude Science connector

--- a/docs/CLAUDE_SCIENCE_QUICKSTART.md
+++ b/docs/CLAUDE_SCIENCE_QUICKSTART.md
@@ -166,7 +166,8 @@ The connector is a bounded viewer/export surface. It does not run a shell or
 external alignment tools, write a hidden sequence database, or upload data to
 a Motif service. Workbench Database JSON and workspace ZIP exports are ordinary
 unencrypted user-owned files; handle them according to the sensitivity of the
-sequence data they contain.
+sequence data they contain. Verify the downloaded file exists and can be
+reopened before treating it as a checkpoint.
 
 For symptom-specific recovery, see
 [Motif + Claude Science troubleshooting](CLAUDE_SCIENCE_TROUBLESHOOTING.md).

--- a/docs/CLAUDE_SCIENCE_TROUBLESHOOTING.md
+++ b/docs/CLAUDE_SCIENCE_TROUBLESHOOTING.md
@@ -166,7 +166,9 @@ The local connector is an ephemeral viewer/export surface:
 - it does not live-update a previously saved HTML snapshot.
 
 Inside the workbench, Database JSON and workspace ZIP are the complete
-portable checkpoint formats. Export before reload when edits matter.
+portable checkpoint formats. Export and verify the resulting file before
+reload when edits matter; a browser download request alone is not a confirmed
+save.
 
 ## Final acceptance checklist
 

--- a/e2e/claude-science-analysis-results.spec.ts
+++ b/e2e/claude-science-analysis-results.spec.ts
@@ -138,6 +138,14 @@ test.describe('Claude Science typed analysis result runtime', () => {
     expect(await page.evaluate(() => (globalThis as { __MOTIF_ANALYSIS_E2E_PWNED__?: boolean }).__MOTIF_ANALYSIS_E2E_PWNED__))
       .toBeUndefined();
 
+    const reportDownloadPromise = page.waitForEvent('download');
+    await resultRow.getByRole('button', { name: 'Download report Agent safety report' }).click();
+    const reportDownload = await reportDownloadPromise;
+    expect(reportDownload.suggestedFilename()).toBe('Agent safety report.txt');
+    await expect(resultsPanel.locator('.motif-cs-agent-results-live')).toContainText(
+      'Download requested for Agent safety report.txt. Verify the file before relying on it.',
+    );
+
     const settings = page.locator('details[data-rail-tool="settings"]');
     await settings.locator(':scope > summary').click();
     const downloadPromise = page.waitForEvent('download');

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -711,7 +711,10 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(save).toBeEnabled();
     await expect(save).toHaveText('Save 2 fragments');
 
-    await page.evaluate((workspace) => window.motifReplaceWorkspace?.(workspace as never), backup);
+    await page.evaluate((workspace) => window.motifReplaceWorkspace?.(
+      workspace as never,
+      { discardUnsavedChanges: true },
+    ), backup);
     await expect(save).toBeDisabled();
     await expect(save).toHaveText('Saved');
     expect(await page.evaluate(() => window.motifGetWorkflowResults?.().length)).toBe(2);
@@ -829,7 +832,7 @@ test.describe('Claude Science artifact campaign', () => {
       topology: 'linear',
       seq: 'ATGC',
       active: true,
-    }] }));
+    }] }, { discardUnsavedChanges: true }));
     await expect(assemblyWindow).toHaveCount(0);
   });
 
@@ -1335,7 +1338,7 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(restoreDialog).toBeVisible();
     await restoreDialog.getByRole('button', { name: 'Replace workspace' }).click();
     await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('Restored record');
-    await expect(page.getByTestId('session-durability-status')).toHaveText('saved');
+    await expect(page.getByTestId('session-durability-status')).toHaveText('session only');
     await expect(page.locator('.motif-cs-dropzone-card')).toContainText('Database JSON restored · 1 record');
     await expect(page.locator('.motif-cs-dropzone')).toBeHidden({ timeout: 4_000 });
     expect(await page.evaluate(() => window.motifGetAlignments())).toHaveLength(1);
@@ -1400,7 +1403,7 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(restoreDialog).toBeVisible();
     await restoreDialog.getByRole('button', { name: 'Replace workspace' }).click();
     await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('Dropped restore');
-    await expect(page.getByTestId('session-durability-status')).toHaveText('saved');
+    await expect(page.getByTestId('session-durability-status')).toHaveText('restored checkpoint');
   });
 
   test('Notes create from a keyboard selection, reveal their range, and stay usable on phone layouts', async ({ page }) => {
@@ -1461,7 +1464,10 @@ test.describe('Claude Science artifact campaign', () => {
       notes: [expect.objectContaining({ id: 'recovery-note' })],
       artifactState: expect.any(Object),
     });
-    expect(await page.evaluate((workspace) => window.motifReplaceWorkspace?.(workspace), snapshot)).toBe(13);
+    expect(await page.evaluate((workspace) => window.motifReplaceWorkspace?.(
+      workspace,
+      { discardUnsavedChanges: true },
+    ), snapshot)).toBe(13);
     const invalid = await page.evaluate(() => {
       try {
         window.motifAddNotes?.({
@@ -1504,11 +1510,14 @@ test.describe('Claude Science artifact campaign', () => {
     await settings.getByTestId('clear-workspace-confirm').click();
     expect(await page.evaluate(() => window.motifGetInventory?.().length)).toBe(0);
     expect(await page.locator('html').getAttribute('data-theme')).toBe(themeBefore);
-    expect(await page.evaluate((workspace) => window.motifReplaceWorkspace?.(workspace), snapshot)).toBe(13);
+    expect(await page.evaluate((workspace) => window.motifReplaceWorkspace?.(
+      workspace,
+      { discardUnsavedChanges: true },
+    ), snapshot)).toBe(13);
     expect(await page.evaluate(() => window.motifGetNotes?.().length)).toBe(1);
   });
 
-  test('durable edits warn before reload and full downloads checkpoint the session', async ({ page }) => {
+  test('durable edits warn before reload and browser downloads remain unverified', async ({ page }) => {
     await openArtifact(page, 1180, 900);
     await expect(page.getByTestId('session-durability-status')).toHaveText('session only');
 
@@ -1532,7 +1541,8 @@ test.describe('Claude Science artifact campaign', () => {
     const downloadPromise = page.waitForEvent('download');
     await exportPanel.getByRole('button', { name: 'Download' }).click();
     await downloadPromise;
-    await expect(page.getByTestId('session-durability-status')).toHaveText('saved');
+    await expect(exportPanel.getByText(/Download requested for motif-inventory\.json/)).toBeVisible();
+    await expect(page.getByTestId('session-durability-status')).toHaveText('unsaved changes');
   });
 
   test('250k records keep sequence and translation DOM bounded and an empty inventory exports only real data', async ({ page }) => {

--- a/e2e/claude-science-workspace-integrity.spec.ts
+++ b/e2e/claude-science-workspace-integrity.spec.ts
@@ -2,6 +2,15 @@ import { expect, test, type Page } from '@playwright/test';
 
 const artifactUrl = process.env.MOTIF_ARTIFACT_URL;
 
+type RuntimeWorkspace = Record<string, unknown> & {
+  exportedAt?: unknown;
+  records: Array<Record<string, unknown> & { id: string; name: string; seq: string }>;
+  notes: Array<Record<string, unknown> & { id: string }>;
+  artifactState: Record<string, unknown> & {
+    translationLayersByRecord: Record<string, Array<Record<string, unknown> & { id: string }>>;
+  };
+};
+
 const createdAt = '2026-07-12T12:00:00.000Z';
 const embeddedWorkspace = {
   schema: 'motif.claude-science.inventory.v2',
@@ -174,5 +183,265 @@ test.describe('Claude Science workspace integrity', () => {
     ]));
     expect(orphanAttempt.after).toEqual(orphanAttempt.before);
     expect(diagnostics).toEqual([]);
+  });
+
+  test('edits sequence, note anchors, and translation anchors as one undoable transaction', async ({ page }) => {
+    await openInjectedWorkspace(page);
+    await page.evaluate((timestamp) => {
+      const workspace = window.motifGetWorkspace?.() as RuntimeWorkspace;
+      delete workspace.exportedAt;
+      workspace.notes = [
+        ...(workspace.notes ?? []),
+        {
+          id: 'range-note',
+          title: 'Tail observation',
+          body: 'Keep this note attached to its bases.',
+          format: 'plain',
+          scope: 'range',
+          recordId: 'record-a',
+          range: { start: 8, end: 12 },
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ];
+      workspace.artifactState.translationLayersByRecord['record-a'].push({
+        id: 'layer-tail',
+        label: 'Tail translation',
+        start: 6,
+        end: 12,
+        strand: 1,
+        frame: 0,
+        source: 'layer',
+      });
+      window.motifReplaceWorkspace?.(workspace);
+    }, createdAt);
+
+    await expect(page.getByTestId('session-durability-status')).toHaveText('session only');
+    const before = await page.evaluate(() => {
+      const workspace = structuredClone(window.motifGetWorkspace?.() as Record<string, unknown>);
+      delete workspace.exportedAt;
+      return workspace;
+    });
+
+    const editor = page.getByRole('textbox', { name: /Editable sequence/ });
+    await editor.click({ position: { x: 70, y: 50 } });
+    await editor.press('End');
+    await editor.press('ArrowLeft');
+    await editor.press('ArrowLeft');
+    await editor.press('ArrowLeft');
+    await expect(page.locator('.motif-cs-edit-hint')).toContainText('Caret 10');
+    await editor.press('t');
+    await expect(page.locator('.motif-cs-edit-hint')).toContainText('Caret 11');
+    const afterSameBase = await page.evaluate(() => {
+      const workspace = structuredClone(window.motifGetWorkspace?.() as Record<string, unknown>);
+      delete workspace.exportedAt;
+      return workspace;
+    });
+    expect(afterSameBase).toEqual(before);
+    await expect(page.getByRole('button', { name: 'Undo' })).toHaveCount(0);
+    await expect(page.getByTestId('session-durability-status')).toHaveText('session only');
+    await editor.press('ArrowLeft');
+    await editor.press('g');
+
+    const edited = await page.evaluate(() => {
+      const workspace = window.motifGetWorkspace?.() as RuntimeWorkspace;
+      return {
+        sequence: workspace.records[0].seq,
+        note: workspace.notes.find((note) => note.id === 'range-note'),
+        layer: workspace.artifactState.translationLayersByRecord['record-a']
+          .find((layer: { id: string }) => layer.id === 'layer-tail'),
+      };
+    });
+    expect(edited.sequence).toBe('ATGGAATTCGAA');
+    expect(edited.note).toMatchObject({
+      scope: 'range',
+      range: { start: 8, end: 12 },
+      provenance: {
+        operation: 'sequence_edit_anchor_review',
+        metadata: { motifRangeAnchor: { status: 'review' } },
+      },
+    });
+    expect(edited.layer).toMatchObject({ start: 6, end: 12, needsReview: true });
+    await expect(page.getByTestId('session-durability-status')).toHaveText('unsaved changes');
+
+    const notesPanel = page.locator('details[data-rail-tool="notes"]');
+    if (!(await notesPanel.getAttribute('open'))) await notesPanel.locator(':scope > summary').click();
+    await expect(notesPanel.getByText('Review range anchor.')).toBeVisible();
+
+    const annotationsPanel = page.locator('details[data-rail-tool="annotations"]');
+    if (!(await annotationsPanel.getAttribute('open'))) await annotationsPanel.locator(':scope > summary').click();
+    await expect(annotationsPanel.getByText('Review anchor')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Undo' }).click();
+    const afterUndo = await page.evaluate(() => {
+      const workspace = structuredClone(window.motifGetWorkspace?.() as Record<string, unknown>);
+      delete workspace.exportedAt;
+      return workspace;
+    });
+    expect(afterUndo).toEqual(before);
+    await expect(page.getByTestId('session-durability-status')).toHaveText('session only');
+
+    await page.getByRole('button', { name: 'Redo' }).click();
+    await expect.poll(() => page.evaluate(() => (
+      (window.motifGetWorkspace?.() as RuntimeWorkspace).records[0].seq
+    ))).toBe('ATGGAATTCGAA');
+    await expect(page.getByTestId('session-durability-status')).toHaveText('unsaved changes');
+  });
+
+  test('undo preserves an absent translation-layer entry exactly', async ({ page }) => {
+    await openInjectedWorkspace(page);
+    await page.evaluate(() => {
+      const workspace = structuredClone(window.motifGetWorkspace?.() as RuntimeWorkspace);
+      delete workspace.exportedAt;
+      workspace.artifactState.translationLayersByRecord = {};
+      window.motifReplaceWorkspace?.(workspace);
+    });
+    await expect(page.getByTestId('session-durability-status')).toHaveText('session only');
+
+    const before = await page.evaluate(() => {
+      const workspace = structuredClone(window.motifGetWorkspace?.() as RuntimeWorkspace);
+      delete workspace.exportedAt;
+      return workspace;
+    });
+    expect(before.artifactState.translationLayersByRecord).not.toHaveProperty('record-a');
+
+    const editor = page.getByRole('textbox', { name: /Editable sequence/ });
+    await editor.click({ position: { x: 70, y: 50 } });
+    await editor.press('End');
+    await editor.press('ArrowLeft');
+    await editor.press('ArrowLeft');
+    await editor.press('ArrowLeft');
+    await editor.press('g');
+    await expect(page.getByTestId('session-durability-status')).toHaveText('unsaved changes');
+
+    await page.getByRole('button', { name: 'Undo' }).click();
+    const afterUndo = await page.evaluate(() => {
+      const workspace = structuredClone(window.motifGetWorkspace?.() as RuntimeWorkspace);
+      delete workspace.exportedAt;
+      return workspace;
+    });
+    expect(afterUndo).toEqual(before);
+    await expect(page.getByTestId('session-durability-status')).toHaveText('session only');
+  });
+
+  test('keeps browser downloads unverified and blocks dirty runtime replacement', async ({ page }) => {
+    await openInjectedWorkspace(page);
+    await expect(page.getByTestId('session-durability-status')).toHaveText('session only');
+
+    await page.evaluate((timestamp) => {
+      window.motifAddRecords?.({
+        id: 'record-b',
+        name: 'Original B',
+        molecule: 'dna',
+        topology: 'linear',
+        seq: 'ATGCCCTAA',
+      });
+      window.motifAddNotes?.({
+        id: 'dirty-note',
+        body: 'Unsaved local observation.',
+        format: 'plain',
+        scope: 'workspace',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+    }, createdAt);
+    await expect(page.getByTestId('session-durability-status')).toHaveText('unsaved changes');
+
+    await page.locator('.motif-cs-record-tab').filter({ hasText: 'Original A' }).click();
+    const dirty = await page.evaluate(() => {
+      const workspace = structuredClone(window.motifGetWorkspace?.() as RuntimeWorkspace);
+      delete workspace.exportedAt;
+      return workspace;
+    });
+    expect(dirty.selectedRecordId).toBe('record-a');
+
+    const selectionOnlyReplacement = structuredClone(dirty);
+    selectionOnlyReplacement.selectedRecordId = 'record-b';
+
+    const identicalCount = await page.evaluate(
+      (workspace) => window.motifReplaceWorkspace?.(workspace),
+      selectionOnlyReplacement,
+    );
+    expect(identicalCount).toBe(2);
+    await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('Original B');
+    const afterSelectionOnlyReplace = await page.evaluate(() => {
+      const workspace = structuredClone(window.motifGetWorkspace?.() as RuntimeWorkspace);
+      delete workspace.exportedAt;
+      return workspace;
+    });
+    expect(afterSelectionOnlyReplace).toEqual(selectionOnlyReplacement);
+    await expect(page.getByTestId('session-durability-status')).toHaveText('unsaved changes');
+
+    const dirtyAfterSelection = selectionOnlyReplacement;
+
+    const blocked = await page.evaluate((workspace) => {
+      const replacement = structuredClone(workspace);
+      replacement.records[0].name = 'Runtime replacement';
+      let error: { code?: string; message: string } | null = null;
+      try {
+        window.motifReplaceWorkspace?.(replacement);
+      } catch (cause) {
+        error = {
+          code: (cause as { code?: string }).code,
+          message: cause instanceof Error ? cause.message : String(cause),
+        };
+      }
+      const after = structuredClone(window.motifGetWorkspace?.() as RuntimeWorkspace);
+      delete after.exportedAt;
+      return { error, after };
+    }, dirtyAfterSelection);
+    expect(blocked.error).toMatchObject({ code: 'MOTIF_UNSAVED_WORKSPACE' });
+    expect(blocked.after).toEqual(dirtyAfterSelection);
+
+    const spoofedDiscard = await page.evaluate((workspace) => {
+      const replacement = structuredClone(workspace);
+      replacement.records[0].name = 'Truthy option must not replace';
+      let error: { code?: string; message: string } | null = null;
+      try {
+        window.motifReplaceWorkspace?.(
+          replacement,
+          { discardUnsavedChanges: 'false' } as never,
+        );
+      } catch (cause) {
+        error = {
+          code: (cause as { code?: string }).code,
+          message: cause instanceof Error ? cause.message : String(cause),
+        };
+      }
+      const after = structuredClone(window.motifGetWorkspace?.() as RuntimeWorkspace);
+      delete after.exportedAt;
+      return { error, after };
+    }, dirtyAfterSelection);
+    expect(spoofedDiscard.error).toMatchObject({ code: 'MOTIF_UNSAVED_WORKSPACE' });
+    expect(spoofedDiscard.after).toEqual(dirtyAfterSelection);
+
+    const exportPanel = page.locator('.motif-cs-sequence-tools-panel');
+    if (!(await exportPanel.getAttribute('open'))) await exportPanel.locator(':scope > summary').click();
+    await exportPanel.locator('select[name="export-format"]').selectOption('inventory-json');
+    const browserDownload = page.waitForEvent('download');
+    await exportPanel.locator('.motif-cs-export-picker-actions').getByRole('button', { name: 'Download' }).click();
+    await browserDownload;
+    await expect(exportPanel.getByText(/Download requested for motif-inventory\.json/)).toBeVisible();
+    await expect(page.getByTestId('session-durability-status')).toHaveText('unsaved changes');
+
+    const checkpointWorkspace = await page.evaluate((workspace) => {
+      const replacement = structuredClone(workspace);
+      replacement.records[0].name = 'Runtime replacement';
+      window.motifReplaceWorkspace?.(replacement, { discardUnsavedChanges: true });
+      return window.motifGetWorkspace?.() as Record<string, unknown>;
+    }, dirtyAfterSelection);
+    await expect(page.getByTestId('session-durability-status')).toHaveText('session only');
+
+    const settings = page.locator('details[data-rail-tool="settings"]');
+    if (!(await settings.getAttribute('open'))) await settings.locator(':scope > summary').click();
+    await settings.getByTestId('restore-workspace-file').setInputFiles({
+      name: 'verified-workspace.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(JSON.stringify(checkpointWorkspace)),
+    });
+    const dialog = page.getByTestId('database-restore-dialog');
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('button', { name: 'Replace workspace' }).click();
+    await expect(page.getByTestId('session-durability-status')).toHaveText('restored checkpoint');
   });
 });

--- a/src/artifacts/ClaudeScienceAgentResultsPanel.tsx
+++ b/src/artifacts/ClaudeScienceAgentResultsPanel.tsx
@@ -1,14 +1,35 @@
-import { useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { useId, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 import type {
   ArtifactAnalysisAsset,
   ArtifactAnalysisKind,
   ArtifactAnalysisResult,
+  ArtifactBlastHit,
 } from './claude-science-analysis-results';
+import {
+  artifactAnalysisResultAssets,
+  artifactTableToTsv,
+  artifactTextPage,
+  resolveArtifactReport,
+  safeAnalysisFilename,
+  sortArtifactBlastHits,
+  type ArtifactBlastSortKey,
+} from './claude-science-analysis-result-viewers';
 import {
   ClaudeScienceFreshnessBadge,
   type ScientificFreshnessDisplayEvaluation,
 } from './ClaudeScienceFreshnessBadge';
 import './claude-science-agent-results.css';
+
+export type ArtifactResultCopyHandler = (
+  label: string,
+  content: string,
+) => void | Promise<void>;
+
+export type ArtifactResultDownloadHandler = (
+  filename: string,
+  content: string,
+  mediaType: string,
+) => void | Promise<void>;
 
 export type ClaudeScienceAgentResultsPanelProps = {
   results: readonly ArtifactAnalysisResult[];
@@ -17,6 +38,10 @@ export type ClaudeScienceAgentResultsPanelProps = {
   freshnessByResultId?: ReadonlyMap<string, ScientificFreshnessDisplayEvaluation>;
   onRevealRecord: (recordId: string) => void;
   onRemove: (resultId: string) => boolean | void;
+  /** Optional host adapter; the standalone workbench otherwise uses the Clipboard API. */
+  onCopyText?: ArtifactResultCopyHandler;
+  /** Optional host adapter; the standalone workbench otherwise downloads a text Blob. */
+  onDownloadText?: ArtifactResultDownloadHandler;
 };
 
 const KIND_LABELS: Record<ArtifactAnalysisKind, string> = {
@@ -31,12 +56,43 @@ const KIND_LABELS: Record<ArtifactAnalysisKind, string> = {
 };
 
 type ResultFilter = 'all' | 'design' | 'sequence' | 'evidence';
+type ReportResult = Extract<ArtifactAnalysisResult, { kind: 'report' }>;
+type TableResult = Extract<ArtifactAnalysisResult, { kind: 'table' }>;
+type BlastResult = Extract<ArtifactAnalysisResult, { kind: 'blast_search' }>;
+
+type ResultTextActions = {
+  copyText: (label: string, content: string) => Promise<void>;
+  downloadText: (filename: string, content: string, mediaType: string) => Promise<void>;
+};
 
 const FILTER_KINDS: Record<Exclude<ResultFilter, 'all'>, ReadonlySet<ArtifactAnalysisKind>> = {
   design: new Set(['primer_design', 'pcr', 'assembly_plan']),
   sequence: new Set(['construct_verification', 'blast_search', 'structure_model']),
   evidence: new Set(['report', 'table']),
 };
+
+const RESULT_PAGE_SIZE = 25;
+const BLAST_PAGE_SIZE = 25;
+const TABLE_PAGE_SIZE = 50;
+const TABLE_BODY_CELL_BUDGET = 1_000;
+const TABLE_CELL_PREVIEW_CHARACTERS = 512;
+const ASSET_PAGE_SIZE = 25;
+const TEXT_PAGE_CHARACTERS = 20_000;
+const ASSET_PREVIEW_CHARACTERS = 12_000;
+
+function boundedTextPreview(text: string, maxCharacters: number): string {
+  const preview = text.slice(0, maxCharacters);
+  const lastCodeUnit = preview.charCodeAt(preview.length - 1);
+  return lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff ? preview.slice(0, -1) : preview;
+}
+
+const BLAST_SORT_OPTIONS: ReadonlyArray<{ value: ArtifactBlastSortKey; label: string }> = [
+  { value: 'evalue', label: 'E-value · lowest first' },
+  { value: 'bit_score', label: 'Bit score · highest first' },
+  { value: 'identity', label: 'Identity · highest first' },
+  { value: 'coverage', label: 'Query coverage · highest first' },
+  { value: 'accession', label: 'Accession · A to Z' },
+];
 
 function timestamp(value: string): string {
   const parsed = Date.parse(value);
@@ -48,6 +104,12 @@ function recordList(ids: readonly string[], names: Readonly<Record<string, strin
   if (ids.length === 0) return 'No linked records';
   const visible = ids.slice(0, 3).map((id) => names[id] ?? id);
   const remaining = ids.length - visible.length;
+  return `${visible.join(', ')}${remaining > 0 ? ` + ${remaining.toLocaleString()} more` : ''}`;
+}
+
+function assetListSummary(assets: readonly ArtifactAnalysisAsset[]): string {
+  const visible = assets.slice(0, 3).map((asset) => `${asset.name} (${asset.mediaType})`);
+  const remaining = assets.length - visible.length;
   return `${visible.join(', ')}${remaining > 0 ? ` + ${remaining.toLocaleString()} more` : ''}`;
 }
 
@@ -97,24 +159,564 @@ function resultFacts(result: ArtifactAnalysisResult): Array<{ label: string; val
   }
 }
 
-function safePreview(result: ArtifactAnalysisResult): string | null {
-  if (result.kind === 'report') return result.data.body?.slice(0, 1_200) ?? null;
-  if (result.kind === 'blast_search') {
-    return result.data.hits.slice(0, 5).map((hit) => (
-      `${hit.accession} · ${hit.identityPercent.toFixed(1)}% identity · ${hit.queryCoveragePercent.toFixed(1)}% coverage · E ${hit.eValue}`
-    )).join('\n') || null;
+function constructVerificationPreview(result: ArtifactAnalysisResult): string | null {
+  if (result.kind !== 'construct_verification') return null;
+  return result.data.reasonCodes.length
+    ? result.data.reasonCodes.map((code) => code.replaceAll('_', ' ')).join('\n')
+    : 'No verification issues recorded.';
+}
+
+function assetExtension(asset: ArtifactAnalysisAsset): string {
+  if (asset.mediaType === 'application/json') return 'json';
+  if (asset.mediaType === 'text/csv') return 'csv';
+  if (asset.mediaType === 'text/markdown') return 'md';
+  if (asset.mediaType === 'text/tab-separated-values') return 'tsv';
+  if (asset.mediaType === 'text/x-fasta') return 'fasta';
+  if (asset.mediaType === 'chemical/x-pdb') return 'pdb';
+  if (asset.mediaType === 'chemical/x-cif' || asset.mediaType === 'chemical/x-mmcif') return 'cif';
+  return 'txt';
+}
+
+async function copyTextInBrowser(content: string): Promise<void> {
+  if (globalThis.navigator?.clipboard?.writeText) {
+    try {
+      await globalThis.navigator.clipboard.writeText(content);
+      return;
+    } catch {
+      // Artifact sandboxes commonly deny the async Clipboard API.
+    }
   }
-  if (result.kind === 'table') {
-    const header = result.data.columns.map((column) => column.label).join('\t');
-    const rows = result.data.rows.slice(0, 8).map((row) => row.map((cell) => String(cell ?? '')).join('\t'));
-    return [header, ...rows].join('\n');
+
+  if (!globalThis.document?.body) throw new Error('Clipboard API unavailable.');
+  const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const textarea = document.createElement('textarea');
+  textarea.value = content;
+  textarea.setAttribute('readonly', 'true');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    if (typeof document.execCommand !== 'function' || !document.execCommand('copy')) {
+      throw new Error('Clipboard API unavailable.');
+    }
+  } finally {
+    textarea.remove();
+    activeElement?.focus({ preventScroll: true });
   }
-  if (result.kind === 'construct_verification') {
-    return result.data.reasonCodes.length
-      ? result.data.reasonCodes.map((code) => code.replaceAll('_', ' ')).join('\n')
-      : 'No verification issues recorded.';
-  }
-  return null;
+}
+
+function downloadTextInBrowser(filename: string, content: string, mediaType: string): void {
+  const url = URL.createObjectURL(new Blob([content], { type: `${mediaType};charset=utf-8` }));
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 1_000);
+}
+
+function PagingControls({
+  label,
+  pageIndex,
+  pageCount,
+  itemStart,
+  itemEnd,
+  itemCount,
+  onPage,
+}: {
+  label: string;
+  pageIndex: number;
+  pageCount: number;
+  itemStart: number;
+  itemEnd: number;
+  itemCount: number;
+  onPage: (page: number) => void;
+}) {
+  if (pageCount <= 1) return null;
+  return (
+    <div className="motif-cs-agent-result-pager" role="group" aria-label={label}>
+      <button
+        className="motif-cs-mini-button"
+        type="button"
+        onClick={() => onPage(pageIndex - 1)}
+        disabled={pageIndex === 0}
+        aria-label={`Previous ${label.toLocaleLowerCase()}`}
+      >Previous</button>
+      <span aria-live="polite" aria-atomic="true">
+        {itemStart.toLocaleString()}–{itemEnd.toLocaleString()} of {itemCount.toLocaleString()}
+      </span>
+      <button
+        className="motif-cs-mini-button"
+        type="button"
+        onClick={() => onPage(pageIndex + 1)}
+        disabled={pageIndex >= pageCount - 1}
+        aria-label={`Next ${label.toLocaleLowerCase()}`}
+      >Next</button>
+    </div>
+  );
+}
+
+function useBoundedPage(pageCount: number, resetToken: unknown) {
+  const [requestedPage, setRequestedPage] = useState(0);
+  const previousResetToken = useRef(resetToken);
+  const pageIndex = Math.max(0, Math.min(requestedPage, pageCount - 1));
+
+  useLayoutEffect(() => {
+    const sourceChanged = !Object.is(previousResetToken.current, resetToken);
+    previousResetToken.current = resetToken;
+    setRequestedPage((current) => (
+      sourceChanged ? 0 : Math.max(0, Math.min(current, pageCount - 1))
+    ));
+  }, [pageCount, resetToken]);
+
+  return { pageIndex, setRequestedPage };
+}
+
+function PagedTextViewer({ text, label }: { text: string; label: string }) {
+  const pageCount = useMemo(() => artifactTextPage(text, 0, TEXT_PAGE_CHARACTERS).pageCount, [text]);
+  const { pageIndex, setRequestedPage } = useBoundedPage(pageCount, text);
+  const page = artifactTextPage(text, pageIndex, TEXT_PAGE_CHARACTERS);
+  return (
+    <div className="motif-cs-agent-text-viewer">
+      <pre aria-label={label} data-empty={text.length === 0 || undefined} tabIndex={0}>{page.text}</pre>
+      <PagingControls
+        label={`Pages for ${label}`}
+        pageIndex={page.pageIndex}
+        pageCount={page.pageCount}
+        itemStart={text.length === 0 ? 0 : page.start + 1}
+        itemEnd={page.end}
+        itemCount={text.length}
+        onPage={setRequestedPage}
+      />
+    </div>
+  );
+}
+
+function AssetViewer({ asset, copyText, downloadText }: { asset: ArtifactAnalysisAsset } & ResultTextActions) {
+  const [open, setOpen] = useState(false);
+  const preview = open ? boundedTextPreview(asset.content, ASSET_PREVIEW_CHARACTERS) : '';
+  const truncated = preview.length < asset.content.length;
+  const filename = safeAnalysisFilename(asset.name, 'analysis-asset', assetExtension(asset));
+  return (
+    <details className="motif-cs-agent-asset" onToggle={(event) => setOpen(event.currentTarget.open)}>
+      <summary>
+        <span className="motif-cs-agent-asset-summary">
+          <span>{asset.name}</span>
+          <small>{asset.mediaType} · {asset.content.length.toLocaleString()} characters</small>
+        </span>
+      </summary>
+      {open ? (
+        <div>
+          <div className="motif-cs-agent-viewer-actions">
+            <button aria-label={`Copy full asset ${asset.name}`} className="motif-cs-mini-button" type="button" onClick={() => void copyText(`Asset ${asset.name}`, asset.content)}>Copy full asset</button>
+            <button aria-label={`Download asset ${asset.name}`} className="motif-cs-mini-button" type="button" onClick={() => void downloadText(filename, asset.content, asset.mediaType)}>Download</button>
+          </div>
+          <pre aria-label={`${asset.name} inert text preview`} tabIndex={0}>{preview}</pre>
+          {truncated ? <p>Preview limited to {ASSET_PREVIEW_CHARACTERS.toLocaleString()} characters. Copy or download retains the complete inert asset.</p> : null}
+        </div>
+      ) : null}
+    </details>
+  );
+}
+
+function AssetList({
+  assets,
+  resultName,
+  copyText,
+  downloadText,
+}: {
+  assets: readonly ArtifactAnalysisAsset[];
+  resultName: string;
+} & ResultTextActions) {
+  const pageCount = Math.max(1, Math.ceil(assets.length / ASSET_PAGE_SIZE));
+  const resetToken = assets.map((asset) => asset.id).join('\u0000');
+  const { pageIndex, setRequestedPage } = useBoundedPage(pageCount, resetToken);
+  if (assets.length === 0) return null;
+  const start = pageIndex * ASSET_PAGE_SIZE;
+  const visibleAssets = assets.slice(start, start + ASSET_PAGE_SIZE);
+  return (
+    <section className="motif-cs-agent-assets" aria-label="Linked inert assets">
+      <strong>Linked assets · {assets.length.toLocaleString()}</strong>
+      {visibleAssets.map((asset) => (
+        <AssetViewer key={asset.id} asset={asset} copyText={copyText} downloadText={downloadText} />
+      ))}
+      <PagingControls
+        label={`Linked asset pages for ${resultName}`}
+        pageIndex={pageIndex}
+        pageCount={pageCount}
+        itemStart={start + 1}
+        itemEnd={start + visibleAssets.length}
+        itemCount={assets.length}
+        onPage={setRequestedPage}
+      />
+    </section>
+  );
+}
+
+function ReportViewer({
+  result,
+  assetsById,
+  copyText,
+  downloadText,
+}: {
+  result: ReportResult;
+  assetsById: ReadonlyMap<string, ArtifactAnalysisAsset>;
+} & ResultTextActions) {
+  const report = resolveArtifactReport(result, assetsById);
+  if (!report) return <p className="motif-cs-agent-viewer-warning" role="alert">The report body asset is unavailable.</p>;
+  const extension = report.format === 'markdown' ? 'md' : 'txt';
+  const mediaType = report.format === 'markdown' ? 'text/markdown' : 'text/plain';
+  const filename = safeAnalysisFilename(result.name, 'analysis-report', extension);
+  return (
+    <section className="motif-cs-agent-data-viewer" aria-label={`${result.name} report viewer`}>
+      <div className="motif-cs-agent-viewer-head">
+        <div>
+          <strong>Full report</strong>
+          <small>{report.format === 'markdown' ? 'Markdown shown as inert source text' : 'Plain text'} · {report.text.length.toLocaleString()} characters</small>
+        </div>
+        <div className="motif-cs-agent-viewer-actions">
+          <button aria-label={`Copy report ${result.name}`} className="motif-cs-mini-button" type="button" onClick={() => void copyText(`Report ${result.name}`, report.text)}>Copy report</button>
+          <button aria-label={`Download report ${result.name}`} className="motif-cs-mini-button" type="button" onClick={() => void downloadText(filename, report.text, mediaType)}>Download</button>
+        </div>
+      </div>
+      <PagedTextViewer text={report.text} label={`${result.name} safe text preview`} />
+    </section>
+  );
+}
+
+function TableViewer({ result, copyText, downloadText }: { result: TableResult } & ResultTextActions) {
+  const rowCount = result.data.rows.length;
+  const rowsPerPage = Math.max(1, Math.min(
+    TABLE_PAGE_SIZE,
+    Math.floor(TABLE_BODY_CELL_BUDGET / Math.max(1, result.data.columns.length)),
+  ));
+  const pageCount = Math.max(1, Math.ceil(rowCount / rowsPerPage));
+  const { pageIndex, setRequestedPage } = useBoundedPage(pageCount, result.data.rows);
+  const start = pageIndex * rowsPerPage;
+  const visibleRows = result.data.rows.slice(start, start + rowsPerPage);
+  const hasTruncatedCells = useMemo(() => result.data.rows.some((row) => row.some((cell) => (
+    typeof cell === 'string' && cell.length > TABLE_CELL_PREVIEW_CHARACTERS
+  ))), [result.data.rows]);
+  const filename = safeAnalysisFilename(result.name, 'analysis-table', 'tsv');
+  const copyTable = () => copyText(`Table ${result.name}`, artifactTableToTsv(result.data));
+  const downloadTable = () => downloadText(filename, artifactTableToTsv(result.data), 'text/tab-separated-values');
+  return (
+    <section className="motif-cs-agent-data-viewer" aria-label={`${result.name} table viewer`}>
+      <div className="motif-cs-agent-viewer-head">
+        <div>
+          <strong>Full table</strong>
+          <small>{rowCount.toLocaleString()} rows · {result.data.columns.length.toLocaleString()} columns</small>
+          {hasTruncatedCells ? <small>Cell previews are limited to {TABLE_CELL_PREVIEW_CHARACTERS.toLocaleString()} characters; TSV retains complete values.</small> : null}
+        </div>
+        <div className="motif-cs-agent-viewer-actions">
+          <button aria-label={`Copy table ${result.name} as TSV`} className="motif-cs-mini-button" type="button" onClick={() => void copyTable()}>Copy TSV</button>
+          <button aria-label={`Download table ${result.name} as TSV`} className="motif-cs-mini-button" type="button" onClick={() => void downloadTable()}>Download TSV</button>
+        </div>
+      </div>
+      <div className="motif-cs-agent-table-scroll" role="region" aria-label={`${result.name} safe text preview`} tabIndex={0}>
+        <table aria-label={`${result.name} data table`}>
+          <thead>
+            <tr>{result.data.columns.map((column) => <th key={column.id} scope="col">{column.label}</th>)}</tr>
+          </thead>
+          <tbody>
+            {visibleRows.map((row, rowOffset) => (
+              <tr key={start + rowOffset}>
+                {row.map((cell, cellIndex) => {
+                  const text = cell === null ? '' : String(cell);
+                  const preview = text.length > TABLE_CELL_PREVIEW_CHARACTERS
+                    ? `${boundedTextPreview(text, TABLE_CELL_PREVIEW_CHARACTERS)}…`
+                    : text;
+                  return <td key={result.data.columns[cellIndex]?.id ?? cellIndex}>{preview}</td>;
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {rowCount === 0 ? <p>No table rows were saved.</p> : null}
+      </div>
+      <PagingControls
+        label={`Table pages for ${result.name}`}
+        pageIndex={pageIndex}
+        pageCount={pageCount}
+        itemStart={rowCount === 0 ? 0 : start + 1}
+        itemEnd={start + visibleRows.length}
+        itemCount={rowCount}
+        onPage={setRequestedPage}
+      />
+    </section>
+  );
+}
+
+function blastCoordinate(start: number | undefined, end: number | undefined): string {
+  return start === undefined || end === undefined ? '—' : `${start.toLocaleString()}–${end.toLocaleString()}`;
+}
+
+function blastEValue(value: number): string {
+  if (value === 0) return '0';
+  return value < 0.001 ? value.toExponential(2) : value.toLocaleString(undefined, { maximumSignificantDigits: 4 });
+}
+
+function BlastAlignmentEvidence({
+  hit,
+  asset,
+  copyText,
+  downloadText,
+}: {
+  hit: ArtifactBlastHit;
+  asset: ArtifactAnalysisAsset | undefined;
+} & ResultTextActions) {
+  const [open, setOpen] = useState(false);
+  const evidenceId = useId();
+  if (!hit.alignmentAssetId) return <span className="motif-cs-agent-no-evidence">—</span>;
+  if (!asset) return <span className="motif-cs-agent-no-evidence">Unavailable</span>;
+  const preview = open ? boundedTextPreview(asset.content, ASSET_PREVIEW_CHARACTERS) : '';
+  const filename = safeAnalysisFilename(asset.name || `${hit.accession}-alignment`, 'blast-alignment', assetExtension(asset));
+  return (
+    <div className="motif-cs-agent-blast-evidence">
+      <button
+        className="motif-cs-mini-button"
+        type="button"
+        aria-label={`${open ? 'Hide' : 'Show'} alignment ${hit.accession}`}
+        aria-expanded={open}
+        aria-controls={evidenceId}
+        onClick={() => setOpen((value) => !value)}
+      >{open ? 'Hide' : 'Show'} alignment</button>
+      {open ? (
+        <div id={evidenceId}>
+          <div className="motif-cs-agent-viewer-actions">
+            <button aria-label={`Copy full evidence ${hit.accession}`} className="motif-cs-mini-button" type="button" onClick={() => void copyText(`BLAST alignment ${hit.accession}`, asset.content)}>Copy full evidence</button>
+            <button aria-label={`Download alignment ${hit.accession}`} className="motif-cs-mini-button" type="button" onClick={() => void downloadText(filename, asset.content, asset.mediaType)}>Download</button>
+          </div>
+          <pre aria-label={`${hit.accession} bounded alignment evidence`} tabIndex={0}>{preview}</pre>
+          {preview.length < asset.content.length ? <p>Showing the first {preview.length.toLocaleString()} of {asset.content.length.toLocaleString()} characters. Copy or download retains the complete evidence.</p> : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function BlastViewer({
+  result,
+  assetsById,
+  copyText,
+  downloadText,
+}: {
+  result: BlastResult;
+  assetsById: ReadonlyMap<string, ArtifactAnalysisAsset>;
+} & ResultTextActions) {
+  const [sortKey, setSortKey] = useState<ArtifactBlastSortKey>('evalue');
+  const sortedHits = useMemo(() => sortArtifactBlastHits(result.data.hits, sortKey), [result.data.hits, sortKey]);
+  const pageCount = Math.max(1, Math.ceil(sortedHits.length / BLAST_PAGE_SIZE));
+  const { pageIndex, setRequestedPage } = useBoundedPage(pageCount, result.data.hits);
+  const start = pageIndex * BLAST_PAGE_SIZE;
+  const visibleHits = sortedHits.slice(start, start + BLAST_PAGE_SIZE);
+  return (
+    <section className="motif-cs-agent-data-viewer" aria-label={`${result.name} safe text preview`}>
+      <div className="motif-cs-agent-viewer-head">
+        <div>
+          <strong>BLAST hits</strong>
+          <small>{sortedHits.length.toLocaleString()} saved hits · inert evidence only</small>
+        </div>
+        <label className="motif-cs-agent-blast-sort">
+          <span>Sort hits</span>
+          <select
+            value={sortKey}
+            onChange={(event) => {
+              setSortKey(event.target.value as ArtifactBlastSortKey);
+              setRequestedPage(0);
+            }}
+          >
+            {BLAST_SORT_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+          </select>
+        </label>
+      </div>
+      {visibleHits.length === 0 ? <p className="motif-cs-agent-viewer-warning">No BLAST hits were saved.</p> : (
+        <div className="motif-cs-agent-table-scroll" role="region" aria-label={`${result.name} BLAST hit table`} tabIndex={0}>
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Accession</th>
+                <th scope="col">Description</th>
+                <th scope="col">Identity</th>
+                <th scope="col">Coverage</th>
+                <th scope="col">E-value</th>
+                <th scope="col">Bit score</th>
+                <th scope="col">Query</th>
+                <th scope="col">Subject</th>
+                <th scope="col">Alignment evidence</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleHits.map((hit, hitOffset) => (
+                <tr key={`${hit.accession}:${start + hitOffset}`}>
+                  <td><code>{hit.accession}</code></td>
+                  <td>{hit.title}</td>
+                  <td>{hit.identityPercent.toFixed(1)}%</td>
+                  <td>{hit.queryCoveragePercent.toFixed(1)}%</td>
+                  <td>{blastEValue(hit.eValue)}</td>
+                  <td>{hit.bitScore.toLocaleString()}</td>
+                  <td>{blastCoordinate(hit.queryStart, hit.queryEnd)}</td>
+                  <td>{blastCoordinate(hit.subjectStart, hit.subjectEnd)}</td>
+                  <td>
+                    <BlastAlignmentEvidence
+                      hit={hit}
+                      asset={hit.alignmentAssetId ? assetsById.get(hit.alignmentAssetId) : undefined}
+                      copyText={copyText}
+                      downloadText={downloadText}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      <PagingControls
+        label={`BLAST hit pages for ${result.name}`}
+        pageIndex={pageIndex}
+        pageCount={pageCount}
+        itemStart={sortedHits.length === 0 ? 0 : start + 1}
+        itemEnd={start + visibleHits.length}
+        itemCount={sortedHits.length}
+        onPage={setRequestedPage}
+      />
+    </section>
+  );
+}
+
+function ResultDataViewer({
+  result,
+  assetsById,
+  copyText,
+  downloadText,
+}: {
+  result: ArtifactAnalysisResult;
+  assetsById: ReadonlyMap<string, ArtifactAnalysisAsset>;
+} & ResultTextActions) {
+  if (result.kind === 'report') return <ReportViewer result={result} assetsById={assetsById} copyText={copyText} downloadText={downloadText} />;
+  if (result.kind === 'table') return <TableViewer result={result} copyText={copyText} downloadText={downloadText} />;
+  if (result.kind === 'blast_search') return <BlastViewer result={result} assetsById={assetsById} copyText={copyText} downloadText={downloadText} />;
+  const preview = constructVerificationPreview(result);
+  return preview ? <pre aria-label={`${result.name} safe text preview`} tabIndex={0}>{preview}</pre> : null;
+}
+
+function AnalysisResultRow({
+  result,
+  assetsById,
+  recordNames,
+  freshness,
+  pendingDelete,
+  cancelRef,
+  setDeleteRef,
+  onRevealRecord,
+  onRequestRemove,
+  onCancelRemove,
+  onConfirmRemove,
+  copyText,
+  downloadText,
+}: {
+  result: ArtifactAnalysisResult;
+  assetsById: ReadonlyMap<string, ArtifactAnalysisAsset>;
+  recordNames: Readonly<Record<string, string>>;
+  freshness: ScientificFreshnessDisplayEvaluation | undefined;
+  pendingDelete: boolean;
+  cancelRef: React.RefObject<HTMLButtonElement | null>;
+  setDeleteRef: (element: HTMLButtonElement | null) => void;
+  onRevealRecord: (recordId: string) => void;
+  onRequestRemove: () => void;
+  onCancelRemove: () => void;
+  onConfirmRemove: () => void;
+} & ResultTextActions) {
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const linkedAssets = useMemo(() => (
+    detailsOpen ? artifactAnalysisResultAssets(result, assetsById) : []
+  ), [assetsById, detailsOpen, result]);
+  const revealId = result.inputRecordIds.find((id) => recordNames[id]);
+  const engine = result.provenance.engine
+    ? `${result.provenance.engine}${result.provenance.engineVersion ? ` ${result.provenance.engineVersion}` : ''}`
+    : result.provenance.source;
+  return (
+    <article className="motif-cs-agent-result-row" data-testid={`analysis-result-${result.id}`}>
+      <div className="motif-cs-agent-result-heading">
+        <div>
+          <span className="motif-cs-agent-result-kind">{KIND_LABELS[result.kind]}</span>
+          <strong>{result.name}</strong>
+          <small>{recordList(result.inputRecordIds, recordNames)}</small>
+        </div>
+        <span className="motif-cs-agent-result-state">
+          <span className="motif-cs-agent-result-status" data-status={result.status}>{result.status}</span>
+          {freshness ? <ClaudeScienceFreshnessBadge evaluation={freshness} recordNames={recordNames} /> : null}
+        </span>
+      </div>
+
+      {result.summary ? <p>{result.summary}</p> : null}
+      <dl className="motif-cs-agent-result-facts">
+        {resultFacts(result).map((fact) => (
+          <div key={fact.label}>
+            <dt>{fact.label}</dt>
+            <dd>{fact.value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <details className="motif-cs-agent-result-details" onToggle={(event) => setDetailsOpen(event.currentTarget.open)}>
+        <summary>Provenance &amp; Data</summary>
+        {detailsOpen ? (
+          <div>
+            <dl>
+              <div><dt>Created</dt><dd><time dateTime={result.createdAt}>{timestamp(result.createdAt)}</time></dd></div>
+              <div><dt>Engine</dt><dd>{engine}</dd></div>
+              <div><dt>Inputs</dt><dd>{recordList(result.inputRecordIds, recordNames)}</dd></div>
+              {result.inputSha256s?.length ? (
+                <div><dt>Hashes</dt><dd>{result.inputSha256s.map((hash) => hash.slice(0, 12)).join(', ')}…</dd></div>
+              ) : null}
+              {freshness ? (
+                <div>
+                  <dt>Freshness</dt>
+                  <dd><ClaudeScienceFreshnessBadge evaluation={freshness} recordNames={recordNames} showReason /></dd>
+                </div>
+              ) : null}
+              {linkedAssets.length ? (
+                <div><dt>Assets</dt><dd>{assetListSummary(linkedAssets)}</dd></div>
+              ) : null}
+            </dl>
+            <ResultDataViewer result={result} assetsById={assetsById} copyText={copyText} downloadText={downloadText} />
+            <AssetList assets={linkedAssets} resultName={result.name} copyText={copyText} downloadText={downloadText} />
+          </div>
+        ) : null}
+      </details>
+
+      {pendingDelete ? (
+        <div
+          className="motif-cs-agent-result-actions motif-cs-agent-result-confirm"
+          role="group"
+          aria-label={`Confirm removal of ${result.name}`}
+          onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+            if (event.key !== 'Escape') return;
+            event.preventDefault();
+            onCancelRemove();
+          }}
+        >
+          <span>Remove this saved result? Linked assets are retained when still in use.</span>
+          <button ref={cancelRef} className="motif-cs-mini-button" type="button" onClick={onCancelRemove}>Cancel</button>
+          <button className="motif-cs-mini-button motif-cs-confirm-delete" type="button" onClick={onConfirmRemove}>Remove Result</button>
+        </div>
+      ) : (
+        <div className="motif-cs-agent-result-actions">
+          {revealId ? <button className="motif-cs-mini-button" type="button" onClick={() => onRevealRecord(revealId)}>Reveal Input</button> : null}
+          <button
+            ref={setDeleteRef}
+            className="motif-cs-mini-button"
+            type="button"
+            onClick={onRequestRemove}
+            aria-label={`Remove ${result.name}`}
+          >Remove</button>
+        </div>
+      )}
+    </article>
+  );
 }
 
 export function ClaudeScienceAgentResultsPanel({
@@ -124,17 +726,43 @@ export function ClaudeScienceAgentResultsPanel({
   freshnessByResultId,
   onRevealRecord,
   onRemove,
+  onCopyText,
+  onDownloadText,
 }: ClaudeScienceAgentResultsPanelProps) {
   const [filter, setFilter] = useState<ResultFilter>('all');
+  const [visibleCount, setVisibleCount] = useState(RESULT_PAGE_SIZE);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [status, setStatus] = useState('');
   const cancelRef = useRef<HTMLButtonElement>(null);
   const deleteRefs = useRef(new Map<string, HTMLButtonElement>());
   const restoreFocusIdRef = useRef<string | null>(null);
+  const showFirstResultsRef = useRef<HTMLButtonElement>(null);
+  const showMoreResultsRef = useRef<HTMLButtonElement>(null);
+  const paginationFocusTargetRef = useRef<'first' | 'more' | null>(null);
   const assetsById = useMemo(() => new Map(assets.map((asset) => [asset.id, asset])), [assets]);
-  const ordered = useMemo(() => [...results]
+  const ordered = useMemo(() => results
     .filter((result) => filter === 'all' || FILTER_KINDS[filter].has(result.kind))
-    .sort((left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt) || left.id.localeCompare(right.id)), [filter, results]);
+    .map((result, originalIndex) => ({ result, originalIndex }))
+    .sort((left, right) => (
+      Date.parse(right.result.createdAt) - Date.parse(left.result.createdAt)
+      || left.result.id.localeCompare(right.result.id)
+      || left.originalIndex - right.originalIndex
+    ))
+    .map(({ result }) => result), [filter, results]);
+  const previousOrderedLengthRef = useRef(ordered.length);
+  const visibleResults = ordered.slice(0, visibleCount);
+  const remainingCount = Math.max(0, ordered.length - visibleResults.length);
+
+  useLayoutEffect(() => {
+    const previousLength = previousOrderedLengthRef.current;
+    previousOrderedLengthRef.current = ordered.length;
+    if (ordered.length >= previousLength) return;
+    const lastFullWindow = Math.max(
+      RESULT_PAGE_SIZE,
+      Math.floor(ordered.length / RESULT_PAGE_SIZE) * RESULT_PAGE_SIZE,
+    );
+    setVisibleCount((current) => Math.min(current, lastFullWindow));
+  }, [ordered.length]);
 
   useLayoutEffect(() => {
     if (pendingDeleteId) {
@@ -145,6 +773,13 @@ export function ClaudeScienceAgentResultsPanel({
     restoreFocusIdRef.current = null;
     if (id) deleteRefs.current.get(id)?.focus();
   }, [pendingDeleteId]);
+
+  useLayoutEffect(() => {
+    const target = paginationFocusTargetRef.current;
+    paginationFocusTargetRef.current = null;
+    if (target === 'first') showFirstResultsRef.current?.focus();
+    if (target === 'more') showMoreResultsRef.current?.focus();
+  }, [visibleResults.length]);
 
   const cancelDelete = (resultId: string) => {
     restoreFocusIdRef.current = resultId;
@@ -157,19 +792,61 @@ export function ClaudeScienceAgentResultsPanel({
     setStatus(removed === false ? 'Remove dependent analysis results first.' : 'Analysis result removed.');
   };
 
+  const showFirstResults = () => {
+    paginationFocusTargetRef.current = 'more';
+    setVisibleCount(RESULT_PAGE_SIZE);
+  };
+
+  const showMoreResults = () => {
+    const nextCount = Math.min(visibleResults.length + RESULT_PAGE_SIZE, ordered.length);
+    paginationFocusTargetRef.current = nextCount >= ordered.length ? 'first' : 'more';
+    setVisibleCount(nextCount);
+  };
+
+  const copyText = async (label: string, content: string) => {
+    try {
+      if (onCopyText) await onCopyText(label, content);
+      else await copyTextInBrowser(content);
+      setStatus(`${label} copied.`);
+    } catch {
+      setStatus(`${label} could not be copied.`);
+    }
+  };
+
+  const downloadText = async (filename: string, content: string, mediaType: string) => {
+    try {
+      if (onDownloadText) await onDownloadText(filename, content, mediaType);
+      else downloadTextInBrowser(filename, content, mediaType);
+      setStatus(`${filename} downloaded.`);
+    } catch {
+      setStatus(`${filename} could not be downloaded.`);
+    }
+  };
+
   return (
     <section className="motif-cs-agent-results" aria-label="Agent and analysis results">
       <div className="motif-cs-agent-results-toolbar">
         <label>
           <span>Show</span>
-          <select name="analysis-result-filter" autoComplete="off" value={filter} onChange={(event) => setFilter(event.target.value as ResultFilter)}>
+          <select
+            name="analysis-result-filter"
+            autoComplete="off"
+            value={filter}
+            onChange={(event) => {
+              setFilter(event.target.value as ResultFilter);
+              setVisibleCount(RESULT_PAGE_SIZE);
+              setPendingDeleteId(null);
+            }}
+          >
             <option value="all">All Results</option>
             <option value="design">Design &amp; PCR</option>
             <option value="sequence">Sequence &amp; Structure</option>
             <option value="evidence">Reports &amp; Tables</option>
           </select>
         </label>
-        <span>{ordered.length.toLocaleString()} shown</span>
+        <span>{visibleResults.length < ordered.length
+          ? `${visibleResults.length.toLocaleString()} of ${ordered.length.toLocaleString()} shown`
+          : `${ordered.length.toLocaleString()} shown`}</span>
       </div>
 
       {results.length === 0 ? (
@@ -184,97 +861,43 @@ export function ClaudeScienceAgentResultsPanel({
         </div>
       ) : (
         <div className="motif-cs-agent-result-list" data-testid="analysis-result-list">
-          {ordered.map((result) => {
-            const revealId = result.inputRecordIds.find((id) => recordNames[id]);
-            const preview = safePreview(result);
-            const linkedAssets = result.assetIds.map((id) => assetsById.get(id)).filter((asset): asset is ArtifactAnalysisAsset => Boolean(asset));
-            const engine = result.provenance.engine
-              ? `${result.provenance.engine}${result.provenance.engineVersion ? ` ${result.provenance.engineVersion}` : ''}`
-              : result.provenance.source;
-            const freshness = freshnessByResultId?.get(result.id);
-            return (
-              <article className="motif-cs-agent-result-row" key={result.id} data-testid={`analysis-result-${result.id}`}>
-                <div className="motif-cs-agent-result-heading">
-                  <div>
-                    <span className="motif-cs-agent-result-kind">{KIND_LABELS[result.kind]}</span>
-                    <strong>{result.name}</strong>
-                    <small>{recordList(result.inputRecordIds, recordNames)}</small>
-                  </div>
-                  <span className="motif-cs-agent-result-state">
-                    <span className="motif-cs-agent-result-status" data-status={result.status}>{result.status}</span>
-                    {freshness ? <ClaudeScienceFreshnessBadge evaluation={freshness} recordNames={recordNames} /> : null}
-                  </span>
-                </div>
-
-                {result.summary ? <p>{result.summary}</p> : null}
-                <dl className="motif-cs-agent-result-facts">
-                  {resultFacts(result).map((fact) => (
-                    <div key={fact.label}>
-                      <dt>{fact.label}</dt>
-                      <dd>{fact.value}</dd>
-                    </div>
-                  ))}
-                </dl>
-
-                <details className="motif-cs-agent-result-details">
-                  <summary>Provenance &amp; Data</summary>
-                  <div>
-                    <dl>
-                      <div><dt>Created</dt><dd><time dateTime={result.createdAt}>{timestamp(result.createdAt)}</time></dd></div>
-                      <div><dt>Engine</dt><dd>{engine}</dd></div>
-                      <div><dt>Inputs</dt><dd>{recordList(result.inputRecordIds, recordNames)}</dd></div>
-                      {result.inputSha256s?.length ? (
-                        <div><dt>Hashes</dt><dd>{result.inputSha256s.map((hash) => hash.slice(0, 12)).join(', ')}…</dd></div>
-                      ) : null}
-                      {freshness ? (
-                        <div>
-                          <dt>Freshness</dt>
-                          <dd><ClaudeScienceFreshnessBadge evaluation={freshness} recordNames={recordNames} showReason /></dd>
-                        </div>
-                      ) : null}
-                      {linkedAssets.length ? (
-                        <div><dt>Assets</dt><dd>{linkedAssets.map((asset) => `${asset.name} (${asset.mediaType})`).join(', ')}</dd></div>
-                      ) : null}
-                    </dl>
-                    {preview ? <pre aria-label={`${result.name} safe text preview`}>{preview}</pre> : null}
-                  </div>
-                </details>
-
-                {pendingDeleteId === result.id ? (
-                  <div
-                    className="motif-cs-agent-result-actions motif-cs-agent-result-confirm"
-                    role="group"
-                    aria-label={`Confirm removal of ${result.name}`}
-                    onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
-                      if (event.key !== 'Escape') return;
-                      event.preventDefault();
-                      cancelDelete(result.id);
-                    }}
-                  >
-                    <span>Remove this saved result? Linked assets are retained when still in use.</span>
-                    <button ref={cancelRef} className="motif-cs-mini-button" type="button" onClick={() => cancelDelete(result.id)}>Cancel</button>
-                    <button className="motif-cs-mini-button motif-cs-confirm-delete" type="button" onClick={() => confirmDelete(result.id)}>Remove Result</button>
-                  </div>
-                ) : (
-                  <div className="motif-cs-agent-result-actions">
-                    {revealId ? <button className="motif-cs-mini-button" type="button" onClick={() => onRevealRecord(revealId)}>Reveal Input</button> : null}
-                    <button
-                      ref={(element) => {
-                        if (element) deleteRefs.current.set(result.id, element);
-                        else deleteRefs.current.delete(result.id);
-                      }}
-                      className="motif-cs-mini-button"
-                      type="button"
-                      onClick={() => setPendingDeleteId(result.id)}
-                      aria-label={`Remove ${result.name}`}
-                    >
-                      Remove
-                    </button>
-                  </div>
-                )}
-              </article>
-            );
-          })}
+          {visibleResults.map((result) => (
+            <AnalysisResultRow
+              key={result.id}
+              result={result}
+              assetsById={assetsById}
+              recordNames={recordNames}
+              freshness={freshnessByResultId?.get(result.id)}
+              pendingDelete={pendingDeleteId === result.id}
+              cancelRef={cancelRef}
+              setDeleteRef={(element) => {
+                if (element) deleteRefs.current.set(result.id, element);
+                else deleteRefs.current.delete(result.id);
+              }}
+              onRevealRecord={onRevealRecord}
+              onRequestRemove={() => setPendingDeleteId(result.id)}
+              onCancelRemove={() => cancelDelete(result.id)}
+              onConfirmRemove={() => confirmDelete(result.id)}
+              copyText={copyText}
+              downloadText={downloadText}
+            />
+          ))}
+          {remainingCount > 0 || visibleResults.length > RESULT_PAGE_SIZE ? (
+            <div className="motif-cs-agent-results-pagination" role="group" aria-label="Analysis result list pagination">
+              <span aria-live="polite" aria-atomic="true">Showing {visibleResults.length.toLocaleString()} of {ordered.length.toLocaleString()}</span>
+              {visibleResults.length > RESULT_PAGE_SIZE ? (
+                <button ref={showFirstResultsRef} className="motif-cs-mini-button" type="button" onClick={showFirstResults}>Show first {RESULT_PAGE_SIZE}</button>
+              ) : null}
+              {remainingCount > 0 ? (
+                <button
+                  ref={showMoreResultsRef}
+                  className="motif-cs-mini-button"
+                  type="button"
+                  onClick={showMoreResults}
+                >Show {Math.min(RESULT_PAGE_SIZE, remainingCount).toLocaleString()} more</button>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       )}
       <p className="motif-cs-agent-results-live" role="status" aria-live="polite" data-empty={!status || undefined}>{status}</p>

--- a/src/artifacts/ClaudeScienceAgentResultsPanel.tsx
+++ b/src/artifacts/ClaudeScienceAgentResultsPanel.tsx
@@ -18,6 +18,7 @@ import {
   ClaudeScienceFreshnessBadge,
   type ScientificFreshnessDisplayEvaluation,
 } from './ClaudeScienceFreshnessBadge';
+import { requestBrowserTextDownload } from './claude-science-download';
 import './claude-science-agent-results.css';
 
 export type ArtifactResultCopyHandler = (
@@ -204,17 +205,6 @@ async function copyTextInBrowser(content: string): Promise<void> {
     textarea.remove();
     activeElement?.focus({ preventScroll: true });
   }
-}
-
-function downloadTextInBrowser(filename: string, content: string, mediaType: string): void {
-  const url = URL.createObjectURL(new Blob([content], { type: `${mediaType};charset=utf-8` }));
-  const anchor = document.createElement('a');
-  anchor.href = url;
-  anchor.download = filename;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  window.setTimeout(() => URL.revokeObjectURL(url), 1_000);
 }
 
 function PagingControls({
@@ -815,11 +805,14 @@ export function ClaudeScienceAgentResultsPanel({
 
   const downloadText = async (filename: string, content: string, mediaType: string) => {
     try {
-      if (onDownloadText) await onDownloadText(filename, content, mediaType);
-      else downloadTextInBrowser(filename, content, mediaType);
-      setStatus(`${filename} downloaded.`);
+      if (onDownloadText) {
+        await onDownloadText(filename, content, mediaType);
+        setStatus(`Download requested for ${filename}. Verify the file before relying on it.`);
+        return;
+      }
+      setStatus(requestBrowserTextDownload(filename, content, mediaType).message);
     } catch {
-      setStatus(`${filename} could not be downloaded.`);
+      setStatus(`Download could not be requested for ${filename}.`);
     }
   };
 

--- a/src/artifacts/ClaudeScienceDataSettings.tsx
+++ b/src/artifacts/ClaudeScienceDataSettings.tsx
@@ -5,8 +5,10 @@ import {
   type ChangeEvent,
   type KeyboardEvent,
 } from 'react';
+import type { BrowserDownloadReceipt } from './claude-science-download';
 
 type MaybePromise = void | Promise<void>;
+type MaybeDownloadPromise = BrowserDownloadReceipt | Promise<BrowserDownloadReceipt>;
 
 export interface ClaudeScienceDataSettingsProps {
   recordCount: number;
@@ -16,7 +18,7 @@ export interface ClaudeScienceDataSettingsProps {
   analysisResultCount?: number;
   sessionOnly: boolean;
   hasUnsavedChanges: boolean;
-  onDownloadBackup: () => MaybePromise;
+  onDownloadBackup: () => MaybeDownloadPromise;
   onRestoreFile: (file: File, returnFocus: HTMLElement | null) => MaybePromise;
   onClearWorkspace: () => MaybePromise;
   onResetDisplayPreferences: () => MaybePromise;
@@ -96,8 +98,8 @@ export default function ClaudeScienceDataSettings({
     setPendingAction('backup');
     setStatus('Preparing workspace backup…');
     try {
-      await onDownloadBackup();
-      setStatus('Workspace backup downloaded.');
+      const receipt = await onDownloadBackup();
+      setStatus(receipt.message);
     } catch (error) {
       setStatus(error instanceof Error ? error.message : 'Workspace backup could not be downloaded.');
     } finally {

--- a/src/artifacts/ClaudeScienceNotesPanel.tsx
+++ b/src/artifacts/ClaudeScienceNotesPanel.tsx
@@ -16,6 +16,7 @@ import {
   type ArtifactNoteScope,
   type ArtifactSequenceRange,
 } from './claude-science-workspace-collections';
+import { getNoteRangeAnchorReview } from './claude-science-sequence-edit';
 
 export type ArtifactNoteInput = Omit<ArtifactNote, 'id' | 'createdAt' | 'updatedAt' | 'provenance'>;
 export type ArtifactNoteTextUpdate = Pick<ArtifactNoteInput, 'title' | 'body' | 'format'>;
@@ -28,6 +29,7 @@ export type ClaudeScienceNotesPanelProps = {
   selectedRange?: ArtifactSequenceRange | null;
   onAdd: (note: ArtifactNoteInput) => void;
   onUpdate: (noteId: string, patch: ArtifactNoteTextUpdate) => void;
+  onConfirmAnchor: (noteId: string) => void;
   onRemove: (noteId: string) => void;
   onReveal: (note: ArtifactNote) => void;
 };
@@ -117,6 +119,7 @@ export function ClaudeScienceNotesPanel({
   selectedRange,
   onAdd,
   onUpdate,
+  onConfirmAnchor,
   onRemove,
   onReveal,
 }: ClaudeScienceNotesPanelProps) {
@@ -282,6 +285,15 @@ export function ClaudeScienceNotesPanel({
     }
   }, [onRemove]);
 
+  const confirmAnchor = useCallback((noteId: string) => {
+    try {
+      onConfirmAnchor(noteId);
+      setStatus('Range anchor confirmed.');
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'The range anchor could not be confirmed.');
+    }
+  }, [onConfirmAnchor]);
+
   const emptyMessage = filter === 'workspace'
     ? 'No workspace notes yet.'
     : filter === 'record'
@@ -392,8 +404,10 @@ export function ClaudeScienceNotesPanel({
       </details>
 
       <div className="motif-cs-annotation-list" data-testid="notes-list">
-        {visibleNotes.length === 0 ? <p className="motif-cs-muted">{emptyMessage}</p> : visibleNotes.map((note) => (
-          <article key={note.id} className="motif-cs-analysis-row" data-testid={`note-${note.id}`}>
+        {visibleNotes.length === 0 ? <p className="motif-cs-muted">{emptyMessage}</p> : visibleNotes.map((note) => {
+          const anchorReview = getNoteRangeAnchorReview(note);
+          return (
+          <article key={note.id} className="motif-cs-analysis-row" data-testid={`note-${note.id}`} data-anchor-review={anchorReview?.status}>
             {editingId === note.id ? (
               <form
                 className="motif-cs-form-body"
@@ -455,6 +469,14 @@ export function ClaudeScienceNotesPanel({
                   <time dateTime={note.updatedAt}>{noteTimestamp(note.updatedAt)}</time>
                 </p>
                 <p>{note.body}</p>
+                {anchorReview ? (
+                  <p className="motif-cs-form-note" role="note">
+                    <strong>Review range anchor.</strong>{' '}
+                    {anchorReview.status === 'detached'
+                      ? `Bases ${anchorReview.previousRange.start + 1}–${anchorReview.previousRange.end} were fully deleted; this note was retained at record level.`
+                      : `The sequence changed inside bases ${anchorReview.previousRange.start + 1}–${anchorReview.previousRange.end}; confirm the updated range after review.`}
+                  </p>
+                ) : null}
               </div>
             )}
 
@@ -505,10 +527,16 @@ export function ClaudeScienceNotesPanel({
                 >
                   Delete
                 </button>
+                {anchorReview?.status === 'review' ? (
+                  <button className="motif-cs-mini-button motif-cs-mini-button-accent" type="button" onClick={() => confirmAnchor(note.id)}>
+                    Confirm anchor
+                  </button>
+                ) : null}
               </div>
             )}
           </article>
-        ))}
+          );
+        })}
       </div>
 
       <p

--- a/src/artifacts/__tests__/ClaudeScienceAgentResultsPanel.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceAgentResultsPanel.jsdom.test.tsx
@@ -211,6 +211,9 @@ describe('ClaudeScienceAgentResultsPanel', () => {
     expect(onCopyText).toHaveBeenCalledWith('Report Agent safety report', reportText);
     await user.click(within(row).getByRole('button', { name: 'Download report Agent safety report' }));
     expect(onDownloadText).toHaveBeenCalledWith('Agent safety report.md', reportText, 'text/markdown');
+    expect(screen.getByRole('status').textContent).toBe(
+      'Download requested for Agent safety report.md. Verify the file before relying on it.',
+    );
   });
 
   it('resolves a report body asset even when it is not repeated in generic assetIds', async () => {
@@ -318,9 +321,9 @@ describe('ClaudeScienceAgentResultsPanel', () => {
       expect(screen.getByRole('status').textContent).toBe('Report Agent safety report copied.');
     } finally {
       if (clipboardDescriptor) Object.defineProperty(navigator, 'clipboard', clipboardDescriptor);
-      else delete (navigator as Navigator & { clipboard?: Clipboard }).clipboard;
+      else Reflect.deleteProperty(navigator, 'clipboard');
       if (execCommandDescriptor) Object.defineProperty(document, 'execCommand', execCommandDescriptor);
-      else delete (document as Document & { execCommand?: typeof document.execCommand }).execCommand;
+      else Reflect.deleteProperty(document, 'execCommand');
     }
   });
 

--- a/src/artifacts/__tests__/ClaudeScienceAgentResultsPanel.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceAgentResultsPanel.jsdom.test.tsx
@@ -1,9 +1,10 @@
 /** @vitest-environment jsdom */
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ClaudeScienceAgentResultsPanel } from '../ClaudeScienceAgentResultsPanel';
-import type { ArtifactAnalysisResult } from '../claude-science-analysis-results';
+import type { ArtifactAnalysisAsset, ArtifactAnalysisResult } from '../claude-science-analysis-results';
 
 const CREATED_AT = '2026-07-12T20:00:00.000Z';
 const provenance = {
@@ -52,23 +53,98 @@ const blastResult: ArtifactAnalysisResult = {
     program: 'blastn',
     database: 'nt',
     queryRecordId: 'puc19',
-    hits: [{
-      accession: 'TEST.1',
-      title: '<img src=x onerror=alert(1)>',
-      identityPercent: 99.2,
-      queryCoveragePercent: 95,
-      eValue: 1e-40,
-      bitScore: 300,
-    }],
+    hits: [
+      {
+        accession: 'TEST.1',
+        title: '<img src=x onerror=alert(1)>',
+        identityPercent: 99.2,
+        queryCoveragePercent: 95,
+        eValue: 1e-40,
+        bitScore: 300,
+        queryStart: 1,
+        queryEnd: 95,
+        subjectStart: 200,
+        subjectEnd: 106,
+        alignmentAssetId: 'blast-alignment',
+      },
+      {
+        accession: 'ZERO.1',
+        title: 'Zero E-value hit',
+        identityPercent: 97,
+        queryCoveragePercent: 100,
+        eValue: 0,
+        bitScore: 450,
+      },
+      {
+        accession: 'IDENTITY.1',
+        title: 'Highest identity hit',
+        identityPercent: 100,
+        queryCoveragePercent: 80,
+        eValue: 1e-10,
+        bitScore: 250,
+      },
+    ],
   },
   createdAt: CREATED_AT,
   provenance: { ...provenance, engine: 'blastn' },
 };
 
+const alignmentContent = `<script>globalThis.pwned=true</script>\n${'A'.repeat(13_000)}`;
+const blastAlignmentAsset: ArtifactAnalysisAsset = {
+  id: 'blast-alignment',
+  name: '../unsafe alignment.txt',
+  mediaType: 'text/plain',
+  content: alignmentContent,
+  createdAt: CREATED_AT,
+  provenance,
+};
+
+const reportText = `<img src=x onerror=alert(1)>\n${'R'.repeat(20_100)}\nREPORT TAIL`;
+const reportResult: ArtifactAnalysisResult = {
+  id: 'report-1',
+  kind: 'report',
+  name: 'Agent safety report',
+  status: 'complete',
+  inputRecordIds: ['puc19'],
+  inputSha256s: ['a'.repeat(64)],
+  dependsOnResultIds: [],
+  assetIds: [],
+  parameters: {},
+  data: { format: 'markdown', body: reportText },
+  createdAt: CREATED_AT,
+  provenance,
+};
+
+const tableResult: ArtifactAnalysisResult = {
+  id: 'table-1',
+  kind: 'table',
+  name: 'QC measurements',
+  status: 'complete',
+  inputRecordIds: ['puc19'],
+  dependsOnResultIds: [],
+  assetIds: [],
+  parameters: {},
+  data: {
+    columns: [
+      { id: 'sample', label: 'Sample', type: 'string' },
+      { id: 'value', label: 'Value', type: 'mixed' },
+      { id: 'accepted', label: 'Accepted', type: 'boolean' },
+    ],
+    rows: Array.from({ length: 55 }, (_, index) => [
+      index === 54 ? '<img src=x onerror=alert(1)>' : `Sample ${index + 1}`,
+      index === 1 ? null : index,
+      index % 2 === 0,
+    ]),
+  },
+  createdAt: CREATED_AT,
+  provenance,
+};
+
 afterEach(cleanup);
 
 describe('ClaudeScienceAgentResultsPanel', () => {
-  it('renders typed facts, provenance, and previews as inert text', () => {
+  it('renders typed facts, provenance, and previews as inert text', async () => {
+    const user = userEvent.setup();
     const view = render(
       <ClaudeScienceAgentResultsPanel
         results={[primerResult, blastResult]}
@@ -82,8 +158,9 @@ describe('ClaudeScienceAgentResultsPanel', () => {
     expect(screen.getByText('420 bp')).toBeTruthy();
     expect(screen.getByText('pUC19 nucleotide search')).toBeTruthy();
     expect(view.container.querySelector('img')).toBeNull();
-    fireEvent.click(screen.getAllByText('Provenance & Data')[1]);
-    expect(screen.getByLabelText('pUC19 nucleotide search safe text preview').textContent).toContain('TEST.1');
+    const blastRow = screen.getByTestId('analysis-result-blast-1');
+    await user.click(within(blastRow).getByText('Provenance & Data'));
+    expect(within(blastRow).getByLabelText('pUC19 nucleotide search safe text preview').textContent).toContain('TEST.1');
   });
 
   it('filters result groups without discarding saved results', () => {
@@ -102,7 +179,400 @@ describe('ClaudeScienceAgentResultsPanel', () => {
     expect(screen.getByText('1 shown')).toBeTruthy();
   });
 
-  it('shows saved-input freshness and its reason without changing the result status', () => {
+  it('pages and copies a complete report while keeping Markdown and HTML-looking text inert', async () => {
+    const user = userEvent.setup();
+    const onCopyText = vi.fn();
+    const onDownloadText = vi.fn();
+    const view = render(
+      <ClaudeScienceAgentResultsPanel
+        results={[reportResult]}
+        assets={[]}
+        recordNames={{ puc19: 'pUC19' }}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+        onCopyText={onCopyText}
+        onDownloadText={onDownloadText}
+      />,
+    );
+    const row = screen.getByTestId('analysis-result-report-1');
+    expect(within(row).queryByLabelText('Agent safety report safe text preview')).toBeNull();
+    await user.click(within(row).getByText('Provenance & Data'));
+
+    const firstPage = within(row).getByLabelText('Agent safety report safe text preview');
+    expect(firstPage.tabIndex).toBe(0);
+    expect(firstPage.textContent).toContain('<img src=x onerror=alert(1)>');
+    expect(firstPage.textContent).not.toContain('REPORT TAIL');
+    expect(view.container.querySelector('img')).toBeNull();
+    expect(view.container.querySelector('script')).toBeNull();
+
+    await user.click(within(row).getByRole('button', { name: 'Next pages for agent safety report safe text preview' }));
+    expect(within(row).getByLabelText('Agent safety report safe text preview').textContent).toContain('REPORT TAIL');
+    await user.click(within(row).getByRole('button', { name: 'Copy report Agent safety report' }));
+    expect(onCopyText).toHaveBeenCalledWith('Report Agent safety report', reportText);
+    await user.click(within(row).getByRole('button', { name: 'Download report Agent safety report' }));
+    expect(onDownloadText).toHaveBeenCalledWith('Agent safety report.md', reportText, 'text/markdown');
+  });
+
+  it('resolves a report body asset even when it is not repeated in generic assetIds', async () => {
+    const user = userEvent.setup();
+    const onCopyText = vi.fn();
+    const bodyAsset: ArtifactAnalysisAsset = {
+      id: 'report-body',
+      name: '<body>.txt',
+      mediaType: 'text/plain',
+      content: '<script>alert(1)</script>\nasset-backed report',
+      createdAt: CREATED_AT,
+      provenance,
+    };
+    const assetReport: ArtifactAnalysisResult = {
+      ...reportResult,
+      id: 'report-asset',
+      name: 'Asset-backed report',
+      assetIds: [],
+      data: { format: 'plain', bodyAssetId: bodyAsset.id },
+    };
+    const view = render(
+      <ClaudeScienceAgentResultsPanel
+        results={[assetReport]}
+        assets={[bodyAsset]}
+        recordNames={{ puc19: 'pUC19' }}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+        onCopyText={onCopyText}
+      />,
+    );
+    const row = screen.getByTestId('analysis-result-report-asset');
+    await user.click(within(row).getByText('Provenance & Data'));
+    expect(within(row).getByLabelText('Asset-backed report safe text preview').textContent).toContain('asset-backed report');
+    expect(within(row).getAllByText(/<body>.txt/).length).toBeGreaterThan(0);
+    expect(view.container.querySelector('script')).toBeNull();
+    await user.click(within(row).getByText('<body>.txt', { selector: 'summary span' }));
+    await user.click(within(row).getByRole('button', { name: 'Copy full asset <body>.txt' }));
+    expect(onCopyText).toHaveBeenCalledWith('Asset <body>.txt', bodyAsset.content);
+  });
+
+  it('pages large linked-asset sets and keeps the provenance summary bounded', async () => {
+    const user = userEvent.setup();
+    const assets = Array.from({ length: 30 }, (_, index): ArtifactAnalysisAsset => ({
+      id: `asset-${index + 1}`,
+      name: `asset-${index + 1}.txt`,
+      mediaType: 'text/plain',
+      content: `asset content ${index + 1}`,
+      createdAt: CREATED_AT,
+      provenance,
+    }));
+    const result: ArtifactAnalysisResult = {
+      ...primerResult,
+      id: 'primer-assets',
+      name: 'Asset-heavy primer result',
+      assetIds: assets.map((asset) => asset.id),
+    };
+    render(
+      <ClaudeScienceAgentResultsPanel
+        results={[result]}
+        assets={assets}
+        recordNames={{ puc19: 'pUC19' }}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    const row = screen.getByTestId('analysis-result-primer-assets');
+    await user.click(within(row).getByText('Provenance & Data'));
+    expect(within(row).getByText(/\+ 27 more/)).toBeTruthy();
+    expect(row.querySelectorAll('.motif-cs-agent-asset')).toHaveLength(25);
+    expect(within(row).queryByText('asset-30.txt', { selector: 'summary span' })).toBeNull();
+
+    await user.click(within(row).getByRole('button', { name: /Next linked asset pages for asset-heavy primer result/i }));
+    expect(row.querySelectorAll('.motif-cs-agent-asset')).toHaveLength(5);
+    expect(within(row).getByText('asset-30.txt', { selector: 'summary span' })).toBeTruthy();
+    expect(within(row).queryByText('asset-1.txt', { selector: 'summary span' })).toBeNull();
+  });
+
+  it('falls back to inert textarea copying when the Clipboard API is denied', async () => {
+    const user = userEvent.setup();
+    const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+    const execCommandDescriptor = Object.getOwnPropertyDescriptor(document, 'execCommand');
+    const writeText = vi.fn().mockRejectedValue(new Error('sandbox denied'));
+    const execCommand = vi.fn(() => true);
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+    Object.defineProperty(document, 'execCommand', { configurable: true, value: execCommand });
+
+    try {
+      render(
+        <ClaudeScienceAgentResultsPanel
+          results={[reportResult]}
+          assets={[]}
+          recordNames={{ puc19: 'pUC19' }}
+          onRevealRecord={vi.fn()}
+          onRemove={vi.fn()}
+        />,
+      );
+      const row = screen.getByTestId('analysis-result-report-1');
+      await user.click(within(row).getByText('Provenance & Data'));
+      await user.click(within(row).getByRole('button', { name: 'Copy report Agent safety report' }));
+
+      expect(writeText).toHaveBeenCalledWith(reportText);
+      expect(execCommand).toHaveBeenCalledWith('copy');
+      expect(document.querySelector('textarea')).toBeNull();
+      expect(screen.getByRole('status').textContent).toBe('Report Agent safety report copied.');
+    } finally {
+      if (clipboardDescriptor) Object.defineProperty(navigator, 'clipboard', clipboardDescriptor);
+      else delete (navigator as Navigator & { clipboard?: Clipboard }).clipboard;
+      if (execCommandDescriptor) Object.defineProperty(document, 'execCommand', execCommandDescriptor);
+      else delete (document as Document & { execCommand?: typeof document.execCommand }).execCommand;
+    }
+  });
+
+  it('renders every table row through semantic pages and exports the complete TSV', async () => {
+    const user = userEvent.setup();
+    const onCopyText = vi.fn();
+    const onDownloadText = vi.fn();
+    const view = render(
+      <ClaudeScienceAgentResultsPanel
+        results={[tableResult]}
+        assets={[]}
+        recordNames={{ puc19: 'pUC19' }}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+        onCopyText={onCopyText}
+        onDownloadText={onDownloadText}
+      />,
+    );
+    const row = screen.getByTestId('analysis-result-table-1');
+    await user.click(within(row).getByText('Provenance & Data'));
+    const table = within(row).getByRole('table');
+    expect(within(table).getAllByRole('columnheader')).toHaveLength(3);
+    expect(within(table).getAllByRole('row')).toHaveLength(51);
+    expect(within(row).getByText('Sample 1')).toBeTruthy();
+    expect(within(row).queryByText('<img src=x onerror=alert(1)>')).toBeNull();
+
+    await user.click(within(row).getByRole('button', { name: 'Next table pages for qc measurements' }));
+    expect(within(table).getAllByRole('row')).toHaveLength(6);
+    expect(within(row).getByText('<img src=x onerror=alert(1)>')).toBeTruthy();
+    expect(view.container.querySelector('img')).toBeNull();
+    await user.click(within(row).getByRole('button', { name: 'Copy table QC measurements as TSV' }));
+    expect(onCopyText.mock.calls[0]?.[0]).toBe('Table QC measurements');
+    expect(onCopyText.mock.calls[0]?.[1]).toContain('<img src=x onerror=alert(1)>\t54\ttrue');
+    await user.click(within(row).getByRole('button', { name: 'Download table QC measurements as TSV' }));
+    expect(onDownloadText.mock.calls[0]?.[0]).toBe('QC measurements.tsv');
+    expect(onDownloadText.mock.calls[0]?.[2]).toBe('text/tab-separated-values');
+
+    view.rerender(
+      <ClaudeScienceAgentResultsPanel
+        results={[{ ...tableResult, data: { ...tableResult.data, rows: tableResult.data.rows.slice(0, 10) } }]}
+        assets={[]}
+        recordNames={{ puc19: 'pUC19' }}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+        onCopyText={onCopyText}
+        onDownloadText={onDownloadText}
+      />,
+    );
+    expect(within(row).getByText('Sample 1')).toBeTruthy();
+    view.rerender(
+      <ClaudeScienceAgentResultsPanel
+        results={[tableResult]}
+        assets={[]}
+        recordNames={{ puc19: 'pUC19' }}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+        onCopyText={onCopyText}
+        onDownloadText={onDownloadText}
+      />,
+    );
+    expect(within(row).getByText('Sample 1')).toBeTruthy();
+    expect(within(row).queryByText('<img src=x onerror=alert(1)>')).toBeNull();
+  });
+
+  it('bounds maximum-width table pages and cell previews while preserving complete export data', async () => {
+    const user = userEvent.setup();
+    const onCopyText = vi.fn();
+    const longCell = `${'L'.repeat(600)}TABLE TAIL`;
+    const columns = Array.from({ length: 256 }, (_, index) => ({
+      id: `column-${index}`,
+      label: `Column ${index + 1}`,
+      type: 'string' as const,
+    }));
+    const wideTable: ArtifactAnalysisResult = {
+      ...tableResult,
+      id: 'table-wide',
+      name: 'Wide measurements',
+      data: {
+        columns,
+        rows: Array.from({ length: 8 }, (_, rowIndex) => (
+          columns.map((_, columnIndex) => rowIndex === 0 && columnIndex === 0 ? longCell : `r${rowIndex}c${columnIndex}`)
+        )),
+      },
+    };
+    render(
+      <ClaudeScienceAgentResultsPanel
+        results={[wideTable]}
+        assets={[]}
+        recordNames={{ puc19: 'pUC19' }}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+        onCopyText={onCopyText}
+      />,
+    );
+
+    const row = screen.getByTestId('analysis-result-table-wide');
+    await user.click(within(row).getByText('Provenance & Data'));
+    const table = within(row).getByRole('table');
+    expect(within(table).getAllByRole('row')).toHaveLength(4);
+    expect(within(table).getAllByRole('cell')).toHaveLength(768);
+    expect(within(row).getByText(/Cell previews are limited to 512 characters/)).toBeTruthy();
+    expect(within(table).queryByText(/TABLE TAIL/)).toBeNull();
+    await user.click(within(row).getByRole('button', { name: 'Next table pages for wide measurements' }));
+    expect(within(table).getAllByRole('row')).toHaveLength(4);
+    await user.click(within(row).getByRole('button', { name: 'Copy table Wide measurements as TSV' }));
+    expect(onCopyText.mock.calls[0]?.[1]).toContain('TABLE TAIL');
+  });
+
+  it('sorts BLAST hits and exposes only bounded inert alignment evidence while copying the full asset', async () => {
+    const user = userEvent.setup();
+    const onCopyText = vi.fn();
+    const onDownloadText = vi.fn();
+    const view = render(
+      <ClaudeScienceAgentResultsPanel
+        results={[blastResult]}
+        assets={[blastAlignmentAsset]}
+        recordNames={{ puc19: 'pUC19' }}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+        onCopyText={onCopyText}
+        onDownloadText={onDownloadText}
+      />,
+    );
+    const row = screen.getByTestId('analysis-result-blast-1');
+    await user.click(within(row).getByText('Provenance & Data'));
+    const hitTable = within(row).getByRole('table');
+    const accessions = () => within(hitTable).getAllByRole('row').slice(1).map((tableRow) => (
+      within(tableRow).getAllByRole('cell')[0]?.textContent
+    ));
+    expect(accessions()).toEqual(['ZERO.1', 'TEST.1', 'IDENTITY.1']);
+    await user.selectOptions(within(row).getByLabelText('Sort hits'), 'identity');
+    expect(accessions()).toEqual(['IDENTITY.1', 'TEST.1', 'ZERO.1']);
+
+    const testHitRow = within(hitTable).getByText('TEST.1').closest('tr');
+    expect(testHitRow).not.toBeNull();
+    const alignmentDisclosure = within(testHitRow as HTMLTableRowElement).getByRole('button', { name: 'Show alignment TEST.1' });
+    const evidenceId = alignmentDisclosure.getAttribute('aria-controls');
+    expect(evidenceId).toBeTruthy();
+    await user.click(alignmentDisclosure);
+    const evidence = within(testHitRow as HTMLTableRowElement).getByLabelText('TEST.1 bounded alignment evidence');
+    expect(document.getElementById(evidenceId as string)?.contains(evidence)).toBe(true);
+    expect(evidence.tabIndex).toBe(0);
+    expect(evidence.textContent?.length).toBe(12_000);
+    expect(evidence.textContent).toContain('<script>globalThis.pwned=true</script>');
+    expect(view.container.querySelector('script')).toBeNull();
+    await user.click(within(testHitRow as HTMLTableRowElement).getByRole('button', { name: 'Copy full evidence TEST.1' }));
+    expect(onCopyText).toHaveBeenCalledWith('BLAST alignment TEST.1', alignmentContent);
+    await user.click(within(testHitRow as HTMLTableRowElement).getByRole('button', { name: 'Download alignment TEST.1' }));
+    expect(onDownloadText).toHaveBeenCalledWith('-unsafe alignment.txt', alignmentContent, 'text/plain');
+  });
+
+  it('pages more than 25 BLAST hits and resets to the first page when sorting changes', async () => {
+    const user = userEvent.setup();
+    const pagedBlast: ArtifactAnalysisResult = {
+      ...blastResult,
+      id: 'blast-paged',
+      name: 'Paged nucleotide search',
+      data: {
+        ...blastResult.data,
+        hits: Array.from({ length: 30 }, (_, index) => ({
+          accession: `HIT.${String(index + 1).padStart(2, '0')}`,
+          title: `Saved hit ${index + 1}`,
+          identityPercent: 60 + index,
+          queryCoveragePercent: 100 - index,
+          eValue: index + 1,
+          bitScore: 300 - index,
+        })),
+      },
+    };
+    render(
+      <ClaudeScienceAgentResultsPanel
+        results={[pagedBlast]}
+        assets={[]}
+        recordNames={{ puc19: 'pUC19' }}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    const row = screen.getByTestId('analysis-result-blast-paged');
+    await user.click(within(row).getByText('Provenance & Data'));
+    const table = within(row).getByRole('table');
+    expect(within(table).getAllByRole('row')).toHaveLength(26);
+    expect(within(table).getByText('HIT.01')).toBeTruthy();
+    expect(within(table).queryByText('HIT.26')).toBeNull();
+
+    await user.click(within(row).getByRole('button', { name: 'Next blast hit pages for paged nucleotide search' }));
+    expect(within(table).getAllByRole('row')).toHaveLength(6);
+    expect(within(table).getByText('HIT.26')).toBeTruthy();
+    await user.selectOptions(within(row).getByLabelText('Sort hits'), 'identity');
+    expect(within(table).getAllByRole('row')).toHaveLength(26);
+    expect(within(table).getByText('HIT.30')).toBeTruthy();
+    expect(within(row).getByText('1–25 of 30')).toBeTruthy();
+  });
+
+  it('progressively renders large result lists and collapses back to the first page', async () => {
+    const user = userEvent.setup();
+    const results = Array.from({ length: 60 }, (_, index): ArtifactAnalysisResult => ({
+      ...primerResult,
+      id: `primer-${String(index).padStart(3, '0')}`,
+      name: `Primer result ${index + 1}`,
+      createdAt: new Date(Date.UTC(2026, 6, 12, 20, 0, index)).toISOString(),
+    }));
+    const view = render(
+      <ClaudeScienceAgentResultsPanel
+        results={results}
+        assets={[]}
+        recordNames={{ puc19: 'pUC19' }}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByTestId(/^analysis-result-primer-/)).toHaveLength(25);
+    expect(screen.getByText('Showing 25 of 60')).toBeTruthy();
+    expect(screen.getByText('25 of 60 shown')).toBeTruthy();
+    await user.click(screen.getByRole('button', { name: 'Show 25 more' }));
+    expect(screen.getAllByTestId(/^analysis-result-primer-/)).toHaveLength(50);
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Show 10 more' }));
+    await user.click(screen.getByRole('button', { name: 'Show 10 more' }));
+    expect(screen.getAllByTestId(/^analysis-result-primer-/)).toHaveLength(60);
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Show first 25' }));
+    await user.click(screen.getByRole('button', { name: 'Show first 25' }));
+    expect(screen.getAllByTestId(/^analysis-result-primer-/)).toHaveLength(25);
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Show 25 more' }));
+
+    await user.click(screen.getByRole('button', { name: 'Show 25 more' }));
+    expect(screen.getAllByTestId(/^analysis-result-primer-/)).toHaveLength(50);
+    view.rerender(
+      <ClaudeScienceAgentResultsPanel
+        results={results.slice(0, 10)}
+        assets={[]}
+        recordNames={{ puc19: 'pUC19' }}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByTestId(/^analysis-result-primer-/)).toHaveLength(10);
+    view.rerender(
+      <ClaudeScienceAgentResultsPanel
+        results={results}
+        assets={[]}
+        recordNames={{ puc19: 'pUC19' }}
+        onRevealRecord={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByTestId(/^analysis-result-primer-/)).toHaveLength(25);
+  });
+
+  it('shows saved-input freshness and its reason without changing the result status', async () => {
+    const user = userEvent.setup();
     render(
       <ClaudeScienceAgentResultsPanel
         results={[primerResult]}
@@ -117,8 +587,9 @@ describe('ClaudeScienceAgentResultsPanel', () => {
       />,
     );
     expect(screen.getByText('complete')).toBeTruthy();
+    expect(screen.getAllByText('Stale')).toHaveLength(1);
+    await user.click(screen.getByText('Provenance & Data'));
     expect(screen.getAllByText('Stale')).toHaveLength(2);
-    fireEvent.click(screen.getByText('Provenance & Data'));
     expect(screen.getByText(/pUC19's sequence has changed/)).toBeTruthy();
   });
 

--- a/src/artifacts/__tests__/ClaudeScienceDataSettings.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceDataSettings.jsdom.test.tsx
@@ -16,7 +16,12 @@ function renderSettings(overrides: Partial<React.ComponentProps<typeof ClaudeSci
     workflowCount: 4,
     sessionOnly: true,
     hasUnsavedChanges: true,
-    onDownloadBackup: vi.fn(),
+    onDownloadBackup: vi.fn(() => ({
+      status: 'requested' as const,
+      channel: 'browser' as const,
+      filename: 'motif-workspace-backup.json',
+      message: 'Download requested. Verify the file before reloading.',
+    })),
     onRestoreFile: vi.fn(),
     onClearWorkspace: vi.fn(),
     onResetDisplayPreferences: vi.fn(),
@@ -27,7 +32,12 @@ function renderSettings(overrides: Partial<React.ComponentProps<typeof ClaudeSci
 
 describe('ClaudeScienceDataSettings', () => {
   it('presents explicit backup/restore controls, counts, and the session privacy boundary', async () => {
-    const onDownloadBackup = vi.fn();
+    const onDownloadBackup = vi.fn(() => ({
+      status: 'requested' as const,
+      channel: 'browser' as const,
+      filename: 'motif-workspace-backup.json',
+      message: 'Download requested. Verify the file before reloading.',
+    }));
     const onRestoreFile = vi.fn();
     const { getByTestId } = renderSettings({ onDownloadBackup, onRestoreFile });
 
@@ -40,7 +50,8 @@ describe('ClaudeScienceDataSettings', () => {
 
     fireEvent.click(getByTestId('download-workspace-backup'));
     await waitFor(() => expect(onDownloadBackup).toHaveBeenCalledTimes(1));
-    expect(getByTestId('data-recovery-status').textContent).toBe('Workspace backup downloaded.');
+    await waitFor(() => expect(getByTestId('data-recovery-status').textContent)
+      .toBe('Download requested. Verify the file before reloading.'));
 
     const backup = new File(['{"schema":"motif"}'], 'workspace.json', { type: 'application/json' });
     const input = getByTestId('restore-workspace-file') as HTMLInputElement;

--- a/src/artifacts/__tests__/ClaudeScienceNotesPanel.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceNotesPanel.jsdom.test.tsx
@@ -58,6 +58,7 @@ function props(overrides: Partial<ClaudeScienceNotesPanelProps> = {}): ClaudeSci
     selectedRange: { start: 9, end: 30 },
     onAdd: vi.fn(),
     onUpdate: vi.fn(),
+    onConfirmAnchor: vi.fn(),
     onRemove: vi.fn(),
     onReveal: vi.fn(),
     ...overrides,
@@ -177,5 +178,32 @@ describe('ClaudeScienceNotesPanel', () => {
     await user.click(within(note).getByRole('button', { name: 'Delete note' }));
     expect(onRemove).toHaveBeenCalledWith('record-note');
     expect(screen.getByRole('status').textContent).toContain('Note deleted.');
+  });
+
+  it('surfaces a remapped range for explicit scientific confirmation', async () => {
+    const user = userEvent.setup();
+    const onConfirmAnchor = vi.fn();
+    const reviewNote: ArtifactNote = {
+      ...notes[2],
+      provenance: {
+        source: 'motif-for-claude-science-artifact',
+        operation: 'sequence_edit_anchor_review',
+        metadata: {
+          motifRangeAnchor: {
+            status: 'review',
+            previousRange: { start: 9, end: 30 },
+            currentRange: { start: 9, end: 31 },
+            edit: { start: 20, deletedLength: 0, insertedLength: 1, oldLength: 100 },
+            editedAt: '2026-07-18T18:00:00.000Z',
+          },
+        },
+      },
+    };
+
+    render(<ClaudeScienceNotesPanel {...props({ notes: [reviewNote], onConfirmAnchor })} />);
+    expect(screen.getByText('Review range anchor.')).toBeTruthy();
+    await user.click(screen.getByRole('button', { name: 'Confirm anchor' }));
+    expect(onConfirmAnchor).toHaveBeenCalledWith(reviewNote.id);
+    expect(screen.getByRole('status').textContent).toContain('Range anchor confirmed.');
   });
 });

--- a/src/artifacts/__tests__/claude-science-analysis-result-viewers.test.ts
+++ b/src/artifacts/__tests__/claude-science-analysis-result-viewers.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  ArtifactAnalysisAsset,
+  ArtifactAnalysisResult,
+  ArtifactBlastHit,
+} from '../claude-science-analysis-results';
+import {
+  artifactAnalysisResultAssetIds,
+  artifactTableToTsv,
+  artifactTextPage,
+  resolveArtifactReport,
+  safeAnalysisFilename,
+  sortArtifactBlastHits,
+} from '../claude-science-analysis-result-viewers';
+
+const createdAt = '2026-07-12T20:00:00.000Z';
+const provenance = { source: 'test' };
+
+function reportResult(overrides: Partial<Extract<ArtifactAnalysisResult, { kind: 'report' }>['data']> = {}): Extract<ArtifactAnalysisResult, { kind: 'report' }> {
+  return {
+    id: 'report-1',
+    kind: 'report',
+    name: 'Safety report',
+    status: 'complete',
+    inputRecordIds: [],
+    dependsOnResultIds: [],
+    assetIds: ['direct-asset'],
+    parameters: {},
+    data: { format: 'plain', body: 'inline report', ...overrides },
+    createdAt,
+    provenance,
+  };
+}
+
+describe('analysis result viewer helpers', () => {
+  it('sorts BLAST hits deterministically without mutating the saved order', () => {
+    const hits: ArtifactBlastHit[] = [
+      { accession: 'B.1', title: 'B', identityPercent: 90, queryCoveragePercent: 100, eValue: 0, bitScore: 200 },
+      { accession: 'A.1', title: 'A', identityPercent: 99, queryCoveragePercent: 80, eValue: 1e-20, bitScore: 300 },
+      { accession: 'C.1', title: 'C', identityPercent: 90, queryCoveragePercent: 90, eValue: 0, bitScore: 210 },
+    ];
+
+    expect(sortArtifactBlastHits(hits, 'evalue').map((hit) => hit.accession)).toEqual(['C.1', 'B.1', 'A.1']);
+    expect(sortArtifactBlastHits(hits, 'identity').map((hit) => hit.accession)).toEqual(['A.1', 'C.1', 'B.1']);
+    expect(sortArtifactBlastHits(hits, 'accession').map((hit) => hit.accession)).toEqual(['A.1', 'B.1', 'C.1']);
+    expect(hits.map((hit) => hit.accession)).toEqual(['B.1', 'A.1', 'C.1']);
+  });
+
+  it('resolves typed asset references in addition to the generic list', () => {
+    const blast: ArtifactAnalysisResult = {
+      id: 'blast-1',
+      kind: 'blast_search',
+      name: 'BLAST',
+      status: 'complete',
+      inputRecordIds: ['query'],
+      dependsOnResultIds: [],
+      assetIds: ['direct-asset'],
+      parameters: {},
+      data: {
+        program: 'blastn',
+        database: 'nt',
+        queryRecordId: 'query',
+        hits: [{
+          accession: 'A.1',
+          title: 'A',
+          identityPercent: 99,
+          queryCoveragePercent: 100,
+          eValue: 0,
+          bitScore: 500,
+          alignmentAssetId: 'alignment-asset',
+        }],
+      },
+      createdAt,
+      provenance,
+    };
+
+    expect(artifactAnalysisResultAssetIds(blast)).toEqual(['direct-asset', 'alignment-asset']);
+    expect(artifactAnalysisResultAssetIds(reportResult({ body: undefined, bodyAssetId: 'report-body' }))).toEqual([
+      'direct-asset',
+      'report-body',
+    ]);
+  });
+
+  it('prefers an inline report and otherwise resolves the exact body asset', () => {
+    const asset: ArtifactAnalysisAsset = {
+      id: 'report-body',
+      name: 'report.txt',
+      mediaType: 'text/plain',
+      content: 'asset report',
+      createdAt,
+      provenance,
+    };
+    const assets = new Map([[asset.id, asset]]);
+
+    expect(resolveArtifactReport(reportResult({ body: 'inline', bodyAssetId: 'report-body' }), assets)?.text).toBe('inline');
+    expect(resolveArtifactReport(reportResult({ body: '', bodyAssetId: 'report-body' }), assets)?.text).toBe('');
+    expect(resolveArtifactReport(reportResult({ body: undefined, bodyAssetId: 'report-body' }), assets)?.text).toBe('asset report');
+    expect(resolveArtifactReport(reportResult({ body: undefined, bodyAssetId: 'missing' }), assets)).toBeNull();
+  });
+
+  it('serializes the complete table as escaped TSV', () => {
+    expect(artifactTableToTsv({
+      columns: [
+        { id: 'name', label: 'Name', type: 'string' },
+        { id: 'value', label: 'Value\tunit', type: 'mixed' },
+      ],
+      rows: [
+        ['alpha', 0],
+        ['line\nbreak', false],
+        ['quote "value"', null],
+      ],
+    })).toBe([
+      'Name\t"Value\tunit"',
+      'alpha\t0',
+      '"line\nbreak"\tfalse',
+      '"quote ""value"""\t',
+    ].join('\n'));
+  });
+
+  it('neutralizes spreadsheet formulas in string cells while preserving numeric values', () => {
+    expect(artifactTableToTsv({
+      columns: [
+        { id: 'formula', label: '=Formula header', type: 'string' },
+        { id: 'text', label: 'Text', type: 'string' },
+        { id: 'number', label: 'Number', type: 'number' },
+      ],
+      rows: [
+        ['+SUM(1,1)', '@HYPERLINK("x")', -12],
+        ['   -cmd', 'safe', 42],
+      ],
+    })).toBe([
+      "'=Formula header\tText\tNumber",
+      "'+SUM(1,1)\t\"'@HYPERLINK(\"\"x\"\")\"\t-12",
+      "'   -cmd\tsafe\t42",
+    ].join('\n'));
+  });
+
+  it('pages every character without splitting a surrogate pair', () => {
+    const text = `${'A'.repeat(19_999)}🧬${'B'.repeat(20_001)}`;
+    const pages = Array.from({ length: artifactTextPage(text, 999, 20_000).pageCount }, (_, index) => (
+      artifactTextPage(text, index, 20_000)
+    ));
+
+    expect(pages.map((page) => page.text).join('')).toBe(text);
+    expect(pages[0].text.endsWith('\ud83e')).toBe(false);
+    expect(pages[1].text.startsWith('\uddec')).toBe(false);
+    expect(artifactTextPage('', 4, 20_000)).toMatchObject({ pageIndex: 0, pageCount: 1, text: '' });
+  });
+
+  it('produces bounded download names without path or control characters', () => {
+    expect(safeAnalysisFilename('../Unsafe\u0000 report?.md', 'report', 'md')).toBe('-Unsafe- report-.md');
+    expect(safeAnalysisFilename('Already.tsv', 'table', 'tsv')).toBe('Already.tsv');
+    expect(safeAnalysisFilename('   ', 'table', 'tsv')).toBe('table.tsv');
+    expect(safeAnalysisFilename('\u202eevil.txt', 'asset', 'txt')).toBe('evil.txt');
+    expect(safeAnalysisFilename(`${'a'.repeat(119)}🧬`, 'asset', 'txt')).toBe(`${'a'.repeat(119)}🧬.txt`);
+  });
+});

--- a/src/artifacts/__tests__/claude-science-download.jsdom.test.ts
+++ b/src/artifacts/__tests__/claude-science-download.jsdom.test.ts
@@ -1,0 +1,51 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  requestBrowserBlobDownload,
+  requestBrowserTextDownload,
+} from '../claude-science-download';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.replaceChildren();
+});
+
+function installObjectUrl(): { create: ReturnType<typeof vi.fn>; revoke: ReturnType<typeof vi.fn> } {
+  const create = vi.fn(() => 'blob:motif-test');
+  const revoke = vi.fn();
+  Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: create });
+  Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revoke });
+  return { create, revoke };
+}
+
+describe('browser download receipts', () => {
+  it('reports only a request after dispatching an anchor download', () => {
+    installObjectUrl();
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+
+    const receipt = requestBrowserTextDownload('workspace.json', '{"records":[]}', 'application/json');
+
+    expect(receipt).toEqual({
+      status: 'requested',
+      channel: 'browser',
+      filename: 'workspace.json',
+      message: 'Download requested for workspace.json. Verify the file before relying on it as a checkpoint.',
+    });
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('a[download="workspace.json"]')).toBeNull();
+  });
+
+  it('returns an explicit failure instead of swallowing blocked downloads', () => {
+    installObjectUrl();
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {
+      throw new Error('sandbox denied the request');
+    });
+
+    const receipt = requestBrowserBlobDownload('workspace.zip', new Blob(['zip']));
+
+    expect(receipt.status).toBe('failed');
+    expect(receipt.message).toMatch(/sandbox denied the request/i);
+    expect(document.querySelector('a')).toBeNull();
+  });
+});

--- a/src/artifacts/__tests__/claude-science-download.jsdom.test.ts
+++ b/src/artifacts/__tests__/claude-science-download.jsdom.test.ts
@@ -30,7 +30,7 @@ describe('browser download receipts', () => {
       status: 'requested',
       channel: 'browser',
       filename: 'workspace.json',
-      message: 'Download requested for workspace.json. Verify the file before relying on it as a checkpoint.',
+      message: 'Download requested for workspace.json. Verify the file before relying on it.',
     });
     expect(click).toHaveBeenCalledTimes(1);
     expect(document.querySelector('a[download="workspace.json"]')).toBeNull();

--- a/src/artifacts/__tests__/claude-science-sequence-edit.test.ts
+++ b/src/artifacts/__tests__/claude-science-sequence-edit.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from 'vitest';
+import type { ArtifactNote } from '../claude-science-workspace-collections';
+import type { PortableTranslationTrack } from '../claude-science-session';
+import {
+  applySequenceEditToAnchors,
+  confirmNoteRangeAnchor,
+  getNoteRangeAnchorReview,
+  restoreNoteAnchors,
+  snapshotNoteAnchors,
+  transformSequenceRange,
+} from '../claude-science-sequence-edit';
+
+const EDITED_AT = '2026-07-18T18:00:00.000Z';
+
+function rangeNote(range = { start: 8, end: 12 }): ArtifactNote {
+  return {
+    id: 'note-1',
+    title: 'Binding site',
+    body: 'Keep this scientific observation attached.',
+    format: 'plain',
+    scope: 'range',
+    recordId: 'record-1',
+    range,
+    createdAt: '2026-07-17T18:00:00.000Z',
+    updatedAt: '2026-07-17T18:00:00.000Z',
+    provenance: { source: 'user', metadata: { retained: true } },
+  };
+}
+
+function translationLayer(range = { start: 6, end: 15 }): PortableTranslationTrack {
+  return {
+    id: 'translation-1',
+    label: 'Candidate ORF',
+    start: range.start,
+    end: range.end,
+    strand: 1,
+    frame: 0,
+    source: 'layer',
+  };
+}
+
+describe('sequence-edit anchor transactions', () => {
+  it('shifts anchors after an insertion without asking for scientific review', () => {
+    const result = applySequenceEditToAnchors({
+      recordId: 'record-1',
+      notes: [rangeNote()],
+      translationLayers: [translationLayer()],
+      edit: { start: 3, deletedLength: 0, insertedLength: 2, oldLength: 20 },
+      editedAt: EDITED_AT,
+    });
+
+    expect(result.notes[0].range).toEqual({ start: 10, end: 14 });
+    expect(getNoteRangeAnchorReview(result.notes[0])).toBeNull();
+    expect(result.translationLayers[0]).toMatchObject({ start: 8, end: 17 });
+    expect(result.translationLayers[0].needsReview).toBeUndefined();
+  });
+
+  it('expands an intersected range and marks both scientific anchors for review', () => {
+    const result = applySequenceEditToAnchors({
+      recordId: 'record-1',
+      notes: [rangeNote()],
+      translationLayers: [translationLayer()],
+      edit: { start: 10, deletedLength: 0, insertedLength: 3, oldLength: 20 },
+      editedAt: EDITED_AT,
+    });
+
+    expect(result.notes[0].range).toEqual({ start: 8, end: 15 });
+    expect(getNoteRangeAnchorReview(result.notes[0])).toEqual({
+      status: 'review',
+      previousRange: { start: 8, end: 12 },
+      currentRange: { start: 8, end: 15 },
+      edit: { start: 10, deletedLength: 0, insertedLength: 3, oldLength: 20 },
+      editedAt: EDITED_AT,
+    });
+    expect(result.translationLayers[0]).toMatchObject({ start: 6, end: 18, needsReview: true });
+    expect(result.adjustedNoteCount).toBe(1);
+    expect(result.adjustedLayerCount).toBe(1);
+  });
+
+  it('does not clear a pending scientific review when a later edit only shifts it', () => {
+    const first = applySequenceEditToAnchors({
+      recordId: 'record-1',
+      notes: [rangeNote()],
+      translationLayers: [],
+      edit: { start: 10, deletedLength: 0, insertedLength: 3, oldLength: 20 },
+      editedAt: EDITED_AT,
+    }).notes;
+    const second = applySequenceEditToAnchors({
+      recordId: 'record-1',
+      notes: first,
+      translationLayers: [],
+      edit: { start: 3, deletedLength: 0, insertedLength: 2, oldLength: 23 },
+      editedAt: '2026-07-18T18:01:00.000Z',
+    }).notes[0];
+
+    expect(getNoteRangeAnchorReview(second)).toMatchObject({
+      status: 'review',
+      previousRange: { start: 8, end: 12 },
+      currentRange: { start: 10, end: 17 },
+      edit: { start: 10, deletedLength: 0, insertedLength: 3, oldLength: 20 },
+      editedAt: EDITED_AT,
+    });
+    expect(second.updatedAt).toBe(EDITED_AT);
+  });
+
+  it('treats half-open insertion boundaries explicitly', () => {
+    expect(transformSequenceRange(
+      { start: 8, end: 12 },
+      { start: 8, deletedLength: 0, insertedLength: 2, oldLength: 20 },
+    ).range).toEqual({ start: 10, end: 14 });
+    expect(transformSequenceRange(
+      { start: 8, end: 12 },
+      { start: 12, deletedLength: 0, insertedLength: 2, oldLength: 20 },
+    )).toEqual({
+      range: { start: 8, end: 12 },
+      changed: false,
+      overlapsMeaning: false,
+    });
+  });
+
+  it('keeps substitution coordinates stable while flagging changed contents', () => {
+    expect(transformSequenceRange(
+      { start: 8, end: 12 },
+      { start: 8, deletedLength: 1, insertedLength: 1, oldLength: 20 },
+    )).toEqual({
+      range: { start: 8, end: 12 },
+      changed: false,
+      overlapsMeaning: true,
+    });
+
+    const result = applySequenceEditToAnchors({
+      recordId: 'record-1',
+      notes: [rangeNote()],
+      translationLayers: [translationLayer()],
+      edit: { start: 9, deletedLength: 1, insertedLength: 1, oldLength: 20 },
+      editedAt: EDITED_AT,
+    });
+    expect(result.notes[0].range).toEqual({ start: 8, end: 12 });
+    expect(getNoteRangeAnchorReview(result.notes[0])?.status).toBe('review');
+    expect(result.translationLayers[0]).toMatchObject({ start: 6, end: 15, needsReview: true });
+  });
+
+  it('clamps deletions and replacements across every interval relationship', () => {
+    const range = { start: 10, end: 20 };
+    const transform = (start: number, deletedLength: number, insertedLength = 0) => (
+      transformSequenceRange(range, { start, deletedLength, insertedLength, oldLength: 30 })
+    );
+
+    expect(transform(2, 3)).toMatchObject({ range: { start: 7, end: 17 }, overlapsMeaning: false });
+    expect(transform(8, 4)).toMatchObject({ range: { start: 8, end: 16 }, overlapsMeaning: true });
+    expect(transform(13, 3)).toMatchObject({ range: { start: 10, end: 17 }, overlapsMeaning: true });
+    expect(transform(18, 5)).toMatchObject({ range: { start: 10, end: 18 }, overlapsMeaning: true });
+    expect(transform(8, 15)).toMatchObject({ range: null, overlapsMeaning: true });
+    expect(transform(20, 2)).toMatchObject({ range, overlapsMeaning: false });
+    expect(transform(8, 15, 4)).toMatchObject({ range: { start: 8, end: 12 }, overlapsMeaning: true });
+    expect(transformSequenceRange(range, {
+      start: 15,
+      deletedLength: 0,
+      insertedLength: 0,
+      oldLength: 30,
+    })).toEqual({ range, changed: false, overlapsMeaning: false });
+  });
+
+  it('rejects unsafe or out-of-bounds edit descriptors without mutating the input range', () => {
+    const range = Object.freeze({ start: 2, end: 8 });
+    expect(() => transformSequenceRange(range, {
+      start: 9,
+      deletedLength: 2,
+      insertedLength: 0,
+      oldLength: 10,
+    })).toThrow(/safe-integer coordinates/i);
+    expect(() => transformSequenceRange(range, {
+      start: Number.MAX_SAFE_INTEGER + 1,
+      deletedLength: 0,
+      insertedLength: 1,
+      oldLength: Number.MAX_SAFE_INTEGER + 1,
+    })).toThrow(/safe-integer coordinates/i);
+    expect(range).toEqual({ start: 2, end: 8 });
+  });
+
+  it('detaches a fully deleted note and removes a collapsed translation layer', () => {
+    const result = applySequenceEditToAnchors({
+      recordId: 'record-1',
+      notes: [rangeNote({ start: 8, end: 10 })],
+      translationLayers: [translationLayer({ start: 8, end: 11 })],
+      edit: { start: 7, deletedLength: 5, insertedLength: 0, oldLength: 20 },
+      editedAt: EDITED_AT,
+    });
+
+    expect(result.notes[0]).toMatchObject({ scope: 'record', recordId: 'record-1' });
+    expect(result.notes[0].range).toBeUndefined();
+    expect(getNoteRangeAnchorReview(result.notes[0])?.status).toBe('detached');
+    expect(result.translationLayers).toEqual([]);
+    expect(result.detachedNoteCount).toBe(1);
+    expect(result.removedLayerCount).toBe(1);
+  });
+
+  it('preserves a valid imported short layer through an unrelated sequence edit', () => {
+    const result = applySequenceEditToAnchors({
+      recordId: 'record-1',
+      notes: [],
+      translationLayers: [translationLayer({ start: 8, end: 10 })],
+      edit: { start: 3, deletedLength: 0, insertedLength: 2, oldLength: 20 },
+      editedAt: EDITED_AT,
+    });
+
+    expect(result.translationLayers).toEqual([
+      expect.objectContaining({ start: 10, end: 12 }),
+    ]);
+    expect(result.adjustedLayerCount).toBe(1);
+    expect(result.removedLayerCount).toBe(0);
+  });
+
+  it('restores anchors for undo without overwriting later note text', () => {
+    const original = rangeNote();
+    const snapshots = snapshotNoteAnchors([original], 'record-1');
+    const edited = applySequenceEditToAnchors({
+      recordId: 'record-1',
+      notes: [original],
+      translationLayers: [],
+      edit: { start: 10, deletedLength: 0, insertedLength: 3, oldLength: 20 },
+      editedAt: EDITED_AT,
+    }).notes[0];
+    const expectedCurrentSnapshots = snapshotNoteAnchors([edited], 'record-1');
+    const laterText = {
+      ...edited,
+      body: 'Edited after the base change.',
+      updatedAt: '2026-07-18T18:05:00.000Z',
+      provenance: {
+        source: 'curation-agent',
+        operation: 'curate_note',
+        metadata: { ...edited.provenance?.metadata, curationPass: 2 },
+      },
+    };
+
+    const [restored] = restoreNoteAnchors(
+      [laterText],
+      'record-1',
+      snapshots,
+      expectedCurrentSnapshots,
+    );
+    expect(restored.body).toBe('Edited after the base change.');
+    expect(restored.range).toEqual({ start: 8, end: 12 });
+    expect(getNoteRangeAnchorReview(restored)).toBeNull();
+    expect(restored.updatedAt).toBe('2026-07-18T18:05:00.000Z');
+    expect(restored.provenance).toEqual({
+      source: 'curation-agent',
+      operation: 'curate_note',
+      metadata: { curationPass: 2, retained: true },
+    });
+  });
+
+  it('restores an untouched note attachment byte-for-byte for clean undo', () => {
+    const original = rangeNote();
+    const snapshots = snapshotNoteAnchors([original], 'record-1');
+    const edited = applySequenceEditToAnchors({
+      recordId: 'record-1',
+      notes: [original],
+      translationLayers: [],
+      edit: { start: 10, deletedLength: 1, insertedLength: 1, oldLength: 20 },
+      editedAt: EDITED_AT,
+    }).notes;
+
+    expect(restoreNoteAnchors(
+      edited,
+      'record-1',
+      snapshots,
+      snapshotNoteAnchors(edited, 'record-1'),
+    )).toEqual([original]);
+  });
+
+  it('round-trips clean note provenance and timestamps through undo and redo', () => {
+    const original = rangeNote();
+    const before = snapshotNoteAnchors([original], 'record-1');
+    const edited = applySequenceEditToAnchors({
+      recordId: 'record-1',
+      notes: [original],
+      translationLayers: [],
+      edit: { start: 10, deletedLength: 0, insertedLength: 1, oldLength: 20 },
+      editedAt: EDITED_AT,
+    }).notes;
+    const after = snapshotNoteAnchors(edited, 'record-1');
+
+    const undone = restoreNoteAnchors(edited, 'record-1', before, after);
+    const redone = restoreNoteAnchors(undone, 'record-1', after, before);
+
+    expect(undone).toEqual([original]);
+    expect(redone).toEqual(edited);
+  });
+
+  it('clears an acknowledged review marker while preserving unrelated provenance', () => {
+    const edited = applySequenceEditToAnchors({
+      recordId: 'record-1',
+      notes: [rangeNote()],
+      translationLayers: [],
+      edit: { start: 10, deletedLength: 0, insertedLength: 1, oldLength: 20 },
+      editedAt: EDITED_AT,
+    }).notes[0];
+    const confirmed = confirmNoteRangeAnchor(edited, '2026-07-18T18:10:00.000Z');
+
+    expect(getNoteRangeAnchorReview(confirmed)).toBeNull();
+    expect(confirmed.provenance?.metadata?.retained).toBe(true);
+    expect(confirmed.provenance?.operation).toBe('sequence_edit_anchor_confirmed');
+  });
+});

--- a/src/artifacts/__tests__/claude-science-session.test.ts
+++ b/src/artifacts/__tests__/claude-science-session.test.ts
@@ -157,6 +157,29 @@ describe('Claude Science durable session validation', () => {
     expect(state.translationLayersByRecord['record-a'].map((track) => track.id)).toEqual(['track', 'track-2']);
   });
 
+  it('round-trips the scientific-review flag on remapped translation layers', () => {
+    const state = normalizeArtifactDurableState({
+      translationLayersByRecord: {
+        'record-a': [{
+          id: 'track',
+          label: 'Review me',
+          start: 3,
+          end: 30,
+          strand: 1,
+          frame: 0,
+          needsReview: true,
+        }],
+      },
+    }, recordLengths);
+
+    expect(state.translationLayersByRecord['record-a'][0].needsReview).toBe(true);
+    expect(() => normalizeArtifactDurableState({
+      translationLayersByRecord: {
+        'record-a': [{ id: 'track', label: 'Bad', start: 3, end: 30, strand: 1, frame: 0, needsReview: 'yes' }],
+      },
+    }, recordLengths)).toThrow(/needsReview must be a boolean/i);
+  });
+
   it('keeps exact-boundary duplicate layer ids unique and stable across serialized normalization', () => {
     const exactBoundaryId = 't'.repeat(MAX_TRANSLATION_LAYER_TEXT_LENGTH);
     const value = {

--- a/src/artifacts/claude-science-agent-results.css
+++ b/src/artifacts/claude-science-agent-results.css
@@ -34,7 +34,9 @@
 }
 
 .motif-cs-agent-results-toolbar select:focus-visible,
-.motif-cs-agent-result-details > summary:focus-visible {
+.motif-cs-agent-result-details > summary:focus-visible,
+.motif-cs-agent-blast-sort select:focus-visible,
+.motif-cs-agent-asset > summary:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
@@ -255,6 +257,223 @@
   word-break: break-word;
 }
 
+.motif-cs-agent-data-viewer,
+.motif-cs-agent-assets {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  padding-top: 7px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.motif-cs-agent-viewer-head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.motif-cs-agent-viewer-head > div:first-child {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.motif-cs-agent-viewer-head strong,
+.motif-cs-agent-assets > strong {
+  color: var(--text-primary);
+  font-size: 10px;
+}
+
+.motif-cs-agent-viewer-head small,
+.motif-cs-agent-asset summary small {
+  color: var(--text-muted);
+  font-size: 9px;
+  line-height: 1.35;
+}
+
+.motif-cs-agent-viewer-actions,
+.motif-cs-agent-result-pager,
+.motif-cs-agent-results-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.motif-cs-agent-result-pager,
+.motif-cs-agent-results-pagination {
+  color: var(--text-muted);
+  font: 9.5px/1.3 var(--font-mono);
+}
+
+.motif-cs-agent-results-pagination {
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--panel-bg);
+}
+
+.motif-cs-agent-results-pagination > span {
+  margin-right: auto;
+}
+
+.motif-cs-agent-text-viewer {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.motif-cs-agent-text-viewer pre[data-empty]::before {
+  color: var(--text-muted);
+  content: '(empty report)';
+}
+
+.motif-cs-agent-table-scroll {
+  min-width: 0;
+  max-height: 320px;
+  overflow: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+}
+
+.motif-cs-agent-table-scroll:focus-visible,
+.motif-cs-agent-result-details pre:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.motif-cs-agent-table-scroll table {
+  width: 100%;
+  min-width: max-content;
+  border-collapse: collapse;
+  color: var(--text-secondary);
+  font-size: 9.5px;
+  line-height: 1.35;
+}
+
+.motif-cs-agent-table-scroll th,
+.motif-cs-agent-table-scroll td {
+  max-width: 320px;
+  padding: 5px 7px;
+  border-right: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+  overflow-wrap: anywhere;
+  text-align: left;
+  vertical-align: top;
+}
+
+.motif-cs-agent-table-scroll th {
+  position: sticky;
+  z-index: 1;
+  top: 0;
+  background: var(--panel-bg);
+  color: var(--text-primary);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.motif-cs-agent-table-scroll tr:last-child td {
+  border-bottom: 0;
+}
+
+.motif-cs-agent-table-scroll th:last-child,
+.motif-cs-agent-table-scroll td:last-child {
+  border-right: 0;
+}
+
+.motif-cs-agent-table-scroll > p,
+.motif-cs-agent-viewer-warning,
+.motif-cs-agent-blast-evidence p,
+.motif-cs-agent-asset > div > p {
+  margin: 0;
+  padding: 7px;
+  color: var(--text-muted);
+  font-size: 9.5px;
+  line-height: 1.4;
+}
+
+.motif-cs-agent-blast-sort {
+  display: grid;
+  gap: 2px;
+  min-width: 160px;
+  color: var(--text-muted);
+  font-size: 9px;
+}
+
+.motif-cs-agent-blast-sort select {
+  min-height: 28px;
+  padding: 3px 22px 3px 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--control-bg);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.motif-cs-agent-blast-evidence {
+  display: grid;
+  gap: 5px;
+  min-width: 132px;
+}
+
+.motif-cs-agent-blast-evidence > div {
+  display: grid;
+  gap: 5px;
+  width: min(520px, 72vw);
+  min-width: 0;
+}
+
+.motif-cs-agent-blast-evidence pre {
+  max-height: 220px;
+}
+
+.motif-cs-agent-no-evidence {
+  color: var(--text-muted);
+}
+
+.motif-cs-agent-assets {
+  gap: 5px;
+}
+
+.motif-cs-agent-asset {
+  min-width: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+}
+
+.motif-cs-agent-asset > summary {
+  min-width: 0;
+  padding: 6px 7px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.motif-cs-agent-asset-summary {
+  display: inline-flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  width: calc(100% - 12px);
+  min-width: 0;
+  vertical-align: top;
+}
+
+.motif-cs-agent-asset-summary > span,
+.motif-cs-agent-asset summary small {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.motif-cs-agent-asset > div {
+  display: grid;
+  gap: 5px;
+  padding: 0 7px 7px;
+}
+
 .motif-cs-agent-result-actions {
   display: flex;
   align-items: center;
@@ -287,12 +506,18 @@
 
 @container (max-width: 310px) {
   .motif-cs-agent-results-toolbar,
-  .motif-cs-agent-result-heading {
+  .motif-cs-agent-result-heading,
+  .motif-cs-agent-viewer-head,
+  .motif-cs-agent-asset-summary {
     align-items: stretch;
     flex-direction: column;
   }
 
   .motif-cs-agent-results-toolbar select {
+    width: 100%;
+  }
+
+  .motif-cs-agent-blast-sort {
     width: 100%;
   }
 

--- a/src/artifacts/claude-science-analysis-result-viewers.ts
+++ b/src/artifacts/claude-science-analysis-result-viewers.ts
@@ -1,0 +1,194 @@
+import type {
+  ArtifactAnalysisAsset,
+  ArtifactAnalysisResult,
+  ArtifactBlastHit,
+  ArtifactReportData,
+  ArtifactTableData,
+} from './claude-science-analysis-results';
+
+export type ArtifactBlastSortKey = 'evalue' | 'bit_score' | 'identity' | 'coverage' | 'accession';
+
+export type ArtifactTextPage = {
+  pageIndex: number;
+  pageCount: number;
+  start: number;
+  end: number;
+  text: string;
+};
+
+type ArtifactReportResult = Extract<ArtifactAnalysisResult, { kind: 'report' }>;
+
+export type ResolvedArtifactReport = {
+  text: string;
+  format: ArtifactReportData['format'];
+  sourceAsset?: ArtifactAnalysisAsset;
+};
+
+function compareNumbers(left: number, right: number, direction: 1 | -1): number {
+  return (left - right) * direction;
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareBlastHits(
+  left: ArtifactBlastHit,
+  right: ArtifactBlastHit,
+  sortKey: ArtifactBlastSortKey,
+): number {
+  if (sortKey === 'evalue') return compareNumbers(left.eValue, right.eValue, 1);
+  if (sortKey === 'bit_score') return compareNumbers(left.bitScore, right.bitScore, -1);
+  if (sortKey === 'identity') return compareNumbers(left.identityPercent, right.identityPercent, -1);
+  if (sortKey === 'coverage') return compareNumbers(left.queryCoveragePercent, right.queryCoveragePercent, -1);
+  return compareStrings(left.accession, right.accession);
+}
+
+/** Return a deterministic copy; never mutate the result payload supplied by the workspace. */
+export function sortArtifactBlastHits(
+  hits: readonly ArtifactBlastHit[],
+  sortKey: ArtifactBlastSortKey,
+): ArtifactBlastHit[] {
+  return hits.map((hit, originalIndex) => ({ hit, originalIndex }))
+    .sort((left, right) => (
+      compareBlastHits(left.hit, right.hit, sortKey)
+      || compareNumbers(left.hit.eValue, right.hit.eValue, 1)
+      || compareNumbers(left.hit.bitScore, right.hit.bitScore, -1)
+      || compareStrings(left.hit.accession, right.hit.accession)
+      || left.originalIndex - right.originalIndex
+    ))
+    .map(({ hit }) => hit);
+}
+
+/**
+ * Result-specific asset references are part of the typed schema even when a
+ * producer does not repeat them in the generic assetIds list.
+ */
+export function artifactAnalysisResultAssetIds(result: ArtifactAnalysisResult): string[] {
+  const ids = new Set(result.assetIds);
+  if (result.kind === 'blast_search') {
+    result.data.hits.forEach((hit) => {
+      if (hit.alignmentAssetId) ids.add(hit.alignmentAssetId);
+    });
+  }
+  if (result.kind === 'structure_model') ids.add(result.data.modelAssetId);
+  if (result.kind === 'report' && result.data.bodyAssetId) ids.add(result.data.bodyAssetId);
+  if (result.kind === 'construct_verification' && result.data.verificationReportAssetId) {
+    ids.add(result.data.verificationReportAssetId);
+  }
+  return Array.from(ids);
+}
+
+export function artifactAnalysisResultAssets(
+  result: ArtifactAnalysisResult,
+  assetsById: ReadonlyMap<string, ArtifactAnalysisAsset>,
+): ArtifactAnalysisAsset[] {
+  return artifactAnalysisResultAssetIds(result)
+    .map((id) => assetsById.get(id))
+    .filter((asset): asset is ArtifactAnalysisAsset => asset !== undefined);
+}
+
+export function resolveArtifactReport(
+  result: ArtifactReportResult,
+  assetsById: ReadonlyMap<string, ArtifactAnalysisAsset>,
+): ResolvedArtifactReport | null {
+  if (result.data.body !== undefined) {
+    return { text: result.data.body, format: result.data.format };
+  }
+  if (!result.data.bodyAssetId) return null;
+  const sourceAsset = assetsById.get(result.data.bodyAssetId);
+  return sourceAsset
+    ? { text: sourceAsset.content, format: result.data.format, sourceAsset }
+    : null;
+}
+
+function startsWithSpreadsheetFormula(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (/\s/u.test(character) || codePoint < 32 || codePoint === 127) continue;
+    return character === '=' || character === '+' || character === '-' || character === '@';
+  }
+  return false;
+}
+
+function tsvCell(value: string | number | boolean | null): string {
+  const rawText = value === null ? '' : String(value);
+  // Spreadsheet applications can execute string cells beginning with formula
+  // markers. Prefix those cells with an apostrophe so copied/downloaded TSV is
+  // interpreted as literal scientific data. Numeric values remain numeric.
+  const text = typeof value === 'string' && startsWithSpreadsheetFormula(value)
+    ? `'${rawText}`
+    : rawText;
+  return /[\t\r\n"]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+/** Serialize every row as spreadsheet-safe TSV; callers invoke this only from explicit actions. */
+export function artifactTableToTsv(data: ArtifactTableData): string {
+  return [
+    data.columns.map((column) => tsvCell(column.label)).join('\t'),
+    ...data.rows.map((row) => row.map(tsvCell).join('\t')),
+  ].join('\n');
+}
+
+function isHighSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
+}
+
+/** Page bounded text without cutting a UTF-16 surrogate pair between pages. */
+export function artifactTextPage(
+  text: string,
+  requestedPage: number,
+  pageSize: number,
+): ArtifactTextPage {
+  if (!Number.isSafeInteger(pageSize) || pageSize < 2) {
+    throw new Error('Text page size must be a safe integer of at least 2.');
+  }
+  const bounds: Array<{ start: number; end: number }> = [];
+  let start = 0;
+  while (start < text.length) {
+    let end = Math.min(text.length, start + pageSize);
+    if (end < text.length && isHighSurrogate(text.charCodeAt(end - 1))) end -= 1;
+    if (end <= start) end = Math.min(text.length, start + pageSize);
+    bounds.push({ start, end });
+    start = end;
+  }
+  if (bounds.length === 0) bounds.push({ start: 0, end: 0 });
+  const normalizedPage = Number.isFinite(requestedPage) ? Math.floor(requestedPage) : 0;
+  const pageIndex = Math.max(0, Math.min(normalizedPage, bounds.length - 1));
+  const active = bounds[pageIndex];
+  return {
+    pageIndex,
+    pageCount: bounds.length,
+    start: active.start,
+    end: active.end,
+    text: text.slice(active.start, active.end),
+  };
+}
+
+const UNSAFE_FILENAME_CHARACTERS = /[<>:"/\\|?*]+/g;
+
+function replaceFilenameControlCharacters(value: string): string {
+  return Array.from(value, (character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (codePoint < 32 || codePoint === 127) return '-';
+    return /\p{Cf}/u.test(character) ? '' : character;
+  }).join('');
+}
+
+export function safeAnalysisFilename(
+  name: string,
+  fallback: string,
+  extension: string,
+): string {
+  const safeExtension = extension.replace(/^\.+/, '').replace(/[^a-z0-9_-]/gi, '') || 'txt';
+  const normalizedStem = replaceFilenameControlCharacters(name)
+    .replace(UNSAFE_FILENAME_CHARACTERS, '-')
+    .replace(/\s+/g, ' ')
+    .replace(/^[. ]+/g, '')
+    .replace(/[. ]+$/g, '')
+    .trim();
+  const stem = Array.from(normalizedStem).slice(0, 120).join('') || fallback;
+  return stem.toLocaleLowerCase().endsWith(`.${safeExtension.toLocaleLowerCase()}`)
+    ? stem
+    : `${stem}.${safeExtension}`;
+}

--- a/src/artifacts/claude-science-download.ts
+++ b/src/artifacts/claude-science-download.ts
@@ -1,0 +1,72 @@
+export type BrowserDownloadReceipt =
+  | {
+      status: 'requested';
+      channel: 'browser';
+      filename: string;
+      message: string;
+    }
+  | {
+      status: 'failed';
+      channel: 'browser';
+      filename: string;
+      message: string;
+    };
+
+function failureMessage(filename: string, cause: unknown): string {
+  const detail = cause instanceof Error && cause.message.trim() ? ` ${cause.message.trim()}` : '';
+  return `Download could not be requested for ${filename}.${detail}`;
+}
+
+export function requestBrowserBlobDownload(
+  filename: string,
+  blob: Blob,
+): BrowserDownloadReceipt {
+  let url: string | null = null;
+  let anchor: HTMLAnchorElement | null = null;
+  try {
+    url = URL.createObjectURL(blob);
+    anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    return {
+      status: 'requested',
+      channel: 'browser',
+      filename,
+      message: `Download requested for ${filename}. Verify the file before relying on it as a checkpoint.`,
+    };
+  } catch (cause) {
+    return {
+      status: 'failed',
+      channel: 'browser',
+      filename,
+      message: failureMessage(filename, cause),
+    };
+  } finally {
+    anchor?.remove();
+    if (url) {
+      const objectUrl = url;
+      const revokeObjectUrl = URL.revokeObjectURL.bind(URL);
+      window.setTimeout(() => revokeObjectUrl(objectUrl), 1_000);
+    }
+  }
+}
+
+export function requestBrowserTextDownload(
+  filename: string,
+  content: string,
+  mime = 'text/plain',
+): BrowserDownloadReceipt {
+  try {
+    const blob = new Blob([content], { type: `${mime};charset=utf-8` });
+    return requestBrowserBlobDownload(filename, blob);
+  } catch (cause) {
+    return {
+      status: 'failed',
+      channel: 'browser',
+      filename,
+      message: failureMessage(filename, cause),
+    };
+  }
+}

--- a/src/artifacts/claude-science-download.ts
+++ b/src/artifacts/claude-science-download.ts
@@ -34,7 +34,7 @@ export function requestBrowserBlobDownload(
       status: 'requested',
       channel: 'browser',
       filename,
-      message: `Download requested for ${filename}. Verify the file before relying on it as a checkpoint.`,
+      message: `Download requested for ${filename}. Verify the file before relying on it.`,
     };
   } catch (cause) {
     return {

--- a/src/artifacts/claude-science-sequence-edit.ts
+++ b/src/artifacts/claude-science-sequence-edit.ts
@@ -1,0 +1,410 @@
+import type {
+  ArtifactJsonObject,
+  ArtifactJsonValue,
+  ArtifactNote,
+  ArtifactSequenceRange,
+} from './claude-science-workspace-collections';
+import type { PortableTranslationTrack } from './claude-science-session';
+
+const RANGE_ANCHOR_METADATA_KEY = 'motifRangeAnchor';
+
+export type SequenceCoordinateEdit = {
+  start: number;
+  deletedLength: number;
+  insertedLength: number;
+  oldLength: number;
+};
+
+export type NoteAnchorSnapshot = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  hadProvenance: boolean;
+  hadProvenanceMetadata: boolean;
+  provenanceSource?: string;
+  provenanceOperation?: string;
+  scope: 'record' | 'range';
+  range?: ArtifactSequenceRange;
+  anchorMetadata?: ArtifactJsonValue;
+};
+
+export type RangeAnchorReview = {
+  status: 'review' | 'detached';
+  previousRange: ArtifactSequenceRange;
+  currentRange?: ArtifactSequenceRange;
+  edit: SequenceCoordinateEdit;
+  editedAt: string;
+};
+
+export type SequenceAnchorEditResult = {
+  notes: ArtifactNote[];
+  translationLayers: PortableTranslationTrack[];
+  adjustedNoteCount: number;
+  detachedNoteCount: number;
+  adjustedLayerCount: number;
+  removedLayerCount: number;
+};
+
+type RangeTransform = {
+  range: ArtifactSequenceRange | null;
+  changed: boolean;
+  overlapsMeaning: boolean;
+};
+
+function isJsonObject(value: ArtifactJsonValue | undefined): value is ArtifactJsonObject {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+function assertSequenceEdit(edit: SequenceCoordinateEdit): void {
+  const nextLength = edit.oldLength - edit.deletedLength + edit.insertedLength;
+  if (
+    !isNonNegativeInteger(edit.start) ||
+    !isNonNegativeInteger(edit.deletedLength) ||
+    !isNonNegativeInteger(edit.insertedLength) ||
+    !isNonNegativeInteger(edit.oldLength) ||
+    edit.start > edit.oldLength ||
+    edit.start + edit.deletedLength > edit.oldLength ||
+    !Number.isSafeInteger(nextLength) ||
+    nextLength < 0
+  ) {
+    throw new Error('Sequence edits must use valid non-negative safe-integer coordinates and lengths.');
+  }
+}
+
+function parseSequenceEdit(value: ArtifactJsonValue | undefined): SequenceCoordinateEdit | null {
+  if (!isJsonObject(value)) return null;
+  const { start, deletedLength, insertedLength, oldLength } = value;
+  if (
+    !isNonNegativeInteger(start) ||
+    !isNonNegativeInteger(deletedLength) ||
+    !isNonNegativeInteger(insertedLength) ||
+    !isNonNegativeInteger(oldLength) ||
+    start > oldLength ||
+    start + deletedLength > oldLength ||
+    !Number.isSafeInteger(oldLength - deletedLength + insertedLength)
+  ) {
+    return null;
+  }
+  return { start, deletedLength, insertedLength, oldLength };
+}
+
+function parseRange(value: ArtifactJsonValue | undefined): ArtifactSequenceRange | null {
+  if (!isJsonObject(value)) return null;
+  const { start, end } = value;
+  if (!isNonNegativeInteger(start) || !isNonNegativeInteger(end) || end <= start) return null;
+  return { start, end };
+}
+
+function rangesEqual(left: ArtifactSequenceRange, right: ArtifactSequenceRange): boolean {
+  return left.start === right.start && left.end === right.end;
+}
+
+export function transformSequenceRange(
+  range: ArtifactSequenceRange,
+  edit: SequenceCoordinateEdit,
+): RangeTransform {
+  assertSequenceEdit(edit);
+  if (
+    range.start < 0 ||
+    !Number.isSafeInteger(range.start) ||
+    !Number.isSafeInteger(range.end) ||
+    range.end <= range.start ||
+    range.end > edit.oldLength
+  ) {
+    throw new Error('Sequence edit and anchor ranges must use valid 0-based half-open coordinates.');
+  }
+  const deleteEnd = edit.start + edit.deletedLength;
+  const deletionOverlaps =
+    edit.deletedLength > 0 && edit.start < range.end && deleteEnd > range.start;
+  const insertionChangesMeaning =
+    edit.insertedLength > 0 && edit.start > range.start && edit.start < range.end;
+
+  let start: number;
+  let end: number;
+  if (edit.deletedLength === 0) {
+    start = range.start;
+    end = range.end;
+    if (edit.start <= start) {
+      start += edit.insertedLength;
+      end += edit.insertedLength;
+    } else if (edit.start < end) {
+      end += edit.insertedLength;
+    }
+  } else if (deleteEnd <= range.start) {
+    const delta = edit.insertedLength - edit.deletedLength;
+    start = range.start + delta;
+    end = range.end + delta;
+  } else if (edit.start >= range.end) {
+    start = range.start;
+    end = range.end;
+  } else {
+    // The edit intersects the anchor. Deleted boundaries clamp to the replacement
+    // interval, while surviving boundaries retain their half-open affinity.
+    start = range.start < edit.start
+      ? range.start
+      : range.start >= deleteEnd
+        ? range.start + edit.insertedLength - edit.deletedLength
+        : edit.start;
+    end = range.end <= edit.start
+      ? range.end
+      : range.end >= deleteEnd
+        ? range.end + edit.insertedLength - edit.deletedLength
+        : edit.start + edit.insertedLength;
+  }
+
+  const transformed = end > start ? { start, end } : null;
+  return {
+    range: transformed,
+    changed: transformed === null || !rangesEqual(range, transformed),
+    overlapsMeaning: deletionOverlaps || insertionChangesMeaning,
+  };
+}
+
+function reviewMetadata(
+  status: RangeAnchorReview['status'],
+  previousRange: ArtifactSequenceRange,
+  currentRange: ArtifactSequenceRange | null,
+  edit: SequenceCoordinateEdit,
+  editedAt: string,
+): ArtifactJsonObject {
+  return {
+    status,
+    previousRange: { ...previousRange },
+    ...(currentRange ? { currentRange: { ...currentRange } } : {}),
+    edit: { ...edit },
+    editedAt,
+  };
+}
+
+function updateNoteAnchor(
+  note: ArtifactNote,
+  transformed: RangeTransform,
+  edit: SequenceCoordinateEdit,
+  editedAt: string,
+): ArtifactNote {
+  const previousRange = note.range as ArtifactSequenceRange;
+  const detached = transformed.range === null;
+  const existingReview = getNoteRangeAnchorReview(note);
+  const needsReview = detached || transformed.overlapsMeaning || existingReview !== null;
+  const preservesExistingReviewCause = existingReview !== null
+    && !detached
+    && !transformed.overlapsMeaning;
+  const reviewPreviousRange = existingReview?.previousRange ?? previousRange;
+  const metadata: ArtifactJsonObject = {
+    ...(note.provenance?.metadata ?? {}),
+    [RANGE_ANCHOR_METADATA_KEY]: needsReview
+      ? reviewMetadata(
+          detached ? 'detached' : 'review',
+          reviewPreviousRange,
+          transformed.range,
+          preservesExistingReviewCause ? existingReview.edit : edit,
+          preservesExistingReviewCause ? existingReview.editedAt : editedAt,
+        )
+      : {
+          status: 'shifted',
+          previousRange: { ...previousRange },
+          ...(transformed.range ? { currentRange: { ...transformed.range } } : {}),
+          edit: { ...edit },
+          editedAt,
+        },
+  };
+
+  return {
+    ...note,
+    scope: detached ? 'record' : 'range',
+    ...(detached ? { range: undefined } : { range: transformed.range as ArtifactSequenceRange }),
+    updatedAt: preservesExistingReviewCause ? note.updatedAt : editedAt,
+    provenance: {
+      ...note.provenance,
+      source: note.provenance?.source ?? 'motif-for-claude-science-artifact',
+      operation: detached
+        ? 'sequence_edit_anchor_detached'
+        : needsReview
+          ? 'sequence_edit_anchor_review'
+          : 'sequence_edit_anchor_shift',
+      metadata,
+    },
+  };
+}
+
+export function applySequenceEditToAnchors(input: {
+  recordId: string;
+  notes: ArtifactNote[];
+  translationLayers: PortableTranslationTrack[];
+  edit: SequenceCoordinateEdit;
+  editedAt: string;
+}): SequenceAnchorEditResult {
+  const { recordId, edit, editedAt } = input;
+  assertSequenceEdit(edit);
+  let adjustedNoteCount = 0;
+  let detachedNoteCount = 0;
+  const notes = input.notes.map((note) => {
+    if (note.scope !== 'range' || note.recordId !== recordId || !note.range) return note;
+    const transformed = transformSequenceRange(note.range, edit);
+    if (!transformed.changed && !transformed.overlapsMeaning) return note;
+    adjustedNoteCount += 1;
+    if (!transformed.range) detachedNoteCount += 1;
+    return updateNoteAnchor(note, transformed, edit, editedAt);
+  });
+
+  let adjustedLayerCount = 0;
+  let removedLayerCount = 0;
+  const translationLayers = input.translationLayers.flatMap((layer) => {
+    const originalLength = layer.end - layer.start;
+    const transformed = transformSequenceRange({ start: layer.start, end: layer.end }, edit);
+    const collapsedByEdit = transformed.range
+      ? originalLength >= 3 && transformed.range.end - transformed.range.start < 3
+      : true;
+    if (!transformed.range || collapsedByEdit) {
+      removedLayerCount += 1;
+      return [];
+    }
+    if (!transformed.changed && !transformed.overlapsMeaning) return [layer];
+    adjustedLayerCount += 1;
+    return [
+      {
+        ...layer,
+        start: transformed.range.start,
+        end: transformed.range.end,
+        ...(layer.needsReview || transformed.overlapsMeaning ? { needsReview: true } : {}),
+      },
+    ];
+  });
+
+  return {
+    notes,
+    translationLayers,
+    adjustedNoteCount,
+    detachedNoteCount,
+    adjustedLayerCount,
+    removedLayerCount,
+  };
+}
+
+export function getNoteRangeAnchorReview(note: ArtifactNote): RangeAnchorReview | null {
+  const raw = note.provenance?.metadata?.[RANGE_ANCHOR_METADATA_KEY];
+  if (!isJsonObject(raw)) return null;
+  if (raw.status !== 'review' && raw.status !== 'detached') return null;
+  const previousRange = parseRange(raw.previousRange);
+  const currentRange = parseRange(raw.currentRange);
+  const edit = parseSequenceEdit(raw.edit);
+  if (!previousRange || !edit || typeof raw.editedAt !== 'string') return null;
+  return {
+    status: raw.status,
+    previousRange,
+    ...(currentRange ? { currentRange } : {}),
+    edit,
+    editedAt: raw.editedAt,
+  };
+}
+
+export function confirmNoteRangeAnchor(note: ArtifactNote, confirmedAt: string): ArtifactNote {
+  if (!getNoteRangeAnchorReview(note)) return note;
+  const metadata = { ...(note.provenance?.metadata ?? {}) };
+  delete metadata[RANGE_ANCHOR_METADATA_KEY];
+  return {
+    ...note,
+    updatedAt: confirmedAt,
+    provenance: {
+      ...note.provenance,
+      source: note.provenance?.source ?? 'motif-for-claude-science-artifact',
+      operation: 'sequence_edit_anchor_confirmed',
+      metadata,
+    },
+  };
+}
+
+export function snapshotNoteAnchors(notes: ArtifactNote[], recordId: string): NoteAnchorSnapshot[] {
+  return notes.flatMap((note) => {
+    if (note.recordId !== recordId || (note.scope !== 'record' && note.scope !== 'range')) return [];
+    const anchorMetadata = note.provenance?.metadata?.[RANGE_ANCHOR_METADATA_KEY];
+    return [
+      {
+        id: note.id,
+        createdAt: note.createdAt,
+        updatedAt: note.updatedAt,
+        hadProvenance: note.provenance !== undefined,
+        hadProvenanceMetadata: note.provenance?.metadata !== undefined,
+        ...(note.provenance?.source ? { provenanceSource: note.provenance.source } : {}),
+        ...(note.provenance?.operation ? { provenanceOperation: note.provenance.operation } : {}),
+        scope: note.scope,
+        ...(note.range ? { range: { ...note.range } } : {}),
+        ...(anchorMetadata !== undefined ? { anchorMetadata } : {}),
+      },
+    ];
+  });
+}
+
+export function restoreNoteAnchors(
+  notes: ArtifactNote[],
+  recordId: string,
+  targetSnapshots: NoteAnchorSnapshot[],
+  expectedCurrentSnapshots: NoteAnchorSnapshot[],
+): ArtifactNote[] {
+  const targetSnapshotsById = new Map(targetSnapshots.map((snapshot) => [snapshot.id, snapshot]));
+  const expectedCurrentSnapshotsById = new Map(
+    expectedCurrentSnapshots.map((snapshot) => [snapshot.id, snapshot]),
+  );
+  return notes.map((note) => {
+    if (note.recordId !== recordId) return note;
+    const snapshot = targetSnapshotsById.get(note.id);
+    if (!snapshot || snapshot.createdAt !== note.createdAt) return note;
+    const expectedCurrent = expectedCurrentSnapshotsById.get(note.id);
+    const currentAnchorMetadata = note.provenance?.metadata?.[RANGE_ANCHOR_METADATA_KEY];
+    const currentMatchesExpectedSnapshot = expectedCurrent !== undefined
+      && expectedCurrent.createdAt === note.createdAt
+      && expectedCurrent.updatedAt === note.updatedAt
+      && expectedCurrent.scope === note.scope
+      && (
+        expectedCurrent.range === undefined
+          ? note.range === undefined
+          : note.range !== undefined && rangesEqual(expectedCurrent.range, note.range)
+      )
+      && expectedCurrent.hadProvenance === (note.provenance !== undefined)
+      && expectedCurrent.hadProvenanceMetadata === (note.provenance?.metadata !== undefined)
+      && expectedCurrent.provenanceSource === note.provenance?.source
+      && expectedCurrent.provenanceOperation === note.provenance?.operation
+      && JSON.stringify(expectedCurrent.anchorMetadata) === JSON.stringify(currentAnchorMetadata);
+    const independentNoteEdit = !currentMatchesExpectedSnapshot;
+    const metadata = { ...(note.provenance?.metadata ?? {}) };
+    if (snapshot.anchorMetadata === undefined) {
+      delete metadata[RANGE_ANCHOR_METADATA_KEY];
+    } else {
+      metadata[RANGE_ANCHOR_METADATA_KEY] = snapshot.anchorMetadata;
+    }
+    const restoredProvenance = independentNoteEdit
+      ? note.provenance && {
+          ...note.provenance,
+          ...(Object.keys(metadata).length > 0 || note.provenance.metadata !== undefined
+            ? { metadata }
+            : { metadata: undefined }),
+        }
+      : !snapshot.hadProvenance
+        ? undefined
+        : {
+            ...(note.provenance as NonNullable<ArtifactNote['provenance']>),
+            source: snapshot.provenanceSource
+              ?? note.provenance?.source
+              ?? 'motif-for-claude-science-artifact',
+            ...(snapshot.provenanceOperation
+              ? { operation: snapshot.provenanceOperation }
+              : { operation: undefined }),
+            ...(
+              snapshot.hadProvenanceMetadata || snapshot.anchorMetadata !== undefined
+                ? { metadata }
+                : { metadata: undefined }
+            ),
+          };
+    return {
+      ...note,
+      scope: snapshot.scope,
+      ...(snapshot.range ? { range: { ...snapshot.range } } : { range: undefined }),
+      updatedAt: independentNoteEdit ? note.updatedAt : snapshot.updatedAt,
+      provenance: restoredProvenance,
+    };
+  });
+}

--- a/src/artifacts/claude-science-session.ts
+++ b/src/artifacts/claude-science-session.ts
@@ -39,6 +39,7 @@ export type PortableTranslationTrack = {
   frame: 0 | 1 | 2;
   source: 'layer';
   color?: string;
+  needsReview?: boolean;
 };
 
 export type ArtifactDurableState = {
@@ -228,7 +229,20 @@ function normalizeTranslationLayers(
       if (frame === null) throw new Error(`${path}.frame must be 0, 1, or 2.`);
       const color = raw.color === undefined ? undefined : requiredString(raw.color, `${path}.color`, 32);
       if (color && !/^#[0-9a-f]{6}$/i.test(color)) throw new Error(`${path}.color must be a 6-digit hex color.`);
-      return { id: uniqueId(baseId, usedIds), label, start, end, strand, frame, source: 'layer', color };
+      if (raw.needsReview !== undefined && typeof raw.needsReview !== 'boolean') {
+        throw new Error(`${path}.needsReview must be a boolean.`);
+      }
+      return {
+        id: uniqueId(baseId, usedIds),
+        label,
+        start,
+        end,
+        strand,
+        frame,
+        source: 'layer',
+        color,
+        ...(raw.needsReview ? { needsReview: true } : {}),
+      };
     });
   }
   return result;

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -166,7 +166,21 @@ import {
   parseArtifactDatabaseJson,
   parseArtifactRecordJson,
   type ArtifactDurableState,
+  type PortableTranslationTrack,
 } from './claude-science-session';
+import {
+  applySequenceEditToAnchors,
+  confirmNoteRangeAnchor,
+  restoreNoteAnchors,
+  snapshotNoteAnchors,
+  type NoteAnchorSnapshot,
+  type SequenceCoordinateEdit,
+} from './claude-science-sequence-edit';
+import {
+  requestBrowserBlobDownload,
+  requestBrowserTextDownload,
+  type BrowserDownloadReceipt,
+} from './claude-science-download';
 import './motif-artifact.css';
 
 const MOTIF_ARTIFACT_VERSION = '0.2.1';
@@ -372,6 +386,7 @@ type PreparedArtifactDatabaseRestore = ReturnType<typeof prepareArtifactDatabase
 type PendingArtifactDatabaseRestore = {
   prepared: PreparedArtifactDatabaseRestore;
   sourceLabel: string;
+  durability: 'durable-checkpoint' | 'session-hydration';
   returnFocus: HTMLElement | null;
 };
 
@@ -433,6 +448,7 @@ type MotifArtifactErrorCode =
   | 'MOTIF_INPUT_LIMIT_EXCEEDED'
   | 'MOTIF_INVALID_ALIGNMENT_INPUT'
   | 'MOTIF_INVALID_WORKSPACE_INPUT'
+  | 'MOTIF_UNSAVED_WORKSPACE'
   | 'MOTIF_INVALID_PRELOAD';
 type MotifArtifactErrorDetails = Record<string, unknown>;
 
@@ -908,7 +924,10 @@ declare global {
     motifGetAnalysisWorkspace?: () => { analysisResults: ArtifactAnalysisResult[]; analysisAssets: ArtifactAnalysisAsset[] };
     motifRemoveAnalysisResults?: (resultIdOrIds: string | string[]) => number;
     motifGetWorkspace?: () => Record<string, unknown>;
-    motifReplaceWorkspace?: (payload: ArtifactPayload) => number;
+    motifReplaceWorkspace?: (
+      payload: ArtifactPayload,
+      options?: { discardUnsavedChanges?: boolean },
+    ) => number;
     motifRemoveRecords?: (recordIdOrIds: string | string[]) => number;
     motifClearWorkspace?: () => void;
     motifDescribe?: () => RecordSummary | null;
@@ -970,7 +989,7 @@ const MOTIF_HELP_API: Record<string, string> = {
   'motifGetAnalysisWorkspace()': 'Return defensive snapshots of typed analysis results and their inert assets.',
   'motifRemoveAnalysisResults(resultIdOrIds)': 'Remove analysis results only when no other result depends on them; returns number removed.',
   'motifGetWorkspace()': 'Return a complete defensive workspace snapshot suitable for motifReplaceWorkspace or JSON backup.',
-  'motifReplaceWorkspace(payload)': 'Validate and replace records, alignments, notes, workflow results, and durable state atomically.',
+  'motifReplaceWorkspace(payload, options?)': 'Validate and replace records, alignments, notes, results, and durable state atomically as a session baseline. A dirty workspace is preserved unless options.discardUnsavedChanges is explicitly true.',
   'motifRemoveRecords(recordIdOrIds)': 'Remove records and dependent notes/workflow results transactionally; returns number removed.',
   'motifClearWorkspace()': 'Clear all workspace data while retaining display preferences.',
   'motifDescribe()': 'Return a text summary of the active record + current selection.',
@@ -1003,7 +1022,7 @@ const MOTIF_HELP: MotifHelp = {
     notes: 'Save workspace, record, or selected-range notes in the Tools pane or with motifAddNotes(...). Markdown is stored as inert text.',
     workflowHistory: 'Store digest, gel, Golden Gate, and ligation result summaries with explicit input/output record ids and engine provenance.',
     analysisResults: 'Store typed primer, PCR, assembly, construct-verification, BLAST, structure, report, or table results. The UI renders supplied content as inert text/data only.',
-    backupRecovery: 'motifGetWorkspace() and Settings → Data & recovery produce a complete v2 JSON snapshot; motifReplaceWorkspace(...) restores it transactionally.',
+    backupRecovery: 'motifGetWorkspace() and Settings → Data & recovery produce a complete v2 JSON snapshot. A browser download is only a request until the file is verified; restoring a selected JSON file establishes a durable checkpoint. motifReplaceWorkspace(...) hydrates a session baseline transactionally.',
     exportInventory: 'The export panel can produce database JSON, CSV, FASTA, multi-FASTA, basic GenBank, HTML/Markdown report, PDF via print, and ZIP. Workspace data lives in this artifact session, so export JSON or ZIP before reloading.',
   },
   agentRules: [
@@ -4192,7 +4211,37 @@ type EditSnapshot = {
   features: readonly Feature[];
   sites: readonly RestrictionSite[];
   sangerTrace?: SangerTraceData;
+  noteAnchors: NoteAnchorSnapshot[];
+  hadTranslationLayerEntry: boolean;
+  translationLayers: PortableTranslationTrack[];
+  selectedTranslationLayerId: string | null;
 };
+
+type EditTransaction = {
+  before: EditSnapshot;
+  after: EditSnapshot;
+};
+
+function portableTranslationLayersByRecord(
+  value: Readonly<Record<string, readonly InlineTranslationTrack[]>>,
+): Record<string, PortableTranslationTrack[]> {
+  return Object.fromEntries(
+    Object.entries(value).map(([id, layers]) => [
+      id,
+      layers.map((layer) => ({
+        id: layer.id,
+        label: layer.label,
+        start: layer.start,
+        end: layer.end,
+        strand: layer.strand,
+        frame: layer.frame,
+        source: 'layer' as const,
+        color: layer.color,
+        ...(layer.needsReview ? { needsReview: true } : {}),
+      })),
+    ]),
+  );
+}
 
 // Accepted keystrokes for base editing: canonical bases + IUPAC ambiguity codes.
 const DNA_EDIT_ALPHABET = 'ACGTRYSWKMBDHVN';
@@ -4410,21 +4459,7 @@ function App() {
   const activeThemeLabel = THEME_OPTIONS.find((option) => option.id === theme)?.label ?? 'Light';
   const artifactState = useMemo<ArtifactDurableState>(() => ({
     customEnzymes: customEnzymes.map((enzyme) => ({ ...enzyme })),
-    translationLayersByRecord: Object.fromEntries(
-      Object.entries(translationLayersByRecord).map(([id, layers]) => [
-        id,
-        layers.map((layer) => ({
-          id: layer.id,
-          label: layer.label,
-          start: layer.start,
-          end: layer.end,
-          strand: layer.strand,
-          frame: layer.frame,
-          source: 'layer' as const,
-          color: layer.color,
-        })),
-      ]),
-    ),
+    translationLayersByRecord: portableTranslationLayersByRecord(translationLayersByRecord),
     enzymeSourcesByRecord: Object.fromEntries(
       Object.entries(enzymeSourcesByRecord).map(([id, sources]) => [id, [...sources]]),
     ),
@@ -4449,13 +4484,32 @@ function App() {
   useEffect(() => {
     artifactStateRef.current = artifactState;
   }, [artifactState]);
+  const updateTranslationLayers = useCallback((
+    updater: (current: Record<string, InlineTranslationTrack[]>) => Record<string, InlineTranslationTrack[]>,
+  ) => {
+    setTranslationLayersByRecord((current) => {
+      const next = updater(current);
+      if (next === current) return current;
+      artifactStateRef.current = {
+        ...artifactStateRef.current,
+        translationLayersByRecord: portableTranslationLayersByRecord(next),
+      };
+      return next;
+    });
+  }, []);
   const currentDurableFingerprint = useMemo(
     () => artifactDurableFingerprint(payload, artifactState),
     [artifactState, payload],
   );
   const [savedDurableFingerprint, setSavedDurableFingerprint] = useState(() => currentDurableFingerprint);
+  const savedDurableFingerprintRef = useRef(savedDurableFingerprint);
   const [hasSessionCheckpoint, setHasSessionCheckpoint] = useState(false);
   const hasUnsavedChanges = currentDurableFingerprint !== savedDurableFingerprint;
+  const establishSessionBaseline = useCallback((fingerprint: string, hasDurableCheckpoint: boolean) => {
+    savedDurableFingerprintRef.current = fingerprint;
+    setSavedDurableFingerprint(fingerprint);
+    setHasSessionCheckpoint(hasDurableCheckpoint);
+  }, []);
   const showWorkbenchNotice = useCallback((message: string, tone: WorkbenchNotice['tone'] = 'status') => {
     if (workbenchNoticeTimerRef.current !== null) window.clearTimeout(workbenchNoticeTimerRef.current);
     setWorkbenchNotice({ message, tone });
@@ -4752,6 +4806,12 @@ function App() {
   const selectRecord = useCallback((nextRecordId: string) => {
     rememberActiveSequenceScroll();
     setSelection(null);
+    const current = payloadRef.current;
+    if (current.selectedRecordId !== nextRecordId) {
+      const nextPayload = { ...current, selectedRecordId: nextRecordId };
+      payloadRef.current = nextPayload;
+      setPayload(nextPayload);
+    }
     selectedRecordIdRef.current = nextRecordId;
     setSelectedRecordId(nextRecordId);
   }, [rememberActiveSequenceScroll]);
@@ -4911,7 +4971,7 @@ function App() {
       : { full: 'no active record', compact: 'empty' };
   const [caret, setCaret] = useState<number | null>(null);
   const [insertMode, setInsertMode] = useState(false);
-  const editHistoryRef = useRef<Record<string, { undo: EditSnapshot[]; redo: EditSnapshot[] }>>({});
+  const editHistoryRef = useRef<Record<string, { undo: EditTransaction[]; redo: EditTransaction[] }>>({});
   const [, bumpEditHistory] = useReducer((tick: number) => tick + 1, 0);
   const canUndo = (editHistoryRef.current[recordId]?.undo.length ?? 0) > 0;
   const canRedo = (editHistoryRef.current[recordId]?.redo.length ?? 0) > 0;
@@ -4994,6 +5054,7 @@ function App() {
   const applyArtifactDatabaseRestore = useCallback((
     restored: PreparedArtifactDatabaseRestore,
     sourceLabel = 'Database JSON',
+    durability: 'durable-checkpoint' | 'session-hydration' = 'durable-checkpoint',
   ): number => {
     const restoredSelectedRecord = restored.payload.records.find(
       (record) => record.id === restored.payload.selectedRecordId,
@@ -5034,8 +5095,10 @@ function App() {
       restored.payload.selectedRecordId,
       restoredSources,
     );
-    setSavedDurableFingerprint(artifactDurableFingerprint(restored.payload, restored.artifactState));
-    setHasSessionCheckpoint(true);
+    establishSessionBaseline(
+      artifactDurableFingerprint(restored.payload, restored.artifactState),
+      durability === 'durable-checkpoint',
+    );
     const count = restored.payload.records.length;
     setDropState({
       active: true,
@@ -5043,12 +5106,13 @@ function App() {
     });
     window.setTimeout(() => setDropState({ active: false, message: '' }), 2200);
     return count;
-  }, [describeRuntimePayloadSnapshot, rememberActiveSequenceScroll, resetRecordTransientState, resetWorkflowWindowState]);
+  }, [describeRuntimePayloadSnapshot, establishSessionBaseline, rememberActiveSequenceScroll, resetRecordTransientState, resetWorkflowWindowState]);
 
   const requestArtifactDatabaseRestore = useCallback((
     rawDatabase: Record<string, unknown>,
     sourceLabel = 'Database JSON',
     requestedReturnFocus: HTMLElement | null = null,
+    durability: 'durable-checkpoint' | 'session-hydration' = 'session-hydration',
   ): number => {
     // Fully validate and normalize both halves before showing the destructive
     // confirmation. Confirming therefore performs one prepared, transactional
@@ -5068,6 +5132,7 @@ function App() {
     setPendingDatabaseRestore({
       prepared,
       sourceLabel,
+      durability,
       returnFocus,
     });
     return prepared.payload.records.length;
@@ -5096,9 +5161,9 @@ function App() {
 
   const confirmArtifactDatabaseRestore = useCallback(() => {
     if (!pendingDatabaseRestore) return;
-    const { prepared, sourceLabel } = pendingDatabaseRestore;
+    const { prepared, sourceLabel, durability } = pendingDatabaseRestore;
     setPendingDatabaseRestore(null);
-    applyArtifactDatabaseRestore(prepared, sourceLabel);
+    applyArtifactDatabaseRestore(prepared, sourceLabel, durability);
     bumpConfirmedDatabaseRestoreCount();
     window.requestAnimationFrame(() => {
       document.querySelector<HTMLButtonElement>('.motif-cs-record-tab[data-active="true"]')?.focus({ preventScroll: true });
@@ -5204,11 +5269,6 @@ function App() {
     window.addEventListener('beforeunload', warnBeforeReload);
     return () => window.removeEventListener('beforeunload', warnBeforeReload);
   }, [hasUnsavedChanges]);
-
-  const markSessionSaved = useCallback(() => {
-    setSavedDurableFingerprint(currentDurableFingerprint);
-    setHasSessionCheckpoint(true);
-  }, [currentDurableFingerprint]);
 
   useEffect(() => {
     selectedRecordIdRef.current = selectedRecordId;
@@ -5601,13 +5661,38 @@ function App() {
       }
     };
     window.motifGetWorkspace = () => createArtifactDatabaseSnapshot(payloadRef.current, artifactStateRef.current);
-    window.motifReplaceWorkspace = (rawWorkspace) => {
+    window.motifReplaceWorkspace = (rawWorkspace, options) => {
       try {
+        const prepared = prepareArtifactDatabaseRestore(
+          rawWorkspace as Record<string, unknown>,
+          selectedRecordIdRef.current,
+        );
+        const currentFingerprint = artifactDurableFingerprint(payloadRef.current, artifactStateRef.current);
+        const incomingFingerprint = artifactDurableFingerprint(prepared.payload, prepared.artifactState);
+        if (incomingFingerprint === currentFingerprint) {
+          const requestedRecordId = prepared.payload.selectedRecordId;
+          if (requestedRecordId !== selectedRecordIdRef.current) {
+            selectRecord(requestedRecordId);
+          }
+          return prepared.payload.records.length;
+        }
+        if (
+          currentFingerprint !== savedDurableFingerprintRef.current
+          && options?.discardUnsavedChanges !== true
+        ) {
+          throw new MotifArtifactRuntimeError(
+            'MOTIF_UNSAVED_WORKSPACE',
+            'The current workspace has unsaved changes and was preserved. Export and verify a backup, or retry with { discardUnsavedChanges: true } for an intentional replacement.',
+            { operation: 'motifReplaceWorkspace', mutated: false, hasUnsavedChanges: true },
+          );
+        }
         return applyArtifactDatabaseRestore(
-          prepareArtifactDatabaseRestore(rawWorkspace as Record<string, unknown>, selectedRecordIdRef.current),
+          prepared,
           'Runtime workspace',
+          'session-hydration',
         );
       } catch (cause) {
+        if (cause instanceof MotifArtifactRuntimeError) throw cause;
         throw new MotifArtifactRuntimeError(
           'MOTIF_INVALID_WORKSPACE_INPUT',
           cause instanceof Error ? cause.message : 'The workspace payload is invalid.',
@@ -5644,7 +5729,7 @@ function App() {
       delete window.motifClearWorkspace;
       delete window.motifHelp;
     };
-  }, [applyArtifactDatabaseRestore, clearWorkspaceData, describeRuntimePayloadSnapshot, rememberActiveSequenceScroll, removeRecords, resetWorkflowWindowState, resetWorkspaceViewState]);
+  }, [applyArtifactDatabaseRestore, clearWorkspaceData, describeRuntimePayloadSnapshot, rememberActiveSequenceScroll, removeRecords, resetWorkflowWindowState, resetWorkspaceViewState, selectRecord]);
 
   useEffect(() => {
     setSelection((current) => {
@@ -6321,70 +6406,236 @@ function App() {
 
   // ── Base editing ──────────────────────────────────────────────────────────
   // Mutations run through the real Motif mutate engine (feature/subRange
-  // coordinates shift automatically). Each edit snapshots the record for undo,
-  // and clears pre-baked sites so the live restriction scan recomputes.
-  const commitEdit = useCallback((result: MutationResult, caretAfter: number) => {
+  // coordinates shift automatically). One transaction also remaps range notes
+  // and pinned translations before either React state is committed.
+  const captureEditSnapshot = useCallback((): EditSnapshot | null => {
+    const current = payloadRef.current;
+    const currentRecord = current.records.find((record) => record.id === recordId);
+    if (!currentRecord) return null;
+    return {
+      sequence: currentRecord.sequence,
+      features: currentRecord.features.map((feature) => ({ ...feature })),
+      sites: currentRecord.sites.map((site) => ({ ...site })),
+      sangerTrace: currentRecord.sangerTrace,
+      noteAnchors: snapshotNoteAnchors(current.notes, recordId),
+      hadTranslationLayerEntry: Object.prototype.hasOwnProperty.call(
+        artifactStateRef.current.translationLayersByRecord,
+        recordId,
+      ),
+      translationLayers: (artifactStateRef.current.translationLayersByRecord[recordId] ?? [])
+        .map((layer) => ({ ...layer })),
+      selectedTranslationLayerId: selectedTranslationLayerByRecord[recordId] ?? null,
+    };
+  }, [recordId, selectedTranslationLayerByRecord]);
+
+  const commitEdit = useCallback((
+    result: MutationResult,
+    caretAfter: number,
+    edit: SequenceCoordinateEdit,
+  ) => {
     if (result.raw.length > MOTIF_MAX_RECORD_LENGTH) {
       showWorkbenchNotice(`Records are limited to ${MOTIF_MAX_RECORD_LENGTH.toLocaleString()} residues. Delete bases or split the record before inserting more.`, 'error');
       return;
     }
+    const current = payloadRef.current;
+    const recordIndex = current.records.findIndex((record) => record.id === recordId);
+    const currentRecord = current.records[recordIndex];
+    if (!currentRecord) return;
+    if (
+      edit.oldLength !== currentRecord.sequence.length
+      || result.raw.length !== edit.oldLength - edit.deletedLength + edit.insertedLength
+    ) {
+      showWorkbenchNotice('The edit was rejected because its coordinate transaction did not match the active sequence.', 'error');
+      return;
+    }
+
+    const before = captureEditSnapshot();
+    if (!before) return;
+    const editedAt = new Date().toISOString();
+    const anchors = applySequenceEditToAnchors({
+      recordId,
+      notes: current.notes,
+      translationLayers: artifactStateRef.current.translationLayersByRecord[recordId] ?? [],
+      edit,
+      editedAt,
+    });
+    const records = [...current.records];
+    records[recordIndex] = {
+      ...currentRecord,
+      sequence: result.raw,
+      features: result.features,
+      sites: [],
+      sangerTrace: undefined,
+    };
+    const recordLengths = new Map(records.map((record) => [record.id, record.sequence.length]));
+    const collections = normalizeArtifactWorkspaceCollections({
+      notes: anchors.notes,
+      workflowResults: current.workflowResults,
+    }, {
+      recordLengths,
+      allowMissingWorkflowOutputRecords: true,
+    });
+    const nextPayload: LoadedPayload = {
+      ...current,
+      records,
+      notes: collections.notes,
+      workflowResults: collections.workflowResults,
+    };
+    const nextTranslationLayersByRecord = { ...artifactStateRef.current.translationLayersByRecord };
+    if (before.hadTranslationLayerEntry || anchors.translationLayers.length > 0) {
+      nextTranslationLayersByRecord[recordId] = anchors.translationLayers;
+    } else {
+      delete nextTranslationLayersByRecord[recordId];
+    }
+    const nextArtifactState = normalizeArtifactDurableState({
+      ...artifactStateRef.current,
+      translationLayersByRecord: nextTranslationLayersByRecord,
+    }, recordLengths);
+
+    // Validate the complete checkpoint shape before publishing either half of
+    // the transaction. This prevents recovery effects from observing sidecars
+    // against a sequence length they no longer satisfy.
+    createArtifactDatabaseSnapshot(nextPayload, nextArtifactState);
+    const after: EditSnapshot = {
+      sequence: result.raw,
+      features: result.features.map((feature) => ({ ...feature })),
+      sites: [],
+      sangerTrace: undefined,
+      noteAnchors: snapshotNoteAnchors(nextPayload.notes, recordId),
+      hadTranslationLayerEntry: Object.prototype.hasOwnProperty.call(
+        nextArtifactState.translationLayersByRecord,
+        recordId,
+      ),
+      translationLayers: anchors.translationLayers.map((layer) => ({ ...layer })),
+      selectedTranslationLayerId: before.selectedTranslationLayerId
+        && anchors.translationLayers.some((layer) => layer.id === before.selectedTranslationLayerId)
+        ? before.selectedTranslationLayerId
+        : null,
+    };
     const store = editHistoryRef.current[recordId] ?? { undo: [], redo: [] };
     editHistoryRef.current[recordId] = {
-      undo: [...store.undo, { sequence, features, sites: vector.sites, sangerTrace: vector.sangerTrace }].slice(-200),
+      undo: [...store.undo, { before, after }].slice(-200),
       redo: [],
     };
-    setPayload((current) => {
-      const idx = current.records.findIndex((r) => r.id === recordId);
-      if (idx < 0) return current;
-      const records = [...current.records];
-      records[idx] = { ...records[idx], sequence: result.raw, features: result.features, sites: [], sangerTrace: undefined };
-      return { ...current, records };
+    payloadRef.current = nextPayload;
+    artifactStateRef.current = nextArtifactState;
+    setPayload(nextPayload);
+    setTranslationLayersByRecord(nextArtifactState.translationLayersByRecord);
+    const notices = [
+      ...(currentRecord.sangerTrace
+        ? ['The edited sequence is no longer linked to its original chromatogram. Undo restores the trace.']
+        : []),
+      ...(anchors.detachedNoteCount > 0
+        ? [`${anchors.detachedNoteCount} fully deleted range note${anchors.detachedNoteCount === 1 ? ' was' : 's were'} retained at record level for review.`]
+        : anchors.adjustedNoteCount > 0
+          ? [`${anchors.adjustedNoteCount} range note anchor${anchors.adjustedNoteCount === 1 ? '' : 's'} updated.`]
+          : []),
+      ...(anchors.removedLayerCount > 0
+        ? [`${anchors.removedLayerCount} collapsed translation layer${anchors.removedLayerCount === 1 ? ' was' : 's were'} removed; Undo restores it.`]
+        : anchors.adjustedLayerCount > 0
+          ? [`${anchors.adjustedLayerCount} translation anchor${anchors.adjustedLayerCount === 1 ? '' : 's'} updated.`]
+          : []),
+    ];
+    if (notices.length > 0) showWorkbenchNotice(notices.join(' '), 'status');
+    setSelectedTranslationLayerByRecord((selected) => {
+      const selectedId = selected[recordId];
+      if (!selectedId || anchors.translationLayers.some((layer) => layer.id === selectedId)) return selected;
+      return { ...selected, [recordId]: null };
     });
-    if (vector.sangerTrace) {
-      showWorkbenchNotice('The edited sequence is no longer linked to its original chromatogram. Undo restores the trace.', 'status');
-    }
     setLockedTranslateTarget(null);
     setSelection(null);
     setMapRangesByRecord((cur) => (cur[recordId] ? { ...cur, [recordId]: null } : cur));
     setCaret(clamp(caretAfter, 0, result.raw.length));
     bumpEditHistory();
-  }, [recordId, sequence, features, showWorkbenchNotice, vector.sangerTrace, vector.sites]);
+  }, [captureEditSnapshot, recordId, showWorkbenchNotice]);
 
-  const restoreSnapshot = useCallback((snap: EditSnapshot) => {
-    setPayload((current) => {
-      const idx = current.records.findIndex((r) => r.id === recordId);
-      if (idx < 0) return current;
-      const records = [...current.records];
-      records[idx] = {
-        ...records[idx],
-        sequence: snap.sequence,
-        features: snap.features as Feature[],
-        sites: snap.sites as RestrictionSite[],
-        sangerTrace: snap.sangerTrace,
-      };
-      return { ...current, records };
+  const restoreSnapshot = useCallback((snap: EditSnapshot, expectedCurrent: EditSnapshot) => {
+    const current = payloadRef.current;
+    const recordIndex = current.records.findIndex((record) => record.id === recordId);
+    if (recordIndex < 0) return;
+    const records = [...current.records];
+    records[recordIndex] = {
+      ...records[recordIndex],
+      sequence: snap.sequence,
+      features: snap.features as Feature[],
+      sites: snap.sites as RestrictionSite[],
+      sangerTrace: snap.sangerTrace,
+    };
+    const recordLengths = new Map(records.map((record) => [record.id, record.sequence.length]));
+    const restoredNotes = restoreNoteAnchors(
+      current.notes,
+      recordId,
+      snap.noteAnchors,
+      expectedCurrent.noteAnchors,
+    );
+    const collections = normalizeArtifactWorkspaceCollections({
+      notes: restoredNotes,
+      workflowResults: current.workflowResults,
+    }, {
+      recordLengths,
+      allowMissingWorkflowOutputRecords: true,
     });
+    const nextPayload: LoadedPayload = {
+      ...current,
+      records,
+      notes: collections.notes,
+      workflowResults: collections.workflowResults,
+    };
+    const restoredTranslationLayersByRecord = {
+      ...artifactStateRef.current.translationLayersByRecord,
+    };
+    if (snap.hadTranslationLayerEntry || snap.translationLayers.length > 0) {
+      restoredTranslationLayersByRecord[recordId] = snap.translationLayers;
+    } else {
+      delete restoredTranslationLayersByRecord[recordId];
+    }
+    const nextArtifactState = normalizeArtifactDurableState({
+      ...artifactStateRef.current,
+      translationLayersByRecord: restoredTranslationLayersByRecord,
+    }, recordLengths);
+    createArtifactDatabaseSnapshot(nextPayload, nextArtifactState);
+    payloadRef.current = nextPayload;
+    artifactStateRef.current = nextArtifactState;
+    setPayload(nextPayload);
+    setTranslationLayersByRecord(nextArtifactState.translationLayersByRecord);
+    setSelectedTranslationLayerByRecord((selected) => ({
+      ...selected,
+      [recordId]: snap.selectedTranslationLayerId
+        && snap.translationLayers.some((layer) => layer.id === snap.selectedTranslationLayerId)
+        ? snap.selectedTranslationLayerId
+        : null,
+    }));
   }, [recordId]);
 
   const undoEdit = useCallback(() => {
     const store = editHistoryRef.current[recordId];
     if (!store || store.undo.length === 0) return;
-    const prev = store.undo[store.undo.length - 1];
-    editHistoryRef.current[recordId] = { undo: store.undo.slice(0, -1), redo: [...store.redo, { sequence, features, sites: vector.sites, sangerTrace: vector.sangerTrace }] };
-    restoreSnapshot(prev);
-    setCaret((c) => (c === null ? null : clamp(c, 0, prev.sequence.length)));
+    const transaction = store.undo[store.undo.length - 1];
+    const currentAfter = captureEditSnapshot() ?? transaction.after;
+    const liveTransaction = { ...transaction, after: currentAfter };
+    restoreSnapshot(liveTransaction.before, transaction.after);
+    editHistoryRef.current[recordId] = {
+      undo: store.undo.slice(0, -1),
+      redo: [...store.redo, liveTransaction],
+    };
+    setCaret((c) => (c === null ? null : clamp(c, 0, liveTransaction.before.sequence.length)));
     bumpEditHistory();
-  }, [recordId, sequence, features, vector.sangerTrace, vector.sites, restoreSnapshot]);
+  }, [captureEditSnapshot, recordId, restoreSnapshot]);
 
   const redoEdit = useCallback(() => {
     const store = editHistoryRef.current[recordId];
     if (!store || store.redo.length === 0) return;
-    const next = store.redo[store.redo.length - 1];
-    editHistoryRef.current[recordId] = { undo: [...store.undo, { sequence, features, sites: vector.sites, sangerTrace: vector.sangerTrace }], redo: store.redo.slice(0, -1) };
-    restoreSnapshot(next);
-    setCaret((c) => (c === null ? null : clamp(c, 0, next.sequence.length)));
+    const transaction = store.redo[store.redo.length - 1];
+    const currentBefore = captureEditSnapshot() ?? transaction.before;
+    const liveTransaction = { ...transaction, before: currentBefore };
+    restoreSnapshot(liveTransaction.after, transaction.before);
+    editHistoryRef.current[recordId] = {
+      undo: [...store.undo, liveTransaction],
+      redo: store.redo.slice(0, -1),
+    };
+    setCaret((c) => (c === null ? null : clamp(c, 0, liveTransaction.after.sequence.length)));
     bumpEditHistory();
-  }, [recordId, sequence, features, vector.sangerTrace, vector.sites, restoreSnapshot]);
+  }, [captureEditSnapshot, recordId, restoreSnapshot]);
 
   const handlePlaceCaret = useCallback((index: number) => {
     setLockedTranslateTarget(null);
@@ -6412,8 +6663,8 @@ function App() {
       case 'ArrowRight': event.preventDefault(); setCaret(Math.min(len, c + 1)); return;
       case 'Home': event.preventDefault(); setCaret(0); return;
       case 'End': event.preventDefault(); setCaret(len); return;
-      case 'Backspace': event.preventDefault(); if (c > 0) commitEdit(applyDeletion(sequence, [], featureList, c - 1, 1), c - 1); return;
-      case 'Delete': event.preventDefault(); if (c < len) commitEdit(applyDeletion(sequence, [], featureList, c, 1), c); return;
+      case 'Backspace': event.preventDefault(); if (c > 0) commitEdit(applyDeletion(sequence, [], featureList, c - 1, 1), c - 1, { start: c - 1, deletedLength: 1, insertedLength: 0, oldLength: len }); return;
+      case 'Delete': event.preventDefault(); if (c < len) commitEdit(applyDeletion(sequence, [], featureList, c, 1), c, { start: c, deletedLength: 1, insertedLength: 0, oldLength: len }); return;
       default: break;
     }
     if (event.key.length === 1) {
@@ -6422,9 +6673,13 @@ function App() {
       if (!alphabet.includes(ch)) return;
       event.preventDefault();
       if (insertMode || c >= len) {
-        commitEdit(applyInsertion(sequence, [], featureList, c - 1, ch), c + 1);
+        commitEdit(applyInsertion(sequence, [], featureList, c - 1, ch), c + 1, { start: c, deletedLength: 0, insertedLength: 1, oldLength: len });
       } else {
-        commitEdit(applySubstitution(sequence, [], featureList, c, ch), c + 1);
+        if (sequence[c]?.toUpperCase() === ch) {
+          setCaret(c + 1);
+          return;
+        }
+        commitEdit(applySubstitution(sequence, [], featureList, c, ch), c + 1, { start: c, deletedLength: 1, insertedLength: 1, oldLength: len });
       }
     }
   }, [isEditable, caret, sequence, features, sequenceType, insertMode, commitEdit, undoEdit, redoEdit]);
@@ -6439,7 +6694,11 @@ function App() {
       showWorkbenchNotice(`This paste would exceed the ${MOTIF_MAX_RECORD_LENGTH.toLocaleString()}-residue record limit.`, 'error');
       return;
     }
-    commitEdit(applyInsertion(sequence, [], features as Feature[], caret - 1, pasted), caret + pasted.length);
+    commitEdit(
+      applyInsertion(sequence, [], features as Feature[], caret - 1, pasted),
+      caret + pasted.length,
+      { start: caret, deletedLength: 0, insertedLength: pasted.length, oldLength: sequence.length },
+    );
   }, [caret, commitEdit, features, isEditable, sequence, sequenceType, showWorkbenchNotice]);
 
   const addRecords = useCallback((recordInputs: readonly ArtifactRecordInput[]): number => {
@@ -6718,7 +6977,7 @@ function App() {
       }
       const [{ file, database }] = databaseFiles;
       try {
-        requestArtifactDatabaseRestore(database, file.name);
+        requestArtifactDatabaseRestore(database, file.name, null, 'durable-checkpoint');
         return { records: [], message: `Review the ${file.name} workspace restore.`, tone: 'status' };
       } catch (error) {
         const message = `${file.name}: ${actionableImportError(error)}`;
@@ -7089,7 +7348,7 @@ function App() {
       source: 'layer',
       color: previewTrack.strand === -1 ? '#c6737b' : '#7e9bbf',
     };
-    setTranslationLayersByRecord((current) => {
+    updateTranslationLayers((current) => {
       const existing = current[recordId] ?? [];
       if (existing.some((entry) => entry.id === layer.id)) return current;
       return { ...current, [recordId]: [...existing, layer] };
@@ -7097,25 +7356,25 @@ function App() {
     if (options?.select !== false) {
       setSelectedTranslationLayerByRecord((current) => ({ ...current, [recordId]: layer.id }));
     }
-  }, [inlineTranslationTracks, previewTrack, recordId, showWorkbenchNotice, translateFrame, translateStrand, translateTarget, translationLayers.length]);
+  }, [inlineTranslationTracks, previewTrack, recordId, showWorkbenchNotice, translateFrame, translateStrand, translateTarget, translationLayers.length, updateTranslationLayers]);
   const clearTranslationLayers = useCallback(() => {
-    setTranslationLayersByRecord((current) => (current[recordId]?.length ? { ...current, [recordId]: [] } : current));
+    updateTranslationLayers((current) => (current[recordId]?.length ? { ...current, [recordId]: [] } : current));
     setSelectedTranslationLayerByRecord((current) => (current[recordId] ? { ...current, [recordId]: null } : current));
-  }, [recordId]);
+  }, [recordId, updateTranslationLayers]);
 
   const updateTranslationLayer = useCallback((layerId: string, patch: Partial<Omit<InlineTranslationTrack, 'id' | 'source'>>) => {
-    setTranslationLayersByRecord((current) => {
+    updateTranslationLayers((current) => {
       const layers = current[recordId] ?? [];
       if (!layers.some((layer) => layer.id === layerId)) return current;
       return {
         ...current,
         [recordId]: layers.map((layer) => (
-          layer.id === layerId ? { ...layer, ...patch, source: 'layer' } : layer
+          layer.id === layerId ? { ...layer, ...patch, needsReview: false, source: 'layer' } : layer
         )),
       };
     });
     setSelectedTranslationLayerByRecord((current) => ({ ...current, [recordId]: layerId }));
-  }, [recordId]);
+  }, [recordId, updateTranslationLayers]);
 
   const deleteTranslationLayer = useCallback((layerId: string) => {
     if (layerId.startsWith('feat:')) {
@@ -7125,7 +7384,7 @@ function App() {
         return { ...current, [recordId]: [...hidden, layerId] };
       });
     } else {
-      setTranslationLayersByRecord((current) => {
+      updateTranslationLayers((current) => {
         const layers = current[recordId] ?? [];
         if (!layers.some((layer) => layer.id === layerId)) return current;
         return { ...current, [recordId]: layers.filter((layer) => layer.id !== layerId) };
@@ -7135,7 +7394,7 @@ function App() {
       current[recordId] === layerId ? { ...current, [recordId]: null } : current
     ));
     setLockedTranslateTarget(null);
-  }, [recordId]);
+  }, [recordId, updateTranslationLayers]);
 
   // Selection-bar "Translate": pin the translation inline (sense reads above the
   // selected bases, antisense below). The floating Translations window opens only
@@ -7299,12 +7558,31 @@ function App() {
 
   const updateWorkspaceNote = useCallback((noteId: string, patch: ArtifactNoteTextUpdate) => {
     const current = payloadRef.current;
+    const existing = current.notes.find((note) => note.id === noteId);
     const recordLengths = new Map(current.records.map((record) => [record.id, record.sequence.length]));
     const notes = updateArtifactNote(current.notes, noteId, {
       ...patch,
       updatedAt: new Date().toISOString(),
-      provenance: { source: 'user', operation: 'update_note' },
+      provenance: { ...existing?.provenance, source: 'user', operation: 'update_note' },
     }, { recordLengths });
+    const nextPayload: LoadedPayload = { ...current, notes };
+    payloadRef.current = nextPayload;
+    setPayload(nextPayload);
+  }, []);
+
+  const confirmWorkspaceNoteAnchor = useCallback((noteId: string) => {
+    const current = payloadRef.current;
+    if (!current.notes.some((note) => note.id === noteId)) throw new Error(`Unknown note id: ${noteId}`);
+    const recordLengths = new Map(current.records.map((record) => [record.id, record.sequence.length]));
+    const notes = normalizeArtifactWorkspaceCollections({
+      notes: current.notes.map((note) => (
+        note.id === noteId ? confirmNoteRangeAnchor(note, new Date().toISOString()) : note
+      )),
+      workflowResults: current.workflowResults,
+    }, {
+      recordLengths,
+      allowMissingWorkflowOutputRecords: true,
+    }).notes;
     const nextPayload: LoadedPayload = { ...current, notes };
     payloadRef.current = nextPayload;
     setPayload(nextPayload);
@@ -8467,14 +8745,13 @@ function App() {
 
   const downloadWorkspaceBackup = useCallback(() => {
     const snapshot = createArtifactDatabaseSnapshot(payloadRef.current, artifactStateRef.current);
-    downloadTextFile('motif-workspace-backup.json', JSON.stringify(snapshot, null, 2), 'application/json');
-    markSessionSaved();
-  }, [markSessionSaved]);
+    return downloadTextFile('motif-workspace-backup.json', JSON.stringify(snapshot, null, 2), 'application/json');
+  }, []);
 
   const restoreWorkspaceBackupFile = useCallback(async (file: File, returnFocus: HTMLElement | null = null) => {
     const rawDatabase = parseArtifactDatabaseJson(await file.text());
     if (!rawDatabase) throw new Error('This file is not a Motif Database JSON backup.');
-    requestArtifactDatabaseRestore(rawDatabase, file.name, returnFocus);
+    requestArtifactDatabaseRestore(rawDatabase, file.name, returnFocus, 'durable-checkpoint');
   }, [requestArtifactDatabaseRestore]);
 
   const toggleToolsPinned = useCallback(() => {
@@ -9721,7 +9998,6 @@ function App() {
               onAddReverseComplement={addContextReverseComplementRecord}
               onAnnotateRange={handleAnnotateRange}
               canAnnotateRange={canAnnotateSelectedMapRange}
-              onSessionSaved={markSessionSaved}
             />
             </section>
             <StackedPaneResizeHandle
@@ -9856,6 +10132,7 @@ function App() {
                   : null}
                 onAdd={addWorkspaceNote}
                 onUpdate={updateWorkspaceNote}
+                onConfirmAnchor={confirmWorkspaceNoteAnchor}
                 onRemove={removeWorkspaceNote}
                 onReveal={revealWorkspaceNote}
               />
@@ -11221,6 +11498,7 @@ function FeatureList({
                 >
                   <span className="motif-cs-swatch" style={{ backgroundColor: track.color ?? 'var(--accent)' }} />
                   <span className="motif-cs-row-main" translate="no">{track.label}</span>
+                  {track.needsReview ? <span className="motif-cs-chip">Review anchor</span> : null}
                   <span className="motif-cs-row-meta">{track.strand === -1 ? 'reverse' : 'forward'} · {mapRangeLabel({ start: track.start, end: track.end }, sequenceLength)}</span>
                 </button>
                 {canDelete ? (
@@ -12050,6 +12328,11 @@ function TranslationLayerEditor({
     <div className="motif-cs-annotation-editor">
       <div className="motif-cs-annotation-section-label">Edit translation</div>
       <div className="motif-cs-feature-form motif-cs-tool-panel-body">
+        {track.needsReview ? (
+          <p className="motif-cs-form-note" role="status">
+            The sequence changed inside this pinned translation. Review its range and frame, then choose Update to confirm it.
+          </p>
+        ) : null}
         <label>
           <span>Label</span>
           <div className="motif-cs-name-edit-row">
@@ -12286,28 +12569,12 @@ function digestRows(fragments: readonly DigestFragment[], sequenceLength: number
   ].join('\n');
 }
 
-function downloadTextFile(filename: string, content: string, mime = 'text/plain'): void {
-  try {
-    const blob = new Blob([content], { type: `${mime};charset=utf-8` });
-    downloadBlobFile(filename, blob);
-  } catch {
-    /* download unavailable (e.g. sandboxed) — clipboard copy actions remain */
-  }
+function downloadTextFile(filename: string, content: string, mime = 'text/plain'): BrowserDownloadReceipt {
+  return requestBrowserTextDownload(filename, content, mime);
 }
 
-function downloadBlobFile(filename: string, blob: Blob): void {
-  try {
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement('a');
-    anchor.href = url;
-    anchor.download = filename;
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-    window.setTimeout(() => URL.revokeObjectURL(url), 1000);
-  } catch {
-    /* download unavailable (e.g. sandboxed) — clipboard copy actions remain */
-  }
+function downloadBlobFile(filename: string, blob: Blob): BrowserDownloadReceipt {
+  return requestBrowserBlobDownload(filename, blob);
 }
 
 function printHtmlReport(html: string): void {
@@ -12636,7 +12903,6 @@ function SequenceToolsPanel({
   onAddReverseComplement,
   onAnnotateRange,
   canAnnotateRange,
-  onSessionSaved,
 }: {
   records: readonly ArtifactVector[];
   record: ArtifactVector;
@@ -12664,12 +12930,12 @@ function SequenceToolsPanel({
   onAddReverseComplement: () => void;
   onAnnotateRange: () => void;
   canAnnotateRange: boolean;
-  onSessionSaved: () => void;
 }) {
   const exportPanelRef = useRef<HTMLDetailsElement>(null);
   const [exportPanelOpen, setExportPanelOpen] = useState(false);
   const [exportPanelHeight, setExportPanelHeight] = useState<number | null>(null);
   const [exportChoiceId, setExportChoiceId] = useState('record-sequence');
+  const [downloadStatus, setDownloadStatus] = useState('');
   const hasActiveRecord = records.length > 0 && record.id !== EMPTY_ARTIFACT_VECTOR.id;
   const needsInventoryExport = exportPanelOpen && !exportChoiceId.startsWith('record-');
   const needsZipExport = exportPanelOpen && exportChoiceId === 'inventory-zip';
@@ -12874,7 +13140,7 @@ function SequenceToolsPanel({
     content?: string;
     downloadName?: string;
     mime?: string;
-    download?: () => void;
+    download?: () => BrowserDownloadReceipt;
     print?: () => void;
   };
   const exportChoices = useMemo<ExportChoice[]>(() => [
@@ -12915,15 +13181,15 @@ function SequenceToolsPanel({
   }, [exportChoice, onCopy]);
   const downloadSelectedExport = useCallback(() => {
     if (!exportChoice) return;
+    let receipt: BrowserDownloadReceipt;
     if (exportChoice.download) {
-      exportChoice.download();
-      if (exportChoice.id === 'inventory-zip') onSessionSaved();
-      return;
+      receipt = exportChoice.download();
+    } else {
+      if (!exportChoice.content || !exportChoice.downloadName) return;
+      receipt = downloadTextFile(exportChoice.downloadName, exportChoice.content, exportChoice.mime);
     }
-    if (!exportChoice.content || !exportChoice.downloadName) return;
-    downloadTextFile(exportChoice.downloadName, exportChoice.content, exportChoice.mime);
-    if (exportChoice.id === 'inventory-json') onSessionSaved();
-  }, [exportChoice, onSessionSaved]);
+    setDownloadStatus(receipt.message);
+  }, [exportChoice]);
   const selectedTargetLabel = selectedFeature
     ? selectedFeature.name
     : selectedMapRange
@@ -12932,7 +13198,7 @@ function SequenceToolsPanel({
   const durabilityStatus = hasUnsavedChanges
     ? 'unsaved changes'
     : hasSessionCheckpoint
-      ? 'saved'
+      ? 'restored checkpoint'
       : 'session only';
 
   const exportPanelBounds = exportPanelHeightBounds();
@@ -12958,7 +13224,7 @@ function SequenceToolsPanel({
           title={hasUnsavedChanges
             ? 'This session changed since its last complete Database JSON or ZIP checkpoint.'
             : hasSessionCheckpoint
-              ? 'The current session matches the last restored or downloaded complete checkpoint.'
+              ? 'The current session matches a complete JSON file restored from disk.'
               : 'Records are kept in this artifact session. Export Database JSON or ZIP before reloading.'}
         >
           {copyStatus ?? durabilityStatus}
@@ -13065,6 +13331,9 @@ function SequenceToolsPanel({
             <button className="motif-cs-mini-button motif-cs-mini-button-accent" type="button" onClick={exportChoice?.print} disabled={!exportChoice?.print}>Print / PDF</button>
           </div>
         </div>
+        <p className="motif-cs-form-note" role="status" aria-live="polite" data-empty={!downloadStatus || undefined}>
+          {downloadStatus}
+        </p>
         <textarea className="motif-cs-textarea motif-cs-sequence-preview" name="sequence-preview" autoComplete="off" readOnly value={exportPreview} aria-label="Selected export preview" />
       </div>
       ) : null}
@@ -14054,6 +14323,7 @@ type InlineTranslationTrack = {
   frame: 0 | 1 | 2;
   source: 'feature' | 'layer';
   color?: string;
+  needsReview?: boolean;
 };
 
 // One residue placed in PLUS-STRAND codon coordinates so it aligns to the bases

--- a/src/artifacts/motif-for-claude-science-plugin/README.md
+++ b/src/artifacts/motif-for-claude-science-plugin/README.md
@@ -155,6 +155,8 @@ truth for current functions, schemas, limits, and examples.
 Edits are session-owned until exported. Database JSON and workspace ZIP are
 the complete checkpoint/restore boundary. The portable HTML is not an
 encrypted vault, a compliance system, or a durable shared database.
+A browser download is only a request until the resulting file is verified and
+can be reopened; do that before relying on it as the session checkpoint.
 
 The Motif connector is an ephemeral viewer/export surface. It does not write a
 hidden database or run native analysis tools. Its registration, server, tools,

--- a/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/SKILL.md
+++ b/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/SKILL.md
@@ -368,9 +368,10 @@ globals were called.
   Do not report success unless `run-msa.mjs` completed and its payload passed
   artifact validation.
 - If the user later changes the inventory in the UI, tell them that records are
-  session-only until exported. Database JSON and ZIP retain the complete
-  artifact record; FASTA, basic GenBank/GFF3, CSV, and reports are also
-  available for interchange.
+  session-only until an exported file is verified on disk. Database JSON and
+  ZIP retain the complete artifact record; FASTA, basic GenBank/GFF3, CSV, and
+  reports are also available for interchange. A browser download request is
+  not itself proof that a checkpoint was saved.
 - For Sanger review, report that AB1 calls were imported and visually checked;
   do not claim the artifact re-base-called the raw electropherogram. State
   whether the read was aligned forward or reverse to the selected template.

--- a/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/workspace-validator.mjs
+++ b/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/workspace-validator.mjs
@@ -104,7 +104,20 @@ function normalizeTranslationLayers(value, recordLengths) {
       if (frame === null) throw new Error(`${path}.frame must be 0, 1, or 2.`);
       const color = raw.color === void 0 ? void 0 : requiredString(raw.color, `${path}.color`, 32);
       if (color && !/^#[0-9a-f]{6}$/i.test(color)) throw new Error(`${path}.color must be a 6-digit hex color.`);
-      return { id: uniqueId(baseId, usedIds), label, start, end, strand, frame, source: "layer", color };
+      if (raw.needsReview !== void 0 && typeof raw.needsReview !== "boolean") {
+        throw new Error(`${path}.needsReview must be a boolean.`);
+      }
+      return {
+        id: uniqueId(baseId, usedIds),
+        label,
+        start,
+        end,
+        strand,
+        frame,
+        source: "layer",
+        color,
+        ...raw.needsReview ? { needsReview: true } : {}
+      };
     });
   }
   return result;

--- a/src/artifacts/motif-for-claude-science-skill/SKILL.md
+++ b/src/artifacts/motif-for-claude-science-skill/SKILL.md
@@ -131,6 +131,7 @@ Preserve user-supplied sequence data exactly except for formatting whitespace.
 Do not hand-edit bundled JavaScript or claim an in-page change succeeded without
 observing it in the rendered artifact.
 
-Records edited in the browser are session-only until exported. Database JSON
-and ZIP preserve the complete artifact record; GenBank and GFF3 are intentionally
-basic interchange exports.
+Records edited in the browser are session-only until an exported file is
+verified on disk. Database JSON and ZIP preserve the complete artifact record;
+GenBank and GFF3 are intentionally basic interchange exports. A browser
+download request is not itself proof that a checkpoint was saved.

--- a/src/bio/__tests__/mutate-feature-locations.test.ts
+++ b/src/bio/__tests__/mutate-feature-locations.test.ts
@@ -21,6 +21,26 @@ function joinedFeature(): Feature {
 }
 
 describe('mutation feature-location integrity', () => {
+  it('uses half-open feature affinity at insertion boundaries', () => {
+    const feature: Feature = {
+      id: 'feature',
+      name: 'feature',
+      type: 'misc_feature',
+      start: 2,
+      end: 5,
+      strand: 1,
+      color: '#888888',
+      metadata: {},
+    };
+
+    expect(applyInsertion('AACCGGTT', [], [feature], 1, 'AA').features[0])
+      .toMatchObject({ start: 4, end: 7 });
+    expect(applyInsertion('AACCGGTT', [], [feature], 2, 'AA').features[0])
+      .toMatchObject({ start: 2, end: 7 });
+    expect(applyInsertion('AACCGGTT', [], [feature], 4, 'AA').features[0])
+      .toMatchObject({ start: 2, end: 5 });
+  });
+
   it('shifts authoritative pieces and recomputes their envelope after insertion', () => {
     const result = applyInsertion('ATGCCCGGGCCA', [], [joinedFeature()], 5, 'AA');
 

--- a/src/bio/mutate.ts
+++ b/src/bio/mutate.ts
@@ -40,13 +40,14 @@ function shiftFeatures(
   editPos: number,
   delta: number,
 ): Feature[] {
+  const insertIndex = editPos + 1;
   return features.map((f) => {
     const newStart = f.start > editPos ? f.start + delta : f.start;
-    const newEnd = f.end > editPos ? f.end + delta : f.end;
+    const newEnd = f.end > insertIndex ? f.end + delta : f.end;
     const newSubRanges = f.subRanges?.map((range) => ({
       ...range,
       start: range.start > editPos ? range.start + delta : range.start,
-      end: range.end > editPos ? range.end + delta : range.end,
+      end: range.end > insertIndex ? range.end + delta : range.end,
     }));
     if (newSubRanges && newSubRanges.length > 0) {
       return {
@@ -140,7 +141,8 @@ export function applySubstitution(
  * Insert `bases` AFTER position `pos`.
  *
  * - Shifts all existing scars at positions > pos by +bases.length.
- * - Shifts features: start > pos gets shifted, end > pos gets shifted.
+ * - Uses half-open feature boundaries: insertion at start shifts the feature,
+ *   insertion strictly inside extends it, and insertion at end leaves it unchanged.
  * - Adds an insertion scar on each newly inserted base position.
  *
  * When `pos` is -1 the insertion happens at the very beginning of the


### PR DESCRIPTION
## Summary

- make sequence edits atomic across sequence data, feature coordinates, range notes, translation anchors, chromatogram links, and undo/redo
- distinguish unsaved changes, session hydration, and verified restore checkpoints; block accidental dirty workspace replacement and report browser downloads as requests
- add bounded, inert viewers for full reports, semantic tables, BLAST hits/evidence, and linked assets with paging, sorting, safe copy/download, and responsive accessibility

## Safety and scope

- no generic DOM, shell, filesystem, or connector bridge was added
- no lockfile or release version change
- spreadsheet formula injection, unsafe filenames, executable assets, oversized rendering, and malformed replacement options are guarded

## Validation

- typecheck and full lint
- 74 files / 857 unit tests
- plugin packaging, CSS-token, and ARIA-control audits
- deterministic production build and strict Claude plugin validation
- 120 enabled browser tests passed; 16 expected environment-gated tests skipped (14 dedicated MSA interaction cases and 2 real-AB1 fixture cases)
- public-range scan found no machine paths, private-repo identifiers, screenshots, credentials, keys, tokens, or assigned secrets
