### PR TITLE
Use vendor-neutral public language

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,9 @@ A passing DOM assertion is not proof that a control is legible or reachable.
   verification, and portable provenance.
 - Do not set raw `innerHTML` from user-controlled data.
 - Do not hardcode visual colors; use the artifact's CSS variables.
+- Use vendor-neutral, behavior-based language in public comments, tests, docs,
+  and commit messages; avoid competitor comparisons and machine-specific or
+  private-repository references.
 - Preserve `data-testid`, keyboard, focus, and ARIA contracts when changing UI.
 - Treat Database JSON and workspace ZIP as portable checkpoints, not encrypted
   durable storage.

--- a/scripts/test-claude-science-plugin-packaging.mjs
+++ b/scripts/test-claude-science-plugin-packaging.mjs
@@ -193,7 +193,7 @@ check('public setup, troubleshooting, and capability docs ship with the plugin',
       const canonical = readFileSync(join(root, 'docs', filename), 'utf8');
       assert.equal(packaged, canonical);
       assert.equal(packaged.toLowerCase().includes(legacyBrand), false);
-      assert.doesNotMatch(packaged, /\/Users\/|github_3/iu);
+      assert.doesNotMatch(packaged, /\/Users\/|github_[0-9]+/iu);
     }
     assert.equal(
       readFileSync(join(fixture, 'examples', 'motif-demo.gb'), 'utf8'),

--- a/src/artifacts/claude-science-digest-workflow.ts
+++ b/src/artifacts/claude-science-digest-workflow.ts
@@ -72,7 +72,7 @@ export type DigestWorkflowSourceRecord = {
 export type DigestFragmentRecordIdentity = {
   /** Caller-owned durable id. When omitted as a collection, ids derive from workflow.id. */
   id: string;
-  /** Caller-owned display name. Omit for the deterministic Benchling-style default. */
+  /** Caller-owned display name. Omit to use the deterministic fragment name. */
   name?: string;
 };
 

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -1435,8 +1435,8 @@ body[data-motif-cs-export-resizing] {
 
 .motif-cs-map-frame {
   position: relative;
-  /* Benchling-style workspace: the map is a primary canvas, so keep the
-     restriction/source panels below it rather than letting them crowd it. */
+  /* Map-first workspace: keep the restriction/source panels below the primary
+     canvas rather than letting them crowd it. */
   height: clamp(560px, 70vh, 820px);
   min-height: 540px;
   padding: 0;
@@ -4590,7 +4590,7 @@ body[data-motif-cs-export-resizing] {
   cursor: pointer;
 }
 
-/* Directional arrowhead (Benchling-style): only the segment holding the true 3'
+/* Directional arrowhead: only the segment holding the true 3'
    terminus is pointed, so a wrapped feature reads as one arrow, not many.
    Strand 0 / none stays a plain rectangular block. */
 .motif-cs-feature-block[data-strand="1"][data-head="true"] {
@@ -9178,7 +9178,7 @@ summary.motif-cs-panel-head:focus-visible {
 
 }
 
-/* Benchling-style split workspace: use the full workbench height for the two
+/* Split workspace: use the full workbench height for the two
    primary canvases. Their compact docks stay at the bottom instead of leaving
    an arbitrary blank band below capped sequence and map viewports. */
 @media (min-width: 768px) {

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -675,7 +675,7 @@ function normalizePaneVisibility(value: unknown): PaneVisibility {
   for (const key of DEFAULT_PANE_ORDER) {
     if (typeof source[key] === 'boolean') next[key] = source[key];
   }
-  // The right rail is a Benchling-style anchor in this artifact; keep it present
+  // The right rail is a persistent workspace anchor; keep it present
   // and let Tools switch between rail and expanded states instead of disappearing.
   next.tools = true;
   // The permanent Tools rail is navigation, not workspace content. Recover old
@@ -14312,7 +14312,7 @@ function RestrictionList({
 }
 
 // An inline amino-acid track: one contiguous translated region shown aligned to
-// the bases (Benchling-style), NOT a whole-entry frame. Forward tracks render
+// the bases, NOT a whole-entry frame. Forward tracks render
 // above the bases, reverse tracks below.
 type InlineTranslationTrack = {
   id: string;

--- a/src/bio/genbank-parser.ts
+++ b/src/bio/genbank-parser.ts
@@ -12,8 +12,8 @@ export const QUALIFIER_TRUNCATED_SUFFIX = '...[truncated]';
  * NCBI strand qualifier from the LOCUS line: `ss-` (single-stranded),
  * `ds-` (double-stranded), or `ms-` (mixed). Absent on most modern records.
  * Preserving the literal token lets a parsed-then-exported record round-trip
- * the strand field that downstream tools (Snapgene, Benchling, BioPython)
- * read from column 22-23. VOG-2000.
+ * the strand field that downstream GenBank consumers read from column 22-23.
+ * VOG-2000.
  */
 export type GenBankStrandedness = 'ss' | 'ds' | 'ms';
 
@@ -438,7 +438,7 @@ export function parseFeatures(featuresText: string): Feature[] {
     // exporter (src/persistence/export.ts) always writes feature.name to /label,
     // so reading /gene first silently reverted a user-renamed feature to its
     // gene/product name on an export→import round-trip. /label-first matches
-    // SnapGene/Benchling; gene-before-product order is preserved for the
+    // common editor behavior; gene-before-product order is preserved for the
     // no-/label case so existing fixtures are unaffected.
     const name =
       (typeof qualifiers['label'] === 'string' && qualifiers['label']) ||
@@ -628,7 +628,7 @@ function parseSingleGenBankRecord(raw: string): GenBankRecord | null {
   let inKeywords = false;
   // VOG-1973: track whether the input ever entered ORIGIN. Combined with
   // `locus.length` (the LOCUS-declared length) we use this to detect
-  // truncation. A NCBI / SnapGene / Geneious export that was cut off
+  // truncation. A GenBank export that was cut off
   // mid-FEATURES (or mid-ORIGIN) shows up here as `originSeen = false`
   // (or as a `parsedSequenceLength` significantly smaller than declared)
   // and the intake pipeline refuses the import instead of materializing

--- a/src/bio/types.ts
+++ b/src/bio/types.ts
@@ -243,11 +243,6 @@ export const BASE_COLORS: Record<string, string> = BASE_COLORS_DARK;
 // 5 classes: Hydrophobic | Polar uncharged | Positive charge | Negative charge | Special
 // AA_COLORS      — dark-mode palette, all colors ≥4.5:1 on #0a0a0a
 // AA_COLORS_LIGHT — light-mode palette, all colors ≥4.5:1 on #ffffff
-//
-// Phase 32 W2-C P0-2: class assignment now derives from `bio/aa-classes.ts`
-// (single source of truth). Notable change vs. pre-Phase-32:
-//   - C (cysteine) was polar/green → now special/gray (Benchling/IMGT consensus
-//     — cysteine forms disulfide bridges; treated as structural, not polar)
 
 /** Amino acid colors for dark backgrounds (#0a0a0a) — WCAG AA ≥4.5:1 */
 export const AA_COLORS: Record<string, string> = {

--- a/src/components/plasmid-map/plasmid-map.css
+++ b/src/components/plasmid-map/plasmid-map.css
@@ -702,7 +702,7 @@
   fill-opacity: 0.62;
 }
 
-/* Type IIS enzymes get the distinct tan language (Benchling).
+/* Type IIS enzymes get a distinct tan visual language.
    TICK is an aggregate cluster flag: any Type IIS site tints the whole tick
    (both topologies). LABEL colors PER-ENZYME so a mixed cluster like
    "BsaI,HpaII,MspI +7" tans ONLY the Type IIS token. Circular labels render as

--- a/src/plasmid-map/__tests__/label-collision.probe.test.ts
+++ b/src/plasmid-map/__tests__/label-collision.probe.test.ts
@@ -1,12 +1,9 @@
 /**
- * CAMPAIGN PROBE (not in the suite include; run explicitly with:
- *   npx vitest run qa-logs/2026-07-03-map-benchling-polish/label-collision.probe.test.ts
- * ). Quantifies VISIBLE-label overlaps in the computed MapLayout across dense
- * scenarios — the north-star invariant of the Benchling-polish campaign
- * ("no two visible labels overlap"). It operates on the PUBLIC MapLayout contract
+ * Regression coverage for VISIBLE-label overlaps in the computed MapLayout
+ * across dense scenarios. The invariant is that no two visible labels overlap.
+ * It operates on the PUBLIC MapLayout contract
  * (features[].label / restrictions[].label / coordinates[].label), so it survives
- * the internal label-placement redesign. Reports "before" numbers now; will be
- * promoted to a strict committed gate (overlaps===0) once fixes land.
+ * internal label-placement changes.
  */
 import { describe, it, expect } from 'vitest';
 import { computeMapLayout } from '../layout';
@@ -302,7 +299,7 @@ const base = (over: Partial<MapInput>): MapInput => ({
   features: [], restrictionSites: [], width: 720, height: 720, ...over,
 });
 
-describe('LABEL-COLLISION PROBE (campaign evidence)', () => {
+describe('label collision regression coverage', () => {
   const scenarios: { name: string; input: MapInput }[] = [
     { name: 'circular 40feat/20site @720', input: base({ mode: 'circular', topology: 'circular', features: denseFeatures(40, 6000), restrictionSites: denseSites(20, 6000) }) },
     { name: 'circular 22feat/12site @720', input: base({ mode: 'circular', topology: 'circular', length: 9276, features: denseFeatures(22, 9276), restrictionSites: denseSites(12, 9276) }) },

--- a/src/plasmid-map/__tests__/layout.test.ts
+++ b/src/plasmid-map/__tests__/layout.test.ts
@@ -1957,8 +1957,8 @@ describe('computeMapLayout: linear + protein', () => {
     // Rebaselined after MapLayout gained explicit linearAxis geometry.
     // Rebaselined after inline labels centered on rendered arrow glyphs and
     // linear restriction labels used center-entering callout leaders.
-    // Rebaselined after linear feature bars became square-ended to match the
-    // artifact's Benchling-style feature treatment.
+    // Rebaselined after linear feature bars adopted the artifact's square-ended
+    // feature treatment.
     expect(layoutHash(layout)).toBe(
       '52c8c1aff95c22cace479fb781b544371c6e54ff277bedce586d95ba4dc5ab90',
     );

--- a/src/plasmid-map/__tests__/linear-restriction-leaders.test.ts
+++ b/src/plasmid-map/__tests__/linear-restriction-leaders.test.ts
@@ -1,9 +1,9 @@
 /**
- * W (map-benchling-polish, linear leaders): the LINEAR restriction-label band must
- * read like Benchling — labels sit close to their ticks so leaders stay SHORT,
+ * The LINEAR restriction-label band keeps labels close to their ticks so leaders
+ * stay SHORT,
  * NEAR-VERTICAL and NON-CROSSING. The old fixed-72px slot de-collision cascaded
  * left-clustered labels far to the right on long shallow (near-horizontal) leaders
- * that fanned across the map — the user-flagged tangle. These tests pin the new
+ * that fanned across the map. These tests pin the
  * width-aware minimum-displacement placement (placeRestrictionRow) and the whole-
  * layout leader geometry so the tangle can't regress.
  */

--- a/src/plasmid-map/geometry/coordinates.ts
+++ b/src/plasmid-map/geometry/coordinates.ts
@@ -1,13 +1,13 @@
 /**
  * Coordinate helpers for both map projections.
  *
- * Circular convention (matches Benchling / SeqViz): base 0 sits at 12 o'clock
+ * Circular map convention: base 0 sits at 12 o'clock
  * (top) and increasing bp runs CLOCKWISE. Angles are measured in degrees
  * clockwise from top. SVG y grows downward, so the standard trig below produces a
  * clockwise sweep without any sign flips beyond the -90deg "top" shift.
  *
- * Pure functions, reimplemented from SeqViz's MIT geometry (findCoor / genArc /
- * rotateCoor) against Motif's own model — no code copied.
+ * Geometry behavior was reimplemented from SeqViz's MIT-licensed reference
+ * against Motif's own model; no source code copied.
  */
 
 export interface Point {
@@ -213,7 +213,7 @@ export function describeArcLine(
 /**
  * Text anchor + upright hint for an outside label at a given angle, so labels on
  * the right half read start-anchored and the left half end-anchored (leaders point
- * inward). Matches Benchling's outside-label behaviour.
+ * inward). This follows the conventional outside-label behavior.
  */
 export function labelSideForAngle(angleDeg: number): 'start' | 'end' {
   const a = ((angleDeg % 360) + 360) % 360;

--- a/src/plasmid-map/layout.ts
+++ b/src/plasmid-map/layout.ts
@@ -152,7 +152,7 @@ const LINEAR_LANE_PITCH_MAX = 46; // dock fill cap: comfortable label clearance 
 const LINEAR_ROW_MIN_HEIGHT = 10;
 const LINEAR_ROW_MIN_GAP = 4;
 const LINEAR_BOTTOM_PAD = 10;
-const LINEAR_FEATURE_RADIUS = 0; // Benchling-style flat feature bars
+const LINEAR_FEATURE_RADIUS = 0; // Square-ended feature bars
 const LINEAR_REC_LABEL_MAX_WIDTH_PX = 64;
 const LINEAR_REC_LABEL_GAP_X = 8;
 const LINEAR_REC_SLOT_PX = LINEAR_REC_LABEL_MAX_WIDTH_PX + LINEAR_REC_LABEL_GAP_X;
@@ -198,7 +198,7 @@ export function computeMapLayout(input: MapInput): MapLayout {
 // The plasmid title sits in the middle of the ring. A long name (e.g. "Clone of
 // pACYC184 + eGFP (Enhanced Green Fluorescent Protein)") would otherwise render
 // wider than the whole backbone circle and spill across the feature arcs. We fit
-// it to the ring — Benchling-style — with a DETERMINISTIC width heuristic (no DOM
+// it to the ring with a DETERMINISTIC width heuristic (no DOM
 // measurement / useEffect, so the render stays pure): short names stay on one
 // line unchanged; a long name wraps onto two balanced lines a notch smaller; any
 // line that still cannot fit is ellipsized. The width budget is a fraction of the

--- a/src/plasmid-map/types.ts
+++ b/src/plasmid-map/types.ts
@@ -6,9 +6,6 @@
  * src/components/plasmid-map/* consume the computed layout objects and map them to
  * SVG — they never re-derive biological ranges.
  *
- * Gated behind the default-off USE_PLASMID_MAP flag and lazy-loaded, so compact/
- * detail sequence flows never pay for any of this. See
- * qa-logs/2026-07-02-plasmid-map/NOTES.md for the reversibility charter.
  */
 import type { Feature, RestrictionSite, FeatureStrand, Topology, SequenceType } from '../bio/types';
 
@@ -142,7 +139,7 @@ export interface MapRestrictionRender {
    * cuts outside its recognition window anywhere in this cluster) plus a trailing
    * non-Type-IIS `+N` overflow segment when present. The renderer joins enzyme
    * tokens with "," and the tail with " ", so the concatenation is IDENTICAL to
-   * `label.text` — only the Type IIS tokens get the tan/orange, matching Benchling.
+   * `label.text` — only the Type IIS tokens get the distinct tan/orange treatment.
    * Additive + optional: absent on linear (single compact token), where the label
    * falls back to the aggregate whole-label color.
    */


### PR DESCRIPTION
## Summary

- replace vendor comparison phrasing with direct descriptions of Motif behavior
- remove stale internal QA references and correct regression-test documentation
- generalize the packaged-doc path guard and add public-language guidance for contributors
- retain intentional MIT-licensed implementation provenance

## Validation

- typecheck
- lint
- 857 unit tests passed in the serialized full-suite run
- plugin packaging, CSS token, and ARIA control checks
- production build and strict plugin validation
- browser suite: 120 passed, 16 expected fixture/configuration skips
- Gitleaks commit scan: no leaks found
- tracked and generated commercial-comparison scan: clean