### PR TITLE
Fix pane geometry and restriction-site alignment

### DIFF
--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -1264,6 +1264,68 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(exportPanel).toHaveAttribute('open', '');
   });
 
+  test('a Tools rail popover grows leftward, shrinks rightward, and docks without stale dimensions', async ({ page }) => {
+    await openArtifact(page, 1180, 820);
+    const toolsToggle = page.getByRole('button', { name: /Tools/ }).first();
+    if ((await toolsToggle.getAttribute('aria-pressed')) === 'true') await toolsToggle.click();
+
+    const primerPanel = page.locator('details[data-rail-tool="primer-design"]');
+    if (!(await primerPanel.getAttribute('open'))) await primerPanel.locator(':scope > summary').click();
+    const panelBody = primerPanel.locator('.motif-cs-tool-panel-body');
+    const resizeHandle = panelBody.getByTestId('rail-popover-resize');
+    await expect(resizeHandle).toBeVisible();
+
+    const before = (await panelBody.boundingBox())!;
+    const growHandleBox = (await resizeHandle.boundingBox())!;
+    await page.mouse.move(growHandleBox.x + growHandleBox.width / 2, growHandleBox.y + growHandleBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(growHandleBox.x + growHandleBox.width / 2 - 96, growHandleBox.y + growHandleBox.height / 2 + 52, { steps: 6 });
+    await page.mouse.up();
+
+    const grown = (await panelBody.boundingBox())!;
+    expect(grown.width).toBeGreaterThan(before.width + 75);
+    expect(grown.height).toBeGreaterThan(before.height + 35);
+    expect(grown.x).toBeLessThan(before.x - 75);
+    expect(Math.abs((grown.x + grown.width) - (before.x + before.width))).toBeLessThan(2);
+
+    const shrinkHandleBox = (await resizeHandle.boundingBox())!;
+    await page.mouse.move(shrinkHandleBox.x + shrinkHandleBox.width / 2, shrinkHandleBox.y + shrinkHandleBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(shrinkHandleBox.x + shrinkHandleBox.width / 2 + 64, shrinkHandleBox.y + shrinkHandleBox.height / 2 - 24, { steps: 5 });
+    await page.mouse.up();
+
+    const shrunk = (await panelBody.boundingBox())!;
+    expect(shrunk.width).toBeLessThan(grown.width - 45);
+    expect(shrunk.height).toBeLessThan(grown.height - 12);
+    expect(Math.abs((shrunk.x + shrunk.width) - (grown.x + grown.width))).toBeLessThan(2);
+
+    await resizeHandle.focus();
+    await page.keyboard.press('ArrowLeft');
+    expect((await panelBody.boundingBox())!.width).toBeGreaterThan(shrunk.width + 7);
+
+    await toolsToggle.click();
+    await expect(page.locator('.motif-cs-main')).toHaveAttribute('data-tools-pinned', 'true');
+    await expect(resizeHandle).toBeHidden();
+    const docked = await panelBody.evaluate((element) => {
+      const body = element as HTMLElement;
+      const computed = getComputedStyle(body);
+      return {
+        inlineWidth: body.style.width,
+        inlineHeight: body.style.height,
+        position: computed.position,
+        width: body.getBoundingClientRect().width,
+        inspectorWidth: body.closest('.motif-cs-inspector')?.getBoundingClientRect().width ?? 0,
+      };
+    });
+    expect(docked.inlineWidth).toBe('');
+    expect(docked.inlineHeight).toBe('');
+    expect(docked.position).not.toBe('fixed');
+    expect(docked.width).toBeLessThanOrEqual(docked.inspectorWidth + 1);
+
+    await toolsToggle.click();
+    await expect(primerPanel).not.toHaveAttribute('open', '');
+  });
+
   test('runtime APIs reject destructive invalid input and expose fresh biology synchronously', async ({ page }) => {
     await openArtifact(page, 1180, 900);
     const result = await page.evaluate(() => {
@@ -1792,6 +1854,14 @@ test.describe('Claude Science artifact campaign', () => {
     const header = dialog.locator('.motif-cs-window-head');
     const resizeHandle = dialog.getByRole('button', { name: /Resize Translations window in 2 dimensions/ });
     const beforeMove = (await dialog.boundingBox())!;
+    const cornerHandleBox = (await resizeHandle.boundingBox())!;
+    expect(Math.abs((cornerHandleBox.x + cornerHandleBox.width) - (beforeMove.x + beforeMove.width))).toBeLessThan(2);
+    expect(Math.abs((cornerHandleBox.y + cornerHandleBox.height) - (beforeMove.y + beforeMove.height))).toBeLessThan(2);
+    const ownsVisibleCorner = await page.evaluate(({ x, y }) => (
+      document.elementFromPoint(x, y)?.closest('.motif-cs-window-resize') !== null
+    ), { x: beforeMove.x + beforeMove.width - 4, y: beforeMove.y + beforeMove.height - 4 });
+    expect(ownsVisibleCorner).toBe(true);
+    expect(beforeMove.x + beforeMove.width).toBeLessThanOrEqual(1180 - 48 - 7);
     const headerBox = (await header.boundingBox())!;
     await page.mouse.move(headerBox.x + headerBox.width / 2, headerBox.y + headerBox.height / 2);
     await page.mouse.down();

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -1303,6 +1303,21 @@ test.describe('Claude Science artifact campaign', () => {
     await page.keyboard.press('ArrowLeft');
     expect((await panelBody.boundingBox())!.width).toBeGreaterThan(shrunk.width + 7);
 
+    const compactHandleBox = (await resizeHandle.boundingBox())!;
+    await page.mouse.move(compactHandleBox.x + compactHandleBox.width / 2, compactHandleBox.y + compactHandleBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(compactHandleBox.x + compactHandleBox.width / 2, compactHandleBox.y + compactHandleBox.height / 2 - 180, { steps: 6 });
+    await page.mouse.up();
+    await panelBody.evaluate((element) => { element.scrollTop = element.scrollHeight; });
+    await expect.poll(() => panelBody.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+    const scrolledBody = (await panelBody.boundingBox())!;
+    const scrolledHandle = (await resizeHandle.boundingBox())!;
+    expect(Math.abs(scrolledHandle.x - scrolledBody.x)).toBeLessThan(2);
+    expect(Math.abs((scrolledHandle.y + scrolledHandle.height) - (scrolledBody.y + scrolledBody.height))).toBeLessThan(2);
+    expect(await page.evaluate(({ x, y }) => (
+      document.elementFromPoint(x, y)?.closest('.motif-cs-rail-popover-resize') !== null
+    ), { x: scrolledBody.x + 5, y: scrolledBody.y + scrolledBody.height - 5 })).toBe(true);
+
     await toolsToggle.click();
     await expect(page.locator('.motif-cs-main')).toHaveAttribute('data-tools-pinned', 'true');
     await expect(resizeHandle).toBeHidden();
@@ -1886,6 +1901,16 @@ test.describe('Claude Science artifact campaign', () => {
     await resizeHandle.focus();
     await page.keyboard.press('Shift+ArrowRight');
     expect((await dialog.boundingBox())!.width).toBeGreaterThan(afterResize.width + 15);
+
+    const beforeBoundaryResize = (await dialog.boundingBox())!;
+    const boundaryHandleBox = (await resizeHandle.boundingBox())!;
+    await page.mouse.move(boundaryHandleBox.x + boundaryHandleBox.width / 2, boundaryHandleBox.y + boundaryHandleBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(boundaryHandleBox.x + boundaryHandleBox.width / 2 + 1_000, boundaryHandleBox.y + boundaryHandleBox.height / 2, { steps: 8 });
+    await page.mouse.up();
+    const afterBoundaryResize = (await dialog.boundingBox())!;
+    expect(Math.abs(afterBoundaryResize.x - beforeBoundaryResize.x)).toBeLessThan(2);
+    expect(afterBoundaryResize.x + afterBoundaryResize.width).toBeLessThanOrEqual(1180 - 48 - 7);
 
     await page.keyboard.press('Escape');
     await expect(dialog).toBeHidden();

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -93,6 +93,58 @@ test.describe('Claude Science artifact campaign', () => {
     await page.screenshot({ path: path.join(outputDir, 'restriction-detail-light.png'), fullPage: true });
   });
 
+  test('late-column restriction labels share the recognition and cut-bond grid', async ({ page }) => {
+    await openArtifact(page);
+    await ensureDetailMode(page);
+
+    const label = page.locator('.motif-cs-restriction-label').filter({ hasText: /^HindIII$/ }).first();
+    await expect(label).toBeVisible();
+    await label.scrollIntoViewIfNeeded();
+    await label.hover();
+
+    const block = label.locator('xpath=ancestor::*[contains(concat(" ", normalize-space(@class), " "), " motif-cs-seq-block ")]');
+    const bases = block.locator('.motif-cs-seq-bases');
+    const recognition = block.locator('.motif-cs-seq-hl-restriction');
+    const ruler = page.locator('.motif-cs-seq-ruler');
+    await expect(recognition).toHaveCount(1);
+
+    const sitePosition = Number(await label.getAttribute('data-site-position'));
+    const lineStart = Number(await bases.getAttribute('data-line-start'));
+    const lineOffset = sitePosition - lineStart;
+    const recognitionLength = Number(await label.getAttribute('data-recognition-length'));
+    const charWidth = (await ruler.evaluate((node) => node.getBoundingClientRect().width)) / 100;
+    const labelBox = (await label.boundingBox())!;
+    const basesBox = (await bases.boundingBox())!;
+    const recognitionBox = (await recognition.boundingBox())!;
+
+    expect(lineOffset).toBeGreaterThan(30);
+    expect(recognitionLength).toBe(6);
+    expect(Math.abs(labelBox.x - recognitionBox.x)).toBeLessThan(0.75);
+    expect(Math.abs(recognitionBox.x - (basesBox.x + lineOffset * charWidth))).toBeLessThan(0.75);
+    expect(Math.abs(recognitionBox.width - recognitionLength * charWidth)).toBeLessThan(0.75);
+
+    const cuts = block.locator('.motif-cs-seq-cut[data-enzyme="HindIII"]');
+    await expect(cuts).toHaveCount(2);
+    const cutGeometry = await cuts.evaluateAll((nodes) => nodes.map((node) => {
+      const element = node as HTMLElement;
+      return {
+        bond: Number(element.dataset.cutBond),
+        strand: element.dataset.strand,
+        x: element.getBoundingClientRect().x,
+      };
+    }));
+    expect(cutGeometry
+      .map(({ bond, strand }) => ({ bond, strand }))
+      .sort((a, b) => a.bond - b.bond)).toEqual([
+      { bond: sitePosition + 1, strand: 'sense' },
+      { bond: sitePosition + 5, strand: 'antisense' },
+    ]);
+    for (const cut of cutGeometry) {
+      const expectedX = basesBox.x + (cut.bond - lineStart) * charWidth;
+      expect(Math.abs(cut.x - expectedX)).toBeLessThan(0.75);
+    }
+  });
+
   test('Type IIS labels reveal the correct staggered cut bonds on hover and selection', async ({ page }) => {
     await openArtifact(page);
     await ensureDetailMode(page);

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -788,7 +788,9 @@ test.describe('Claude Science artifact campaign', () => {
     await assemblyWindow.getByRole('button', { name: 'Maximize Cloning Workspace' }).click();
     await expect(assemblyWindow).toHaveAttribute('data-maximized', 'true');
     const maximized = (await assemblyWindow.boundingBox())!;
-    expect(maximized.width).toBeGreaterThanOrEqual(1420);
+    const toolsRail = (await page.locator('.motif-cs-inspector[data-tools-pinned="false"]').boundingBox())!;
+    expect(maximized.x).toBeLessThanOrEqual(12);
+    expect(toolsRail.x - (maximized.x + maximized.width)).toBeLessThanOrEqual(12);
     expect(maximized.height).toBeGreaterThanOrEqual(880);
     await assemblyWindow.getByRole('button', { name: 'Restore Cloning Workspace' }).click();
     await expect(assemblyWindow).not.toHaveAttribute('data-maximized', 'true');
@@ -1339,6 +1341,34 @@ test.describe('Claude Science artifact campaign', () => {
 
     await toolsToggle.click();
     await expect(primerPanel).not.toHaveAttribute('open', '');
+  });
+
+  test('a short Tools rail popover keeps its resize grip on the visible corner after growing', async ({ page }) => {
+    await openArtifact(page, 1180, 820);
+    const toolsToggle = page.getByRole('button', { name: /Tools/ }).first();
+    if ((await toolsToggle.getAttribute('aria-pressed')) === 'true') await toolsToggle.click();
+
+    const workflows = page.locator('details[data-rail-tool="workflows"]');
+    await workflows.locator(':scope > summary').click();
+    const panelBody = workflows.locator('.motif-cs-tool-panel-body');
+    const resizeHandle = panelBody.getByTestId('rail-popover-resize');
+    await expect(resizeHandle).toBeVisible();
+    const before = (await panelBody.boundingBox())!;
+    const handle = (await resizeHandle.boundingBox())!;
+    await page.mouse.move(handle.x + handle.width / 2, handle.y + handle.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(handle.x + handle.width / 2, handle.y + handle.height / 2 + 150, { steps: 6 });
+    await page.mouse.up();
+
+    const grown = (await panelBody.boundingBox())!;
+    const grownHandle = (await resizeHandle.boundingBox())!;
+    expect(grown.height).toBeGreaterThan(before.height + 120);
+    expect(await panelBody.evaluate((element) => element.scrollHeight - element.clientHeight)).toBeLessThanOrEqual(1);
+    expect(Math.abs(grownHandle.x - grown.x)).toBeLessThan(2);
+    expect(Math.abs((grownHandle.y + grownHandle.height) - (grown.y + grown.height))).toBeLessThan(2);
+    expect(await page.evaluate(({ x, y }) => (
+      document.elementFromPoint(x, y)?.closest('.motif-cs-rail-popover-resize') !== null
+    ), { x: grown.x + 5, y: grown.y + grown.height - 5 })).toBe(true);
   });
 
   test('runtime APIs reject destructive invalid input and expose fresh biology synchronously', async ({ page }) => {
@@ -1912,6 +1942,20 @@ test.describe('Claude Science artifact campaign', () => {
     expect(Math.abs(afterBoundaryResize.x - beforeBoundaryResize.x)).toBeLessThan(2);
     expect(afterBoundaryResize.x + afterBoundaryResize.width).toBeLessThanOrEqual(1180 - 48 - 7);
 
+    const blurHandle = (await resizeHandle.boundingBox())!;
+    await page.mouse.move(blurHandle.x + blurHandle.width / 2, blurHandle.y + blurHandle.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(blurHandle.x + blurHandle.width / 2 - 20, blurHandle.y + blurHandle.height / 2 - 20);
+    await expect(page.locator('body')).toHaveAttribute('data-motif-cs-window-dragging', 'resize');
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await expect(page.locator('body')).not.toHaveAttribute('data-motif-cs-window-dragging');
+    const afterBlur = (await dialog.boundingBox())!;
+    await page.mouse.move(blurHandle.x + blurHandle.width / 2 - 80, blurHandle.y + blurHandle.height / 2 - 80);
+    const afterPostBlurMove = (await dialog.boundingBox())!;
+    expect(Math.abs(afterPostBlurMove.width - afterBlur.width)).toBeLessThan(1);
+    expect(Math.abs(afterPostBlurMove.height - afterBlur.height)).toBeLessThan(1);
+    await page.mouse.up();
+
     await page.keyboard.press('Escape');
     await expect(dialog).toBeHidden();
     await expect(toggle).toBeFocused();
@@ -2140,6 +2184,58 @@ test.describe('Claude Science artifact campaign', () => {
     const main = page.locator('.motif-cs-main');
     const dimensions = await main.evaluate((element) => ({ clientWidth: element.clientWidth, scrollWidth: element.scrollWidth }));
     expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + 2);
+  });
+
+  test('pane resize modes clean up on blur and Escape docking', async ({ page }) => {
+    await openArtifact(page, 640, 500);
+    const toolsToggle = page.getByRole('button', { name: /Tools/ }).first();
+    if ((await toolsToggle.getAttribute('aria-pressed')) !== 'true') await toolsToggle.click();
+
+    const inventory = page.locator('[data-pane-key="inventory"]');
+    const inventoryResize = page.getByRole('separator', { name: 'Resize inventory pane' });
+    const inventoryHandle = (await inventoryResize.boundingBox())!;
+    await page.mouse.move(inventoryHandle.x + inventoryHandle.width / 2, inventoryHandle.y + inventoryHandle.height / 2);
+    await page.mouse.down();
+    await expect(page.locator('body')).toHaveAttribute('data-motif-cs-resizing', 'inventory');
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await expect(page.locator('body')).not.toHaveAttribute('data-motif-cs-resizing');
+    const widthAfterBlur = (await inventory.boundingBox())!.width;
+    await page.mouse.move(inventoryHandle.x + inventoryHandle.width / 2 + 80, inventoryHandle.y + inventoryHandle.height / 2);
+    expect(Math.abs((await inventory.boundingBox())!.width - widthAfterBlur)).toBeLessThan(1);
+    await page.mouse.up();
+
+    await inventoryResize.evaluate((element) => {
+      element.setPointerCapture = () => { throw new DOMException('capture unavailable', 'NotFoundError'); };
+    });
+    const fallbackHandle = (await inventoryResize.boundingBox())!;
+    await page.mouse.move(fallbackHandle.x + fallbackHandle.width / 2, fallbackHandle.y + fallbackHandle.height / 2);
+    await page.mouse.down();
+    await expect(page.locator('body')).toHaveAttribute('data-motif-cs-resizing', 'inventory');
+    await page.mouse.move(fallbackHandle.x + fallbackHandle.width / 2 + 24, fallbackHandle.y + fallbackHandle.height / 2);
+    await page.mouse.up();
+    await expect(page.locator('body')).not.toHaveAttribute('data-motif-cs-resizing');
+
+    const rowResize = page.getByRole('separator', { name: 'Resize stacked sequence pane' });
+    const rowHandle = (await rowResize.boundingBox())!;
+    await page.mouse.move(rowHandle.x + rowHandle.width / 2, rowHandle.y + rowHandle.height / 2);
+    await page.mouse.down();
+    await expect(page.locator('body')).toHaveAttribute('data-motif-cs-stacked-resizing', 'sequence');
+    await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+    await expect(page.locator('body')).not.toHaveAttribute('data-motif-cs-stacked-resizing');
+    await page.mouse.up();
+
+    await inventory.getByRole('button', { name: 'Pop out Inventory pane' }).click();
+    const floatingHeader = inventory.locator(':scope > .motif-cs-pane-title');
+    await floatingHeader.focus();
+    const floatingHeaderBox = (await floatingHeader.boundingBox())!;
+    await page.mouse.move(floatingHeaderBox.x + 60, floatingHeaderBox.y + floatingHeaderBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(floatingHeaderBox.x + 85, floatingHeaderBox.y + 20);
+    await expect(page.locator('body')).toHaveAttribute('data-motif-cs-pane-floating-action', 'move');
+    await page.keyboard.press('Escape');
+    await expect(inventory).toHaveAttribute('data-pane-placement', 'docked');
+    await expect(page.locator('body')).not.toHaveAttribute('data-motif-cs-pane-floating-action');
+    await page.mouse.up();
   });
 
   test('640px two-row layout exposes only the resize axes rendered on screen', async ({ page }) => {
@@ -3215,18 +3311,20 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(restore).toBeVisible();
 
     const maximizedAt1180 = (await dialog.boundingBox())!;
+    const toolsRailAt1180 = (await page.locator('.motif-cs-inspector[data-tools-pinned="false"]').boundingBox())!;
     expect(maximizedAt1180.x).toBeLessThanOrEqual(12);
     expect(maximizedAt1180.y).toBeLessThanOrEqual(12);
-    expect(1180 - (maximizedAt1180.x + maximizedAt1180.width)).toBeLessThanOrEqual(12);
+    expect(toolsRailAt1180.x - (maximizedAt1180.x + maximizedAt1180.width)).toBeLessThanOrEqual(12);
     expect(820 - (maximizedAt1180.y + maximizedAt1180.height)).toBeLessThanOrEqual(12);
 
     await page.setViewportSize({ width: 1440, height: 1000 });
     await expect.poll(async () => {
       const box = (await dialog.boundingBox())!;
+      const rail = (await page.locator('.motif-cs-inspector[data-tools-pinned="false"]').boundingBox())!;
       return {
         left: Math.round(box.x),
         top: Math.round(box.y),
-        rightGap: Math.round(1440 - box.x - box.width),
+        rightGap: Math.round(rail.x - box.x - box.width),
         bottomGap: Math.round(1000 - box.y - box.height),
       };
     }).toEqual({ left: 8, top: 8, rightGap: 8, bottomGap: 8 });
@@ -4007,7 +4105,7 @@ test.describe('Claude Science artifact campaign', () => {
   });
 
   test('MSA 100-row density preserves suffixes, semantics, and chained scrolling', async ({ page }) => {
-    test.slow();
+    test.setTimeout(120_000);
     await openArtifact(page, 1180, 820);
     await page.evaluate(() => {
       const reference = 'ACGT'.repeat(375);

--- a/e2e/claude-science-pane-placement.spec.ts
+++ b/e2e/claude-science-pane-placement.spec.ts
@@ -1,12 +1,14 @@
 import { expect, test, type Page } from '@playwright/test';
 
+const artifactUrl = process.env.MOTIF_ARTIFACT_URL ?? '/motif.html';
+
 async function openArtifact(page: Page, width: number, height: number) {
   await page.setViewportSize({ width, height });
   await page.addInitScript(() => {
     window.localStorage.clear();
     window.sessionStorage.clear();
   });
-  await page.goto('/motif.html');
+  await page.goto(artifactUrl);
   await expect(page.locator('.motif-cs-shell')).toBeVisible();
 }
 
@@ -55,6 +57,18 @@ test.describe('state-preserving pane placement', () => {
     expect(resized!.width).toBeGreaterThan(moved!.width);
     expect(resized!.height).toBeGreaterThan(moved!.height);
 
+    await tools.evaluate((element) => { element.scrollTop = element.scrollHeight; });
+    await expect.poll(() => tools.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+    const scrolledTools = await tools.boundingBox();
+    const scrolledResize = await resize.boundingBox();
+    expect(scrolledTools).not.toBeNull();
+    expect(scrolledResize).not.toBeNull();
+    expect(Math.abs((scrolledResize!.x + scrolledResize!.width) - (scrolledTools!.x + scrolledTools!.width))).toBeLessThan(2);
+    expect(Math.abs((scrolledResize!.y + scrolledResize!.height) - (scrolledTools!.y + scrolledTools!.height))).toBeLessThan(2);
+    expect(await page.evaluate(({ x, y }) => (
+      document.elementFromPoint(x, y)?.closest('.motif-cs-floating-pane-resize') !== null
+    ), { x: scrolledTools!.x + scrolledTools!.width - 5, y: scrolledTools!.y + scrolledTools!.height - 5 })).toBe(true);
+
     await tools.getByRole('button', { name: 'Dock Tools pane' }).click();
     await expect(tools).toHaveAttribute('data-pane-placement', 'docked');
     await expect(draftTitle).toHaveValue('Uncommitted pane draft');
@@ -90,5 +104,20 @@ test.describe('state-preserving pane placement', () => {
     await page.keyboard.press('Escape');
     await expect(inventory).toHaveAttribute('data-pane-placement', 'docked');
     await expect(inventory.getByRole('button', { name: 'Pop out Inventory pane' })).toBeFocused();
+  });
+
+  test('visibility controls keep one content pane docked while other panes float', async ({ page }) => {
+    await openArtifact(page, 1180, 820);
+    const map = page.locator('[data-pane-key="map"]');
+    await map.getByRole('button', { name: 'Pop out Map pane' }).click();
+    await page.locator('[data-pane-toggle="inventory"]').click();
+
+    const sequenceToggle = page.locator('[data-pane-toggle="sequence"]');
+    await expect(sequenceToggle).toBeDisabled();
+    await expect(sequenceToggle).toHaveAttribute('title', 'Keep one content pane docked in the workspace');
+    const sequenceCollapse = page.locator('[data-pane-key="sequence"]').getByRole('button', { name: /Sequence pane cannot be collapsed/ });
+    await expect(sequenceCollapse).toBeDisabled();
+    await expect(sequenceCollapse).toHaveAttribute('title', 'Keep one content pane docked in the workspace');
+    await expect(page.locator('.motif-cs-main')).toHaveAttribute('data-content-pane-count', '1');
   });
 });

--- a/e2e/claude-science-pane-placement.spec.ts
+++ b/e2e/claude-science-pane-placement.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function openArtifact(page: Page, width: number, height: number) {
+  await page.setViewportSize({ width, height });
+  await page.addInitScript(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+  await page.goto('/motif.html');
+  await expect(page.locator('.motif-cs-shell')).toBeVisible();
+}
+
+test.describe('state-preserving pane placement', () => {
+  test('Tools keeps its open workflow draft through pop out, move, resize, and dock', async ({ page }) => {
+    await openArtifact(page, 1180, 900);
+    const toolsToggle = page.locator('[data-pane-toggle="tools"]');
+    if ((await toolsToggle.getAttribute('aria-pressed')) !== 'true') await toolsToggle.click();
+
+    const tools = page.locator('[data-pane-key="tools"]');
+    const notes = tools.locator('details[data-rail-tool="notes"]');
+    await notes.locator(':scope > summary').click();
+    await notes.locator('.motif-cs-annotation-editor-drawer > summary').click();
+    const draftTitle = notes.getByLabel('Title');
+    const draftBody = notes.locator('.motif-cs-annotation-editor-drawer textarea');
+    await draftTitle.fill('Uncommitted pane draft');
+    await draftBody.fill('This stays local while the same Tools subtree changes placement.');
+
+    await tools.getByRole('button', { name: 'Pop out Tools pane' }).click();
+    await expect(tools).toHaveAttribute('data-pane-placement', 'floating');
+    await expect(notes).toHaveAttribute('open', '');
+    await expect(draftTitle).toHaveValue('Uncommitted pane draft');
+    const before = await tools.boundingBox();
+    expect(before).not.toBeNull();
+
+    const head = tools.locator(':scope > .motif-cs-pane-title');
+    const headBox = await head.boundingBox();
+    expect(headBox).not.toBeNull();
+    await page.mouse.move(headBox!.x + 70, headBox!.y + headBox!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(headBox!.x + 20, headBox!.y + 55, { steps: 5 });
+    await page.mouse.up();
+    const moved = await tools.boundingBox();
+    expect(moved).not.toBeNull();
+    expect(Math.abs(moved!.x - before!.x) + Math.abs(moved!.y - before!.y)).toBeGreaterThan(20);
+
+    const resize = tools.getByTestId('floating-pane-resize-tools');
+    const resizeBox = await resize.boundingBox();
+    expect(resizeBox).not.toBeNull();
+    await page.mouse.move(resizeBox!.x + resizeBox!.width / 2, resizeBox!.y + resizeBox!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(resizeBox!.x + 76, resizeBox!.y + 60, { steps: 5 });
+    await page.mouse.up();
+    const resized = await tools.boundingBox();
+    expect(resized).not.toBeNull();
+    expect(resized!.width).toBeGreaterThan(moved!.width);
+    expect(resized!.height).toBeGreaterThan(moved!.height);
+
+    await tools.getByRole('button', { name: 'Dock Tools pane' }).click();
+    await expect(tools).toHaveAttribute('data-pane-placement', 'docked');
+    await expect(draftTitle).toHaveValue('Uncommitted pane draft');
+    await expect(draftBody).toHaveValue('This stays local while the same Tools subtree changes placement.');
+    await expect(tools.getByRole('button', { name: 'Pop out Tools pane' })).toBeFocused();
+  });
+
+  test('Escape docks a floating pane and the phone layout uses a bounded sheet', async ({ page }) => {
+    await openArtifact(page, 390, 760);
+    const inventory = page.locator('[data-pane-key="inventory"]');
+    await inventory.getByRole('button', { name: 'Pop out Inventory pane' }).click();
+    await expect(inventory).toHaveAttribute('data-pane-placement', 'floating');
+
+    const sheet = await inventory.boundingBox();
+    expect(sheet).not.toBeNull();
+    expect(sheet!.x).toBeGreaterThanOrEqual(7);
+    expect(sheet!.x + sheet!.width).toBeLessThanOrEqual(383);
+    expect(sheet!.y).toBeGreaterThan(38);
+    expect(sheet!.y + sheet!.height).toBeLessThanOrEqual(753);
+    await expect(inventory.getByTestId('floating-pane-resize-inventory')).toBeHidden();
+
+    await inventory.getByRole('button', { name: 'Add entry' }).click();
+    const addEntry = inventory.locator('#motif-cs-add-entry');
+    await expect(addEntry).toBeVisible();
+    const addEntryBox = await addEntry.boundingBox();
+    expect(addEntryBox).not.toBeNull();
+    expect(addEntryBox!.x).toBeGreaterThanOrEqual(sheet!.x);
+    expect(addEntryBox!.x + addEntryBox!.width).toBeLessThanOrEqual(sheet!.x + sheet!.width);
+
+    await inventory.getByRole('button', { name: 'Add entry' }).click();
+    await expect(addEntry).toBeHidden();
+    await inventory.getByRole('button', { name: 'Dock Inventory pane' }).focus();
+    await page.keyboard.press('Escape');
+    await expect(inventory).toHaveAttribute('data-pane-placement', 'docked');
+    await expect(inventory.getByRole('button', { name: 'Pop out Inventory pane' })).toBeFocused();
+  });
+});

--- a/e2e/playwright.pane-placement.config.ts
+++ b/e2e/playwright.pane-placement.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from '@playwright/test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const port = Number(process.env.MOTIF_PANE_E2E_PORT ?? 5227);
+
+export default defineConfig({
+  testDir: resolve(root, 'e2e'),
+  testMatch: 'claude-science-pane-placement.spec.ts',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  workers: 1,
+  reporter: process.env.CI ? 'line' : 'list',
+  outputDir: resolve(root, 'test-results/pane-placement'),
+  timeout: 60_000,
+  use: {
+    browserName: 'chromium',
+    baseURL: `http://127.0.0.1:${port}`,
+    contextOptions: { reducedMotion: 'reduce' },
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: `node_modules/.bin/vite --config vite.claude-science.config.ts --port ${port} --strictPort --host 127.0.0.1`,
+    url: `http://127.0.0.1:${port}/motif.html`,
+    cwd: root,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/src/artifacts/__tests__/claude-science-accessibility-interaction-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-accessibility-interaction-guards.test.ts
@@ -44,10 +44,10 @@ describe('Claude Science accessibility and interaction guards', () => {
     expect(artifactSource).toContain("collapsePaneAndRestoreFocus('tools')");
   });
 
-  it('announces and disables pane-local collapse controls for the last content pane', () => {
-    expect(artifactSource).toContain('const canCollapseContentPane = visibleContentPaneCount > 1;');
-    expect(artifactSource.match(/disabled=\{!canCollapseContentPane\}/g)).toHaveLength(3);
-    expect(artifactSource.match(/at least one content pane must stay visible/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
+  it('announces and disables pane-local collapse controls for the last visible or docked content pane', () => {
+    expect(artifactSource).toContain('const canHideContentPane = (pane:');
+    expect(artifactSource.match(/disabled=\{!canHideContentPane\('/g)).toHaveLength(3);
+    expect(artifactSource).toContain('Keep one content pane docked in the workspace');
     expect(artifactCss).toContain('.motif-cs-pane-collapse:disabled');
   });
 
@@ -93,6 +93,8 @@ describe('Claude Science accessibility and interaction guards', () => {
     expect(floatingWindow).toContain('Resize ${title} window in 2 dimensions');
     expect(floatingWindow).toContain('aria-keyshortcuts="ArrowLeft ArrowRight ArrowUp ArrowDown"');
     expect(floatingWindow).not.toContain('aria-orientation="horizontal"');
+    expect(floatingWindow).toContain("window.addEventListener('blur', endDragFromBlur)");
+    expect(floatingWindow).toContain("dragSurface.addEventListener('lostpointercapture', endLostPointerCapture)");
   });
 
   it('keeps a background workflow mounted but inert while a child workflow is active', () => {

--- a/src/artifacts/__tests__/claude-science-msa-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-msa-guards.test.ts
@@ -35,7 +35,9 @@ describe('Claude Science MSA integration guards', () => {
     expect(artifactSource).toContain('aria-label={maximized ? `Restore ${title}` : `Maximize ${title}`}');
     expect(artifactSource).toContain('data-maximized={maximized || undefined}');
     expect(artifactSource).toContain('const restoreRectRef = useRef(initial);');
-    expect(artifactSource).toContain(': clampWindowRect(restoreRectRef.current);');
+    expect(artifactSource).toContain(
+      ': clampWindowRect(restoreRectRef.current, window.innerWidth, window.innerHeight, rightInset);',
+    );
     expect(artifactSource).toContain('<ClaudeScienceMsaViewer');
     expect(artifactCss).toMatch(/\.motif-cs-alignment-tool-body\s*\{[\s\S]*?display:\s*grid;[\s\S]*?gap:\s*10px;[\s\S]*?padding:\s*12px;/);
     expect(artifactCss).toMatch(/\.motif-cs-alignment-launch\s*\{[\s\S]*?width:\s*100%;[\s\S]*?white-space:\s*normal;/);

--- a/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
@@ -71,7 +71,7 @@ describe('Claude Science rail popover regression guards', () => {
     expect(compactLayout).toMatch(
       /\.motif-cs-inspector\[data-tools-pinned="false"\]\s*\{[\s\S]*?z-index:\s*70;/,
     );
-    expect(artifactSource).toContain('rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}');
+    expect(artifactSource).toContain('rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}');
     expect(artifactSource).toContain('viewportWidth - safeRightInset - w - 8');
     expect(artifactCss).not.toContain('.motif-cs-window-resize {\n    right: 58px;');
   });
@@ -259,8 +259,9 @@ describe('Claude Science rail popover regression guards', () => {
     const railBody = artifactCss.slice(railBodyStart, railBodyEnd);
     expect(artifactCss).toMatch(/\.motif-cs-inspector\[data-tools-pinned="false"\] \.motif-cs-panel\[open\] > \.motif-cs-tool-panel-body\s*\{[\s\S]*?width:\s*min\(var\(--rail-popover-width,[\s\S]*?height:\s*var\(--rail-popover-height, auto\)/);
     expect(railBody).not.toContain('resize: both');
-    expect(artifactCss).toMatch(/\.motif-cs-inspector\[data-tools-pinned="false"\][\s\S]*?\.motif-cs-rail-popover-resize\s*\{[\s\S]*?position:\s*sticky;[\s\S]*?bottom:\s*0;[\s\S]*?left:\s*0;/);
+    expect(artifactCss).toMatch(/\.motif-cs-inspector\[data-tools-pinned="false"\][\s\S]*?\.motif-cs-rail-popover-resize\s*\{[\s\S]*?position:\s*fixed;/);
     expect(artifactSource).toContain('data-testid="rail-popover-resize"');
+    expect(artifactSource).toContain('style={{ left: resizeCorner.left, top: resizeCorner.top }}');
     expect(artifactSource).toContain('createPortal(');
     expect(artifactSource).toContain('active.base.width - (moveEvent.clientX - active.startX)');
     expect(artifactSource).toContain("window.addEventListener('pointercancel', endPointerResize);");

--- a/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
@@ -71,9 +71,9 @@ describe('Claude Science rail popover regression guards', () => {
     expect(compactLayout).toMatch(
       /\.motif-cs-inspector\[data-tools-pinned="false"\]\s*\{[\s\S]*?z-index:\s*70;/,
     );
-    expect(artifactCss).toMatch(
-      /\.motif-cs-window:has\(\.motif-cs-msa-workspace\)[\s\S]*?\.motif-cs-window-body\s*\{[\s\S]*?padding-right:\s*58px;/,
-    );
+    expect(artifactSource).toContain('rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}');
+    expect(artifactSource).toContain('viewportWidth - safeRightInset - w - 8');
+    expect(artifactCss).not.toContain('.motif-cs-window-resize {\n    right: 58px;');
   });
 
   it('requires an explicit second action in the detailed annotation editors', () => {
@@ -253,9 +253,15 @@ describe('Claude Science rail popover regression guards', () => {
     expect(artifactCss).toContain('.motif-cs-theme-grid');
   });
 
-  it('lets dense rail popovers open taller and resize from a visible corner', () => {
-    expect(artifactCss).toMatch(/\.motif-cs-inspector\[data-tools-pinned="false"\] \.motif-cs-panel\[open\] > \.motif-cs-tool-panel-body\s*\{[\s\S]*?max-width:\s*min\(620px,[\s\S]*?resize:\s*both/);
-    expect(artifactCss).toContain('background-image: linear-gradient(135deg');
+  it('resizes rail popovers from an explicit bottom-left handle without leaking native dimensions', () => {
+    expect(artifactCss).toMatch(/\.motif-cs-inspector\[data-tools-pinned="false"\] \.motif-cs-panel\[open\] > \.motif-cs-tool-panel-body\s*\{[\s\S]*?width:\s*min\(var\(--rail-popover-width,[\s\S]*?height:\s*var\(--rail-popover-height, auto\)/);
+    expect(artifactCss).not.toContain('resize: both');
+    expect(artifactCss).toMatch(/\.motif-cs-inspector\[data-tools-pinned="false"\][\s\S]*?\.motif-cs-rail-popover-resize\s*\{[\s\S]*?bottom:\s*0;[\s\S]*?left:\s*0;/);
+    expect(artifactSource).toContain('data-testid="rail-popover-resize"');
+    expect(artifactSource).toContain('active.base.width - (moveEvent.clientX - active.startX)');
+    expect(artifactSource).toContain("window.addEventListener('pointercancel', endPointerResize);");
+    expect(artifactSource).toContain("handle.addEventListener('lostpointercapture', endLostPointerCapture);");
+    expect(artifactSource).toContain('widthDelta = event.key === \'ArrowLeft\' ? step');
     expect(artifactCss).toMatch(/@media \(max-width: 1280px\)[\s\S]*?max-height:\s*min\(calc\(100vh - var\(--rail-popover-fixed-top\) - 22px\), 600px\)/);
   });
 

--- a/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
@@ -254,10 +254,14 @@ describe('Claude Science rail popover regression guards', () => {
   });
 
   it('resizes rail popovers from an explicit bottom-left handle without leaking native dimensions', () => {
+    const railBodyStart = artifactCss.indexOf('.motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel[open] > .motif-cs-tool-panel-body {');
+    const railBodyEnd = artifactCss.indexOf('@media (max-width: 1280px)', railBodyStart);
+    const railBody = artifactCss.slice(railBodyStart, railBodyEnd);
     expect(artifactCss).toMatch(/\.motif-cs-inspector\[data-tools-pinned="false"\] \.motif-cs-panel\[open\] > \.motif-cs-tool-panel-body\s*\{[\s\S]*?width:\s*min\(var\(--rail-popover-width,[\s\S]*?height:\s*var\(--rail-popover-height, auto\)/);
-    expect(artifactCss).not.toContain('resize: both');
-    expect(artifactCss).toMatch(/\.motif-cs-inspector\[data-tools-pinned="false"\][\s\S]*?\.motif-cs-rail-popover-resize\s*\{[\s\S]*?bottom:\s*0;[\s\S]*?left:\s*0;/);
+    expect(railBody).not.toContain('resize: both');
+    expect(artifactCss).toMatch(/\.motif-cs-inspector\[data-tools-pinned="false"\][\s\S]*?\.motif-cs-rail-popover-resize\s*\{[\s\S]*?position:\s*sticky;[\s\S]*?bottom:\s*0;[\s\S]*?left:\s*0;/);
     expect(artifactSource).toContain('data-testid="rail-popover-resize"');
+    expect(artifactSource).toContain('createPortal(');
     expect(artifactSource).toContain('active.base.width - (moveEvent.clientX - active.startX)');
     expect(artifactSource).toContain("window.addEventListener('pointercancel', endPointerResize);");
     expect(artifactSource).toContain("handle.addEventListener('lostpointercapture', endLostPointerCapture);");

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -203,7 +203,11 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toContain('[neighbor]: startWidths[neighbor] - appliedDelta');
     expect(artifactSource).toContain('if (moveEvent.pointerId !== pointerId) return;');
     expect(artifactSource).toContain('if (endEvent.pointerId !== pointerId) return;');
-    expect(artifactSource).toContain("window.addEventListener('pointercancel', handlePointerUp);");
+    expect(artifactSource).toContain("window.addEventListener('pointercancel', handlePointerEnd);");
+    expect(artifactSource).toContain("window.addEventListener('blur', handleWindowBlur);");
+    expect(artifactSource).toContain("resizeHandle.addEventListener('lostpointercapture', handleLostPointerCapture);");
+    expect(artifactSource).toContain('stopPaneResize();');
+    expect(artifactSource).toContain('stopStackedPaneResize();');
     expect(artifactCss).toContain('var(--motif-cs-tools-pane-width, 280px)');
     expect(artifactCss).toMatch(/@media \(min-width: 640px\) and \(max-width: 1535px\)[\s\S]*?\.motif-cs-resize-handle\[data-pane="sequence"\]\s*\{[\s\S]*?display:\s*none/);
   });
@@ -451,7 +455,7 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toContain('aria-keyshortcuts="ArrowLeft ArrowRight ArrowUp ArrowDown"');
     expect(artifactCss).toContain('.motif-cs-window-resize:focus-visible');
     expect(artifactCss).toMatch(/\.motif-cs-window-resize\s*\{[\s\S]*?width:\s*28px;[\s\S]*?height:\s*28px/);
-    expect(artifactSource).toContain('rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}');
+    expect(artifactSource).toContain('rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}');
     expect(artifactSource).toContain('clampWindowRect(raw, vw, vh, rightInset)');
     expect(artifactSource).toContain('vw - rightInset - drag.base.x - 8');
     expect(artifactCss).not.toContain('.motif-cs-window-resize {\n    right: 58px;');

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -190,7 +190,8 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toContain("const overlayTools = pane === 'tools' && overlayLayout;");
     expect(artifactSource).toContain("visibleResizablePanes.filter((pane) => pane !== 'tools')");
     expect(artifactSource).toContain("visibleResizablePanes.filter((pane) => pane === 'inventory' || pane === 'sequence')");
-    expect(artifactSource).toContain('saveWorkspaceLayoutPrefs({ theme, paneWidths: preferredPaneWidths');
+    expect(artifactSource).toContain('saveWorkspaceLayoutPrefs({');
+    expect(artifactSource).toContain('floatingPaneRects,');
     expect(artifactSource).toContain('const next = clampPaneWidthsForViewport(preferredPaneWidths);');
     expect(artifactSource).toContain("'--motif-cs-inventory-pane-width': `${paneWidths.inventory}px`");
     expect(artifactSource).toContain("'--motif-cs-sequence-pane-width': `${paneWidths.sequence}px`");
@@ -208,7 +209,7 @@ describe('Claude Science workspace layout guards', () => {
   });
 
   it('reflows a pinned compact workspace without overlaying or reserving a hidden map lane', () => {
-    expect(artifactSource).toContain('data-tools-pinned={toolsPinned || undefined}');
+    expect(artifactSource).toContain('data-tools-pinned={toolsDocked || undefined}');
     expect(artifactCss).toMatch(/@media \(min-width: 640px\) and \(max-width: 1535px\)[\s\S]*?\.motif-cs-main\[data-tools-pinned="true"\]\s*\{[\s\S]*?display:\s*grid/);
     expect(artifactCss).toContain('.motif-cs-main[data-tools-pinned="true"] > .motif-cs-stacked-resize-handle[data-pane="sequence"]');
     expect(artifactSource).toContain('COMPACT_PINNED_LAYOUT_MEDIA');
@@ -539,7 +540,7 @@ describe('Claude Science workspace layout guards', () => {
   });
 
   it('collapses absent intermediate-width pane tracks and preserves wider-layout preferences', () => {
-    expect(artifactSource).toContain('data-content-pane-count={visibleContentPaneCount}');
+    expect(artifactSource).toContain('data-content-pane-count={dockedContentPaneCount}');
     expect(artifactSource).toContain("&& visibleContentPanes.length === 3");
     expect(artifactSource).toContain("if (twoRowLayout && pane === 'inventory') return 'sequence';");
     expect(artifactSource).toContain('const startPreferredWidths = { ...preferredPaneWidths };');

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -450,7 +450,9 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toContain('aria-keyshortcuts="ArrowLeft ArrowRight ArrowUp ArrowDown"');
     expect(artifactCss).toContain('.motif-cs-window-resize:focus-visible');
     expect(artifactCss).toMatch(/\.motif-cs-window-resize\s*\{[\s\S]*?width:\s*28px;[\s\S]*?height:\s*28px/);
-    expect(artifactCss).toContain('.motif-cs-shell:has(.motif-cs-inspector[data-tools-pinned="false"]) .motif-cs-window-resize {\n    right: 58px;');
+    expect(artifactSource).toContain('rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}');
+    expect(artifactSource).toContain('clampWindowRect(raw, vw, vh, rightInset)');
+    expect(artifactCss).not.toContain('.motif-cs-window-resize {\n    right: 58px;');
   });
 
   it('limits floating-window drags to the initiating primary pointer', () => {
@@ -493,7 +495,7 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toContain('w: clamp(drag.base.w + dx, 280');
     expect(artifactSource).toContain('h: clamp(drag.base.h + dy, 180');
     expect(artifactCss).toMatch(/@media \(max-width: 840px\)[\s\S]*?\.motif-cs-window\s*\{\s*border-color:/);
-    expect(artifactCss).toMatch(/@media \(max-width: 840px\)[\s\S]*?\.motif-cs-window\[data-collapsed\]\s*\{[\s\S]*?left:\s*8px !important;[\s\S]*?width:\s*calc\(100vw - 16px\) !important/);
+    expect(artifactCss).toMatch(/@media \(max-width: 840px\)[\s\S]*?\.motif-cs-window\[data-collapsed\]\s*\{[\s\S]*?left:\s*8px !important;[\s\S]*?width:\s*calc\(100vw - 16px - var\(--motif-cs-floating-right-inset, 0px\)\) !important/);
     expect(artifactCss).not.toMatch(/@media \(max-width: 840px\)[\s\S]*?\.motif-cs-window\s*\{[\s\S]*?height:\s*min\(30vh, 240px\) !important/);
   });
 

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -452,6 +452,7 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactCss).toMatch(/\.motif-cs-window-resize\s*\{[\s\S]*?width:\s*28px;[\s\S]*?height:\s*28px/);
     expect(artifactSource).toContain('rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}');
     expect(artifactSource).toContain('clampWindowRect(raw, vw, vh, rightInset)');
+    expect(artifactSource).toContain('vw - rightInset - drag.base.x - 8');
     expect(artifactCss).not.toContain('.motif-cs-window-resize {\n    right: 58px;');
   });
 

--- a/src/artifacts/__tests__/floating-surface-geometry.test.ts
+++ b/src/artifacts/__tests__/floating-surface-geometry.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  clampFloatingSurfaceRect,
+  moveFloatingSurfaceRect,
+  resizeFloatingSurfaceRectFromBottomLeft,
+  resizeFloatingSurfaceRectFromBottomRight,
+  type FloatingSurfaceRect,
+} from '../floating-surface-geometry';
+
+const viewport = {
+  width: 1_000,
+  height: 700,
+  insets: { top: 40, right: 60, bottom: 30, left: 20 },
+};
+
+describe('floating surface geometry', () => {
+  it('clamps position and size against every viewport inset', () => {
+    expect(clampFloatingSurfaceRect(
+      { x: -100, y: -100, w: 1_200, h: 900 },
+      viewport,
+    )).toEqual({ x: 20, y: 40, w: 920, h: 630 });
+
+    expect(moveFloatingSurfaceRect(
+      { x: 300, y: 200, w: 320, h: 240 },
+      { dx: 2_000, dy: 2_000 },
+      viewport,
+    )).toEqual({ x: 620, y: 430, w: 320, h: 240 });
+  });
+
+  it('shrinks effective minima to fit a narrow safe viewport', () => {
+    expect(clampFloatingSurfaceRect(
+      { x: 400, y: 300, w: 500, h: 400 },
+      {
+        width: 240,
+        height: 170,
+        insets: { top: 12, right: 18, bottom: 14, left: 16 },
+      },
+    )).toEqual({ x: 16, y: 12, w: 206, h: 144 });
+  });
+
+  it('grows leftward from the bottom-left while keeping the right edge anchored', () => {
+    const before = { x: 500, y: 100, w: 320, h: 240 };
+    const after = resizeFloatingSurfaceRectFromBottomLeft(
+      before,
+      { dx: -120, dy: 50 },
+      viewport,
+    );
+
+    expect(after).toEqual({ x: 380, y: 100, w: 440, h: 290 });
+    expect(after.x + after.w).toBe(before.x + before.w);
+  });
+
+  it('keeps bottom-left growth inside the left and bottom insets', () => {
+    expect(resizeFloatingSurfaceRectFromBottomLeft(
+      { x: 500, y: 100, w: 320, h: 240 },
+      { dx: -1_000, dy: 1_000 },
+      viewport,
+    )).toEqual({ x: 20, y: 100, w: 800, h: 570 });
+  });
+
+  it('keeps the top-left corner anchored during bottom-right resizing', () => {
+    expect(resizeFloatingSurfaceRectFromBottomRight(
+      { x: 300, y: 200, w: 320, h: 240 },
+      { dx: 800, dy: 800 },
+      viewport,
+    )).toEqual({ x: 300, y: 200, w: 640, h: 470 });
+  });
+
+  it('clamps stably without changing the preferred desktop rectangle', () => {
+    const preferred: FloatingSurfaceRect = Object.freeze({ x: 620, y: 180, w: 520, h: 360 });
+    const narrowViewport = {
+      width: 420,
+      height: 320,
+      insets: { top: 24, right: 12, bottom: 12, left: 12 },
+    };
+    const narrow = clampFloatingSurfaceRect(preferred, narrowViewport);
+
+    expect(narrow).toEqual({ x: 12, y: 24, w: 396, h: 284 });
+    expect(clampFloatingSurfaceRect(narrow, narrowViewport)).toEqual(narrow);
+    expect(preferred).toEqual({ x: 620, y: 180, w: 520, h: 360 });
+    expect(clampFloatingSurfaceRect(preferred, {
+      width: 1_400,
+      height: 900,
+      insets: { top: 8, right: 8, bottom: 8, left: 8 },
+    })).toEqual(preferred);
+  });
+});

--- a/src/artifacts/__tests__/pane-placement-guards.test.ts
+++ b/src/artifacts/__tests__/pane-placement-guards.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const artifactSource = readFileSync(resolve(here, '..', 'motif-artifact.tsx'), 'utf8');
+const artifactCss = readFileSync(resolve(here, '..', 'motif-artifact.css'), 'utf8');
+
+describe('workspace pane placement guards', () => {
+  it('moves each existing pane node instead of rendering a floating duplicate', () => {
+    for (const pane of ['inventory', 'map', 'sequence', 'tools']) {
+      expect(artifactSource.match(new RegExp(`data-pane-key="${pane}"`, 'g'))).toHaveLength(1);
+    }
+    expect(artifactSource.match(/data-pane-placement=\{panePlacements\./g)).toHaveLength(4);
+  });
+
+  it('excludes floating panes from docked topology and resets every pane to docked', () => {
+    expect(artifactSource).toContain("paneVisibility[pane] && panePlacements[pane] === 'docked'");
+    expect(artifactSource).toContain('data-content-pane-count={dockedContentPaneCount}');
+    expect(artifactSource).toContain("panePlacements.sequence === 'docked' && panePlacements.map === 'docked'");
+    expect(artifactSource).toContain('setPanePlacements({ ...DEFAULT_WORKSPACE_LAYOUT.panePlacements });');
+    expect(artifactSource).toContain("disabled={dockedContentPaneCount <= 1}");
+  });
+
+  it('uses bounded geometry and cleans every pointer termination path', () => {
+    expect(artifactSource).toContain('moveFloatingSurfaceRect(');
+    expect(artifactSource).toContain('resizeFloatingSurfaceRectFromBottomRight(');
+    expect(artifactSource).toContain("window.addEventListener('pointercancel', finishPointer)");
+    expect(artifactSource).toContain("window.addEventListener('blur', finishFromBlur)");
+    expect(artifactSource).toContain("surface.addEventListener('lostpointercapture', finishPointer)");
+    expect(artifactSource).toContain('if (!event.isPrimary || event.button !== 0) return;');
+  });
+
+  it('keeps responsive floating overrides last and gives phones a reachable sheet', () => {
+    const placementBlock = artifactCss.lastIndexOf('/* Pane placement');
+    const lastResponsiveRule = artifactCss.lastIndexOf('@media');
+    expect(placementBlock).toBeGreaterThan(0);
+    expect(lastResponsiveRule).toBeGreaterThan(placementBlock);
+    expect(artifactCss.slice(placementBlock)).toContain('.motif-cs-main > .motif-cs-pane[data-pane-placement="floating"]');
+    expect(artifactCss.slice(lastResponsiveRule)).toContain('width: auto !important;');
+    expect(artifactCss.slice(lastResponsiveRule)).toContain('.motif-cs-floating-pane-resize');
+    expect(artifactCss.slice(lastResponsiveRule)).toContain('display: none;');
+  });
+});

--- a/src/artifacts/__tests__/pane-placement-guards.test.ts
+++ b/src/artifacts/__tests__/pane-placement-guards.test.ts
@@ -16,11 +16,13 @@ describe('workspace pane placement guards', () => {
   });
 
   it('excludes floating panes from docked topology and resets every pane to docked', () => {
-    expect(artifactSource).toContain("paneVisibility[pane] && panePlacements[pane] === 'docked'");
+    expect(artifactSource).toContain("panePlacements[pane] === 'docked' && dockedContentCount <= 1");
     expect(artifactSource).toContain('data-content-pane-count={dockedContentPaneCount}');
     expect(artifactSource).toContain("panePlacements.sequence === 'docked' && panePlacements.map === 'docked'");
     expect(artifactSource).toContain('setPanePlacements({ ...DEFAULT_WORKSPACE_LAYOUT.panePlacements });');
     expect(artifactSource).toContain("disabled={dockedContentPaneCount <= 1}");
+    expect(artifactSource).toContain("paneVisibility[pane] && panePlacements[pane] === 'docked'");
+    expect(artifactSource).toContain("panePlacements = { ...panePlacements, [fallbackPane]: 'docked' };");
   });
 
   it('uses bounded geometry and cleans every pointer termination path', () => {
@@ -38,6 +40,7 @@ describe('workspace pane placement guards', () => {
     expect(placementBlock).toBeGreaterThan(0);
     expect(lastResponsiveRule).toBeGreaterThan(placementBlock);
     expect(artifactCss.slice(placementBlock)).toContain('.motif-cs-main > .motif-cs-pane[data-pane-placement="floating"]');
+    expect(artifactCss.slice(placementBlock)).toMatch(/\.motif-cs-floating-pane-resize\s*\{[\s\S]*?position:\s*fixed;/);
     expect(artifactCss.slice(lastResponsiveRule)).toContain('width: auto !important;');
     expect(artifactCss.slice(lastResponsiveRule)).toContain('.motif-cs-floating-pane-resize');
     expect(artifactCss.slice(lastResponsiveRule)).toContain('display: none;');

--- a/src/artifacts/floating-surface-geometry.ts
+++ b/src/artifacts/floating-surface-geometry.ts
@@ -1,0 +1,200 @@
+export type FloatingSurfaceRect = Readonly<{
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}>;
+
+export type FloatingSurfaceDelta = Readonly<{
+  dx: number;
+  dy: number;
+}>;
+
+export type FloatingSurfaceInsets = Readonly<{
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}>;
+
+export type FloatingSurfaceViewport = Readonly<{
+  width: number;
+  height: number;
+  insets?: Partial<FloatingSurfaceInsets>;
+}>;
+
+export type FloatingSurfaceSizeLimits = Readonly<{
+  minWidth?: number;
+  minHeight?: number;
+  maxWidth?: number;
+  maxHeight?: number;
+}>;
+
+export const DEFAULT_FLOATING_SURFACE_INSETS: FloatingSurfaceInsets = {
+  top: 8,
+  right: 8,
+  bottom: 8,
+  left: 8,
+};
+
+export const DEFAULT_FLOATING_SURFACE_SIZE_LIMITS: Required<FloatingSurfaceSizeLimits> = {
+  minWidth: 280,
+  minHeight: 180,
+  maxWidth: Number.POSITIVE_INFINITY,
+  maxHeight: Number.POSITIVE_INFINITY,
+};
+
+type FloatingSurfaceBounds = Readonly<{
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}>;
+
+type ResolvedSizeLimits = Readonly<{
+  minWidth: number;
+  minHeight: number;
+  maxWidth: number;
+  maxHeight: number;
+}>;
+
+function finiteOr(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) ? value as number : fallback;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(maximum, value));
+}
+
+function resolveAxisBounds(
+  length: number,
+  leadingInset: number | undefined,
+  trailingInset: number | undefined,
+  defaultLeadingInset: number,
+  defaultTrailingInset: number,
+): readonly [number, number] {
+  const safeLength = Math.max(0, finiteOr(length, 0));
+  const leading = clamp(finiteOr(leadingInset, defaultLeadingInset), 0, safeLength);
+  const trailing = clamp(finiteOr(trailingInset, defaultTrailingInset), 0, safeLength - leading);
+  return [leading, safeLength - trailing];
+}
+
+function resolveViewportBounds(viewport: FloatingSurfaceViewport): FloatingSurfaceBounds {
+  const [left, right] = resolveAxisBounds(
+    viewport.width,
+    viewport.insets?.left,
+    viewport.insets?.right,
+    DEFAULT_FLOATING_SURFACE_INSETS.left,
+    DEFAULT_FLOATING_SURFACE_INSETS.right,
+  );
+  const [top, bottom] = resolveAxisBounds(
+    viewport.height,
+    viewport.insets?.top,
+    viewport.insets?.bottom,
+    DEFAULT_FLOATING_SURFACE_INSETS.top,
+    DEFAULT_FLOATING_SURFACE_INSETS.bottom,
+  );
+  return { left, top, right, bottom };
+}
+
+function resolveSizeLimits(limits: FloatingSurfaceSizeLimits = {}): ResolvedSizeLimits {
+  const minWidth = Math.max(0, finiteOr(limits.minWidth, DEFAULT_FLOATING_SURFACE_SIZE_LIMITS.minWidth));
+  const minHeight = Math.max(0, finiteOr(limits.minHeight, DEFAULT_FLOATING_SURFACE_SIZE_LIMITS.minHeight));
+  const maxWidth = Math.max(0, finiteOr(limits.maxWidth, DEFAULT_FLOATING_SURFACE_SIZE_LIMITS.maxWidth));
+  const maxHeight = Math.max(0, finiteOr(limits.maxHeight, DEFAULT_FLOATING_SURFACE_SIZE_LIMITS.maxHeight));
+  return { minWidth, minHeight, maxWidth, maxHeight };
+}
+
+function resolveAxisSize(value: number, available: number, minimum: number, maximum: number): number {
+  const effectiveMaximum = Math.min(available, maximum);
+  const effectiveMinimum = Math.min(minimum, effectiveMaximum);
+  return clamp(finiteOr(value, effectiveMinimum), effectiveMinimum, effectiveMaximum);
+}
+
+/**
+ * Fits a surface into the viewport's safe rectangle without mutating the
+ * preferred rectangle. Callers can therefore clamp the same desktop
+ * preference for a narrow viewport and recover it when the viewport expands.
+ */
+export function clampFloatingSurfaceRect(
+  preferred: FloatingSurfaceRect,
+  viewport: FloatingSurfaceViewport,
+  limits: FloatingSurfaceSizeLimits = {},
+): FloatingSurfaceRect {
+  const bounds = resolveViewportBounds(viewport);
+  const sizeLimits = resolveSizeLimits(limits);
+  const availableWidth = bounds.right - bounds.left;
+  const availableHeight = bounds.bottom - bounds.top;
+  const w = resolveAxisSize(preferred.w, availableWidth, sizeLimits.minWidth, sizeLimits.maxWidth);
+  const h = resolveAxisSize(preferred.h, availableHeight, sizeLimits.minHeight, sizeLimits.maxHeight);
+  const x = clamp(finiteOr(preferred.x, bounds.left), bounds.left, bounds.right - w);
+  const y = clamp(finiteOr(preferred.y, bounds.top), bounds.top, bounds.bottom - h);
+  return { x, y, w, h };
+}
+
+export function moveFloatingSurfaceRect(
+  preferred: FloatingSurfaceRect,
+  delta: FloatingSurfaceDelta,
+  viewport: FloatingSurfaceViewport,
+  limits: FloatingSurfaceSizeLimits = {},
+): FloatingSurfaceRect {
+  const current = clampFloatingSurfaceRect(preferred, viewport, limits);
+  return clampFloatingSurfaceRect({
+    ...current,
+    x: current.x + finiteOr(delta.dx, 0),
+    y: current.y + finiteOr(delta.dy, 0),
+  }, viewport, limits);
+}
+
+export function resizeFloatingSurfaceRectFromBottomRight(
+  preferred: FloatingSurfaceRect,
+  delta: FloatingSurfaceDelta,
+  viewport: FloatingSurfaceViewport,
+  limits: FloatingSurfaceSizeLimits = {},
+): FloatingSurfaceRect {
+  const bounds = resolveViewportBounds(viewport);
+  const sizeLimits = resolveSizeLimits(limits);
+  const current = clampFloatingSurfaceRect(preferred, viewport, limits);
+  const availableWidth = bounds.right - current.x;
+  const availableHeight = bounds.bottom - current.y;
+  const w = resolveAxisSize(
+    current.w + finiteOr(delta.dx, 0),
+    availableWidth,
+    sizeLimits.minWidth,
+    sizeLimits.maxWidth,
+  );
+  const h = resolveAxisSize(
+    current.h + finiteOr(delta.dy, 0),
+    availableHeight,
+    sizeLimits.minHeight,
+    sizeLimits.maxHeight,
+  );
+  return { x: current.x, y: current.y, w, h };
+}
+
+export function resizeFloatingSurfaceRectFromBottomLeft(
+  preferred: FloatingSurfaceRect,
+  delta: FloatingSurfaceDelta,
+  viewport: FloatingSurfaceViewport,
+  limits: FloatingSurfaceSizeLimits = {},
+): FloatingSurfaceRect {
+  const bounds = resolveViewportBounds(viewport);
+  const sizeLimits = resolveSizeLimits(limits);
+  const current = clampFloatingSurfaceRect(preferred, viewport, limits);
+  const anchoredRight = current.x + current.w;
+  const availableWidth = anchoredRight - bounds.left;
+  const availableHeight = bounds.bottom - current.y;
+  const w = resolveAxisSize(
+    current.w - finiteOr(delta.dx, 0),
+    availableWidth,
+    sizeLimits.minWidth,
+    sizeLimits.maxWidth,
+  );
+  const h = resolveAxisSize(
+    current.h + finiteOr(delta.dy, 0),
+    availableHeight,
+    sizeLimits.minHeight,
+    sizeLimits.maxHeight,
+  );
+  return { x: anchoredRight - w, y: current.y, w, h };
+}

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -1255,10 +1255,8 @@ body[data-motif-cs-rail-popover-resizing] {
 }
 
 .motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel[open] > .motif-cs-tool-panel-body > .motif-cs-rail-popover-resize {
-  position: sticky;
-  z-index: 3;
-  bottom: 0;
-  left: 0;
+  position: fixed;
+  z-index: 72;
   display: block;
   width: 28px;
   height: 28px;
@@ -1268,10 +1266,6 @@ body[data-motif-cs-rail-popover-resizing] {
   background: transparent;
   cursor: nesw-resize;
   touch-action: none;
-  transform: translate(
-    calc(var(--rail-popover-title-offset-x, 0px) * -1),
-    var(--rail-popover-title-offset-y, 0px)
-  );
 }
 
 .motif-cs-rail-popover-resize::after {
@@ -10050,10 +10044,10 @@ summary.motif-cs-panel-head:focus-visible {
 
 .motif-cs-main > .motif-cs-pane[data-pane-placement="floating"] {
   position: fixed !important;
-  top: var(--motif-cs-floating-pane-top) !important;
-  left: var(--motif-cs-floating-pane-left) !important;
-  width: var(--motif-cs-floating-pane-width) !important;
-  height: var(--motif-cs-floating-pane-height) !important;
+  top: var(--motif-cs-floating-pane-top, 8px) !important;
+  left: var(--motif-cs-floating-pane-left, 8px) !important;
+  width: var(--motif-cs-floating-pane-width, 340px) !important;
+  height: var(--motif-cs-floating-pane-height, 520px) !important;
   grid-column: auto !important;
   grid-row: auto !important;
   align-self: auto !important;
@@ -10122,10 +10116,10 @@ summary.motif-cs-panel-head:focus-visible {
 }
 
 .motif-cs-floating-pane-resize {
-  position: absolute;
+  position: fixed;
   z-index: 8;
-  right: 0;
-  bottom: 0;
+  top: calc(var(--motif-cs-floating-pane-top, 8px) + var(--motif-cs-floating-pane-height, 520px) - 28px);
+  left: calc(var(--motif-cs-floating-pane-left, 8px) + var(--motif-cs-floating-pane-width, 340px) - 28px);
   width: 28px;
   height: 28px;
   padding: 0;

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -10011,3 +10011,173 @@ summary.motif-cs-panel-head:focus-visible {
     scrollbar-gutter: stable;
   }
 }
+
+/* Pane placement ---------------------------------------------------------
+   A pane keeps one React/DOM identity while moving between the workspace and
+   a floating surface. These overrides intentionally follow every responsive
+   layout rule so old grid tracks cannot pull a floating pane back into flow. */
+.motif-cs-pane-placement-button {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.motif-cs-pane-placement-button:hover,
+.motif-cs-pane-placement-button:focus-visible {
+  border-color: var(--border-subtle);
+  background: var(--control-hover);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.motif-cs-pane-placement-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.motif-cs-pane-placement-button svg {
+  display: block;
+}
+
+.motif-cs-main > .motif-cs-pane[data-pane-placement="floating"] {
+  position: fixed !important;
+  top: var(--motif-cs-floating-pane-top) !important;
+  left: var(--motif-cs-floating-pane-left) !important;
+  width: var(--motif-cs-floating-pane-width) !important;
+  height: var(--motif-cs-floating-pane-height) !important;
+  grid-column: auto !important;
+  grid-row: auto !important;
+  align-self: auto !important;
+  flex: none !important;
+  max-width: none !important;
+  max-height: none !important;
+  min-width: 0 !important;
+  min-height: 0 !important;
+  overflow: auto !important;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  border: 1px solid var(--border-strong) !important;
+  border-radius: 4px;
+  background-color: var(--bg-primary);
+  box-shadow: var(--elevation-popover);
+  isolation: isolate;
+}
+
+.motif-cs-main > .motif-cs-sidebar[data-pane-placement="floating"] {
+  overflow: hidden !important;
+  background-color: var(--panel-bg);
+}
+
+.motif-cs-main > .motif-cs-pane[data-pane-placement="floating"] > .motif-cs-pane-title,
+.motif-cs-main > .motif-cs-pane[data-pane-placement="floating"] > .motif-cs-sequence-title {
+  position: sticky;
+  z-index: 4;
+  top: 0;
+  min-height: 34px;
+  cursor: grab;
+  touch-action: none;
+  border-bottom: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--bg-primary) 90%, var(--bg-secondary));
+}
+
+.motif-cs-main > .motif-cs-pane[data-pane-placement="floating"] > .motif-cs-pane-title:active,
+.motif-cs-main > .motif-cs-pane[data-pane-placement="floating"] > .motif-cs-sequence-title:active {
+  cursor: grabbing;
+}
+
+.motif-cs-main > .motif-cs-sidebar[data-pane-placement="floating"] > .motif-cs-pane-title {
+  padding-inline: 10px 8px;
+}
+
+.motif-cs-main > .motif-cs-map-column[data-pane-placement="floating"] > .motif-cs-pane-title {
+  padding: 5px 7px 5px 10px;
+}
+
+.motif-cs-main > .motif-cs-sequence-column[data-pane-placement="floating"] > .motif-cs-sequence-title {
+  padding: 6px 8px 7px 10px;
+}
+
+.motif-cs-main > .motif-cs-inspector[data-pane-placement="floating"] {
+  gap: 0;
+  padding-block: 8px;
+}
+
+.motif-cs-sidebar[data-pane-placement="floating"] .motif-cs-import-panel[open] {
+  position: absolute;
+  z-index: 6;
+  top: 38px;
+  right: 8px;
+  left: 8px;
+  width: auto;
+  max-height: calc(100% - 46px);
+}
+
+.motif-cs-floating-pane-resize {
+  position: absolute;
+  z-index: 8;
+  right: 0;
+  bottom: 0;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 8px 0 3px;
+  background:
+    linear-gradient(135deg, transparent 0 48%, var(--border-strong) 49% 55%, transparent 56% 65%, var(--border-strong) 66% 72%, transparent 73%);
+  color: transparent;
+  cursor: nwse-resize;
+  touch-action: none;
+}
+
+.motif-cs-floating-pane-resize:hover,
+.motif-cs-floating-pane-resize:focus-visible {
+  background:
+    linear-gradient(135deg, transparent 0 48%, var(--accent) 49% 55%, transparent 56% 65%, var(--accent) 66% 72%, transparent 73%);
+  outline: 2px solid color-mix(in srgb, var(--accent) 62%, transparent);
+  outline-offset: -3px;
+}
+
+body[data-motif-cs-pane-floating-action="move"] {
+  cursor: grabbing;
+  user-select: none;
+}
+
+body[data-motif-cs-pane-floating-action="resize"] {
+  cursor: nwse-resize;
+  user-select: none;
+}
+
+@media (max-width: 520px) {
+  .motif-cs-main > .motif-cs-pane[data-pane-placement="floating"] {
+    top: calc(var(--motif-cs-topbar-height, 38px) + 8px) !important;
+    right: 8px !important;
+    bottom: 8px !important;
+    left: 8px !important;
+    width: auto !important;
+    height: auto !important;
+    border-radius: 8px 8px 3px 3px;
+  }
+
+  .motif-cs-main:has(> .motif-cs-inspector[data-tools-pinned="false"]) > .motif-cs-pane[data-pane-placement="floating"]:not(.motif-cs-inspector) {
+    right: 56px !important;
+  }
+
+  .motif-cs-main > .motif-cs-pane[data-pane-placement="floating"] > .motif-cs-pane-title,
+  .motif-cs-main > .motif-cs-pane[data-pane-placement="floating"] > .motif-cs-sequence-title {
+    cursor: default;
+    touch-action: auto;
+  }
+
+  .motif-cs-floating-pane-resize {
+    display: none;
+  }
+}

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -1255,7 +1255,7 @@ body[data-motif-cs-rail-popover-resizing] {
 }
 
 .motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel[open] > .motif-cs-tool-panel-body > .motif-cs-rail-popover-resize {
-  position: absolute;
+  position: sticky;
   z-index: 3;
   bottom: 0;
   left: 0;
@@ -1268,6 +1268,10 @@ body[data-motif-cs-rail-popover-resizing] {
   background: transparent;
   cursor: nesw-resize;
   touch-action: none;
+  transform: translate(
+    calc(var(--rail-popover-title-offset-x, 0px) * -1),
+    var(--rail-popover-title-offset-y, 0px)
+  );
 }
 
 .motif-cs-rail-popover-resize::after {

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -4516,9 +4516,18 @@ body[data-motif-cs-export-resizing] {
   min-width: 0;
 }
 
-.motif-cs-restriction-label {
+.motif-cs-restriction-label-anchor {
   position: absolute;
   top: 0;
+  /* This element owns the `left: …ch` coordinate and therefore stays on the
+     same character grid as the sequence bases. The button inside can use
+     smaller label typography without changing that coordinate unit. */
+  font: 12px/13px var(--font-mono);
+}
+
+.motif-cs-restriction-label {
+  position: relative;
+  display: block;
   max-width: 18ch;
   overflow: hidden;
   padding: 0 3px 1px;

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -994,8 +994,13 @@ body[data-motif-cs-resizing] {
 
 body[data-motif-cs-pane-dragging],
 body[data-motif-cs-window-dragging],
-body[data-motif-cs-export-resizing] {
+body[data-motif-cs-export-resizing],
+body[data-motif-cs-rail-popover-resizing] {
   user-select: none;
+}
+
+body[data-motif-cs-rail-popover-resizing] {
+  cursor: nesw-resize;
 }
 
 .motif-cs-stacked-resize-handle {
@@ -1136,22 +1141,18 @@ body[data-motif-cs-export-resizing] {
   top: var(--rail-popover-fixed-top);
   right: 58px;
   z-index: 70;
-  width: min(344px, calc(100vw - 104px));
+  width: min(var(--rail-popover-width, 344px), calc(100vw - 104px));
   min-width: min(280px, calc(100vw - 104px));
   max-width: min(620px, calc(100vw - 104px));
+  height: var(--rail-popover-height, auto);
   min-height: 96px;
   max-height: min(calc(100vh - var(--rail-popover-fixed-top) - 22px), 600px);
   overflow: auto;
   overscroll-behavior: contain;
-  resize: both;
   scrollbar-gutter: stable;
   border: 1px solid var(--border-strong);
   border-radius: 2px;
   background-color: var(--bg-primary);
-  background-image: linear-gradient(135deg, transparent 0 52%, var(--border-strong) 53% 59%, transparent 60% 68%, var(--border-strong) 69% 75%, transparent 76%);
-  background-repeat: no-repeat;
-  background-position: right 3px bottom 3px;
-  background-size: 12px 12px;
   box-shadow: var(--elevation-popover);
 }
 
@@ -1168,7 +1169,7 @@ body[data-motif-cs-export-resizing] {
 @media (max-width: 520px) {
   .motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel[open] > .motif-cs-tool-panel-body {
     right: 50px;
-    width: min(344px, calc(100vw - 62px));
+    width: min(var(--rail-popover-width, 344px), calc(100vw - 62px));
   }
 }
 
@@ -1247,6 +1248,48 @@ body[data-motif-cs-export-resizing] {
   background: var(--control-hover);
   color: var(--text-primary);
   outline: none;
+}
+
+.motif-cs-rail-popover-resize {
+  display: none;
+}
+
+.motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel[open] > .motif-cs-tool-panel-body > .motif-cs-rail-popover-resize {
+  position: absolute;
+  z-index: 3;
+  bottom: 0;
+  left: 0;
+  display: block;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 0 var(--radius-sm) 0 0;
+  background: transparent;
+  cursor: nesw-resize;
+  touch-action: none;
+}
+
+.motif-cs-rail-popover-resize::after {
+  position: absolute;
+  bottom: 2px;
+  left: 2px;
+  width: 13px;
+  height: 13px;
+  background: linear-gradient(45deg, transparent 0 46%, var(--border) 46% 54%, transparent 54% 100%);
+  content: '';
+  pointer-events: none;
+}
+
+.motif-cs-rail-popover-resize:hover::after,
+.motif-cs-rail-popover-resize:focus-visible::after,
+body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
+  background: linear-gradient(45deg, transparent 0 46%, var(--accent) 46% 54%, transparent 54% 100%);
+}
+
+.motif-cs-rail-popover-resize:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
 }
 
 .motif-cs-inspector[data-tools-pinned="true"] {
@@ -5142,6 +5185,7 @@ body[data-motif-cs-export-resizing] {
 .motif-cs-restriction-select:focus-visible,
 .motif-cs-orf-select:focus-visible,
 .motif-cs-rail-popover-close:focus-visible,
+.motif-cs-rail-popover-resize:focus-visible,
 .motif-cs-segmented button:focus-visible,
 .motif-cs-window-icon:focus-visible,
 summary.motif-cs-panel-head:focus-visible {
@@ -5163,22 +5207,13 @@ summary.motif-cs-panel-head:focus-visible {
     left: 8px !important;
     top: auto !important;
     bottom: 8px;
-    width: calc(100vw - 16px) !important;
+    width: calc(100vw - 16px - var(--motif-cs-floating-right-inset, 0px)) !important;
     height: auto !important;
     min-height: 0;
   }
 
   .motif-cs-window-body {
     padding: 8px 10px 10px;
-  }
-
-  /* A compact MSA window can extend beneath the persistent 48px Tools rail.
-     Reserve its body gutter so Viewer/Text/View controls and matrix content
-     remain visible and hit-testable while the rail itself stays available. */
-  .motif-cs-shell:has(.motif-cs-inspector[data-tools-pinned="false"])
-    .motif-cs-window:has(.motif-cs-msa-workspace)
-    .motif-cs-window-body {
-    padding-right: 58px;
   }
 
   .motif-cs-protein-readout {
@@ -9582,18 +9617,6 @@ summary.motif-cs-panel-head:focus-visible {
     border-left-color: var(--border-strong);
     background: var(--panel-bg);
     box-shadow: 0 10px 28px color-mix(in srgb, var(--shadow-ink) 20%, transparent);
-  }
-
-  /* The collapsed 48 px tool rail intentionally sits above floating windows.
-     Reserve its hit area so window actions and scientific content remain
-     reachable instead of being painted underneath the rail. */
-  .motif-cs-shell:has(.motif-cs-inspector[data-tools-pinned="false"]) .motif-cs-window-head,
-  .motif-cs-shell:has(.motif-cs-inspector[data-tools-pinned="false"]) .motif-cs-window-body {
-    padding-right: 58px;
-  }
-
-  .motif-cs-shell:has(.motif-cs-inspector[data-tools-pinned="false"]) .motif-cs-window-resize {
-    right: 58px;
   }
 
   .motif-cs-resize-handle[data-pane="tools"] {

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -805,14 +805,21 @@ type MapDragState = {
 
 type WindowRect = { x: number; y: number; w: number; h: number };
 
-function clampWindowRect(rect: WindowRect, viewportWidth = window.innerWidth, viewportHeight = window.innerHeight): WindowRect {
-  const minW = Math.min(280, Math.max(1, viewportWidth - 16));
+function clampWindowRect(
+  rect: WindowRect,
+  viewportWidth = window.innerWidth,
+  viewportHeight = window.innerHeight,
+  rightInset = 0,
+): WindowRect {
+  const safeRightInset = clamp(rightInset, 0, Math.max(0, viewportWidth - 17));
+  const availableWidth = Math.max(1, viewportWidth - safeRightInset);
+  const minW = Math.min(280, Math.max(1, availableWidth - 16));
   const minH = Math.min(180, Math.max(1, viewportHeight - 16));
-  const maxW = Math.max(minW, viewportWidth - 16);
+  const maxW = Math.max(minW, availableWidth - 16);
   const maxH = Math.max(minH, viewportHeight - 16);
   const w = clamp(rect.w, minW, maxW);
   const h = clamp(rect.h, minH, maxH);
-  const x = clamp(rect.x, 8, Math.max(8, viewportWidth - w - 8));
+  const x = clamp(rect.x, 8, Math.max(8, viewportWidth - safeRightInset - w - 8));
   const y = clamp(rect.y, 8, Math.max(8, viewportHeight - Math.min(h, viewportHeight - 16) - 8));
   return { x, y, w, h };
 }
@@ -11006,6 +11013,7 @@ function App() {
           title="Translations"
           subtitle={vector.name}
           initial={translationsWin}
+          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
           onClose={() => setShowTranslations(false)}
           onCommit={setTranslationsWin}
           returnFocusRef={translationsToggleRef}
@@ -11045,6 +11053,7 @@ function App() {
           title="Gel Preview"
           subtitle="qualitative agarose"
           initial={gelWin}
+          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
           onClose={() => setShowGel(false)}
           onCommit={setGelWin}
           returnFocusRef={gelReturnFocusRef}
@@ -11087,6 +11096,7 @@ function App() {
           title="Primer Design"
           subtitle={cloningPrimerRequest ? `${vector.name} · cloning preparation` : vector.name}
           initial={primerWin}
+          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
           onClose={closePrimerWorkspace}
           onCommit={setPrimerWin}
           returnFocusRef={primerToggleRef}
@@ -11146,6 +11156,7 @@ function App() {
           title="Cloning Workspace"
           subtitle="Golden Gate + ligation"
           initial={assemblyWin}
+          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
           onClose={() => setShowAssembly(false)}
           onCommit={setAssemblyWin}
           returnFocusRef={cloningToggleRef}
@@ -11165,6 +11176,7 @@ function App() {
           title="Cloning Design"
           subtitle="Golden Gate profiles + Gibson"
           initial={cloningDesignWin}
+          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
           onClose={() => setShowCloningDesign(false)}
           onCommit={setCloningDesignWin}
           returnFocusRef={cloningToggleRef}
@@ -11187,6 +11199,7 @@ function App() {
           title="Construct Verification"
           subtitle={`${constructVerificationReadCount} eligible Sanger read${constructVerificationReadCount === 1 ? '' : 's'}`}
           initial={constructVerificationWin}
+          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
           onClose={() => setShowConstructVerification(false)}
           onCommit={setConstructVerificationWin}
           returnFocusRef={constructVerificationToggleRef}
@@ -11207,6 +11220,7 @@ function App() {
           title="Multiple Sequence Alignment"
           subtitle={payload.alignments.length ? `${payload.alignments.length} in session` : 'local + imported'}
           initial={alignmentWin}
+          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
           onClose={() => setShowAlignment(false)}
           onCommit={setAlignmentWin}
           returnFocusRef={alignmentToggleRef}
@@ -12008,7 +12022,154 @@ function FeatureList({
   );
 }
 
+type RailPopoverSize = { width: number; height: number };
+
+function cssPixelValue(value: string, fallback: number): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 function RailPopoverTitle({ title, meta }: { title: string; meta?: string }) {
+  const [size, setSize] = useState<RailPopoverSize | null>(null);
+  const resizeHandleRef = useRef<HTMLButtonElement>(null);
+  const panelBodyRef = useRef<HTMLElement | null>(null);
+  const resizeRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    base: RailPopoverSize;
+    limits: { minWidth: number; maxWidth: number; minHeight: number; maxHeight: number };
+  } | null>(null);
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
+
+  useLayoutEffect(() => {
+    const panelBody = resizeHandleRef.current?.closest<HTMLElement>('.motif-cs-tool-panel-body') ?? null;
+    panelBodyRef.current = panelBody;
+    return () => {
+      panelBody?.style.removeProperty('--rail-popover-width');
+      panelBody?.style.removeProperty('--rail-popover-height');
+      delete panelBody?.dataset.railPopoverResized;
+      panelBodyRef.current = null;
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const panelBody = panelBodyRef.current;
+    if (!panelBody) return;
+    if (!size) {
+      panelBody.style.removeProperty('--rail-popover-width');
+      panelBody.style.removeProperty('--rail-popover-height');
+      delete panelBody.dataset.railPopoverResized;
+      return;
+    }
+    panelBody.style.setProperty('--rail-popover-width', `${size.width}px`);
+    panelBody.style.setProperty('--rail-popover-height', `${size.height}px`);
+    panelBody.dataset.railPopoverResized = 'true';
+  }, [size]);
+
+  const stopResize = useCallback(() => {
+    resizeCleanupRef.current?.();
+    resizeCleanupRef.current = null;
+    resizeRef.current = null;
+    delete document.body.dataset.motifCsRailPopoverResizing;
+  }, []);
+
+  useEffect(() => () => stopResize(), [stopResize]);
+
+  const resizeLimits = useCallback((panelBody: HTMLElement) => {
+    const computed = window.getComputedStyle(panelBody);
+    const rect = panelBody.getBoundingClientRect();
+    return {
+      minWidth: cssPixelValue(computed.minWidth, Math.min(280, window.innerWidth - 16)),
+      maxWidth: cssPixelValue(computed.maxWidth, Math.max(rect.width, window.innerWidth - 16)),
+      minHeight: cssPixelValue(computed.minHeight, 96),
+      maxHeight: cssPixelValue(computed.maxHeight, Math.max(rect.height, window.innerHeight - 16)),
+    };
+  }, []);
+
+  const beginResize = useCallback((event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (!event.isPrimary || event.button !== 0) return;
+    const panelBody = panelBodyRef.current;
+    if (!panelBody) return;
+    event.preventDefault();
+    event.stopPropagation();
+    stopResize();
+
+    const rect = panelBody.getBoundingClientRect();
+    resizeRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      base: { width: rect.width, height: rect.height },
+      limits: resizeLimits(panelBody),
+    };
+    document.body.dataset.motifCsRailPopoverResizing = 'true';
+
+    const handle = event.currentTarget;
+    try {
+      handle.setPointerCapture?.(event.pointerId);
+    } catch {
+      /* Window listeners keep the resize usable when capture is unavailable. */
+    }
+
+    const removeListeners = () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', endPointerResize);
+      window.removeEventListener('pointercancel', endPointerResize);
+      window.removeEventListener('blur', endResizeFromBlur);
+      handle.removeEventListener('lostpointercapture', endLostPointerCapture);
+      if (resizeCleanupRef.current === removeListeners) resizeCleanupRef.current = null;
+    };
+
+    function handlePointerMove(moveEvent: PointerEvent) {
+      const active = resizeRef.current;
+      if (!active || moveEvent.pointerId !== active.pointerId) return;
+      moveEvent.preventDefault();
+      setSize({
+        width: clamp(active.base.width - (moveEvent.clientX - active.startX), active.limits.minWidth, active.limits.maxWidth),
+        height: clamp(active.base.height + (moveEvent.clientY - active.startY), active.limits.minHeight, active.limits.maxHeight),
+      });
+    }
+
+    function endPointerResize(endEvent: PointerEvent) {
+      if (endEvent.pointerId !== resizeRef.current?.pointerId) return;
+      stopResize();
+    }
+
+    function endLostPointerCapture(lostEvent: PointerEvent) {
+      if (lostEvent.pointerId !== resizeRef.current?.pointerId) return;
+      stopResize();
+    }
+
+    function endResizeFromBlur() {
+      stopResize();
+    }
+
+    resizeCleanupRef.current = removeListeners;
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', endPointerResize);
+    window.addEventListener('pointercancel', endPointerResize);
+    window.addEventListener('blur', endResizeFromBlur);
+    handle.addEventListener('lostpointercapture', endLostPointerCapture);
+  }, [resizeLimits, stopResize]);
+
+  const resizeFromKeyboard = useCallback((event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)) return;
+    const panelBody = panelBodyRef.current;
+    if (!panelBody) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const rect = panelBody.getBoundingClientRect();
+    const limits = resizeLimits(panelBody);
+    const step = event.shiftKey ? 24 : 10;
+    const widthDelta = event.key === 'ArrowLeft' ? step : event.key === 'ArrowRight' ? -step : 0;
+    const heightDelta = event.key === 'ArrowUp' ? -step : event.key === 'ArrowDown' ? step : 0;
+    setSize({
+      width: clamp(rect.width + widthDelta, limits.minWidth, limits.maxWidth),
+      height: clamp(rect.height + heightDelta, limits.minHeight, limits.maxHeight),
+    });
+  }, [resizeLimits]);
+
   const closePopover = (event: ReactMouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -12021,22 +12182,36 @@ function RailPopoverTitle({ title, meta }: { title: string; meta?: string }) {
   };
 
   return (
-    <div className="motif-cs-rail-popover-title">
-      <strong>{title}</strong>
-      <div className="motif-cs-rail-popover-actions">
-        {meta ? <span>{meta}</span> : null}
-        <button
-          className="motif-cs-rail-popover-close"
-          type="button"
-          onClick={closePopover}
-          aria-label={`Close ${title}`}
-          title={`Close ${title}`}
-          data-testid="rail-popover-close"
-        >
-          <X size={14} strokeWidth={2.2} aria-hidden="true" />
-        </button>
+    <>
+      <div className="motif-cs-rail-popover-title">
+        <strong>{title}</strong>
+        <div className="motif-cs-rail-popover-actions">
+          {meta ? <span>{meta}</span> : null}
+          <button
+            className="motif-cs-rail-popover-close"
+            type="button"
+            onClick={closePopover}
+            aria-label={`Close ${title}`}
+            title={`Close ${title}`}
+            data-testid="rail-popover-close"
+          >
+            <X size={14} strokeWidth={2.2} aria-hidden="true" />
+          </button>
+        </div>
       </div>
-    </div>
+      <button
+        ref={resizeHandleRef}
+        className="motif-cs-rail-popover-resize"
+        type="button"
+        onPointerDown={beginResize}
+        onKeyDown={resizeFromKeyboard}
+        onDoubleClick={() => setSize(null)}
+        aria-label={`Resize ${title} panel. Left Arrow grows width; Right Arrow shrinks width; Up and Down Arrow change height.`}
+        aria-keyshortcuts="ArrowLeft ArrowRight ArrowUp ArrowDown"
+        title={`Resize ${title}; double-click to reset`}
+        data-testid="rail-popover-resize"
+      />
+    </>
   );
 }
 
@@ -13913,6 +14088,7 @@ function FloatingWindow({
   title,
   subtitle,
   initial,
+  rightInset = 0,
   onClose,
   onCommit,
   returnFocusRef,
@@ -13923,6 +14099,8 @@ function FloatingWindow({
   title: string;
   subtitle?: string;
   initial: WindowRect;
+  /** Keeps the permanent right rail outside the movable window's geometry. */
+  rightInset?: number;
   onClose: () => void;
   onCommit?: (rect: WindowRect) => void;
   returnFocusRef?: RefObject<HTMLElement | null>;
@@ -13931,7 +14109,7 @@ function FloatingWindow({
   inactive?: boolean;
   children: ReactNode;
 }) {
-  const [rect, setRect] = useState<WindowRect>(() => clampWindowRect(initial));
+  const [rect, setRect] = useState<WindowRect>(() => clampWindowRect(initial, window.innerWidth, window.innerHeight, rightInset));
   const [collapsed, setCollapsed] = useState(false);
   const [maximized, setMaximized] = useState(false);
   const dragRef = useRef<{
@@ -14005,22 +14183,22 @@ function FloatingWindow({
   useEffect(() => {
     const handleResize = () => setRect(() => {
       const next = maximized
-        ? clampWindowRect({ x: 8, y: 8, w: window.innerWidth - 16, h: window.innerHeight - 16 })
-        : clampWindowRect(restoreRectRef.current);
+        ? clampWindowRect({ x: 8, y: 8, w: window.innerWidth - rightInset - 16, h: window.innerHeight - 16 }, window.innerWidth, window.innerHeight, rightInset)
+        : clampWindowRect(restoreRectRef.current, window.innerWidth, window.innerHeight, rightInset);
       rectRef.current = next;
       return next;
     });
     handleResize();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, [maximized]);
+  }, [maximized, rightInset]);
 
   const restoreWindow = useCallback(() => {
-    const next = clampWindowRect(restoreRectRef.current);
+    const next = clampWindowRect(restoreRectRef.current, window.innerWidth, window.innerHeight, rightInset);
     rectRef.current = next;
     setRect(next);
     setMaximized(false);
-  }, []);
+  }, [rightInset]);
 
   const toggleMaximized = useCallback(() => {
     stopActiveDrag(false);
@@ -14028,16 +14206,16 @@ function FloatingWindow({
       restoreWindow();
       return;
     }
-    const next = clampWindowRect({ x: 8, y: 8, w: window.innerWidth - 16, h: window.innerHeight - 16 });
+    const next = clampWindowRect({ x: 8, y: 8, w: window.innerWidth - rightInset - 16, h: window.innerHeight - 16 }, window.innerWidth, window.innerHeight, rightInset);
     rectRef.current = next;
     setCollapsed(false);
     setMaximized(true);
     setRect(next);
-  }, [maximized, restoreWindow, stopActiveDrag]);
+  }, [maximized, restoreWindow, rightInset, stopActiveDrag]);
 
   const toggleCollapsed = useCallback(() => {
     if (maximized) {
-      const next = clampWindowRect(restoreRectRef.current);
+      const next = clampWindowRect(restoreRectRef.current, window.innerWidth, window.innerHeight, rightInset);
       rectRef.current = next;
       setRect(next);
       setMaximized(false);
@@ -14045,7 +14223,7 @@ function FloatingWindow({
       return;
     }
     setCollapsed((value) => !value);
-  }, [maximized]);
+  }, [maximized, rightInset]);
 
   const beginDrag = (mode: 'move' | 'resize') => (event: ReactPointerEvent) => {
     // Ignore drags that start on the header buttons (collapse / close) so a single
@@ -14088,7 +14266,7 @@ function FloatingWindow({
         w: clamp(drag.base.w + dx, 280, Math.max(280, vw - drag.base.x - 8)),
         h: clamp(drag.base.h + dy, 180, Math.max(180, vh - drag.base.y - 8)),
       };
-      const next = clampWindowRect(raw, vw, vh);
+      const next = clampWindowRect(raw, vw, vh, rightInset);
       rectRef.current = next;
       setRect(next);
     };
@@ -14119,12 +14297,12 @@ function FloatingWindow({
 
   const commitKeyboardRect = useCallback((next: WindowRect) => {
     if (maximized) return;
-    const clamped = clampWindowRect(next);
+    const clamped = clampWindowRect(next, window.innerWidth, window.innerHeight, rightInset);
     rectRef.current = clamped;
     restoreRectRef.current = clamped;
     setRect(clamped);
     onCommit?.(clamped);
-  }, [maximized, onCommit]);
+  }, [maximized, onCommit, rightInset]);
 
   const moveFromKeyboard = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (!event.altKey || !['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)) return;
@@ -14156,7 +14334,13 @@ function FloatingWindow({
       data-collapsed={collapsed || undefined}
       data-maximized={maximized || undefined}
       data-inactive={inactive || undefined}
-      style={{ left: rect.x, top: rect.y, width: rect.w, height: collapsed ? undefined : rect.h }}
+      style={{
+        left: rect.x,
+        top: rect.y,
+        width: rect.w,
+        height: collapsed ? undefined : rect.h,
+        '--motif-cs-floating-right-inset': `${rightInset}px`,
+      } as CSSProperties}
     >
       <div
         className="motif-cs-window-head"

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -799,12 +799,17 @@ function normalizeFloatingPaneRects(value: unknown): FloatingPaneRects {
 
 function normalizeWorkspaceLayout(value: unknown): WorkspaceLayoutPrefs {
   const source = value && typeof value === 'object' ? value as Partial<Record<keyof WorkspaceLayoutPrefs, unknown>> : {};
-  const panePlacements = normalizePanePlacements(source.panePlacements);
+  const paneVisibility = normalizePaneVisibility(source.paneVisibility);
+  let panePlacements = normalizePanePlacements(source.panePlacements);
+  if (!CONTENT_PANE_KEYS.some((pane) => paneVisibility[pane] && panePlacements[pane] === 'docked')) {
+    const fallbackPane = CONTENT_PANE_KEYS.find((pane) => paneVisibility[pane]) ?? 'sequence';
+    panePlacements = { ...panePlacements, [fallbackPane]: 'docked' };
+  }
   return {
     theme: normalizeArtifactThemeName(source.theme),
     paneWidths: normalizePaneWidths(source.paneWidths),
     stackedPaneHeights: normalizeStackedPaneHeights(source.stackedPaneHeights),
-    paneVisibility: normalizePaneVisibility(source.paneVisibility),
+    paneVisibility,
     paneOrder: normalizePaneOrder(source.paneOrder),
     toolsPinned: panePlacements.tools === 'floating'
       ? true
@@ -4765,6 +4770,8 @@ function App() {
     base: FloatingSurfaceRect;
   } | null>(null);
   const floatingPaneInteractionCleanupRef = useRef<(() => void) | null>(null);
+  const paneResizeCleanupRef = useRef<(() => void) | null>(null);
+  const stackedPaneResizeCleanupRef = useRef<(() => void) | null>(null);
   const sequenceScrollByRecordRef = useRef<Record<string, number>>({});
   const mapDragRef = useRef<MapDragState | null>(null);
   const mapPointerIdRef = useRef<number | null>(null);
@@ -8063,7 +8070,23 @@ function App() {
     delete document.body.dataset.motifCsPaneFloatingAction;
   }, []);
 
-  useEffect(() => () => stopFloatingPaneInteraction(), [stopFloatingPaneInteraction]);
+  const stopPaneResize = useCallback(() => {
+    paneResizeCleanupRef.current?.();
+    paneResizeCleanupRef.current = null;
+    delete document.body.dataset.motifCsResizing;
+  }, []);
+
+  const stopStackedPaneResize = useCallback(() => {
+    stackedPaneResizeCleanupRef.current?.();
+    stackedPaneResizeCleanupRef.current = null;
+    delete document.body.dataset.motifCsStackedResizing;
+  }, []);
+
+  useEffect(() => () => {
+    stopFloatingPaneInteraction();
+    stopPaneResize();
+    stopStackedPaneResize();
+  }, [stopFloatingPaneInteraction, stopPaneResize, stopStackedPaneResize]);
 
   const setFloatingPaneRect = useCallback((pane: PaneKey, rect: FloatingSurfaceRect) => {
     floatingPaneRectsRef.current = { ...floatingPaneRectsRef.current, [pane]: rect };
@@ -8187,11 +8210,12 @@ function App() {
       if (!pane || !DEFAULT_PANE_ORDER.includes(pane)) return;
       event.preventDefault();
       event.stopPropagation();
+      stopFloatingPaneInteraction();
       dockPane(pane);
     };
     window.addEventListener('keydown', dockFocusedFloatingPane);
     return () => window.removeEventListener('keydown', dockFocusedFloatingPane);
-  }, [dockPane]);
+  }, [dockPane, stopFloatingPaneInteraction]);
 
   const scrollPaneIntoView = useCallback((pane: PaneKey) => {
     if (typeof document === 'undefined') return;
@@ -9530,6 +9554,10 @@ function App() {
     setPaneVisibility((current) => {
       const openContentCount = CONTENT_PANE_KEYS.filter((key) => current[key]).length;
       if (pane !== 'tools' && current[pane] && openContentCount <= 1) return current;
+      const dockedContentCount = CONTENT_PANE_KEYS.filter((key) => (
+        current[key] && panePlacements[key] === 'docked'
+      )).length;
+      if (pane !== 'tools' && current[pane] && panePlacements[pane] === 'docked' && dockedContentCount <= 1) return current;
       return { ...current, [pane]: !current[pane] };
     });
     if ((isStacked || panePlacements[pane] === 'floating') && !paneVisibility[pane]) {
@@ -9781,7 +9809,7 @@ function App() {
       ? visibleResizablePanes.filter((pane) => pane !== 'tools')
       : visibleResizablePanes;
     if (fittedPanes.length === 0) return widths;
-    const mainWidth = document.querySelector<HTMLElement>('.motif-cs-main')?.clientWidth ?? window.innerWidth;
+    const mainWidth = Math.max(1, workspaceMainSize.width);
     const effectiveHandleCount = twoRowLayout
       ? Number(fittedPanes.includes('inventory') && fittedPanes.includes('sequence'))
       : resizeHandleCount - (overlayTools && showToolsResizeHandle ? 1 : 0);
@@ -9813,7 +9841,7 @@ function App() {
       deficit -= consumed;
     }
     return next;
-  }, [compactPinnedLayout, paneWidthLimitsForCurrentLayout, resizeHandleCount, showToolsResizeHandle, stableCompactTopology, toolsRailWidth, visibleContentPanes.length, visibleResizablePanes]);
+  }, [compactPinnedLayout, paneWidthLimitsForCurrentLayout, resizeHandleCount, showToolsResizeHandle, stableCompactTopology, toolsRailWidth, visibleContentPanes.length, visibleResizablePanes, workspaceMainSize.width]);
 
   useEffect(() => {
     const clampForCurrentViewport = () => {
@@ -9891,7 +9919,7 @@ function App() {
       .reduce((sum, key) => sum + paneWidths[key], effectiveToolsRailWidth);
     const effectiveHandleCount = resizeHandleCount - (overlayLayout && showToolsResizeHandle ? 1 : 0);
     const resizeHandleSpace = Math.max(0, effectiveHandleCount) * resizeHandleWidth;
-    const mainWidth = document.querySelector<HTMLElement>('.motif-cs-main')?.clientWidth ?? window.innerWidth;
+    const mainWidth = Math.max(1, workspaceMainSize.width);
     const overlayTools = pane === 'tools' && overlayLayout;
     const compactRowMaxWidth = compactPinnedLayout && pane === 'inventory'
       ? mainWidth - resizeHandleWidth - PANE_WIDTH_LIMITS.sequence.min
@@ -9906,10 +9934,9 @@ function App() {
             limits.min,
             Math.min(limits.max, mainWidth - otherPaneWidth - resizeHandleSpace),
           );
-    document.body.dataset.motifCsResizing = pane;
+    stopPaneResize();
     const resizeHandle = event.currentTarget;
     const pointerId = event.pointerId;
-    resizeHandle.setPointerCapture?.(pointerId);
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
       if (moveEvent.pointerId !== pointerId) return;
@@ -9927,26 +9954,49 @@ function App() {
         return;
       }
       const nextWidth = clamp(startWidth + delta, limits.min, maxWidthForViewport);
-      setPreferredPaneWidths((current) => {
-        const nextPreferred = { ...current, [pane]: nextWidth };
-        setPaneWidths(clampPaneWidthsForViewport(nextPreferred));
-        return nextPreferred;
-      });
+      const nextPreferred = { ...startPreferredWidths, [pane]: nextWidth };
+      setPreferredPaneWidths(nextPreferred);
+      setPaneWidths(clampPaneWidthsForViewport(nextPreferred));
     };
 
-    const handlePointerUp = (endEvent: PointerEvent) => {
-      if (endEvent.pointerId !== pointerId) return;
-      delete document.body.dataset.motifCsResizing;
+    const removeListeners = () => {
       window.removeEventListener('pointermove', handlePointerMove);
-      window.removeEventListener('pointerup', handlePointerUp);
-      window.removeEventListener('pointercancel', handlePointerUp);
-      if (resizeHandle.hasPointerCapture?.(pointerId)) resizeHandle.releasePointerCapture?.(pointerId);
+      window.removeEventListener('pointerup', handlePointerEnd);
+      window.removeEventListener('pointercancel', handlePointerEnd);
+      window.removeEventListener('blur', handleWindowBlur);
+      resizeHandle.removeEventListener('lostpointercapture', handleLostPointerCapture);
+      if (paneResizeCleanupRef.current === removeListeners) paneResizeCleanupRef.current = null;
+      try {
+        if (resizeHandle.hasPointerCapture?.(pointerId)) resizeHandle.releasePointerCapture?.(pointerId);
+      } catch {
+        /* Capture may already be gone after blur or DOM removal. */
+      }
     };
+    function handlePointerEnd(endEvent: PointerEvent) {
+      if (endEvent.pointerId !== pointerId) return;
+      stopPaneResize();
+    }
+    function handleLostPointerCapture(lostEvent: PointerEvent) {
+      if (lostEvent.pointerId !== pointerId) return;
+      stopPaneResize();
+    }
+    function handleWindowBlur() {
+      stopPaneResize();
+    }
 
+    paneResizeCleanupRef.current = removeListeners;
+    document.body.dataset.motifCsResizing = pane;
     window.addEventListener('pointermove', handlePointerMove);
-    window.addEventListener('pointerup', handlePointerUp);
-    window.addEventListener('pointercancel', handlePointerUp);
-  }, [clampPaneWidthsForViewport, compactPinnedLayout, paneResizeNeighbor, paneWidthLimitsForCurrentLayout, paneWidths, preferredPaneWidths, resizeHandleCount, resizePanePair, showToolsResizeHandle, toolsRailWidth, visibleResizablePanes]);
+    window.addEventListener('pointerup', handlePointerEnd);
+    window.addEventListener('pointercancel', handlePointerEnd);
+    window.addEventListener('blur', handleWindowBlur);
+    resizeHandle.addEventListener('lostpointercapture', handleLostPointerCapture);
+    try {
+      resizeHandle.setPointerCapture?.(pointerId);
+    } catch {
+      /* Window listeners keep resizing active when capture is unavailable. */
+    }
+  }, [clampPaneWidthsForViewport, compactPinnedLayout, paneResizeNeighbor, paneWidthLimitsForCurrentLayout, paneWidths, preferredPaneWidths, resizeHandleCount, resizePanePair, showToolsResizeHandle, stopPaneResize, toolsRailWidth, visibleResizablePanes, workspaceMainSize.width]);
   const resizePaneFromKeyboard = useCallback((pane: ResizablePaneKey, event: ReactKeyboardEvent<HTMLDivElement>, edge: ResizeEdge = 'after') => {
     if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
     event.preventDefault();
@@ -9965,14 +10015,12 @@ function App() {
       setPaneWidths(nextWidths);
       return;
     }
-    setPreferredPaneWidths((current) => {
-      const limits = paneWidthLimitsForCurrentLayout(pane);
-      const requested = clamp(current[pane] + screenDirection * direction * step, limits.min, limits.max);
-      const nextPreferred = { ...current, [pane]: requested };
-      setPaneWidths(clampPaneWidthsForViewport(nextPreferred));
-      return nextPreferred;
-    });
-  }, [clampPaneWidthsForViewport, paneResizeNeighbor, paneWidthLimitsForCurrentLayout, paneWidths, resizePanePair]);
+    const limits = paneWidthLimitsForCurrentLayout(pane);
+    const requested = clamp(preferredPaneWidths[pane] + screenDirection * direction * step, limits.min, limits.max);
+    const nextPreferred = { ...preferredPaneWidths, [pane]: requested };
+    setPreferredPaneWidths(nextPreferred);
+    setPaneWidths(clampPaneWidthsForViewport(nextPreferred));
+  }, [clampPaneWidthsForViewport, paneResizeNeighbor, paneWidthLimitsForCurrentLayout, paneWidths, preferredPaneWidths, resizePanePair]);
 
   const resizeStackedPaneTo = useCallback((pane: StackedResizablePaneKey, height: number) => {
     const bounds = stackedPaneBoundsForCurrentLayout(pane);
@@ -9995,27 +10043,51 @@ function App() {
     const startHeight = paneElement.getBoundingClientRect().height;
     const resizeHandle = event.currentTarget;
     const pointerId = event.pointerId;
-    resizeHandle.setPointerCapture?.(pointerId);
-    document.body.dataset.motifCsStackedResizing = pane;
+    stopStackedPaneResize();
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
       if (moveEvent.pointerId !== pointerId) return;
       moveEvent.preventDefault();
       resizeStackedPaneTo(pane, startHeight + moveEvent.clientY - startY);
     };
-    const stopResize = (endEvent: PointerEvent) => {
-      if (endEvent.pointerId !== pointerId) return;
-      delete document.body.dataset.motifCsStackedResizing;
+    const removeListeners = () => {
       window.removeEventListener('pointermove', handlePointerMove);
-      window.removeEventListener('pointerup', stopResize);
-      window.removeEventListener('pointercancel', stopResize);
-      if (resizeHandle.hasPointerCapture?.(pointerId)) resizeHandle.releasePointerCapture?.(pointerId);
+      window.removeEventListener('pointerup', handlePointerEnd);
+      window.removeEventListener('pointercancel', handlePointerEnd);
+      window.removeEventListener('blur', handleWindowBlur);
+      resizeHandle.removeEventListener('lostpointercapture', handleLostPointerCapture);
+      if (stackedPaneResizeCleanupRef.current === removeListeners) stackedPaneResizeCleanupRef.current = null;
+      try {
+        if (resizeHandle.hasPointerCapture?.(pointerId)) resizeHandle.releasePointerCapture?.(pointerId);
+      } catch {
+        /* Capture may already be gone after blur or DOM removal. */
+      }
     };
+    function handlePointerEnd(endEvent: PointerEvent) {
+      if (endEvent.pointerId !== pointerId) return;
+      stopStackedPaneResize();
+    }
+    function handleLostPointerCapture(lostEvent: PointerEvent) {
+      if (lostEvent.pointerId !== pointerId) return;
+      stopStackedPaneResize();
+    }
+    function handleWindowBlur() {
+      stopStackedPaneResize();
+    }
 
+    stackedPaneResizeCleanupRef.current = removeListeners;
+    document.body.dataset.motifCsStackedResizing = pane;
     window.addEventListener('pointermove', handlePointerMove);
-    window.addEventListener('pointerup', stopResize);
-    window.addEventListener('pointercancel', stopResize);
-  }, [resizeStackedPaneTo, toolsDocked]);
+    window.addEventListener('pointerup', handlePointerEnd);
+    window.addEventListener('pointercancel', handlePointerEnd);
+    window.addEventListener('blur', handleWindowBlur);
+    resizeHandle.addEventListener('lostpointercapture', handleLostPointerCapture);
+    try {
+      resizeHandle.setPointerCapture?.(pointerId);
+    } catch {
+      /* Window listeners keep resizing active when capture is unavailable. */
+    }
+  }, [resizeStackedPaneTo, stopStackedPaneResize, toolsDocked]);
 
   const resizeStackedPaneFromKeyboard = useCallback((pane: StackedResizablePaneKey, event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
@@ -10033,7 +10105,17 @@ function App() {
     paneVisibility[pane] && panePlacements[pane] === 'docked'
   )).length;
   const dockedPaneCount = dockedContentPaneCount + Number(paneVisibility.tools && toolsDocked);
-  const canCollapseContentPane = visibleContentPaneCount > 1;
+  const canHideContentPane = (pane: Exclude<PaneKey, 'tools'>) => (
+    visibleContentPaneCount > 1
+    && (panePlacements[pane] !== 'docked' || dockedContentPaneCount > 1)
+  );
+  const contentPaneHideBlockReason = (pane: Exclude<PaneKey, 'tools'>) => (
+    visibleContentPaneCount <= 1
+      ? 'At least one content pane must stay visible'
+      : panePlacements[pane] === 'docked' && dockedContentPaneCount <= 1
+        ? 'Keep one content pane docked in the workspace'
+        : ''
+  );
   const stackedInventoryBounds = stackedPaneBoundsForCurrentLayout('inventory');
   const effectiveStackedInventoryHeight = stackedPaneHeights.inventory === null
     ? null
@@ -10135,7 +10217,8 @@ function App() {
             {paneOrder.map((pane) => {
               const PaneIcon = PANE_ICONS[pane];
               const paneOn = pane === 'tools' ? true : paneVisibility[pane];
-              const isLastVisiblePane = pane !== 'tools' && paneOn && visibleContentPaneCount <= 1;
+              const paneHideBlocked = pane !== 'tools' && paneOn && !canHideContentPane(pane);
+              const paneHideBlockReason = pane === 'tools' ? '' : contentPaneHideBlockReason(pane);
               const paneFloating = panePlacements[pane] === 'floating';
               return (
                 <button
@@ -10147,7 +10230,7 @@ function App() {
                   data-dragging={paneDragUi?.dragged === pane || undefined}
                   data-drop-target={paneDragUi?.target === pane && paneDragUi.dragged !== pane || undefined}
                   draggable={paneReorderAvailable}
-                  disabled={pane !== 'tools' && isLastVisiblePane}
+                  disabled={paneHideBlocked}
                   onClick={() => handlePaneToggleClick(pane)}
                   onKeyDown={(event) => handlePaneToggleKeyDown(pane, event)}
                   onDragStart={(event) => handlePaneDragStart(pane, event)}
@@ -10158,11 +10241,11 @@ function App() {
                   aria-keyshortcuts={paneReorderAvailable ? 'Alt+Shift+ArrowLeft Alt+Shift+ArrowRight' : undefined}
                   aria-label={pane === 'tools'
                     ? `Tools ${toolsFloating ? 'floating' : toolsDocked ? 'expanded' : 'rail'}${paneReorderAvailable ? '; drag or use Alt+Shift+Left/Right Arrow to reorder' : ''}`
-                    : `${PANE_LABELS[pane]} pane ${paneOn ? paneFloating ? 'floating' : 'on' : 'off'}${isLastVisiblePane ? '; at least one pane must stay visible' : paneReorderAvailable ? '; drag or use Alt+Shift+Left/Right Arrow to reorder' : ''}`}
+                    : `${PANE_LABELS[pane]} pane ${paneOn ? paneFloating ? 'floating' : 'on' : 'off'}${paneHideBlocked ? `; ${paneHideBlockReason.toLowerCase()}` : paneReorderAvailable ? '; drag or use Alt+Shift+Left/Right Arrow to reorder' : ''}`}
                   title={pane === 'tools'
                     ? `${toolsFloating || toolsDocked ? 'Minimize tools to the right rail' : 'Expand tools panel'}${paneReorderAvailable ? '; drag to reorder' : ''}`
-                    : isLastVisiblePane
-                      ? 'At least one pane must stay visible'
+                    : paneHideBlocked
+                      ? paneHideBlockReason
                       : `${paneOn ? 'Hide' : 'Show'} ${PANE_LABELS[pane]} pane${paneReorderAvailable ? '; drag to reorder' : ''}`}
                 >
                   <PaneIcon className="motif-cs-nav-icon" aria-hidden="true" />
@@ -10310,10 +10393,10 @@ function App() {
                 <button
                   className="motif-cs-pane-collapse"
                   type="button"
-                  disabled={!canCollapseContentPane}
+                  disabled={!canHideContentPane('inventory')}
                   onClick={() => collapsePaneAndRestoreFocus('inventory')}
-                  aria-label={canCollapseContentPane ? 'Collapse inventory pane' : 'Inventory pane cannot be collapsed; at least one content pane must stay visible'}
-                  title={canCollapseContentPane ? 'Collapse inventory pane' : 'At least one content pane must stay visible'}
+                  aria-label={canHideContentPane('inventory') ? 'Collapse inventory pane' : `Inventory pane cannot be collapsed; ${contentPaneHideBlockReason('inventory').toLowerCase()}`}
+                  title={canHideContentPane('inventory') ? 'Collapse inventory pane' : contentPaneHideBlockReason('inventory')}
                 >
                   {paneCollapsePointsRight('inventory') ? (
                     <ChevronRight size={14} strokeWidth={2.2} aria-hidden="true" />
@@ -10395,10 +10478,10 @@ function App() {
                 <button
                   className="motif-cs-pane-collapse"
                   type="button"
-                  disabled={!canCollapseContentPane}
+                  disabled={!canHideContentPane('map')}
                   onClick={() => collapsePaneAndRestoreFocus('map')}
-                  aria-label={canCollapseContentPane ? 'Collapse map pane' : 'Map pane cannot be collapsed; at least one content pane must stay visible'}
-                  title={canCollapseContentPane ? 'Collapse map pane' : 'At least one content pane must stay visible'}
+                  aria-label={canHideContentPane('map') ? 'Collapse map pane' : `Map pane cannot be collapsed; ${contentPaneHideBlockReason('map').toLowerCase()}`}
+                  title={canHideContentPane('map') ? 'Collapse map pane' : contentPaneHideBlockReason('map')}
                 >
                   {paneCollapsePointsRight('map') ? (
                     <ChevronRight size={14} strokeWidth={2.2} aria-hidden="true" />
@@ -10648,10 +10731,10 @@ function App() {
                 <button
                   className="motif-cs-pane-collapse"
                   type="button"
-                  disabled={!canCollapseContentPane}
+                  disabled={!canHideContentPane('sequence')}
                   onClick={() => collapsePaneAndRestoreFocus('sequence')}
-                  aria-label={canCollapseContentPane ? 'Collapse sequence pane' : 'Sequence pane cannot be collapsed; at least one content pane must stay visible'}
-                  title={canCollapseContentPane ? 'Collapse sequence pane' : 'At least one content pane must stay visible'}
+                  aria-label={canHideContentPane('sequence') ? 'Collapse sequence pane' : `Sequence pane cannot be collapsed; ${contentPaneHideBlockReason('sequence').toLowerCase()}`}
+                  title={canHideContentPane('sequence') ? 'Collapse sequence pane' : contentPaneHideBlockReason('sequence')}
                 >
                   {paneCollapsePointsRight('sequence') ? (
                     <ChevronRight size={14} strokeWidth={2.2} aria-hidden="true" />
@@ -11477,7 +11560,7 @@ function App() {
           title="Translations"
           subtitle={vector.name}
           initial={translationsWin}
-          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
+          rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={() => setShowTranslations(false)}
           onCommit={setTranslationsWin}
           returnFocusRef={translationsToggleRef}
@@ -11517,7 +11600,7 @@ function App() {
           title="Gel Preview"
           subtitle="qualitative agarose"
           initial={gelWin}
-          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
+          rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={() => setShowGel(false)}
           onCommit={setGelWin}
           returnFocusRef={gelReturnFocusRef}
@@ -11560,7 +11643,7 @@ function App() {
           title="Primer Design"
           subtitle={cloningPrimerRequest ? `${vector.name} · cloning preparation` : vector.name}
           initial={primerWin}
-          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
+          rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={closePrimerWorkspace}
           onCommit={setPrimerWin}
           returnFocusRef={primerToggleRef}
@@ -11620,7 +11703,7 @@ function App() {
           title="Cloning Workspace"
           subtitle="Golden Gate + ligation"
           initial={assemblyWin}
-          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
+          rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={() => setShowAssembly(false)}
           onCommit={setAssemblyWin}
           returnFocusRef={cloningToggleRef}
@@ -11640,7 +11723,7 @@ function App() {
           title="Cloning Design"
           subtitle="Golden Gate profiles + Gibson"
           initial={cloningDesignWin}
-          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
+          rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={() => setShowCloningDesign(false)}
           onCommit={setCloningDesignWin}
           returnFocusRef={cloningToggleRef}
@@ -11663,7 +11746,7 @@ function App() {
           title="Construct Verification"
           subtitle={`${constructVerificationReadCount} eligible Sanger read${constructVerificationReadCount === 1 ? '' : 's'}`}
           initial={constructVerificationWin}
-          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
+          rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={() => setShowConstructVerification(false)}
           onCommit={setConstructVerificationWin}
           returnFocusRef={constructVerificationToggleRef}
@@ -11684,7 +11767,7 @@ function App() {
           title="Multiple Sequence Alignment"
           subtitle={payload.alignments.length ? `${payload.alignments.length} in session` : 'local + imported'}
           initial={alignmentWin}
-          rightInset={toolsPinned ? 0 : TOOLS_RAIL_WIDTH}
+          rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={() => setShowAlignment(false)}
           onCommit={setAlignmentWin}
           returnFocusRef={alignmentToggleRef}
@@ -12547,6 +12630,7 @@ function FeatureList({
 }
 
 type RailPopoverSize = { width: number; height: number };
+type RailPopoverCorner = { left: number; top: number };
 
 function cssPixelValue(value: string, fallback: number): number {
   const parsed = Number.parseFloat(value);
@@ -12556,6 +12640,7 @@ function cssPixelValue(value: string, fallback: number): number {
 function RailPopoverTitle({ title, meta }: { title: string; meta?: string }) {
   const [size, setSize] = useState<RailPopoverSize | null>(null);
   const [panelBody, setPanelBody] = useState<HTMLElement | null>(null);
+  const [resizeCorner, setResizeCorner] = useState<RailPopoverCorner | null>(null);
   const titleRef = useRef<HTMLDivElement>(null);
   const resizeHandleRef = useRef<HTMLButtonElement>(null);
   const panelBodyRef = useRef<HTMLElement | null>(null);
@@ -12593,6 +12678,28 @@ function RailPopoverTitle({ title, meta }: { title: string; meta?: string }) {
     panelBody.style.setProperty('--rail-popover-height', `${size.height}px`);
     panelBody.dataset.railPopoverResized = 'true';
   }, [size]);
+
+  useLayoutEffect(() => {
+    if (!panelBody) {
+      setResizeCorner(null);
+      return undefined;
+    }
+    const updateCorner = () => {
+      const rect = panelBody.getBoundingClientRect();
+      const next = rect.width > 0 && rect.height > 0
+        ? { left: rect.left, top: rect.bottom - 28 }
+        : null;
+      setResizeCorner((current) => current?.left === next?.left && current?.top === next?.top ? current : next);
+    };
+    updateCorner();
+    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(updateCorner);
+    observer?.observe(panelBody);
+    window.addEventListener('resize', updateCorner);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener('resize', updateCorner);
+    };
+  }, [panelBody, size]);
 
   const stopResize = useCallback(() => {
     resizeCleanupRef.current?.();
@@ -12726,7 +12833,7 @@ function RailPopoverTitle({ title, meta }: { title: string; meta?: string }) {
           </button>
         </div>
       </div>
-      {panelBody ? createPortal(
+      {panelBody && resizeCorner ? createPortal(
         <button
           ref={resizeHandleRef}
           className="motif-cs-rail-popover-resize"
@@ -12738,6 +12845,7 @@ function RailPopoverTitle({ title, meta }: { title: string; meta?: string }) {
           aria-keyshortcuts="ArrowLeft ArrowRight ArrowUp ArrowDown"
           title={`Resize ${title}; double-click to reset`}
           data-testid="rail-popover-resize"
+          style={{ left: resizeCorner.left, top: resizeCorner.top }}
         />,
         panelBody,
       ) : null}
@@ -14764,6 +14872,7 @@ function FloatingWindow({
     if (!event.isPrimary || event.button !== 0) return;
     event.preventDefault();
     stopActiveDrag(false);
+    const dragSurface = event.currentTarget as HTMLElement;
     // Set drag state first; pointer capture is best-effort (it can throw for
     // synthetic/invalid pointer ids) and must never abort the drag.
     dragRef.current = {
@@ -14775,7 +14884,7 @@ function FloatingWindow({
     };
     document.body.dataset.motifCsWindowDragging = mode;
     try {
-      (event.currentTarget as HTMLElement).setPointerCapture?.(event.pointerId);
+      dragSurface.setPointerCapture?.(event.pointerId);
     } catch {
       /* capture unavailable — window listeners below still keep the drag alive */
     }
@@ -14805,7 +14914,14 @@ function FloatingWindow({
       window.removeEventListener('pointermove', handlePointerMove);
       window.removeEventListener('pointerup', endDrag);
       window.removeEventListener('pointercancel', endDrag);
+      window.removeEventListener('blur', endDragFromBlur);
+      dragSurface.removeEventListener('lostpointercapture', endLostPointerCapture);
       if (dragCleanupRef.current === removeDragListeners) dragCleanupRef.current = null;
+      try {
+        if (dragSurface.hasPointerCapture?.(event.pointerId)) dragSurface.releasePointerCapture?.(event.pointerId);
+      } catch {
+        /* Capture may already be gone after blur or DOM removal. */
+      }
     };
 
     function handlePointerMove(moveEvent: PointerEvent) {
@@ -14819,10 +14935,21 @@ function FloatingWindow({
       stopActiveDrag(true);
     }
 
+    function endLostPointerCapture(lostEvent: PointerEvent) {
+      if (lostEvent.pointerId !== dragRef.current?.pointerId) return;
+      stopActiveDrag(true);
+    }
+
+    function endDragFromBlur() {
+      stopActiveDrag(true);
+    }
+
     dragCleanupRef.current = removeDragListeners;
     window.addEventListener('pointermove', handlePointerMove);
     window.addEventListener('pointerup', endDrag);
     window.addEventListener('pointercancel', endDrag);
+    window.addEventListener('blur', endDragFromBlur);
+    dragSurface.addEventListener('lostpointercapture', endLostPointerCapture);
   };
 
   const commitKeyboardRect = useCallback((next: WindowRect) => {

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -138,6 +138,14 @@ import {
   type ArtifactAnalysisResult,
 } from './claude-science-analysis-results';
 import {
+  clampFloatingSurfaceRect,
+  moveFloatingSurfaceRect,
+  resizeFloatingSurfaceRectFromBottomRight,
+  type FloatingSurfaceRect,
+  type FloatingSurfaceSizeLimits,
+  type FloatingSurfaceViewport,
+} from './floating-surface-geometry';
+import {
   addArtifactNote,
   appendArtifactWorkflowResult,
   getArtifactNotesSnapshot,
@@ -434,6 +442,9 @@ type ArtifactThemeName = 'light' | 'dark' | 'claude-light' | 'claude-dark';
 type SequenceViewMode = 'standard' | 'detail';
 type MapThemeName = 'dark' | 'light';
 type PaneKey = 'inventory' | 'map' | 'sequence' | 'tools';
+type PanePlacement = 'docked' | 'floating';
+type PanePlacements = Record<PaneKey, PanePlacement>;
+type FloatingPaneRects = Record<PaneKey, FloatingSurfaceRect>;
 type ResizablePaneKey = 'inventory' | 'sequence' | 'map' | 'tools';
 type StackedResizablePaneKey = 'inventory' | 'sequence';
 type ResizeEdge = 'before' | 'after';
@@ -624,6 +635,49 @@ const PANE_ICONS: Record<PaneKey, LucideIcon> = {
   tools: Wrench,
 };
 
+const DEFAULT_PANE_PLACEMENTS: PanePlacements = {
+  inventory: 'docked',
+  map: 'docked',
+  sequence: 'docked',
+  tools: 'docked',
+};
+
+const FLOATING_PANE_LIMITS: Record<PaneKey, FloatingSurfaceSizeLimits> = {
+  inventory: { minWidth: 260, minHeight: 280, maxWidth: 620, maxHeight: 760 },
+  sequence: { minWidth: 420, minHeight: 320, maxWidth: 1040, maxHeight: 900 },
+  map: { minWidth: 340, minHeight: 320, maxWidth: 900, maxHeight: 900 },
+  tools: { minWidth: 280, minHeight: 280, maxWidth: 720, maxHeight: 900 },
+};
+
+function floatingPaneViewport(): FloatingSurfaceViewport {
+  const topbarBottom = typeof document === 'undefined'
+    ? 0
+    : document.querySelector<HTMLElement>('.motif-cs-topbar')?.getBoundingClientRect().bottom ?? 0;
+  const toolsRailWidth = typeof document === 'undefined'
+    ? 0
+    : document.querySelector<HTMLElement>('.motif-cs-inspector[data-tools-pinned="false"]')?.getBoundingClientRect().width ?? 0;
+  return {
+    width: typeof window === 'undefined' ? 1280 : window.innerWidth,
+    height: typeof window === 'undefined' ? 800 : window.innerHeight,
+    insets: {
+      top: Math.max(8, topbarBottom + 8),
+      right: Math.max(8, toolsRailWidth + 8),
+      bottom: 8,
+      left: 8,
+    },
+  };
+}
+
+function defaultFloatingPaneRects(viewport = floatingPaneViewport()): FloatingPaneRects {
+  const defaults: FloatingPaneRects = {
+    inventory: { x: 24, y: 92, w: 340, h: 520 },
+    sequence: { x: Math.max(24, viewport.width * 0.18), y: 76, w: 680, h: 620 },
+    map: { x: Math.max(24, viewport.width - 620), y: 92, w: 580, h: 580 },
+    tools: { x: Math.max(24, viewport.width - 420), y: 84, w: 360, h: 620 },
+  };
+  return defaults;
+}
+
 type WorkspaceLayoutPrefs = {
   theme: ArtifactThemeName;
   paneWidths: PaneWidths;
@@ -631,6 +685,8 @@ type WorkspaceLayoutPrefs = {
   paneVisibility: PaneVisibility;
   paneOrder: PaneKey[];
   toolsPinned: boolean;
+  panePlacements: PanePlacements;
+  floatingPaneRects: FloatingPaneRects;
 };
 
 const WORKSPACE_LAYOUT_STORAGE_KEY = 'motif.claude-science.workspace-layout.v1';
@@ -642,6 +698,8 @@ const DEFAULT_WORKSPACE_LAYOUT: WorkspaceLayoutPrefs = {
   paneVisibility: DEFAULT_PANE_VISIBILITY,
   paneOrder: [...DEFAULT_PANE_ORDER],
   toolsPinned: false,
+  panePlacements: DEFAULT_PANE_PLACEMENTS,
+  floatingPaneRects: defaultFloatingPaneRects(),
 };
 
 function isPaneKey(value: unknown): value is PaneKey {
@@ -706,15 +764,53 @@ function normalizePaneOrder(value: unknown): PaneKey[] {
   return [...ordered, ...DEFAULT_PANE_ORDER].filter((pane, index, list) => list.indexOf(pane) === index);
 }
 
+function normalizePanePlacements(value: unknown): PanePlacements {
+  const source = value && typeof value === 'object' ? value as Partial<Record<PaneKey, unknown>> : {};
+  return Object.fromEntries(DEFAULT_PANE_ORDER.map((pane) => [
+    pane,
+    source[pane] === 'floating' ? 'floating' : 'docked',
+  ])) as PanePlacements;
+}
+
+function normalizeFloatingPaneRects(value: unknown): FloatingPaneRects {
+  const source = value && typeof value === 'object' ? value as Partial<Record<PaneKey, unknown>> : {};
+  const defaults = defaultFloatingPaneRects();
+  return Object.fromEntries(DEFAULT_PANE_ORDER.map((pane) => {
+    const candidate = source[pane];
+    const rect = candidate && typeof candidate === 'object' ? candidate as Partial<FloatingSurfaceRect> : {};
+    const limits = FLOATING_PANE_LIMITS[pane];
+    const preferred = {
+      x: Number.isFinite(rect.x) ? rect.x as number : defaults[pane].x,
+      y: Number.isFinite(rect.y) ? rect.y as number : defaults[pane].y,
+      w: clamp(
+        Number.isFinite(rect.w) ? rect.w as number : defaults[pane].w,
+        limits.minWidth ?? 1,
+        limits.maxWidth ?? Number.POSITIVE_INFINITY,
+      ),
+      h: clamp(
+        Number.isFinite(rect.h) ? rect.h as number : defaults[pane].h,
+        limits.minHeight ?? 1,
+        limits.maxHeight ?? Number.POSITIVE_INFINITY,
+      ),
+    };
+    return [pane, preferred];
+  })) as FloatingPaneRects;
+}
+
 function normalizeWorkspaceLayout(value: unknown): WorkspaceLayoutPrefs {
   const source = value && typeof value === 'object' ? value as Partial<Record<keyof WorkspaceLayoutPrefs, unknown>> : {};
+  const panePlacements = normalizePanePlacements(source.panePlacements);
   return {
     theme: normalizeArtifactThemeName(source.theme),
     paneWidths: normalizePaneWidths(source.paneWidths),
     stackedPaneHeights: normalizeStackedPaneHeights(source.stackedPaneHeights),
     paneVisibility: normalizePaneVisibility(source.paneVisibility),
     paneOrder: normalizePaneOrder(source.paneOrder),
-    toolsPinned: typeof source.toolsPinned === 'boolean' ? source.toolsPinned : DEFAULT_WORKSPACE_LAYOUT.toolsPinned,
+    toolsPinned: panePlacements.tools === 'floating'
+      ? true
+      : typeof source.toolsPinned === 'boolean' ? source.toolsPinned : DEFAULT_WORKSPACE_LAYOUT.toolsPinned,
+    panePlacements,
+    floatingPaneRects: normalizeFloatingPaneRects(source.floatingPaneRects),
   };
 }
 
@@ -4536,6 +4632,12 @@ function App() {
   const [paneVisibility, setPaneVisibility] = useState<PaneVisibility>(initialWorkspaceLayout.paneVisibility);
   const [toolsPinned, setToolsPinned] = useState(initialWorkspaceLayout.toolsPinned);
   const [paneOrder, setPaneOrder] = useState<PaneKey[]>(initialWorkspaceLayout.paneOrder);
+  const [panePlacements, setPanePlacements] = useState<PanePlacements>(initialWorkspaceLayout.panePlacements);
+  const [floatingPaneRects, setFloatingPaneRects] = useState<FloatingPaneRects>(initialWorkspaceLayout.floatingPaneRects);
+  const [floatingPaneZOrder, setFloatingPaneZOrder] = useState<PaneKey[]>(() => (
+    DEFAULT_PANE_ORDER.filter((pane) => initialWorkspaceLayout.panePlacements[pane] === 'floating')
+  ));
+  const [floatingViewport, setFloatingViewport] = useState(floatingPaneViewport);
   // Translations live in a floating "dynamic window" (toggle in the top bar). Rect
   // is remembered so it reopens where the user left it; seeded to the lower-right.
   const [showTranslations, setShowTranslations] = useState(false);
@@ -4653,6 +4755,16 @@ function App() {
   const workspaceMainRef = useRef<HTMLElement | null>(null);
   const [topbarHeight, setTopbarHeight] = useState(38);
   const [workspaceMainSize, setWorkspaceMainSize] = useState({ width: 1280, height: 720 });
+  const floatingPaneRectsRef = useRef(floatingPaneRects);
+  const floatingPaneInteractionRef = useRef<{
+    pane: PaneKey;
+    mode: 'move' | 'resize';
+    pointerId: number;
+    startX: number;
+    startY: number;
+    base: FloatingSurfaceRect;
+  } | null>(null);
+  const floatingPaneInteractionCleanupRef = useRef<(() => void) | null>(null);
   const sequenceScrollByRecordRef = useRef<Record<string, number>>({});
   const mapDragRef = useRef<MapDragState | null>(null);
   const mapPointerIdRef = useRef<number | null>(null);
@@ -7898,10 +8010,198 @@ function App() {
     setPaneVisibility((current) => current[pane] ? current : { ...current, [pane]: true });
   }, []);
 
+  useEffect(() => {
+    floatingPaneRectsRef.current = floatingPaneRects;
+  }, [floatingPaneRects]);
+
+  useEffect(() => {
+    const updateViewport = () => setFloatingViewport(floatingPaneViewport());
+    updateViewport();
+    window.addEventListener('resize', updateViewport);
+    return () => window.removeEventListener('resize', updateViewport);
+  }, []);
+
+  const paneElementForKey = useCallback((pane: PaneKey): HTMLElement | null => {
+    if (pane === 'inventory') return inventoryColumnRef.current;
+    if (pane === 'map') return mapColumnRef.current;
+    if (pane === 'sequence') return sequenceColumnRef.current;
+    return toolsInspectorRef.current;
+  }, []);
+
+  const bringFloatingPaneToFront = useCallback((pane: PaneKey) => {
+    setFloatingPaneZOrder((current) => current[current.length - 1] === pane
+      ? current
+      : [...current.filter((candidate) => candidate !== pane), pane]);
+  }, []);
+
+  const popOutPane = useCallback((pane: PaneKey) => {
+    setPaneVisibility((current) => current[pane] ? current : { ...current, [pane]: true });
+    setPanePlacements((current) => current[pane] === 'floating'
+      ? current
+      : { ...current, [pane]: 'floating' });
+    if (pane === 'tools') setToolsPinned(true);
+    bringFloatingPaneToFront(pane);
+    window.requestAnimationFrame(() => {
+      paneElementForKey(pane)?.querySelector<HTMLButtonElement>('[data-pane-dock]')?.focus({ preventScroll: true });
+    });
+  }, [bringFloatingPaneToFront, paneElementForKey]);
+
+  const dockPane = useCallback((pane: PaneKey) => {
+    setPanePlacements((current) => current[pane] === 'docked'
+      ? current
+      : { ...current, [pane]: 'docked' });
+    setFloatingPaneZOrder((current) => current.filter((candidate) => candidate !== pane));
+    window.requestAnimationFrame(() => {
+      paneElementForKey(pane)?.querySelector<HTMLButtonElement>('[data-pane-popout]')?.focus({ preventScroll: true });
+    });
+  }, [paneElementForKey]);
+
+  const stopFloatingPaneInteraction = useCallback(() => {
+    floatingPaneInteractionCleanupRef.current?.();
+    floatingPaneInteractionCleanupRef.current = null;
+    floatingPaneInteractionRef.current = null;
+    delete document.body.dataset.motifCsPaneFloatingAction;
+  }, []);
+
+  useEffect(() => () => stopFloatingPaneInteraction(), [stopFloatingPaneInteraction]);
+
+  const setFloatingPaneRect = useCallback((pane: PaneKey, rect: FloatingSurfaceRect) => {
+    floatingPaneRectsRef.current = { ...floatingPaneRectsRef.current, [pane]: rect };
+    setFloatingPaneRects((current) => ({ ...current, [pane]: rect }));
+  }, []);
+
+  const beginFloatingPaneInteraction = useCallback((
+    pane: PaneKey,
+    mode: 'move' | 'resize',
+    event: ReactPointerEvent<HTMLElement>,
+  ) => {
+    if (panePlacements[pane] !== 'floating' || window.innerWidth <= 520) return;
+    if (!event.isPrimary || event.button !== 0) return;
+    if (mode === 'move' && (event.target as HTMLElement).closest('button, input, textarea, select, a, summary, [contenteditable="true"]')) return;
+    event.preventDefault();
+    stopFloatingPaneInteraction();
+    bringFloatingPaneToFront(pane);
+    const surface = event.currentTarget;
+    const base = clampFloatingSurfaceRect(
+      floatingPaneRectsRef.current[pane],
+      floatingPaneViewport(),
+      FLOATING_PANE_LIMITS[pane],
+    );
+    floatingPaneInteractionRef.current = {
+      pane,
+      mode,
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      base,
+    };
+    document.body.dataset.motifCsPaneFloatingAction = mode;
+    try {
+      surface.setPointerCapture?.(event.pointerId);
+    } catch {
+      /* Window listeners keep the interaction alive when capture is unavailable. */
+    }
+
+    const applyPointer = (clientX: number, clientY: number) => {
+      const interaction = floatingPaneInteractionRef.current;
+      if (!interaction) return;
+      const delta = {
+        dx: clientX - interaction.startX,
+        dy: clientY - interaction.startY,
+      };
+      const viewport = floatingPaneViewport();
+      const next = interaction.mode === 'move'
+        ? moveFloatingSurfaceRect(interaction.base, delta, viewport, FLOATING_PANE_LIMITS[interaction.pane])
+        : resizeFloatingSurfaceRectFromBottomRight(interaction.base, delta, viewport, FLOATING_PANE_LIMITS[interaction.pane]);
+      setFloatingPaneRect(interaction.pane, next);
+    };
+
+    const removeListeners = () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', finishPointer);
+      window.removeEventListener('pointercancel', finishPointer);
+      window.removeEventListener('blur', finishFromBlur);
+      surface.removeEventListener('lostpointercapture', finishPointer);
+      if (floatingPaneInteractionCleanupRef.current === removeListeners) {
+        floatingPaneInteractionCleanupRef.current = null;
+      }
+    };
+    function handlePointerMove(moveEvent: PointerEvent) {
+      if (moveEvent.pointerId !== floatingPaneInteractionRef.current?.pointerId) return;
+      moveEvent.preventDefault();
+      applyPointer(moveEvent.clientX, moveEvent.clientY);
+    }
+    function finishPointer(endEvent: PointerEvent) {
+      if (endEvent.pointerId !== floatingPaneInteractionRef.current?.pointerId) return;
+      stopFloatingPaneInteraction();
+    }
+    function finishFromBlur() {
+      stopFloatingPaneInteraction();
+    }
+    floatingPaneInteractionCleanupRef.current = removeListeners;
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', finishPointer);
+    window.addEventListener('pointercancel', finishPointer);
+    window.addEventListener('blur', finishFromBlur);
+    surface.addEventListener('lostpointercapture', finishPointer);
+  }, [bringFloatingPaneToFront, panePlacements, setFloatingPaneRect, stopFloatingPaneInteraction]);
+
+  const moveFloatingPaneFromKeyboard = useCallback((pane: PaneKey, event: ReactKeyboardEvent<HTMLElement>) => {
+    if (panePlacements[pane] !== 'floating' || !event.altKey) return;
+    if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)) return;
+    event.preventDefault();
+    const step = event.shiftKey ? 24 : 10;
+    const delta = {
+      dx: event.key === 'ArrowLeft' ? -step : event.key === 'ArrowRight' ? step : 0,
+      dy: event.key === 'ArrowUp' ? -step : event.key === 'ArrowDown' ? step : 0,
+    };
+    setFloatingPaneRect(pane, moveFloatingSurfaceRect(
+      floatingPaneRectsRef.current[pane],
+      delta,
+      floatingPaneViewport(),
+      FLOATING_PANE_LIMITS[pane],
+    ));
+  }, [panePlacements, setFloatingPaneRect]);
+
+  const resizeFloatingPaneFromKeyboard = useCallback((pane: PaneKey, event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)) return;
+    event.preventDefault();
+    const step = event.shiftKey ? 24 : 10;
+    setFloatingPaneRect(pane, resizeFloatingSurfaceRectFromBottomRight(
+      floatingPaneRectsRef.current[pane],
+      {
+        dx: event.key === 'ArrowLeft' ? -step : event.key === 'ArrowRight' ? step : 0,
+        dy: event.key === 'ArrowUp' ? -step : event.key === 'ArrowDown' ? step : 0,
+      },
+      floatingPaneViewport(),
+      FLOATING_PANE_LIMITS[pane],
+    ));
+  }, [setFloatingPaneRect]);
+
+  useEffect(() => {
+    const dockFocusedFloatingPane = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented) return;
+      const targetPane = (event.target as HTMLElement | null)?.closest<HTMLElement>('[data-pane-placement="floating"]');
+      if (!targetPane || (event.target as HTMLElement | null)?.closest('[data-motif-cs-escape-scope="true"]')) return;
+      const pane = targetPane.dataset.paneKey as PaneKey | undefined;
+      if (!pane || !DEFAULT_PANE_ORDER.includes(pane)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      dockPane(pane);
+    };
+    window.addEventListener('keydown', dockFocusedFloatingPane);
+    return () => window.removeEventListener('keydown', dockFocusedFloatingPane);
+  }, [dockPane]);
+
   const scrollPaneIntoView = useCallback((pane: PaneKey) => {
     if (typeof document === 'undefined') return;
+    if (panePlacements[pane] === 'floating') {
+      bringFloatingPaneToFront(pane);
+      paneElementForKey(pane)?.focus({ preventScroll: true });
+      return;
+    }
     document.querySelector(PANE_SELECTOR[pane])?.scrollIntoView({ block: 'start', behavior: 'auto' });
-  }, []);
+  }, [bringFloatingPaneToFront, paneElementForKey, panePlacements]);
 
   const revealSequencePaneIfStacked = useCallback(() => {
     // Selection focus belongs to the sequence pane's own scroller. Moving the
@@ -9160,8 +9460,17 @@ function App() {
   }, [closeOpenToolDetails, mapFrameRef]);
 
   useEffect(() => {
-    saveWorkspaceLayoutPrefs({ theme, paneWidths: preferredPaneWidths, stackedPaneHeights, paneVisibility, paneOrder, toolsPinned });
-  }, [paneOrder, paneVisibility, preferredPaneWidths, stackedPaneHeights, theme, toolsPinned]);
+    saveWorkspaceLayoutPrefs({
+      theme,
+      paneWidths: preferredPaneWidths,
+      stackedPaneHeights,
+      paneVisibility,
+      paneOrder,
+      toolsPinned,
+      panePlacements,
+      floatingPaneRects,
+    });
+  }, [floatingPaneRects, paneOrder, panePlacements, paneVisibility, preferredPaneWidths, stackedPaneHeights, theme, toolsPinned]);
 
   useEffect(() => {
     saveMsaViewPreferences(msaViewPreferences);
@@ -9175,6 +9484,9 @@ function App() {
     setPaneVisibility({ ...DEFAULT_WORKSPACE_LAYOUT.paneVisibility });
     setToolsPinned(DEFAULT_WORKSPACE_LAYOUT.toolsPinned);
     setPaneOrder([...DEFAULT_WORKSPACE_LAYOUT.paneOrder]);
+    setPanePlacements({ ...DEFAULT_WORKSPACE_LAYOUT.panePlacements });
+    setFloatingPaneRects(defaultFloatingPaneRects());
+    setFloatingPaneZOrder([]);
   }, []);
 
   const resetDisplayPreferences = useCallback(() => {
@@ -9196,6 +9508,14 @@ function App() {
 
   const toggleToolsPinned = useCallback(() => {
     setPaneVisibility((current) => current.tools ? current : { ...current, tools: true });
+    if (panePlacements.tools === 'floating') {
+      stopFloatingPaneInteraction();
+      setPanePlacements((current) => ({ ...current, tools: 'docked' }));
+      setFloatingPaneZOrder((current) => current.filter((pane) => pane !== 'tools'));
+      setToolsPinned(false);
+      window.requestAnimationFrame(closeOpenToolDetails);
+      return;
+    }
     setToolsPinned((current) => {
       const next = !current;
       if (!next && typeof window !== 'undefined') {
@@ -9203,7 +9523,7 @@ function App() {
       }
       return next;
     });
-  }, [closeOpenToolDetails]);
+  }, [closeOpenToolDetails, panePlacements.tools, stopFloatingPaneInteraction]);
 
   const togglePane = useCallback((pane: PaneKey) => {
     const isStacked = typeof window !== 'undefined' && window.matchMedia(STACKED_LAYOUT_MEDIA).matches;
@@ -9212,10 +9532,10 @@ function App() {
       if (pane !== 'tools' && current[pane] && openContentCount <= 1) return current;
       return { ...current, [pane]: !current[pane] };
     });
-    if (isStacked && !paneVisibility[pane]) {
+    if ((isStacked || panePlacements[pane] === 'floating') && !paneVisibility[pane]) {
       window.requestAnimationFrame(() => scrollPaneIntoView(pane));
     }
-  }, [paneVisibility, scrollPaneIntoView]);
+  }, [panePlacements, paneVisibility, scrollPaneIntoView]);
 
   const reorderPane = useCallback((dragged: PaneKey, target: PaneKey) => {
     if (dragged === target) return;
@@ -9304,13 +9624,18 @@ function App() {
     return base + 1;
   }, [paneOrderIndex]);
 
+  const toolsFloating = panePlacements.tools === 'floating';
+  const toolsDocked = panePlacements.tools === 'docked' && toolsPinned;
+  const toolsRail = panePlacements.tools === 'docked' && !toolsPinned;
   const visibleOrderedPanes = useMemo(
-    () => paneOrder.filter((pane) => paneVisibility[pane]),
-    [paneOrder, paneVisibility],
+    () => paneOrder.filter((pane) => paneVisibility[pane] && panePlacements[pane] === 'docked'),
+    [paneOrder, panePlacements, paneVisibility],
   );
   const visibleContentPanes = useMemo(
-    () => paneOrder.filter((pane): pane is Exclude<PaneKey, 'tools'> => pane !== 'tools' && paneVisibility[pane]),
-    [paneOrder, paneVisibility],
+    () => paneOrder.filter((pane): pane is Exclude<PaneKey, 'tools'> => (
+      pane !== 'tools' && paneVisibility[pane] && panePlacements[pane] === 'docked'
+    )),
+    [paneOrder, panePlacements, paneVisibility],
   );
   const paneCollapsePointsRight = useCallback((pane: Exclude<PaneKey, 'tools'>) => {
     const index = visibleContentPanes.indexOf(pane);
@@ -9320,22 +9645,26 @@ function App() {
     const index = visibleOrderedPanes.indexOf(pane);
     return index > 0 ? visibleOrderedPanes[index - 1] : undefined;
   }, [visibleOrderedPanes]);
-  const sequenceBeforeMap = paneVisibility.sequence && paneVisibility.map && previousVisiblePane('map') === 'sequence';
-  const mapBeforeSequence = paneVisibility.sequence && paneVisibility.map && previousVisiblePane('sequence') === 'map';
+  const sequenceBeforeMap = paneVisibility.sequence && paneVisibility.map
+    && panePlacements.sequence === 'docked' && panePlacements.map === 'docked'
+    && previousVisiblePane('map') === 'sequence';
+  const mapBeforeSequence = paneVisibility.sequence && paneVisibility.map
+    && panePlacements.sequence === 'docked' && panePlacements.map === 'docked'
+    && previousVisiblePane('sequence') === 'map';
   const showSequenceMapResizeHandle = sequenceBeforeMap || mapBeforeSequence;
-  const showToolsResizeHandle = paneVisibility.tools && visibleOrderedPanes[0] !== 'tools';
+  const showToolsResizeHandle = paneVisibility.tools && toolsDocked && visibleOrderedPanes[0] !== 'tools';
   const visibleResizablePanes = useMemo(() => {
     const keys: ResizablePaneKey[] = [];
-    if (paneVisibility.inventory) keys.push('inventory');
-    if (paneVisibility.sequence) keys.push('sequence');
-    if (paneVisibility.map) keys.push('map');
-    if (paneVisibility.tools && toolsPinned) keys.push('tools');
+    if (paneVisibility.inventory && panePlacements.inventory === 'docked') keys.push('inventory');
+    if (paneVisibility.sequence && panePlacements.sequence === 'docked') keys.push('sequence');
+    if (paneVisibility.map && panePlacements.map === 'docked') keys.push('map');
+    if (paneVisibility.tools && toolsDocked) keys.push('tools');
     return keys;
-  }, [paneVisibility, toolsPinned]);
-  const resizeHandleCount = (paneVisibility.inventory ? 1 : 0)
+  }, [panePlacements, paneVisibility, toolsDocked]);
+  const resizeHandleCount = (paneVisibility.inventory && panePlacements.inventory === 'docked' ? 1 : 0)
     + (showSequenceMapResizeHandle ? 1 : 0)
-    + (showToolsResizeHandle && toolsPinned ? 1 : 0);
-  const toolsRailWidth = paneVisibility.tools && !toolsPinned ? TOOLS_RAIL_WIDTH : 0;
+    + (showToolsResizeHandle ? 1 : 0);
+  const toolsRailWidth = paneVisibility.tools && toolsRail ? TOOLS_RAIL_WIDTH : 0;
 
   useLayoutEffect(() => {
     const node = topbarRef.current;
@@ -9385,14 +9714,14 @@ function App() {
       document.querySelector<HTMLButtonElement>(`[data-pane-toggle="${pane}"]`)?.focus({ preventScroll: true });
     });
   }, [paneReorderAvailable]);
-  const compactPinnedLayout = toolsPinned && stableCompactTopology;
+  const compactPinnedLayout = toolsDocked && stableCompactTopology;
   const compactMapHiddenTwoRowLayout = compactPinnedLayout
     && workspaceMainSize.width <= 767
-    && !paneVisibility.map;
+    && (!paneVisibility.map || panePlacements.map === 'floating');
   const compactRowResizeActive = compactPinnedLayout
-    && paneVisibility.sequence
-    && (paneVisibility.map || compactMapHiddenTwoRowLayout);
-  const twoRowResizeActive = !toolsPinned
+    && paneVisibility.sequence && panePlacements.sequence === 'docked'
+    && ((paneVisibility.map && panePlacements.map === 'docked') || compactMapHiddenTwoRowLayout);
+  const twoRowResizeActive = !toolsDocked
     && stableCompactTopology
     && visibleContentPanes.length === 3
     && paneVisibility.sequence
@@ -9455,7 +9784,7 @@ function App() {
     const mainWidth = document.querySelector<HTMLElement>('.motif-cs-main')?.clientWidth ?? window.innerWidth;
     const effectiveHandleCount = twoRowLayout
       ? Number(fittedPanes.includes('inventory') && fittedPanes.includes('sequence'))
-      : resizeHandleCount - (overlayTools && showToolsResizeHandle && toolsPinned ? 1 : 0);
+      : resizeHandleCount - (overlayTools && showToolsResizeHandle ? 1 : 0);
     const resizeHandleSpace = Math.max(0, effectiveHandleCount) * 7;
     const effectiveToolsRailWidth = overlayTools ? TOOLS_RAIL_WIDTH : toolsRailWidth;
     const next = { ...widths };
@@ -9484,7 +9813,7 @@ function App() {
       deficit -= consumed;
     }
     return next;
-  }, [compactPinnedLayout, paneWidthLimitsForCurrentLayout, resizeHandleCount, showToolsResizeHandle, stableCompactTopology, toolsPinned, toolsRailWidth, visibleContentPanes.length, visibleResizablePanes]);
+  }, [compactPinnedLayout, paneWidthLimitsForCurrentLayout, resizeHandleCount, showToolsResizeHandle, stableCompactTopology, toolsRailWidth, visibleContentPanes.length, visibleResizablePanes]);
 
   useEffect(() => {
     const clampForCurrentViewport = () => {
@@ -9560,7 +9889,7 @@ function App() {
     const otherPaneWidth = fittedPanes
       .filter((key) => key !== pane)
       .reduce((sum, key) => sum + paneWidths[key], effectiveToolsRailWidth);
-    const effectiveHandleCount = resizeHandleCount - (overlayLayout && showToolsResizeHandle && toolsPinned ? 1 : 0);
+    const effectiveHandleCount = resizeHandleCount - (overlayLayout && showToolsResizeHandle ? 1 : 0);
     const resizeHandleSpace = Math.max(0, effectiveHandleCount) * resizeHandleWidth;
     const mainWidth = document.querySelector<HTMLElement>('.motif-cs-main')?.clientWidth ?? window.innerWidth;
     const overlayTools = pane === 'tools' && overlayLayout;
@@ -9617,7 +9946,7 @@ function App() {
     window.addEventListener('pointermove', handlePointerMove);
     window.addEventListener('pointerup', handlePointerUp);
     window.addEventListener('pointercancel', handlePointerUp);
-  }, [clampPaneWidthsForViewport, compactPinnedLayout, paneResizeNeighbor, paneWidthLimitsForCurrentLayout, paneWidths, preferredPaneWidths, resizeHandleCount, resizePanePair, showToolsResizeHandle, toolsPinned, toolsRailWidth, visibleResizablePanes]);
+  }, [clampPaneWidthsForViewport, compactPinnedLayout, paneResizeNeighbor, paneWidthLimitsForCurrentLayout, paneWidths, preferredPaneWidths, resizeHandleCount, resizePanePair, showToolsResizeHandle, toolsRailWidth, visibleResizablePanes]);
   const resizePaneFromKeyboard = useCallback((pane: ResizablePaneKey, event: ReactKeyboardEvent<HTMLDivElement>, edge: ResizeEdge = 'after') => {
     if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
     event.preventDefault();
@@ -9657,7 +9986,7 @@ function App() {
     if (!event.isPrimary || event.button !== 0) return;
     const supportsRowResize = window.matchMedia(STACKED_LAYOUT_MEDIA).matches
       || window.matchMedia(TWO_ROW_LAYOUT_MEDIA).matches
-      || (toolsPinned && window.matchMedia(COMPACT_PINNED_LAYOUT_MEDIA).matches);
+      || (toolsDocked && window.matchMedia(COMPACT_PINNED_LAYOUT_MEDIA).matches);
     if (!supportsRowResize) return;
     const paneElement = pane === 'inventory' ? inventoryColumnRef.current : sequenceColumnRef.current;
     if (!paneElement) return;
@@ -9686,7 +10015,7 @@ function App() {
     window.addEventListener('pointermove', handlePointerMove);
     window.addEventListener('pointerup', stopResize);
     window.addEventListener('pointercancel', stopResize);
-  }, [resizeStackedPaneTo, toolsPinned]);
+  }, [resizeStackedPaneTo, toolsDocked]);
 
   const resizeStackedPaneFromKeyboard = useCallback((pane: StackedResizablePaneKey, event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
@@ -9699,9 +10028,11 @@ function App() {
     resizeStackedPaneTo(pane, currentHeight + (event.key === 'ArrowDown' ? step : -step));
   }, [resizeStackedPaneTo, stackedPaneHeights]);
 
-  const visiblePaneCount = (['inventory', 'map', 'sequence', 'tools'] as const)
-    .filter((pane) => paneVisibility[pane]).length;
   const visibleContentPaneCount = CONTENT_PANE_KEYS.filter((pane) => paneVisibility[pane]).length;
+  const dockedContentPaneCount = CONTENT_PANE_KEYS.filter((pane) => (
+    paneVisibility[pane] && panePlacements[pane] === 'docked'
+  )).length;
+  const dockedPaneCount = dockedContentPaneCount + Number(paneVisibility.tools && toolsDocked);
   const canCollapseContentPane = visibleContentPaneCount > 1;
   const stackedInventoryBounds = stackedPaneBoundsForCurrentLayout('inventory');
   const effectiveStackedInventoryHeight = stackedPaneHeights.inventory === null
@@ -9723,6 +10054,27 @@ function App() {
   const renderedStackedSequenceHeight = effectiveStackedSequenceHeight
     ?? (workspaceRowResizeActive ? defaultCompactTopRowHeight : 360);
   const activeRecordTabIndex = Math.max(0, payload.records.findIndex((record) => record.id === recordId));
+  const floatingPaneStyle = (pane: PaneKey): CSSProperties => {
+    if (panePlacements[pane] !== 'floating') return {};
+    const safeViewport: FloatingSurfaceViewport = {
+      width: floatingViewport.width,
+      height: floatingViewport.height,
+      insets: { top: topbarHeight + 8, right: toolsRail ? TOOLS_RAIL_WIDTH + 8 : 8, bottom: 8, left: 8 },
+    };
+    const rect = clampFloatingSurfaceRect(floatingPaneRects[pane], safeViewport, FLOATING_PANE_LIMITS[pane]);
+    const zIndex = 60 + Math.max(0, floatingPaneZOrder.indexOf(pane));
+    return {
+      '--motif-cs-floating-pane-left': `${rect.x}px`,
+      '--motif-cs-floating-pane-top': `${rect.y}px`,
+      '--motif-cs-floating-pane-width': `${rect.w}px`,
+      '--motif-cs-floating-pane-height': `${rect.h}px`,
+      left: rect.x,
+      top: rect.y,
+      width: rect.w,
+      height: rect.h,
+      zIndex,
+    } as CSSProperties;
+  };
 
   return (
     <div
@@ -9784,13 +10136,14 @@ function App() {
               const PaneIcon = PANE_ICONS[pane];
               const paneOn = pane === 'tools' ? true : paneVisibility[pane];
               const isLastVisiblePane = pane !== 'tools' && paneOn && visibleContentPaneCount <= 1;
+              const paneFloating = panePlacements[pane] === 'floating';
               return (
                 <button
                   key={pane}
                   className="motif-cs-pane-toggle"
                   type="button"
                   data-pane-toggle={pane}
-                  data-active={(pane === 'tools' ? toolsPinned : paneOn) || undefined}
+                  data-active={(pane === 'tools' ? toolsDocked || toolsFloating : paneOn) || undefined}
                   data-dragging={paneDragUi?.dragged === pane || undefined}
                   data-drop-target={paneDragUi?.target === pane && paneDragUi.dragged !== pane || undefined}
                   draggable={paneReorderAvailable}
@@ -9801,20 +10154,21 @@ function App() {
                   onDragOver={handlePaneDragOver}
                   onDrop={(event) => handlePaneDrop(pane, event)}
                   onDragEnd={handlePaneDragEnd}
-                  aria-pressed={pane === 'tools' ? toolsPinned : paneOn}
+                  aria-pressed={pane === 'tools' ? toolsDocked || toolsFloating : paneOn}
                   aria-keyshortcuts={paneReorderAvailable ? 'Alt+Shift+ArrowLeft Alt+Shift+ArrowRight' : undefined}
                   aria-label={pane === 'tools'
-                    ? `Tools ${toolsPinned ? 'expanded' : 'rail'}${paneReorderAvailable ? '; drag or use Alt+Shift+Left/Right Arrow to reorder' : ''}`
-                    : `${PANE_LABELS[pane]} pane ${paneOn ? 'on' : 'off'}${isLastVisiblePane ? '; at least one pane must stay visible' : paneReorderAvailable ? '; drag or use Alt+Shift+Left/Right Arrow to reorder' : ''}`}
+                    ? `Tools ${toolsFloating ? 'floating' : toolsDocked ? 'expanded' : 'rail'}${paneReorderAvailable ? '; drag or use Alt+Shift+Left/Right Arrow to reorder' : ''}`
+                    : `${PANE_LABELS[pane]} pane ${paneOn ? paneFloating ? 'floating' : 'on' : 'off'}${isLastVisiblePane ? '; at least one pane must stay visible' : paneReorderAvailable ? '; drag or use Alt+Shift+Left/Right Arrow to reorder' : ''}`}
                   title={pane === 'tools'
-                    ? `${toolsPinned ? 'Minimize tools to the right rail' : 'Expand tools panel'}${paneReorderAvailable ? '; drag to reorder' : ''}`
+                    ? `${toolsFloating || toolsDocked ? 'Minimize tools to the right rail' : 'Expand tools panel'}${paneReorderAvailable ? '; drag to reorder' : ''}`
                     : isLastVisiblePane
                       ? 'At least one pane must stay visible'
                       : `${paneOn ? 'Hide' : 'Show'} ${PANE_LABELS[pane]} pane${paneReorderAvailable ? '; drag to reorder' : ''}`}
                 >
                   <PaneIcon className="motif-cs-nav-icon" aria-hidden="true" />
                   <span>{PANE_LABELS[pane]}</span>
-                  {pane === 'tools' && !toolsPinned ? <small className="motif-cs-pane-state">Rail</small> : null}
+                  {paneFloating ? <small className="motif-cs-pane-state">Float</small> : null}
+                  {pane === 'tools' && toolsRail ? <small className="motif-cs-pane-state">Rail</small> : null}
                 </button>
               );
             })}
@@ -9882,12 +10236,12 @@ function App() {
         aria-labelledby={payload.records.length > 0 ? `motif-cs-record-tab-${activeRecordTabIndex}` : undefined}
         aria-label={payload.records.length === 0 ? 'Sequence workspace; no records open' : undefined}
         tabIndex={-1}
-        data-visible-pane-count={visiblePaneCount}
-        data-content-pane-count={visibleContentPaneCount}
-        data-inventory-hidden={!paneVisibility.inventory || undefined}
-        data-map-hidden={!paneVisibility.map || undefined}
-        data-sequence-hidden={!paneVisibility.sequence || undefined}
-        data-tools-pinned={toolsPinned || undefined}
+        data-visible-pane-count={dockedPaneCount}
+        data-content-pane-count={dockedContentPaneCount}
+        data-inventory-hidden={!paneVisibility.inventory || panePlacements.inventory === 'floating' || undefined}
+        data-map-hidden={!paneVisibility.map || panePlacements.map === 'floating' || undefined}
+        data-sequence-hidden={!paneVisibility.sequence || panePlacements.sequence === 'floating' || undefined}
+        data-tools-pinned={toolsDocked || undefined}
         style={{
           '--motif-cs-inventory-pane-width': `${paneWidths.inventory}px`,
           '--motif-cs-sequence-pane-width': `${paneWidths.sequence}px`,
@@ -9904,17 +10258,33 @@ function App() {
         {paneVisibility.inventory ? (
           <>
             <aside
+              key="inventory-pane"
               ref={inventoryColumnRef}
               className="motif-cs-sidebar motif-cs-pane"
+              data-pane-key="inventory"
+              data-pane-placement={panePlacements.inventory}
               data-stacked-resized={effectiveStackedInventoryHeight !== null || undefined}
+              role={panePlacements.inventory === 'floating' ? 'dialog' : undefined}
+              aria-label={panePlacements.inventory === 'floating' ? 'Inventory pane' : undefined}
+              tabIndex={panePlacements.inventory === 'floating' ? -1 : undefined}
+              onPointerDown={() => panePlacements.inventory === 'floating' && bringFloatingPaneToFront('inventory')}
+              onFocusCapture={() => panePlacements.inventory === 'floating' && bringFloatingPaneToFront('inventory')}
               style={{
                 '--motif-cs-inventory-pane-width': `${paneWidths.inventory}px`,
                 '--motif-cs-stacked-inventory-pane-height': effectiveStackedInventoryHeight === null ? undefined : `${effectiveStackedInventoryHeight}px`,
                 flexBasis: paneWidths.inventory,
                 order: paneCssOrder('inventory'),
+                ...floatingPaneStyle('inventory'),
               } as CSSProperties}
             >
-              <div className="motif-cs-pane-title">
+              <div
+                className="motif-cs-pane-title"
+                tabIndex={panePlacements.inventory === 'floating' ? 0 : undefined}
+                role={panePlacements.inventory === 'floating' ? 'group' : undefined}
+                aria-label={panePlacements.inventory === 'floating' ? 'Move Inventory pane; use Alt plus arrow keys' : undefined}
+                onPointerDown={(event) => beginFloatingPaneInteraction('inventory', 'move', event)}
+                onKeyDown={(event) => moveFloatingPaneFromKeyboard('inventory', event)}
+              >
                 <div>
                   <span>Inventory</span>
                 </div>
@@ -9929,6 +10299,14 @@ function App() {
                 >
                   <Plus size={15} strokeWidth={2.3} aria-hidden="true" />
                 </button>
+                <PanePlacementControl
+                  pane="inventory"
+                  title="Inventory"
+                  floating={panePlacements.inventory === 'floating'}
+                  disabled={dockedContentPaneCount <= 1}
+                  onPopOut={popOutPane}
+                  onDock={dockPane}
+                />
                 <button
                   className="motif-cs-pane-collapse"
                   type="button"
@@ -9955,9 +10333,12 @@ function App() {
                 onRestoreDatabase={(database) => requestArtifactDatabaseRestore(database)}
               />
               <InventoryList records={payload.records} selectedRecordId={recordId} onSelect={selectRecord} />
+              {panePlacements.inventory === 'floating' ? (
+                <FloatingPaneResizeHandle pane="inventory" title="Inventory" onPointerDown={beginFloatingPaneInteraction} onKeyDown={resizeFloatingPaneFromKeyboard} />
+              ) : null}
             </aside>
-            <PaneResizeHandle pane="inventory" label="Resize inventory pane" width={paneWidths.inventory} limits={paneWidthLimitsForCurrentLayout('inventory')} edge="after" onPointerDown={startPaneResize} onKeyDown={resizePaneFromKeyboard} style={{ order: paneCssOrder('inventory', 'after') }} />
-            <StackedPaneResizeHandle
+            {panePlacements.inventory === 'docked' ? <PaneResizeHandle pane="inventory" label="Resize inventory pane" width={paneWidths.inventory} limits={paneWidthLimitsForCurrentLayout('inventory')} edge="after" onPointerDown={startPaneResize} onKeyDown={resizePaneFromKeyboard} style={{ order: paneCssOrder('inventory', 'after') }} /> : null}
+            {panePlacements.inventory === 'docked' ? <StackedPaneResizeHandle
               pane="inventory"
               label="Inventory"
               height={effectiveStackedInventoryHeight ?? 160}
@@ -9967,26 +10348,50 @@ function App() {
               onKeyDown={resizeStackedPaneFromKeyboard}
               onReset={(pane) => setStackedPaneHeights((current) => ({ ...current, [pane]: null }))}
               style={{ order: paneCssOrder('inventory', 'after') }}
-            />
+            /> : null}
           </>
         ) : null}
 
         {paneVisibility.map ? (
           <>
             <section
+              key="map-pane"
               ref={mapColumnRef}
               className="motif-cs-map-column motif-cs-pane"
+              data-pane-key="map"
+              data-pane-placement={panePlacements.map}
+              role={panePlacements.map === 'floating' ? 'dialog' : undefined}
+              aria-label={panePlacements.map === 'floating' ? 'Map pane' : undefined}
+              tabIndex={panePlacements.map === 'floating' ? -1 : undefined}
+              onPointerDown={() => panePlacements.map === 'floating' && bringFloatingPaneToFront('map')}
+              onFocusCapture={() => panePlacements.map === 'floating' && bringFloatingPaneToFront('map')}
               style={{
                 '--motif-cs-map-pane-width': `${paneWidths.map}px`,
                 flexBasis: paneWidths.map,
                 order: paneCssOrder('map'),
+                ...floatingPaneStyle('map'),
               } as CSSProperties}
             >
-              <div className="motif-cs-pane-title">
+              <div
+                className="motif-cs-pane-title"
+                tabIndex={panePlacements.map === 'floating' ? 0 : undefined}
+                role={panePlacements.map === 'floating' ? 'group' : undefined}
+                aria-label={panePlacements.map === 'floating' ? 'Move Map pane; use Alt plus arrow keys' : undefined}
+                onPointerDown={(event) => beginFloatingPaneInteraction('map', 'move', event)}
+                onKeyDown={(event) => moveFloatingPaneFromKeyboard('map', event)}
+              >
                 <div>
                   <span>{hasActiveRecord ? mapPaneTitle : 'Map'}</span>
                   <small>{hasActiveRecord ? `${topology} · ${sequenceLengthLabel(sequence.length, sequenceType)}` : 'No active record'}</small>
                 </div>
+                <PanePlacementControl
+                  pane="map"
+                  title="Map"
+                  floating={panePlacements.map === 'floating'}
+                  disabled={dockedContentPaneCount <= 1}
+                  onPopOut={popOutPane}
+                  onDock={dockPane}
+                />
                 <button
                   className="motif-cs-pane-collapse"
                   type="button"
@@ -10173,6 +10578,9 @@ function App() {
                   onSelectRange={selectSequenceRangeAndReveal}
                 />
               </div>
+              {panePlacements.map === 'floating' ? (
+                <FloatingPaneResizeHandle pane="map" title="Map" onPointerDown={beginFloatingPaneInteraction} onKeyDown={resizeFloatingPaneFromKeyboard} />
+              ) : null}
             </section>
             {showSequenceMapResizeHandle ? (
               <PaneResizeHandle
@@ -10191,17 +10599,33 @@ function App() {
         {paneVisibility.sequence ? (
           <>
             <section
+              key="sequence-pane"
               ref={sequenceColumnRef}
               className="motif-cs-sequence-column motif-cs-pane motif-cs-primary-pane"
+              data-pane-key="sequence"
+              data-pane-placement={panePlacements.sequence}
               data-stacked-resized={effectiveStackedSequenceHeight !== null || undefined}
+              role={panePlacements.sequence === 'floating' ? 'dialog' : undefined}
+              aria-label={panePlacements.sequence === 'floating' ? 'Sequence pane' : undefined}
+              tabIndex={panePlacements.sequence === 'floating' ? -1 : undefined}
+              onPointerDown={() => panePlacements.sequence === 'floating' && bringFloatingPaneToFront('sequence')}
+              onFocusCapture={() => panePlacements.sequence === 'floating' && bringFloatingPaneToFront('sequence')}
               style={{
                 '--motif-cs-sequence-pane-width': `${paneWidths.sequence}px`,
                 '--motif-cs-stacked-sequence-pane-height': effectiveStackedSequenceHeight === null ? undefined : `${effectiveStackedSequenceHeight}px`,
                 flexBasis: paneWidths.sequence,
                 order: paneCssOrder('sequence'),
+                ...floatingPaneStyle('sequence'),
               } as CSSProperties}
             >
-            <div className="motif-cs-title-row motif-cs-sequence-title">
+            <div
+              className="motif-cs-title-row motif-cs-sequence-title"
+              tabIndex={panePlacements.sequence === 'floating' ? 0 : undefined}
+              role={panePlacements.sequence === 'floating' ? 'group' : undefined}
+              aria-label={panePlacements.sequence === 'floating' ? 'Move Sequence pane; use Alt plus arrow keys' : undefined}
+              onPointerDown={(event) => beginFloatingPaneInteraction('sequence', 'move', event)}
+              onKeyDown={(event) => moveFloatingPaneFromKeyboard('sequence', event)}
+            >
               <div>
                 {hasActiveRecord ? <EditableRecordTitle record={vector} onUpdate={updateRecordDetails} /> : <h1>No sequence loaded</h1>}
                 <p title={vector.description ?? payload.inventory.description}>{vector.description ?? payload.inventory.description}</p>
@@ -10213,6 +10637,14 @@ function App() {
                     <span className="motif-cs-chip">{sequenceLengthLabel(sequence.length, sequenceType)}</span>
                   </>
                 ) : null}
+                <PanePlacementControl
+                  pane="sequence"
+                  title="Sequence"
+                  floating={panePlacements.sequence === 'floating'}
+                  disabled={dockedContentPaneCount <= 1}
+                  onPopOut={popOutPane}
+                  onDock={dockPane}
+                />
                 <button
                   className="motif-cs-pane-collapse"
                   type="button"
@@ -10439,8 +10871,11 @@ function App() {
               onAnnotateRange={handleAnnotateRange}
               canAnnotateRange={canAnnotateSelectedMapRange}
             />
+            {panePlacements.sequence === 'floating' ? (
+              <FloatingPaneResizeHandle pane="sequence" title="Sequence" onPointerDown={beginFloatingPaneInteraction} onKeyDown={resizeFloatingPaneFromKeyboard} />
+            ) : null}
             </section>
-            <StackedPaneResizeHandle
+            {panePlacements.sequence === 'docked' ? <StackedPaneResizeHandle
               pane="sequence"
               label="Sequence"
               height={renderedStackedSequenceHeight}
@@ -10450,36 +10885,61 @@ function App() {
               onKeyDown={resizeStackedPaneFromKeyboard}
               onReset={(pane) => setStackedPaneHeights((current) => ({ ...current, [pane]: null }))}
               style={{ order: paneCssOrder('sequence', 'after') }}
-            />
+            /> : null}
           </>
         ) : null}
 
         {paneVisibility.tools ? (
           <>
-            {showToolsResizeHandle && toolsPinned ? <PaneResizeHandle pane="tools" label="Resize tools pane" width={paneWidths.tools} limits={paneWidthLimitsForCurrentLayout('tools')} edge="before" onPointerDown={startPaneResize} onKeyDown={resizePaneFromKeyboard} style={{ order: paneCssOrder('tools', 'before') }} /> : null}
+            {showToolsResizeHandle ? <PaneResizeHandle pane="tools" label="Resize tools pane" width={paneWidths.tools} limits={paneWidthLimitsForCurrentLayout('tools')} edge="before" onPointerDown={startPaneResize} onKeyDown={resizePaneFromKeyboard} style={{ order: paneCssOrder('tools', 'before') }} /> : null}
             <aside
+              key="tools-pane"
               ref={toolsInspectorRef}
               className="motif-cs-inspector motif-cs-pane"
-              data-tools-pinned={toolsPinned ? 'true' : 'false'}
+              data-pane-key="tools"
+              data-pane-placement={panePlacements.tools}
+              data-tools-pinned={toolsDocked || toolsFloating ? 'true' : 'false'}
+              role={toolsFloating ? 'dialog' : undefined}
+              aria-label={toolsFloating ? 'Tools pane' : undefined}
+              tabIndex={toolsFloating ? -1 : undefined}
+              onPointerDown={() => toolsFloating && bringFloatingPaneToFront('tools')}
+              onFocusCapture={() => toolsFloating && bringFloatingPaneToFront('tools')}
               style={{
                 '--motif-cs-tools-pane-width': `${paneWidths.tools}px`,
                 flexBasis: paneWidths.tools,
                 order: paneCssOrder('tools'),
+                ...floatingPaneStyle('tools'),
               } as CSSProperties}
             >
-              <div className="motif-cs-pane-title">
+              <div
+                className="motif-cs-pane-title"
+                tabIndex={toolsFloating ? 0 : undefined}
+                role={toolsFloating ? 'group' : undefined}
+                aria-label={toolsFloating ? 'Move Tools pane; use Alt plus arrow keys' : undefined}
+                onPointerDown={(event) => beginFloatingPaneInteraction('tools', 'move', event)}
+                onKeyDown={(event) => moveFloatingPaneFromKeyboard('tools', event)}
+              >
                 <div>
                   <span>Tools</span>
                   <small>selection + analysis</small>
                 </div>
+                {toolsDocked || toolsFloating ? (
+                  <PanePlacementControl
+                    pane="tools"
+                    title="Tools"
+                    floating={toolsFloating}
+                    onPopOut={popOutPane}
+                    onDock={dockPane}
+                  />
+                ) : null}
                 <button
                   className="motif-cs-pane-collapse"
                   type="button"
                   onClick={() => collapsePaneAndRestoreFocus('tools')}
-                  aria-label={toolsPinned ? 'Minimize tools panel to rail' : 'Expand tools panel'}
-                  title={toolsPinned ? 'Minimize tools panel to rail' : 'Expand tools panel'}
+                  aria-label={toolsDocked || toolsFloating ? 'Minimize tools panel to rail' : 'Expand tools panel'}
+                  title={toolsDocked || toolsFloating ? 'Minimize tools panel to rail' : 'Expand tools panel'}
                 >
-                  {toolsPinned ? (
+                  {toolsDocked || toolsFloating ? (
                     <ChevronRight size={14} strokeWidth={2.2} aria-hidden="true" />
                   ) : (
                     <ChevronLeft size={14} strokeWidth={2.2} aria-hidden="true" />
@@ -10496,7 +10956,7 @@ function App() {
             selectedFeatureId={selectedFeatureId}
             translationTracks={inlineTranslationTracks}
             selectedTranslationLayerId={selectedTranslationLayerId}
-            defaultOpen={toolsPinned}
+            defaultOpen={toolsDocked || toolsFloating}
             editorRequest={featureEditorRequest}
             editorLabel={
               selectedTranslationLayer
@@ -11004,6 +11464,9 @@ function App() {
               </div>
             </div>
           </details>
+            {toolsFloating ? (
+              <FloatingPaneResizeHandle pane="tools" title="Tools" onPointerDown={beginFloatingPaneInteraction} onKeyDown={resizeFloatingPaneFromKeyboard} />
+            ) : null}
             </aside>
           </>
         ) : null}
@@ -11324,6 +11787,66 @@ function RestoreWorkspaceDialog({
         </div>
       </div>
     </div>
+  );
+}
+
+function PanePlacementControl({
+  pane,
+  title,
+  floating,
+  disabled = false,
+  onPopOut,
+  onDock,
+}: {
+  pane: PaneKey;
+  title: string;
+  floating: boolean;
+  disabled?: boolean;
+  onPopOut: (pane: PaneKey) => void;
+  onDock: (pane: PaneKey) => void;
+}) {
+  return (
+    <button
+      className="motif-cs-pane-placement-button"
+      type="button"
+      data-pane-popout={!floating || undefined}
+      data-pane-dock={floating || undefined}
+      disabled={!floating && disabled}
+      onClick={() => floating ? onDock(pane) : onPopOut(pane)}
+      aria-label={floating ? `Dock ${title} pane` : `Pop out ${title} pane`}
+      title={floating
+        ? `Dock ${title} back into the workspace`
+        : disabled
+          ? 'Keep one content pane docked in the workspace'
+          : `Open ${title} as a movable pane`}
+    >
+      {floating ? <Minimize2 size={14} strokeWidth={2.1} aria-hidden="true" /> : <Maximize2 size={14} strokeWidth={2.1} aria-hidden="true" />}
+    </button>
+  );
+}
+
+function FloatingPaneResizeHandle({
+  pane,
+  title,
+  onPointerDown,
+  onKeyDown,
+}: {
+  pane: PaneKey;
+  title: string;
+  onPointerDown: (pane: PaneKey, mode: 'move' | 'resize', event: ReactPointerEvent<HTMLElement>) => void;
+  onKeyDown: (pane: PaneKey, event: ReactKeyboardEvent<HTMLButtonElement>) => void;
+}) {
+  return (
+    <button
+      className="motif-cs-floating-pane-resize"
+      type="button"
+      data-testid={`floating-pane-resize-${pane}`}
+      onPointerDown={(event) => onPointerDown(pane, 'resize', event)}
+      onKeyDown={(event) => onKeyDown(pane, event)}
+      aria-label={`Resize ${title} pane in 2 dimensions`}
+      aria-keyshortcuts="ArrowLeft ArrowRight ArrowUp ArrowDown"
+      title={`Drag to resize ${title}; use arrow keys for precise control`}
+    />
   );
 }
 

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-refresh/only-export-components -- artifact entry exports pure runtime test seams */
 import { Component, useCallback, useDeferredValue, useEffect, useId, useLayoutEffect, useMemo, useReducer, useRef, useState, type ClipboardEvent as ReactClipboardEvent, type CSSProperties, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type RefObject } from 'react';
+import { createPortal } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { Activity, AlignCenter, Beaker, ChevronDown, ChevronLeft, ChevronRight, Crosshair, Dna, FileText, History, Info, Languages, LayoutGrid, List, Map as MapIcon, Maximize2, Minimize2, NotebookPen, Plus, Redo2, Search, Settings, ShieldCheck, Tag, Trash2, Undo2, Workflow, Wrench, X, type LucideIcon } from 'lucide-react';
 import vectorsRaw from '../../public/data/vectors.json?raw';
@@ -12031,6 +12032,8 @@ function cssPixelValue(value: string, fallback: number): number {
 
 function RailPopoverTitle({ title, meta }: { title: string; meta?: string }) {
   const [size, setSize] = useState<RailPopoverSize | null>(null);
+  const [panelBody, setPanelBody] = useState<HTMLElement | null>(null);
+  const titleRef = useRef<HTMLDivElement>(null);
   const resizeHandleRef = useRef<HTMLButtonElement>(null);
   const panelBodyRef = useRef<HTMLElement | null>(null);
   const resizeRef = useRef<{
@@ -12043,12 +12046,13 @@ function RailPopoverTitle({ title, meta }: { title: string; meta?: string }) {
   const resizeCleanupRef = useRef<(() => void) | null>(null);
 
   useLayoutEffect(() => {
-    const panelBody = resizeHandleRef.current?.closest<HTMLElement>('.motif-cs-tool-panel-body') ?? null;
-    panelBodyRef.current = panelBody;
+    const owner = titleRef.current?.closest<HTMLElement>('.motif-cs-tool-panel-body') ?? null;
+    panelBodyRef.current = owner;
+    setPanelBody(owner);
     return () => {
-      panelBody?.style.removeProperty('--rail-popover-width');
-      panelBody?.style.removeProperty('--rail-popover-height');
-      delete panelBody?.dataset.railPopoverResized;
+      owner?.style.removeProperty('--rail-popover-width');
+      owner?.style.removeProperty('--rail-popover-height');
+      delete owner?.dataset.railPopoverResized;
       panelBodyRef.current = null;
     };
   }, []);
@@ -12183,7 +12187,7 @@ function RailPopoverTitle({ title, meta }: { title: string; meta?: string }) {
 
   return (
     <>
-      <div className="motif-cs-rail-popover-title">
+      <div ref={titleRef} className="motif-cs-rail-popover-title">
         <strong>{title}</strong>
         <div className="motif-cs-rail-popover-actions">
           {meta ? <span>{meta}</span> : null}
@@ -12199,18 +12203,21 @@ function RailPopoverTitle({ title, meta }: { title: string; meta?: string }) {
           </button>
         </div>
       </div>
-      <button
-        ref={resizeHandleRef}
-        className="motif-cs-rail-popover-resize"
-        type="button"
-        onPointerDown={beginResize}
-        onKeyDown={resizeFromKeyboard}
-        onDoubleClick={() => setSize(null)}
-        aria-label={`Resize ${title} panel. Left Arrow grows width; Right Arrow shrinks width; Up and Down Arrow change height.`}
-        aria-keyshortcuts="ArrowLeft ArrowRight ArrowUp ArrowDown"
-        title={`Resize ${title}; double-click to reset`}
-        data-testid="rail-popover-resize"
-      />
+      {panelBody ? createPortal(
+        <button
+          ref={resizeHandleRef}
+          className="motif-cs-rail-popover-resize"
+          type="button"
+          onPointerDown={beginResize}
+          onKeyDown={resizeFromKeyboard}
+          onDoubleClick={() => setSize(null)}
+          aria-label={`Resize ${title} panel. Left Arrow grows width; Right Arrow shrinks width; Up and Down Arrow change height.`}
+          aria-keyshortcuts="ArrowLeft ArrowRight ArrowUp ArrowDown"
+          title={`Resize ${title}; double-click to reset`}
+          data-testid="rail-popover-resize"
+        />,
+        panelBody,
+      ) : null}
     </>
   );
 }
@@ -14263,7 +14270,7 @@ function FloatingWindow({
         y: drag.base.y + dy,
       } : {
         ...drag.base,
-        w: clamp(drag.base.w + dx, 280, Math.max(280, vw - drag.base.x - 8)),
+        w: clamp(drag.base.w + dx, 280, Math.max(280, vw - rightInset - drag.base.x - 8)),
         h: clamp(drag.base.h + dy, 180, Math.max(180, vh - drag.base.y - 8)),
       };
       const next = clampWindowRect(raw, vw, vh, rightInset);

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -15795,32 +15795,36 @@ function SequenceText({
                     return restrictionEnzymeIsTypeIIS(enzyme);
                   });
                   return (
-                    <button
+                    <span
                       key={label.key}
-                      type="button"
-                      className="motif-cs-restriction-label"
-                      data-selected={selected || undefined}
-                      aria-pressed={selected}
-                      aria-label={`${label.label}, restriction ${label.sites.length === 1 ? 'site' : 'cluster'} at ${primary.position + 1} bp, ${primaryCutLabel}, ${primary.overhang === 'blunt' ? 'blunt' : `${primary.overhang === '5prime' ? "5 prime" : "3 prime"} overhang`}, ${primary.strand === -1 ? 'reverse' : 'forward'} strand`}
-                      data-type-iis={typeIIS || undefined}
-                      data-site-position={primary.position}
-                      data-recognition-length={primary.recognitionSequence.length}
-                      data-site-strand={primary.strand === -1 ? -1 : 1}
+                      className="motif-cs-restriction-label-anchor"
                       style={{ left: `${label.start - lineStart}ch` }}
-                      onPointerDown={(event) => event.stopPropagation()}
-                      onPointerEnter={() => setHoveredRestrictionTickIds(label.sites.map(restrictionSiteTickId))}
-                      onPointerLeave={() => setHoveredRestrictionTickIds([])}
-                      onFocus={() => setHoveredRestrictionTickIds(label.sites.map(restrictionSiteTickId))}
-                      onBlur={() => setHoveredRestrictionTickIds([])}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        suppressNextFocusScrollRef.current = true;
-                        onRestrictionSelect(primary);
-                      }}
-                      title={`${label.label} · ${primary.recognitionSequence} · ${primary.overhang === 'blunt' ? 'blunt' : `${primary.overhang === '5prime' ? "5′" : "3′"} overhang`}`}
                     >
-                      <span translate="no">{label.label}</span>
-                    </button>
+                      <button
+                        type="button"
+                        className="motif-cs-restriction-label"
+                        data-selected={selected || undefined}
+                        aria-pressed={selected}
+                        aria-label={`${label.label}, restriction ${label.sites.length === 1 ? 'site' : 'cluster'} at ${primary.position + 1} bp, ${primaryCutLabel}, ${primary.overhang === 'blunt' ? 'blunt' : `${primary.overhang === '5prime' ? "5 prime" : "3 prime"} overhang`}, ${primary.strand === -1 ? 'reverse' : 'forward'} strand`}
+                        data-type-iis={typeIIS || undefined}
+                        data-site-position={primary.position}
+                        data-recognition-length={primary.recognitionSequence.length}
+                        data-site-strand={primary.strand === -1 ? -1 : 1}
+                        onPointerDown={(event) => event.stopPropagation()}
+                        onPointerEnter={() => setHoveredRestrictionTickIds(label.sites.map(restrictionSiteTickId))}
+                        onPointerLeave={() => setHoveredRestrictionTickIds([])}
+                        onFocus={() => setHoveredRestrictionTickIds(label.sites.map(restrictionSiteTickId))}
+                        onBlur={() => setHoveredRestrictionTickIds([])}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          suppressNextFocusScrollRef.current = true;
+                          onRestrictionSelect(primary);
+                        }}
+                        title={`${label.label} · ${primary.recognitionSequence} · ${primary.overhang === 'blunt' ? 'blunt' : `${primary.overhang === '5prime' ? "5′" : "3′"} overhang`}`}
+                      >
+                        <span translate="no">{label.label}</span>
+                      </button>
+                    </span>
                   );
                 })}
               </div>

--- a/src/bio/__tests__/restriction-sites.test.ts
+++ b/src/bio/__tests__/restriction-sites.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { RESTRICTION_ENZYMES, findRestrictionSites } from '../restriction-sites';
+
+function enzyme(name: string) {
+  const match = RESTRICTION_ENZYMES.find((candidate) => candidate.name === name);
+  if (!match) throw new Error(`Missing restriction enzyme fixture: ${name}`);
+  return match;
+}
+
+describe('restriction-site scanning', () => {
+  it('reports a non-palindromic reverse-strand Type IIS site with its mirrored cut', () => {
+    const sites = findRestrictionSites('AAAAAAGAGACCTTTTT', [enzyme('BsaI')]);
+
+    expect(sites).toEqual([{
+      enzyme: 'BsaI',
+      position: 6,
+      cutPosition: 1,
+      recognitionSequence: 'GGTCTC',
+      overhang: '5prime',
+      strand: -1,
+    }]);
+  });
+
+  it('finds and wraps a palindromic site that crosses a circular origin once', () => {
+    const sequence = 'AATTCCCCCG';
+    const ecoRI = enzyme('EcoRI');
+
+    expect(findRestrictionSites(sequence, [ecoRI])).toEqual([]);
+    expect(findRestrictionSites(sequence, [ecoRI], { topology: 'circular' })).toEqual([{
+      enzyme: 'EcoRI',
+      position: 9,
+      cutPosition: 0,
+      recognitionSequence: 'GAATTC',
+      overhang: '5prime',
+      strand: 1,
+    }]);
+  });
+});

--- a/src/bio/__tests__/restriction-sites.test.ts
+++ b/src/bio/__tests__/restriction-sites.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { RESTRICTION_ENZYMES_FULL } from '../enzyme-data';
+import { reverseComplement } from '../reverse-complement';
 import { RESTRICTION_ENZYMES, findRestrictionSites } from '../restriction-sites';
 
 function enzyme(name: string) {
@@ -7,7 +9,73 @@ function enzyme(name: string) {
   return match;
 }
 
+const iupacBases: Record<string, readonly string[]> = {
+  A: ['A'], C: ['C'], G: ['G'], T: ['T'],
+  R: ['A', 'G'], Y: ['C', 'T'], S: ['G', 'C'], W: ['A', 'T'],
+  K: ['G', 'T'], M: ['A', 'C'], B: ['C', 'G', 'T'], D: ['A', 'G', 'T'],
+  H: ['A', 'C', 'T'], V: ['A', 'C', 'G'], N: ['A', 'C', 'G', 'T'],
+};
+
+function materializeRecognitionSequence(recognitionSequence: string): string {
+  return [...recognitionSequence.toUpperCase()]
+    .map((base) => iupacBases[base]?.[0] ?? base)
+    .join('');
+}
+
+function reverseOnlyRecognitionExample(recognitionSequence: string): string | null {
+  const forward = recognitionSequence.toUpperCase();
+  const reverse = reverseComplement(forward);
+  if (reverse === forward) return null;
+  const sequence = [...reverse].map((base) => iupacBases[base]?.[0] ?? base);
+  for (let index = 0; index < reverse.length; index++) {
+    const forwardChoices = new Set(iupacBases[forward[index]] ?? [forward[index]]);
+    const reverseOnlyBase = (iupacBases[reverse[index]] ?? [reverse[index]])
+      .find((base) => !forwardChoices.has(base));
+    if (reverseOnlyBase) {
+      sequence[index] = reverseOnlyBase;
+      return sequence.join('');
+    }
+  }
+  return null;
+}
+
 describe('restriction-site scanning', () => {
+  it('anchors every catalog recognition sequence and sense-strand cut at its actual match', () => {
+    for (const candidate of RESTRICTION_ENZYMES_FULL) {
+      const sequence = materializeRecognitionSequence(candidate.recognitionSequence);
+      const sites = findRestrictionSites(sequence, [candidate]);
+
+      expect(sites, candidate.name).toContainEqual({
+        enzyme: candidate.name,
+        position: 0,
+        cutPosition: candidate.cutOffset,
+        recognitionSequence: candidate.recognitionSequence,
+        overhang: candidate.overhang,
+        strand: 1,
+      });
+    }
+  });
+
+  it('anchors every non-palindromic catalog entry on the reverse strand with its mirrored cut', () => {
+    let checked = 0;
+    for (const candidate of RESTRICTION_ENZYMES_FULL) {
+      const sequence = reverseOnlyRecognitionExample(candidate.recognitionSequence);
+      if (!sequence) continue;
+      checked += 1;
+      const sites = findRestrictionSites(sequence, [candidate]);
+
+      expect(sites, candidate.name).toContainEqual({
+        enzyme: candidate.name,
+        position: 0,
+        cutPosition: candidate.recognitionSequence.length - candidate.complementCutOffset,
+        recognitionSequence: candidate.recognitionSequence,
+        overhang: candidate.overhang,
+        strand: -1,
+      });
+    }
+    expect(checked).toBeGreaterThan(15);
+  });
+
   it('reports a non-palindromic reverse-strand Type IIS site with its mirrored cut', () => {
     const sites = findRestrictionSites('AAAAAAGAGACCTTTTT', [enzyme('BsaI')]);
 


### PR DESCRIPTION
## Summary

- align restriction-site labels and cut markers with the sequence grid, including reverse and circular cases
- make Tools and floating surfaces resize from their visible corners with complete pointer and keyboard cleanup
- add state-preserving pop-out and dock controls for Inventory, Sequence, Map, and Tools
- keep responsive layouts bounded and preserve at least one docked content pane

## Validation

- typecheck, lint, and 987 unit tests
- plugin packaging and strict plugin validation
- CSS token and ARIA control checks
- production artifact build
- full browser matrix: 127 passed, 42 opt-in cases skipped
- dedicated alignment interactions: 40 passed
- dedicated pane placement: 3 passed
- public hygiene and secret scans clean