### PR TITLE
Improve MSA comparison and reference-coordinate workflows

### DIFF
--- a/e2e/claude-science-msa-interactions.spec.ts
+++ b/e2e/claude-science-msa-interactions.spec.ts
@@ -85,6 +85,53 @@ test.describe('Motif MSA viewer interactions', () => {
     return page.locator('[data-msa-grid-cell="true"][data-active-cell="true"]');
   }
 
+  test('reference coordinates and strict ambiguity mode work through the saved-result UI', async ({ page }) => {
+    await page.setViewportSize({ width: 1180, height: 820 });
+    await page.addInitScript(() => { window.localStorage.clear(); window.sessionStorage.clear(); });
+    await page.goto('/motif.html');
+    await expect(page.locator('.motif-cs-shell')).toBeVisible();
+    await page.evaluate(() => {
+      const api = (window as unknown as { motifAddAlignments?: (a: unknown) => number }).motifAddAlignments;
+      if (!api) throw new Error('motifAddAlignments unavailable');
+      api({
+        id: 'reference-coordinate-e2e',
+        name: 'Reference coordinate E2E',
+        molecule: 'dna',
+        referenceRowId: 'reference',
+        referenceNumbering: { rowId: 'reference', firstResiduePosition: 100 },
+        rows: [
+          { id: 'reference', name: 'Reference', aligned: 'AC--GTACGTAC' },
+          { id: 'read', name: 'Read', aligned: 'RCTTGTACGTAC' },
+        ],
+      });
+    });
+    await page.getByTestId('msa-open-button').dispatchEvent('click');
+    await expect(page.getByTestId('msa-alignment-view')).toBeVisible();
+
+    const referenceAxis = page.getByRole('row', { name: 'Reference positions for Reference' });
+    await expect(referenceAxis).toBeVisible();
+    await expect(referenceAxis.locator('[data-reference-coordinate="101B"]')).toBeVisible();
+    const compatibleCell = page.locator('[data-msa-row-id="read"] [data-alignment-column="1"]');
+    await expect(compatibleCell).toHaveAttribute('data-cell-outcome', 'ambiguous');
+    await expect(compatibleCell).toHaveAttribute('aria-label', /reference position 100/);
+
+    await page.getByTestId('msa-coordinate-system').selectOption('template');
+    const coordinateInput = page.getByTestId('msa-coordinate-input');
+    await expect(coordinateInput).toHaveAttribute('type', 'text');
+    await coordinateInput.fill('101b');
+    await page.getByRole('button', { name: 'Go', exact: true }).click();
+    await expect(page.locator('[data-msa-row-id="reference"] [data-alignment-column="4"]')).toHaveAttribute('data-jump', 'true');
+
+    await page.getByTestId('msa-view-menu-button').click();
+    await expect(page.getByTestId('msa-reference-numbering-editor')).toContainText('On');
+    await page.getByRole('checkbox', { name: 'Strict differences' }).check();
+    await expect(compatibleCell).toHaveAttribute('data-cell-outcome', 'substitution');
+
+    await page.getByTestId('msa-clear-reference-numbering').click();
+    await expect(page.getByRole('row', { name: 'Template positions for Reference' })).toBeVisible();
+    await expect(page.getByTestId('msa-reference-numbering-editor')).toContainText('Plain 1-based');
+  });
+
   test('keyboard arrows move the active gridcell and announce its residue', async ({ page }) => {
     await setup(page);
     const initial = activeGridCell(page);

--- a/src/artifacts/ClaudeScienceMsaViewer.tsx
+++ b/src/artifacts/ClaudeScienceMsaViewer.tsx
@@ -25,10 +25,12 @@ import {
   ArtifactAlignmentError,
   MSA_MOTIF_SEARCH_MAX_QUERY_LENGTH,
   clampMsaClientPoint,
+  classifyResidueDifference,
   computeAlignmentImageLayout,
   computeMsaColumnStats,
   computeSequenceLogoColumns,
   createLocalArtifactAlignment,
+  detectAlphabetAnomalies,
   estimateLocalAlignmentWork,
   findMsaMotifMatches,
   formatAlignedFasta,
@@ -110,6 +112,7 @@ export type PairwiseRowStats = {
   ungappedLength: number;
   comparableColumns: number;
   mismatches: number;
+  ambiguities: number;
   identity: number;
 };
 
@@ -117,7 +120,7 @@ type ArtifactAlignmentRow = ArtifactAlignment['rows'][number];
 
 type AlignmentCoverage = { first: number; last: number } | null;
 
-export type MsaCellOutcome = 'match' | 'substitution' | 'deletion' | 'insertion' | 'uncovered' | 'gap';
+export type MsaCellOutcome = 'match' | 'substitution' | 'deletion' | 'insertion' | 'uncovered' | 'gap' | 'ambiguous';
 
 function alignmentCoverage(aligned: string): AlignmentCoverage {
   const first = aligned.search(/[^-]/);
@@ -137,13 +140,15 @@ export function classifyMsaCell(
   referenceResidue: string,
   rowResidue: string,
   isColumnCoveredByRow: boolean,
+  molecule: SequenceType = 'dna',
+  strictDifferences = false,
 ): MsaCellOutcome {
   if (referenceResidue === '-' && rowResidue === '-') return 'gap';
   if (rowResidue === '-' && !isColumnCoveredByRow) return 'uncovered';
-  if (rowResidue === referenceResidue) return 'match';
   if (referenceResidue === '-') return 'insertion';
   if (rowResidue === '-') return 'deletion';
-  return 'substitution';
+  if (strictDifferences) return referenceResidue === rowResidue ? 'match' : 'substitution';
+  return classifyResidueDifference(referenceResidue, rowResidue, molecule);
 }
 
 function isMsaCellDifference(outcome: MsaCellOutcome): boolean {
@@ -161,6 +166,68 @@ function templatePositionCoordinates(aligned: string): Array<number | null> {
     }
   }
   return coordinates;
+}
+
+export type MsaReferenceCoordinateLabel = {
+  referencePosition: number;
+  insertionCode: string;
+  label: string;
+};
+
+function referenceInsertionCode(ordinal: number): string {
+  let value = ordinal + 1;
+  let code = '';
+  while (value > 0) {
+    value -= 1;
+    code = String.fromCharCode(65 + (value % 26)) + code;
+    value = Math.floor(value / 26);
+  }
+  return code;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components -- pure MSA helper exported for unit tests
+export function referenceCoordinateLabels(
+  referenceAligned: string,
+  firstResiduePosition: number,
+): MsaReferenceCoordinateLabel[] {
+  if (!Number.isSafeInteger(firstResiduePosition) || firstResiduePosition < 1) {
+    throw new RangeError('firstResiduePosition must be a positive safe integer.');
+  }
+  const labels = new Array<MsaReferenceCoordinateLabel>(referenceAligned.length);
+  let referencePosition = firstResiduePosition - 1;
+  let insertionOrdinal = 0;
+  for (let column = 0; column < referenceAligned.length; column += 1) {
+    const isGap = referenceAligned[column] === '-' || referenceAligned[column] === '.';
+    if (isGap) {
+      const insertionCode = referenceInsertionCode(insertionOrdinal);
+      labels[column] = { referencePosition, insertionCode, label: `${referencePosition}${insertionCode}` };
+      insertionOrdinal += 1;
+      continue;
+    }
+    referencePosition += 1;
+    if (!Number.isSafeInteger(referencePosition)) throw new RangeError('Reference coordinates exceed the safe integer range.');
+    insertionOrdinal = 0;
+    labels[column] = { referencePosition, insertionCode: '', label: String(referencePosition) };
+  }
+  return labels;
+}
+
+const REFERENCE_COORDINATE_PATTERN = /^(0|[1-9]\d*)([A-Z]*)$/;
+
+// eslint-disable-next-line react-refresh/only-export-components -- pure MSA helper exported for unit tests
+export function parseReferenceCoordinateColumn(
+  input: string,
+  coordinates: readonly MsaReferenceCoordinateLabel[],
+): number | null {
+  const match = REFERENCE_COORDINATE_PATTERN.exec(input.trim().toUpperCase());
+  if (!match) return null;
+  const referencePosition = Number(match[1]);
+  if (!Number.isSafeInteger(referencePosition)) return null;
+  const insertionCode = match[2];
+  const column = coordinates.findIndex((coordinate) => (
+    coordinate.referencePosition === referencePosition && coordinate.insertionCode === insertionCode
+  ));
+  return column < 0 ? null : column;
 }
 
 export type ClaudeScienceMsaViewerProps = {
@@ -688,7 +755,11 @@ function ResidueColorLegend({ molecule, colorScheme }: {
 }
 
 // eslint-disable-next-line react-refresh/only-export-components -- pure MSA helper exported for unit tests
-export function differenceColumns(alignment: ArtifactAlignment, referenceRowId: string): number[] {
+export function differenceColumns(
+  alignment: ArtifactAlignment,
+  referenceRowId: string,
+  strictDifferences = false,
+): number[] {
   const reference = alignment.rows.find((row) => row.id === referenceRowId) ?? alignment.rows[0];
   if (!reference) return [];
   const referenceCoverage = alignmentCoverage(reference.aligned);
@@ -702,8 +773,43 @@ export function differenceColumns(alignment: ArtifactAlignment, referenceRowId: 
         reference.aligned[column] ?? '-',
         row.aligned[column] ?? '-',
         coversColumn(rowCoverage.get(row.id) ?? null, column),
+        alignment.molecule,
+        strictDifferences,
       ))
     ))) columns.push(column);
+  }
+  return columns;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components -- pure MSA helper exported for unit tests
+export function ambiguousColumns(
+  alignment: ArtifactAlignment,
+  referenceRowId: string,
+  strictDifferences = false,
+): number[] {
+  if (strictDifferences) return [];
+  const reference = alignment.rows.find((row) => row.id === referenceRowId) ?? alignment.rows[0];
+  if (!reference) return [];
+  const referenceCoverage = alignmentCoverage(reference.aligned);
+  const rowCoverage = new Map(alignment.rows.map((row) => [row.id, alignmentCoverage(row.aligned)]));
+  const columns: number[] = [];
+  for (let column = 0; column < alignment.alignmentLength; column += 1) {
+    if (alignment.gapOnly[column] || !coversColumn(referenceCoverage, column)) continue;
+    let hasAmbiguity = false;
+    let hasDifference = false;
+    for (const row of alignment.rows) {
+      if (row.id === reference.id) continue;
+      const outcome = classifyMsaCell(
+        reference.aligned[column] ?? '-',
+        row.aligned[column] ?? '-',
+        coversColumn(rowCoverage.get(row.id) ?? null, column),
+        alignment.molecule,
+        false,
+      );
+      if (isMsaCellDifference(outcome)) { hasDifference = true; break; }
+      if (outcome === 'ambiguous') hasAmbiguity = true;
+    }
+    if (!hasDifference && hasAmbiguity) columns.push(column);
   }
   return columns;
 }
@@ -731,22 +837,31 @@ function rowNameParts(name: string, allNames: readonly string[]): { leading: str
 }
 
 // eslint-disable-next-line react-refresh/only-export-components -- pure MSA helper exported for unit tests
-export function pairwiseRowStats(aligned: string, template: string): PairwiseRowStats {
+export function pairwiseRowStats(
+  aligned: string,
+  template: string,
+  molecule: SequenceType = 'dna',
+  strictDifferences = false,
+): PairwiseRowStats {
   const rowCoverage = alignmentCoverage(aligned);
   const templateCoverage = alignmentCoverage(template);
   let ungappedLength = 0;
   let comparable = 0;
   let matches = 0;
   let mismatches = 0;
+  let ambiguities = 0;
   for (let column = 0; column < Math.max(aligned.length, template.length); column += 1) {
     const symbol = aligned[column] ?? '-';
     const templateSymbol = template[column] ?? '-';
     if (symbol !== '-') ungappedLength += 1;
     if (!coversColumn(templateCoverage, column)) continue;
-    const outcome = classifyMsaCell(templateSymbol, symbol, coversColumn(rowCoverage, column));
+    const outcome = classifyMsaCell(templateSymbol, symbol, coversColumn(rowCoverage, column), molecule, strictDifferences);
     if (outcome === 'match') {
       comparable += 1;
       matches += 1;
+    } else if (outcome === 'ambiguous') {
+      comparable += 1;
+      ambiguities += 1;
     } else if (isMsaCellDifference(outcome)) {
       comparable += 1;
       mismatches += 1;
@@ -756,6 +871,7 @@ export function pairwiseRowStats(aligned: string, template: string): PairwiseRow
     ungappedLength,
     comparableColumns: comparable,
     mismatches,
+    ambiguities,
     identity: comparable > 0 ? Math.round((matches / comparable) * 10_000) / 100 : 0,
   };
 }
@@ -764,7 +880,12 @@ function formatIdentity(identity: number): string {
   return identity < 100 && identity >= 99.9 ? identity.toFixed(2) : identity.toFixed(1);
 }
 
-function firstRowDifferenceColumn(aligned: string, template: string): number | null {
+function firstRowDifferenceColumn(
+  aligned: string,
+  template: string,
+  molecule: SequenceType,
+  strictDifferences = false,
+): number | null {
   const rowCoverage = alignmentCoverage(aligned);
   const templateCoverage = alignmentCoverage(template);
   for (let column = 0; column < Math.max(aligned.length, template.length); column += 1) {
@@ -773,6 +894,8 @@ function firstRowDifferenceColumn(aligned: string, template: string): number | n
       template[column] ?? '-',
       aligned[column] ?? '-',
       coversColumn(rowCoverage, column),
+      molecule,
+      strictDifferences,
     );
     if (isMsaCellDifference(outcome)) return column;
   }
@@ -800,7 +923,12 @@ function sortedMsaRows(
 }
 
 // eslint-disable-next-line react-refresh/only-export-components -- pure MSA helper exported for unit tests
-export function mismatchOverviewBins(alignment: ArtifactAlignment, referenceRowId: string, binCount: number): number[] {
+export function mismatchOverviewBins(
+  alignment: ArtifactAlignment,
+  referenceRowId: string,
+  binCount: number,
+  strictDifferences = false,
+): number[] {
   const bins = Array.from({ length: binCount }, () => 0);
   if (alignment.alignmentLength === 0 || binCount === 0) return bins;
   const template = alignment.rows.find((row) => row.id === referenceRowId) ?? alignment.rows[0];
@@ -815,8 +943,15 @@ export function mismatchOverviewBins(alignment: ArtifactAlignment, referenceRowI
     for (const [rowIndex, row] of alignment.rows.entries()) {
       if (row.id === template.id) continue;
       const symbol = row.aligned[column] ?? '-';
-      const outcome = classifyMsaCell(templateSymbol, symbol, coversColumn(rowCoverage[rowIndex], column));
+      const outcome = classifyMsaCell(
+        templateSymbol,
+        symbol,
+        coversColumn(rowCoverage[rowIndex], column),
+        alignment.molecule,
+        strictDifferences,
+      );
       if (outcome === 'match') comparable += 1;
+      else if (outcome === 'ambiguous') comparable += 1;
       else if (isMsaCellDifference(outcome)) {
         comparable += 1;
         mismatches += 1;
@@ -880,12 +1015,14 @@ function MsaRowStatsPanel({
   alignment,
   referenceRowId,
   sortMode,
+  strictDifferences,
   onSortModeChange,
   onJump,
 }: {
   alignment: ArtifactAlignment;
   referenceRowId: string;
   sortMode: RowSortMode;
+  strictDifferences: boolean;
   onSortModeChange: (sortMode: RowSortMode) => void;
   onJump: (rowId: string, column: number) => void;
 }) {
@@ -895,16 +1032,16 @@ function MsaRowStatsPanel({
   const template = alignment.rows.find((row) => row.id === referenceRowId) ?? alignment.rows[0];
   const statsByRow = useMemo(() => new Map(alignment.rows.map((row) => [
     row.id,
-    pairwiseRowStats(row.aligned, template?.aligned ?? ''),
-  ])), [alignment.rows, template]);
+    pairwiseRowStats(row.aligned, template?.aligned ?? '', alignment.molecule, strictDifferences),
+  ])), [alignment.molecule, alignment.rows, strictDifferences, template]);
   const orderedRows = useMemo(
     () => sortedMsaRows(alignment.rows, template, sortMode, statsByRow),
     [alignment.rows, sortMode, statsByRow, template],
   );
   const firstDifferenceByRow = useMemo(() => new Map(alignment.rows.map((row) => [
     row.id,
-    firstRowDifferenceColumn(row.aligned, template?.aligned ?? ''),
-  ])), [alignment.rows, template]);
+    firstRowDifferenceColumn(row.aligned, template?.aligned ?? '', alignment.molecule, strictDifferences),
+  ])), [alignment.molecule, alignment.rows, strictDifferences, template]);
   const activeSortLabel = sortMode === 'original'
     ? 'Original order'
     : sortMode === 'name'
@@ -964,11 +1101,14 @@ function MsaRowStatsPanel({
                   </button>
                 </th>
               ))}
+              <th scope="col" aria-label="Compatible ambiguity-code calls">
+                <span title="Compatible ambiguity-code calls (not counted as differences)">≈</span>
+              </th>
             </tr>
           </thead>
           <tbody>
             {orderedRows.map((row) => {
-              const stats = statsByRow.get(row.id) ?? pairwiseRowStats(row.aligned, template?.aligned ?? '');
+              const stats = statsByRow.get(row.id) ?? pairwiseRowStats(row.aligned, template?.aligned ?? '', alignment.molecule, strictDifferences);
               const isTemplate = row.id === template?.id;
               const firstDifference = firstDifferenceByRow.get(row.id) ?? null;
               const jump = firstDifference === null ? null : () => onJump(row.id, firstDifference);
@@ -995,6 +1135,7 @@ function MsaRowStatsPanel({
                   <td className="motif-cs-msa-row-stats-number">{stats.mismatches.toLocaleString()}</td>
                   <td className="motif-cs-msa-row-stats-number">{stats.ungappedLength.toLocaleString()} {sequenceUnit(alignment.molecule)}</td>
                   <td className="motif-cs-msa-row-stats-number">{formatIdentity(stats.identity)}%</td>
+                  <td className="motif-cs-msa-row-stats-number">{stats.ambiguities.toLocaleString()}</td>
                 </tr>
               );
             })}
@@ -1008,6 +1149,7 @@ function MsaRowStatsPanel({
 function AlignmentMatrix({
   alignment,
   referenceRowId,
+  referenceCoordinates,
   emphasis,
   colorMode,
   colorScheme,
@@ -1023,6 +1165,7 @@ function AlignmentMatrix({
   focusRequest,
   searchActive,
   sortMode,
+  strictDifferences,
   visibility,
   resetToken,
   onTemplateChange,
@@ -1032,6 +1175,7 @@ function AlignmentMatrix({
 }: {
   alignment: ArtifactAlignment;
   referenceRowId: string;
+  referenceCoordinates: readonly MsaReferenceCoordinateLabel[] | null;
   emphasis: EmphasisMode;
   colorMode: ColorMode;
   colorScheme: MsaColorScheme;
@@ -1047,6 +1191,7 @@ function AlignmentMatrix({
   focusRequest: MatrixFocusRequest | null;
   searchActive: boolean;
   sortMode: RowSortMode;
+  strictDifferences: boolean;
   visibility: MsaMatrixVisibility;
   resetToken: number;
   onTemplateChange: (rowId: string) => void;
@@ -1065,6 +1210,7 @@ function AlignmentMatrix({
   const lastResetTokenRef = useRef(resetToken);
   const overviewDraggingRef = useRef(false);
   const [selection, setSelection] = useState<MatrixSelection | null>(null);
+  const [isSelecting, setIsSelecting] = useState(false);
   const [hoverCell, setHoverCell] = useState<HoverCell | null>(null);
   const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null);
   const [contextMenu, setContextMenu] = useState<MatrixContextMenu | null>(null);
@@ -1114,6 +1260,10 @@ function AlignmentMatrix({
     Math.min(sequenceViewportWidth, sequenceViewportWidth * (sequenceViewportWidth / Math.max(sequenceViewportWidth, sequenceWidth))),
   );
   const template = alignment.rows.find((row) => row.id === referenceRowId) ?? alignment.rows[0];
+  const referenceNumbering = alignment.referenceNumbering;
+  const numberingReference = referenceNumbering
+    ? alignment.rows.find((row) => row.id === referenceNumbering.rowId)
+    : undefined;
   const templateCoverage = useMemo(() => alignmentCoverage(template?.aligned ?? ''), [template]);
   const rowCoverageById = useMemo(() => new Map(alignment.rows.map((row) => [
     row.id,
@@ -1147,8 +1297,8 @@ function AlignmentMatrix({
   const activeSearchRowId = activeSearchMatch?.rowId ?? null;
   const statsByRow = useMemo(() => new Map(alignment.rows.map((row) => [
     row.id,
-    pairwiseRowStats(row.aligned, template?.aligned ?? ''),
-  ])), [alignment.rows, template]);
+    pairwiseRowStats(row.aligned, template?.aligned ?? '', alignment.molecule, strictDifferences),
+  ])), [alignment.molecule, alignment.rows, strictDifferences, template]);
   const orderedRows = useMemo(() => {
     if (manualOrder) {
       const byId = new Map(alignment.rows.map((row) => [row.id, row] as const));
@@ -1188,8 +1338,8 @@ function AlignmentMatrix({
   ])), [alignment.rows, allRowNames]);
   const overviewBinCount = Math.min(512, Math.max(1, alignment.alignmentLength));
   const overviewBins = useMemo(
-    () => mismatchOverviewBins(alignment, template?.id ?? referenceRowId, overviewBinCount),
-    [alignment, overviewBinCount, template, referenceRowId],
+    () => mismatchOverviewBins(alignment, template?.id ?? referenceRowId, overviewBinCount, strictDifferences),
+    [alignment, overviewBinCount, template, referenceRowId, strictDifferences],
   );
   const overviewPath = useMemo(() => overviewBins.map((density, index) => {
     if (density <= 0) return '';
@@ -1470,16 +1620,8 @@ function AlignmentMatrix({
     return ids;
   }, [orderedRows, selection]);
 
-  const selectionSummary = useMemo(() => {
+  const selectionCoordinates = useMemo(() => {
     if (!selection) return null;
-    // Stats describe the SELECTED block only — slice each selected row to the
-    // selected columns so unselected rows never skew the readout. Bounded by the
-    // selection size, so it stays cheap even mid-drag on a wide alignment.
-    const selectedRows = orderedRows
-      .slice(selection.rowStart, selection.rowEnd + 1)
-      .map((row) => ({ ...row, aligned: row.aligned.slice(selection.colStart, selection.colEnd + 1) }));
-    const blockStats = computeMsaColumnStats(selectedRows, alignment.molecule);
-    const stats = summarizeSelectionColumns(blockStats, { start: 0, end: selection.colEnd - selection.colStart });
     // Template coordinates: first/last non-gap position within the range, so a
     // gapped endpoint doesn't hide the whole template range.
     let startPosition: number | null = null;
@@ -1490,8 +1632,31 @@ function AlignmentMatrix({
     for (let column = selection.colEnd; column >= selection.colStart; column -= 1) {
       if (templateCoordinates[column] != null) { endPosition = templateCoordinates[column]!; break; }
     }
-    return { stats, startPosition, endPosition, rows: selectedRows.length };
-  }, [orderedRows, selection, templateCoordinates, alignment.molecule]);
+    return {
+      columns: selection.colEnd - selection.colStart + 1,
+      startPosition,
+      endPosition,
+      rows: selection.rowEnd - selection.rowStart + 1,
+    };
+  }, [selection, templateCoordinates]);
+
+  const selectionSummary = useMemo(() => {
+    if (!selection || isSelecting) return null;
+    // Stats describe the selected block only. Pointer drags keep the cheap
+    // coordinate summary live, then pay this block-sized cost at settle.
+    const selectedRows = orderedRows
+      .slice(selection.rowStart, selection.rowEnd + 1)
+      .map((row) => ({ ...row, aligned: row.aligned.slice(selection.colStart, selection.colEnd + 1) }));
+    const blockStats = computeMsaColumnStats(selectedRows, alignment.molecule);
+    return summarizeSelectionColumns(blockStats, { start: 0, end: selection.colEnd - selection.colStart });
+  }, [orderedRows, selection, alignment.molecule, isSelecting]);
+
+  const selectionReferenceRange = useMemo(() => {
+    if (!selection || !referenceCoordinates) return null;
+    const start = referenceCoordinates[selection.colStart];
+    const end = referenceCoordinates[selection.colEnd];
+    return start && end ? { start: start.label, end: end.label } : null;
+  }, [referenceCoordinates, selection]);
 
   const columnFromClientX = useCallback((clientX: number, clampToViewport = false): number | null => {
     const viewport = viewportRef.current;
@@ -1632,8 +1797,9 @@ function AlignmentMatrix({
     if (!(event.shiftKey && selectionAnchorRef.current)) {
       selectionAnchorRef.current = { column: cell.column, rowIndex: cell.rowIndex };
     }
-    applySelectionTo(cell);
     selectingRef.current = true;
+    setIsSelecting(true);
+    applySelectionTo(cell);
     stopDragAutoScroll();
     try { event.currentTarget.setPointerCapture(event.pointerId); } catch { /* capture is best-effort */ }
   };
@@ -1659,6 +1825,7 @@ function AlignmentMatrix({
       if (cell) applySelectionTo(cell);
     }
     selectingRef.current = false;
+    setIsSelecting(false);
     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
       event.currentTarget.releasePointerCapture(event.pointerId);
     }
@@ -1719,6 +1886,7 @@ function AlignmentMatrix({
 
   const clearSelection = useCallback(() => {
     setSelection(null);
+    setIsSelecting(false);
     selectionAnchorRef.current = null;
     setContextMenu(null);
   }, []);
@@ -1963,6 +2131,7 @@ function AlignmentMatrix({
     setContextMenu(null);
     selectionAnchorRef.current = null;
     selectingRef.current = false;
+    setIsSelecting(false);
     rulerSelectingRef.current = false;
     setManualOrder(null);
     setRowDrag(null);
@@ -2093,12 +2262,15 @@ function AlignmentMatrix({
           && resolvedRowIndex >= selection.rowStart && resolvedRowIndex <= selection.rowEnd;
         const rowName = rowIndex === null ? '' : orderedRows[resolvedRowIndex]?.name ?? '';
         const residueLabel = symbol === '-' || symbol === '.' ? 'Gap' : `Residue ${symbol}`;
+        const referenceCoordinate = referenceCoordinates?.[column];
         const templateSymbol = template?.aligned[column] ?? '-';
         const isTemplate = rowId === template?.id;
         const cellOutcome = classifyMsaCell(
           templateSymbol,
           symbol,
           coversColumn(rowCoverageById.get(rowId) ?? null, column),
+          alignment.molecule,
+          strictDifferences,
         );
         const matchesTemplate = cellOutcome === 'match';
         const isDifference = coversColumn(templateCoverage, column) && isMsaCellDifference(cellOutcome);
@@ -2130,7 +2302,9 @@ function AlignmentMatrix({
             tabIndex={isGridCell ? (isActive ? 0 : -1) : undefined}
             aria-colindex={isGridCell ? column + 1 : undefined}
             aria-selected={isGridCell ? Boolean(isSelected) : undefined}
-            aria-label={isGridCell ? `${residueLabel}, alignment column ${column + 1}, row ${rowName}` : undefined}
+            aria-label={isGridCell
+              ? `${residueLabel}, alignment column ${column + 1}${referenceCoordinate ? `, reference position ${referenceCoordinate.label}` : ''}, row ${rowName}`
+              : undefined}
           >
             {display}
           </span>
@@ -2402,28 +2576,41 @@ function AlignmentMatrix({
             data-alignment-axis={visibility.showAlignmentAxis || undefined}
             role="row"
             aria-rowindex={visibility.showAlignmentAxis ? 2 : 1}
-            aria-label={`Template positions for ${template?.name ?? 'template'}`}
+            aria-label={referenceCoordinates
+              ? `Reference positions for ${numberingReference?.name ?? 'reference'}`
+              : `Template positions for ${template?.name ?? 'template'}`}
           >
             <div
               className="motif-cs-msa-sticky-label motif-cs-msa-ruler-label motif-cs-msa-template-ruler-label"
               role="columnheader"
-              title={`Template position · ${template?.name ?? 'Template'} · ungapped template-row coordinates`}
+              title={referenceCoordinates
+                ? `Reference position · ${numberingReference?.name ?? 'Reference'} · first residue ${referenceNumbering?.firstResiduePosition}`
+                : `Template position · ${template?.name ?? 'Template'} · ungapped template-row coordinates`}
             >
-              <span>Template position</span>
-              <small translate="no">{template?.name ?? 'Template'}</small>
+              <span>{referenceCoordinates ? 'Reference position' : 'Template position'}</span>
+              <small translate="no">{referenceCoordinates ? numberingReference?.name ?? 'Reference' : template?.name ?? 'Template'}</small>
             </div>
             <div className="motif-cs-msa-ruler-window" style={{ left: labelWidth + (startColumn * cellWidth) }} aria-hidden="true">
               {templateCoordinates.slice(startColumn, endColumn).map((position, offset) => {
                 const column = startColumn + offset;
-                const show = position !== null && (position === 1 || position % 10 === 0);
+                const referenceCoordinate = referenceCoordinates?.[column];
+                const show = referenceCoordinate
+                  ? referenceCoordinate.insertionCode !== ''
+                    || referenceCoordinate.referencePosition === referenceNumbering?.firstResiduePosition
+                    || referenceCoordinate.referencePosition % 10 === 0
+                  : position !== null && (position === 1 || position % 10 === 0);
                 return (
                   <span
                     key={column}
                     className="motif-cs-msa-ruler-cell"
                     data-alignment-column={String(column + 1)}
                     data-template-position={position === null ? 'gap' : String(position)}
+                    data-reference-coordinate={referenceCoordinate?.label}
+                    data-reference-insertion={referenceCoordinate?.insertionCode || undefined}
+                    data-reference-label-lane={referenceCoordinate?.insertionCode ? String(column % 3) : undefined}
+                    title={referenceCoordinate?.label}
                   >
-                    {show ? position : ''}
+                    {show ? referenceCoordinate?.label ?? position : ''}
                   </span>
                 );
               })}
@@ -2432,7 +2619,7 @@ function AlignmentMatrix({
 
           {orderedRows.map((row, rowIndex) => {
             const label = rowLabelsById.get(row.id) ?? { leading: row.name, trailing: '' };
-            const stats = statsByRow.get(row.id) ?? pairwiseRowStats(row.aligned, template?.aligned ?? '');
+            const stats = statsByRow.get(row.id) ?? pairwiseRowStats(row.aligned, template?.aligned ?? '', alignment.molecule, strictDifferences);
             const isTemplate = row.id === template?.id;
             return (
               <div
@@ -2449,7 +2636,7 @@ function AlignmentMatrix({
                 role="row"
                 aria-rowindex={firstSequenceRow + rowIndex}
                 aria-label={visibility.showRowStats
-                  ? `${row.name}; ${stats.mismatches} mismatches; ${stats.ungappedLength} ungapped ${sequenceUnit(alignment.molecule)}; ${formatIdentity(stats.identity)} percent identity to template; ${isTemplate ? 'template row' : 'alignment row'}`
+                  ? `${row.name}; ${stats.mismatches} mismatches; ${stats.ambiguities > 0 ? `${stats.ambiguities} compatible ambiguity ${stats.ambiguities === 1 ? 'call' : 'calls'}; ` : ''}${stats.ungappedLength} ungapped ${sequenceUnit(alignment.molecule)}; ${formatIdentity(stats.identity)} percent identity to template; ${isTemplate ? 'template row' : 'alignment row'}`
                   : `${row.name}; ${isTemplate ? 'template row' : 'alignment row'}`}
               >
                 <div className="motif-cs-msa-sticky-label motif-cs-msa-row-label motif-cs-msa-row-label-draggable" role="rowheader">
@@ -2487,6 +2674,9 @@ function AlignmentMatrix({
                     {visibility.showRowStats ? (
                       <>
                         <small className="motif-cs-msa-row-stat motif-cs-msa-row-stat-mismatch">{stats.mismatches.toLocaleString()}Δ</small>
+                        {stats.ambiguities > 0 ? (
+                          <small className="motif-cs-msa-row-stat motif-cs-msa-row-stat-ambiguous" title="Compatible ambiguity-code calls (not counted as differences)">{stats.ambiguities.toLocaleString()}≈</small>
+                        ) : null}
                         <small className="motif-cs-msa-row-stat motif-cs-msa-row-stat-length">{stats.ungappedLength.toLocaleString()} {sequenceUnit(alignment.molecule)}</small>
                         <small className="motif-cs-msa-row-stat">{formatIdentity(stats.identity)}%</small>
                       </>
@@ -2612,7 +2802,9 @@ function AlignmentMatrix({
           />
         </div>
       ) : null}
-      <span id="motif-cs-msa-matrix-help" className="motif-cs-visually-hidden">Alignment positions count gapped columns. Template positions count non-gap residues in the chosen template; blank template-axis cells are gaps. Choose any row header button to make that row the template. In the grid, use Arrow keys to move the active residue, Shift plus Arrow keys to extend a selection, Home and End for row boundaries, Control or Command plus Home or End for grid boundaries, Page Up and Page Down to move by a viewport, Space to select a column, and Shift plus F10 or the Context Menu key for selection actions. The Columns slider and Shift plus wheel also pan the alignment. Switch to Text to read or copy the complete aligned sequences with assistive technology.</span>
+      <span id="motif-cs-msa-matrix-help" className="motif-cs-visually-hidden">{referenceCoordinates
+        ? 'Alignment positions count gapped columns. Reference positions use the saved first-residue coordinate; reference-gap columns append stable insertion letters, and leading gaps use the preceding coordinate. Choose any row header button to make that row the comparison template. In the grid, use Arrow keys to move the active residue, Shift plus Arrow keys to extend a selection, Home and End for row boundaries, Control or Command plus Home or End for grid boundaries, Page Up and Page Down to move by a viewport, Space to select a column, and Shift plus F10 or the Context Menu key for selection actions. The Columns slider and Shift plus wheel also pan the alignment. Switch to Text to read or copy the complete aligned sequences with assistive technology.'
+        : 'Alignment positions count gapped columns. Template positions count non-gap residues in the chosen template; blank template-axis cells are gaps. Choose any row header button to make that row the template. In the grid, use Arrow keys to move the active residue, Shift plus Arrow keys to extend a selection, Home and End for row boundaries, Control or Command plus Home or End for grid boundaries, Page Up and Page Down to move by a viewport, Space to select a column, and Shift plus F10 or the Context Menu key for selection actions. The Columns slider and Shift plus wheel also pan the alignment. Switch to Text to read or copy the complete aligned sequences with assistive technology.'}</span>
       <div className="motif-cs-msa-window-note" aria-live="polite">
         Alignment columns {visibleStartColumn + 1}–{Math.max(visibleStartColumn + 1, visibleEndColumn)} of {alignment.alignmentLength.toLocaleString()}
       </div>
@@ -2624,16 +2816,18 @@ function AlignmentMatrix({
         </div>
       ) : null}
       <span className="motif-cs-visually-hidden" data-testid="msa-reorder-status" role="status" aria-live="polite">{reorderStatus}</span>
-      {selection && selectionSummary ? (
+      {selection && selectionCoordinates ? (
         <div className="motif-cs-msa-selection-readout" data-testid="msa-selection-readout" role="status" aria-live="polite">
           <strong>Selected</strong>
-          <span>cols {selection.colStart + 1}–{selection.colEnd + 1} ({selectionSummary.stats.columns.toLocaleString()})</span>
-          {selectionSummary.startPosition != null && selectionSummary.endPosition != null
-            ? <span>· template {selectionSummary.startPosition}–{selectionSummary.endPosition}</span>
+          <span>cols {selection.colStart + 1}–{selection.colEnd + 1} ({selectionCoordinates.columns.toLocaleString()})</span>
+          {selectionReferenceRange
+            ? <span>· reference {selectionReferenceRange.start}–{selectionReferenceRange.end}</span>
+            : selectionCoordinates.startPosition != null && selectionCoordinates.endPosition != null
+            ? <span>· template {selectionCoordinates.startPosition}–{selectionCoordinates.endPosition}</span>
             : null}
-          <span>· {selectionSummary.rows} row{selectionSummary.rows === 1 ? '' : 's'}</span>
-          <span>· {selectionSummary.stats.variableColumns.toLocaleString()} variable</span>
-          <span>· {Math.round(selectionSummary.stats.meanIdentity * 100)}% mean id</span>
+          <span>· {selectionCoordinates.rows} row{selectionCoordinates.rows === 1 ? '' : 's'}</span>
+          <span data-testid="msa-selection-variable">· {selectionSummary ? selectionSummary.variableColumns.toLocaleString() : '…'} variable</span>
+          <span data-testid="msa-selection-identity">· {selectionSummary ? `${Math.round(selectionSummary.meanIdentity * 100)}%` : '…'} mean id</span>
           <button type="button" className="motif-cs-mini-button" onClick={clearSelection}>Clear</button>
         </div>
       ) : null}
@@ -2641,7 +2835,11 @@ function AlignmentMatrix({
         <div ref={hoverReadoutRef} className="motif-cs-msa-hover-readout" style={{ left: hoverPosition?.x ?? hoverCell.clientX + 14, top: hoverPosition?.y ?? hoverCell.clientY + 16 }} aria-hidden="true">
           <b>{orderedRows[hoverCell.rowIndex]?.aligned[hoverCell.column] ?? '-'}</b>
           <span>col {hoverCell.column + 1}</span>
-          <span>· {templateCoordinates[hoverCell.column] != null ? `tpl ${templateCoordinates[hoverCell.column]}` : 'tpl gap'}</span>
+          <span>· {referenceCoordinates?.[hoverCell.column]
+            ? `ref ${referenceCoordinates[hoverCell.column].label}`
+            : templateCoordinates[hoverCell.column] != null
+              ? `tpl ${templateCoordinates[hoverCell.column]}`
+              : 'tpl gap'}</span>
           <span className="motif-cs-msa-hover-readout-name">{orderedRows[hoverCell.rowIndex]?.name}</span>
         </div>
       ) : null}
@@ -2694,7 +2892,7 @@ export function ClaudeScienceMsaViewer({
   const [importMolecule, setImportMolecule] = useState<SequenceType>('dna');
   const [error, setError] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
-  const { displayMode, emphasis, colorMode, colorScheme, shadeMode, sortMode, fontSize, zoom, translationFrame, textFormat } = viewPreferences;
+  const { displayMode, emphasis, colorMode, colorScheme, shadeMode, sortMode, fontSize, zoom, translationFrame, textFormat, strictDifferences } = viewPreferences;
   const [referenceRowId, setReferenceRowId] = useState(activeAlignment?.referenceRowId ?? '');
   const [differenceIndex, setDifferenceIndex] = useState(-1);
   const [jumpColumn, setJumpColumn] = useState<number | null>(null);
@@ -2709,7 +2907,16 @@ export function ClaudeScienceMsaViewer({
   const [columnDraft, setColumnDraft] = useState('');
   const [columnError, setColumnError] = useState<string | null>(null);
   const [columnStatus, setColumnStatus] = useState('');
+  const [referenceNumberingRowDraft, setReferenceNumberingRowDraft] = useState(
+    activeAlignment?.referenceNumbering?.rowId ?? activeAlignment?.referenceRowId ?? '',
+  );
+  const [firstResiduePositionDraft, setFirstResiduePositionDraft] = useState(
+    String(activeAlignment?.referenceNumbering?.firstResiduePosition ?? 1),
+  );
+  const [referenceNumberingError, setReferenceNumberingError] = useState<string | null>(null);
+  const [referenceNumberingStatus, setReferenceNumberingStatus] = useState('');
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [dismissedAlphabetWarningId, setDismissedAlphabetWarningId] = useState<string | null>(null);
   const [dropActive, setDropActive] = useState(false);
   const [intakeStatus, setIntakeStatus] = useState<{ message: string; tone: 'status' | 'error' } | null>(null);
   const [copyStatus, setCopyStatus] = useState<{ label: string; message: string; tone: 'status' | 'error' } | null>(null);
@@ -2726,6 +2933,7 @@ export function ClaudeScienceMsaViewer({
   const copyStatusTimerRef = useRef<number | null>(null);
   const viewMenuRef = useRef<HTMLDetailsElement>(null);
   const viewMenuButtonRef = useRef<HTMLElement>(null);
+  const pendingReferenceNumberingStatusRef = useRef<{ alignmentId: string; message: string } | null>(null);
   const explicitlySelectedTemplateIdRef = useRef<string | null>(null);
   // Latest visible column window reported by the matrix, for "Visible view" export.
   const visibleColumnsRef = useRef<{ start: number; end: number } | null>(null);
@@ -2751,6 +2959,16 @@ export function ClaudeScienceMsaViewer({
     setColumnDraft('');
     setColumnError(null);
     setColumnStatus('');
+    setReferenceNumberingRowDraft(activeAlignment?.referenceNumbering?.rowId ?? activeAlignment?.referenceRowId ?? activeAlignment?.rows[0]?.id ?? '');
+    setFirstResiduePositionDraft(String(activeAlignment?.referenceNumbering?.firstResiduePosition ?? 1));
+    setReferenceNumberingError(null);
+    const pendingNumberingStatus = pendingReferenceNumberingStatusRef.current;
+    setReferenceNumberingStatus(
+      pendingNumberingStatus && activeAlignment && pendingNumberingStatus.alignmentId === activeAlignment.id
+        ? pendingNumberingStatus.message
+        : '',
+    );
+    pendingReferenceNumberingStatusRef.current = null;
     setPendingDeleteId(null);
     // Drop any stale visible window from the previous alignment; the matrix
     // reports a fresh range on mount (undefined until then falls back to whole).
@@ -2840,8 +3058,16 @@ export function ClaudeScienceMsaViewer({
   const workEstimate = useMemo(() => estimateLocalAlignmentWork(selectedRecords), [selectedRecords]);
   const exceedsLocalBudget = workEstimate > ARTIFACT_MSA_LOCAL_WORK_BUDGET;
   const differences = useMemo(
-    () => activeAlignment ? differenceColumns(activeAlignment, referenceRowId) : [],
-    [activeAlignment, referenceRowId],
+    () => activeAlignment ? differenceColumns(activeAlignment, referenceRowId, strictDifferences) : [],
+    [activeAlignment, referenceRowId, strictDifferences],
+  );
+  const ambiguities = useMemo(
+    () => activeAlignment ? ambiguousColumns(activeAlignment, referenceRowId, strictDifferences) : [],
+    [activeAlignment, referenceRowId, strictDifferences],
+  );
+  const alphabetAnomalies = useMemo(
+    () => (activeAlignment ? detectAlphabetAnomalies(activeAlignment.rows, activeAlignment.molecule) : []),
+    [activeAlignment],
   );
   const computedSearchResult = useMemo(
     () => (activeAlignment && deferredSearchQuery.trim()
@@ -2866,10 +3092,20 @@ export function ClaudeScienceMsaViewer({
     : 0;
   const activeTemplate = activeAlignment?.rows.find((row) => row.id === referenceRowId)
     ?? activeAlignment?.rows[0];
+  const activeReferenceNumbering = activeAlignment?.referenceNumbering;
+  const activeNumberingReference = activeReferenceNumbering
+    ? activeAlignment?.rows.find((row) => row.id === activeReferenceNumbering.rowId)
+    : undefined;
+  const activeReferenceCoordinates = useMemo(
+    () => (activeReferenceNumbering && activeNumberingReference
+      ? referenceCoordinateLabels(activeNumberingReference.aligned, activeReferenceNumbering.firstResiduePosition)
+      : null),
+    [activeNumberingReference, activeReferenceNumbering],
+  );
   const comparisonStats = activeTemplate
     ? (activeAlignment?.rows ?? [])
       .filter((row) => row.id !== activeTemplate.id)
-      .map((row) => pairwiseRowStats(row.aligned, activeTemplate.aligned))
+      .map((row) => pairwiseRowStats(row.aligned, activeTemplate.aligned, activeAlignment?.molecule ?? 'dna', strictDifferences))
       .filter((stats) => stats.comparableColumns > 0)
     : [];
   const hasComparableRows = comparisonStats.length > 0;
@@ -3143,6 +3379,11 @@ export function ClaudeScienceMsaViewer({
     setColumnDraft('');
     setColumnError(null);
     setColumnStatus('');
+    if (!activeAlignment.referenceNumbering) {
+      setReferenceNumberingRowDraft(rowId);
+      setReferenceNumberingError(null);
+      setReferenceNumberingStatus('');
+    }
     if (activeAlignment.referenceRowId === rowId) return;
     onUpdateAlignmentTemplate(activeAlignment.id, rowId);
   }, [activeAlignment, onUpdateAlignmentTemplate]);
@@ -3322,20 +3563,34 @@ export function ClaudeScienceMsaViewer({
   const goToCoordinate = () => {
     if (!activeAlignment) return;
     const normalized = columnDraft.trim();
-    const requested = /^\d+$/.test(normalized) ? Number(normalized) : Number.NaN;
     const template = activeAlignment.rows.find((row) => row.id === referenceRowId) ?? activeAlignment.rows[0];
-    const maximum = coordinateSystem === 'alignment'
-      ? activeAlignment.alignmentLength
-      : template?.aligned.replace(/-/g, '').length ?? 0;
-    if (!Number.isInteger(requested) || requested < 1 || requested > maximum) {
-      setColumnError(`Enter a whole ${coordinateSystem === 'alignment' ? 'column' : 'template position'} from 1 to ${maximum.toLocaleString()}.`);
-      setColumnStatus('');
-      return;
+    const requested = /^\d+$/.test(normalized) ? Number(normalized) : Number.NaN;
+    let column: number | null;
+    if (coordinateSystem === 'alignment') {
+      const maximum = activeAlignment.alignmentLength;
+      if (!Number.isInteger(requested) || requested < 1 || requested > maximum) {
+        setColumnError(`Enter a whole column from 1 to ${maximum.toLocaleString()}.`);
+        setColumnStatus('');
+        return;
+      }
+      column = requested - 1;
+    } else if (activeReferenceCoordinates) {
+      column = parseReferenceCoordinateColumn(normalized, activeReferenceCoordinates);
+      if (column === null) {
+        setColumnError('Enter a reference position present in this alignment, such as 101 or 101A.');
+        setColumnStatus('');
+        return;
+      }
+    } else {
+      const maximum = template?.aligned.replace(/-/g, '').length ?? 0;
+      if (!Number.isInteger(requested) || requested < 1 || requested > maximum) {
+        setColumnError(`Enter a whole template position from 1 to ${maximum.toLocaleString()}.`);
+        setColumnStatus('');
+        return;
+      }
+      column = templatePositionCoordinates(template?.aligned ?? '').findIndex((position) => position === requested);
     }
-    const column = coordinateSystem === 'alignment'
-      ? requested - 1
-      : templatePositionCoordinates(template?.aligned ?? '').findIndex((position) => position === requested);
-    if (column < 0) {
+    if (column === null || column < 0) {
       setColumnError(`Template position ${requested.toLocaleString()} could not be mapped in this alignment.`);
       setColumnStatus('');
       return;
@@ -3347,7 +3602,72 @@ export function ClaudeScienceMsaViewer({
     setJumpToken((token) => token + 1);
     setColumnStatus(coordinateSystem === 'alignment'
       ? `Alignment column ${requested.toLocaleString()} shown.`
-      : `Template position ${requested.toLocaleString()} in ${template?.name ?? 'template'} shown at alignment column ${(column + 1).toLocaleString()}.`);
+      : activeReferenceCoordinates
+        ? `Reference position ${activeReferenceCoordinates[column].label} in ${activeNumberingReference?.name ?? 'reference'} shown at alignment column ${(column + 1).toLocaleString()}.`
+        : `Template position ${requested.toLocaleString()} in ${template?.name ?? 'template'} shown at alignment column ${(column + 1).toLocaleString()}.`);
+  };
+
+  const applyReferenceNumbering = () => {
+    if (!activeAlignment) return;
+    const numberingRow = activeAlignment.rows.find((row) => row.id === referenceNumberingRowDraft);
+    const normalizedPosition = firstResiduePositionDraft.trim();
+    const firstResiduePosition = /^[1-9]\d*$/.test(normalizedPosition)
+      ? Number(normalizedPosition)
+      : Number.NaN;
+    if (!numberingRow) {
+      setReferenceNumberingError('Choose a reference row from this alignment.');
+      setReferenceNumberingStatus('');
+      return;
+    }
+    const residueCount = numberingRow.aligned.replace(/[-.]/g, '').length;
+    if (
+      !Number.isSafeInteger(firstResiduePosition)
+      || firstResiduePosition < 1
+      || !Number.isSafeInteger(firstResiduePosition + residueCount - 1)
+    ) {
+      setReferenceNumberingError('First residue position must be a positive whole number in the safe coordinate range.');
+      setReferenceNumberingStatus('');
+      return;
+    }
+    if (
+      activeAlignment.referenceNumbering?.rowId === numberingRow.id
+      && activeAlignment.referenceNumbering.firstResiduePosition === firstResiduePosition
+    ) {
+      setReferenceNumberingError(null);
+      setReferenceNumberingStatus('Reference numbering is already applied.');
+      return;
+    }
+    const successMessage = 'Reference numbering saved as a new session result and opened.';
+    try {
+      const saved = onSaveAlignment({
+        ...activeAlignment,
+        referenceNumbering: { rowId: numberingRow.id, firstResiduePosition },
+      });
+      pendingReferenceNumberingStatusRef.current = { alignmentId: saved.id, message: successMessage };
+      setReferenceNumberingError(null);
+      setReferenceNumberingStatus(successMessage);
+      onActiveAlignmentChange(saved.id);
+    } catch (caught) {
+      setReferenceNumberingError(caught instanceof Error ? caught.message : 'Reference numbering could not be saved.');
+      setReferenceNumberingStatus('');
+    }
+  };
+
+  const clearReferenceNumbering = () => {
+    if (!activeAlignment?.referenceNumbering) return;
+    const plainAlignment = { ...activeAlignment };
+    delete plainAlignment.referenceNumbering;
+    const successMessage = 'Plain 1-based numbering saved as a new session result and opened.';
+    try {
+      const saved = onSaveAlignment(plainAlignment);
+      pendingReferenceNumberingStatusRef.current = { alignmentId: saved.id, message: successMessage };
+      setReferenceNumberingError(null);
+      setReferenceNumberingStatus(successMessage);
+      onActiveAlignmentChange(saved.id);
+    } catch (caught) {
+      setReferenceNumberingError(caught instanceof Error ? caught.message : 'Plain numbering could not be saved.');
+      setReferenceNumberingStatus('');
+    }
   };
 
   const resetAlignmentView = useCallback(() => {
@@ -3708,7 +4028,7 @@ export function ClaudeScienceMsaViewer({
                 {([
                   ['showOverview', 'Overview'],
                   ['showAlignmentAxis', 'Alignment axis'],
-                  ['showTemplateAxis', 'Template axis'],
+                  ['showTemplateAxis', activeReferenceCoordinates ? 'Reference axis' : 'Template axis'],
                   ['showRowStats', 'Row statistics'],
                   ['showRowStatsPanel', 'Row statistics table'],
                   ['showConservation', 'Conservation marks'],
@@ -3784,6 +4104,60 @@ export function ClaudeScienceMsaViewer({
                     <option value="taylor">Taylor</option>
                   </select>
                 </label>
+                <label title="When off, compatible IUPAC ambiguity codes are shown separately from hard differences.">
+                  <input
+                    type="checkbox"
+                    checked={strictDifferences}
+                    onChange={(event) => updateViewPreferences({ strictDifferences: event.target.checked })}
+                  />
+                  <span>Strict differences</span>
+                </label>
+                <div className="motif-cs-msa-reference-numbering" data-testid="msa-reference-numbering-editor" data-active={activeReferenceCoordinates ? true : undefined}>
+                  <div className="motif-cs-msa-reference-numbering-heading">
+                    <strong>Reference numbering</strong>
+                    <span>{activeReferenceCoordinates ? 'On' : 'Plain 1-based'}</span>
+                  </div>
+                  <label className="motif-cs-msa-view-select">
+                    <span>Reference row</span>
+                    <select
+                      value={referenceNumberingRowDraft}
+                      aria-label="Numbering reference row"
+                      onChange={(event) => {
+                        setReferenceNumberingRowDraft(event.target.value);
+                        setReferenceNumberingError(null);
+                        setReferenceNumberingStatus('');
+                      }}
+                    >
+                      {activeAlignment.rows.map((row) => <option key={row.id} value={row.id}>{row.name}</option>)}
+                    </select>
+                  </label>
+                  <label className="motif-cs-msa-reference-numbering-position">
+                    <span>First residue position</span>
+                    <input
+                      className="motif-cs-input"
+                      data-testid="msa-reference-numbering-position"
+                      type="number"
+                      inputMode="numeric"
+                      min={1}
+                      step={1}
+                      value={firstResiduePositionDraft}
+                      aria-invalid={referenceNumberingError ? true : undefined}
+                      aria-describedby="motif-cs-msa-reference-numbering-convention"
+                      onChange={(event) => {
+                        setFirstResiduePositionDraft(event.target.value);
+                        setReferenceNumberingError(null);
+                        setReferenceNumberingStatus('');
+                      }}
+                    />
+                  </label>
+                  <small id="motif-cs-msa-reference-numbering-convention">Gap columns append A…Z, AA… to the preceding position; leading gaps use one less than the first residue. Changes save as a new session result.</small>
+                  <div className="motif-cs-msa-reference-numbering-actions">
+                    <button className="motif-cs-mini-button" data-testid="msa-apply-reference-numbering" type="button" onClick={applyReferenceNumbering}>Apply to saved result</button>
+                    <button className="motif-cs-mini-button" data-testid="msa-clear-reference-numbering" type="button" disabled={!activeAlignment.referenceNumbering} onClick={clearReferenceNumbering}>Use plain 1-based</button>
+                  </div>
+                  {referenceNumberingError ? <span className="motif-cs-msa-reference-numbering-error" role="alert">{referenceNumberingError}</span> : null}
+                  <span className="motif-cs-msa-reference-numbering-status" data-empty={!referenceNumberingStatus || undefined} role="status" aria-live="polite">{referenceNumberingStatus}</span>
+                </div>
                 {colorMode === 'residue' ? (
                   <ResidueColorLegend molecule={activeAlignment.molecule} colorScheme={colorScheme} />
                 ) : null}
@@ -3820,6 +4194,28 @@ export function ClaudeScienceMsaViewer({
               <button ref={deleteButtonRef} className="motif-cs-mini-button motif-cs-msa-delete" type="button" onClick={() => setPendingDeleteId(activeAlignment.id)} title="Delete this alignment from the session" aria-label="Delete this alignment from the session"><Trash2 size={13} aria-hidden="true" /></button>
             )}
           </div>
+
+          {alphabetAnomalies.length > 0 && dismissedAlphabetWarningId !== activeAlignment.id ? (
+            <div
+              className="motif-cs-msa-alphabet-warning"
+              data-testid="msa-alphabet-warning"
+              role="status"
+              aria-live="polite"
+            >
+              <span>
+                <strong>Check molecule type.</strong>{' '}
+                {alphabetAnomalies.length} of {activeAlignment.rows.length} sequences contain only nucleotide letters but are displayed as protein.
+              </span>
+              <button
+                className="motif-cs-mini-button"
+                type="button"
+                aria-label="Dismiss molecule type warning"
+                onClick={() => setDismissedAlphabetWarningId(activeAlignment.id)}
+              >
+                Dismiss
+              </button>
+            </div>
+          ) : null}
 
           <details
             className="motif-cs-msa-provenance"
@@ -3861,6 +4257,11 @@ export function ClaudeScienceMsaViewer({
             <span><strong>{conservedPct}%</strong> conserved</span>
             <span><strong>{avgIdentity === null ? 'N/A' : `${formatIdentity(avgIdentity)}%`}</strong> avg to template</span>
             <span><strong>{differences.length.toLocaleString()}</strong> differences in overlap</span>
+            {ambiguities.length > 0 ? (
+              <span className="motif-cs-msa-stats-ambiguous" data-testid="msa-ambiguous-count" title="Columns with compatible ambiguity-code calls, counted separately from hard differences">
+                <strong>{ambiguities.length.toLocaleString()}</strong> compatible
+              </span>
+            ) : null}
           </div>
 
           {displayMode === 'viewer' ? (
@@ -3953,27 +4354,33 @@ export function ClaudeScienceMsaViewer({
                       }}
                     >
                       <option value="alignment">Alignment column</option>
-                      <option value="template">Template position</option>
+                      <option value="template">{activeReferenceCoordinates ? 'Reference position' : 'Template position'}</option>
                     </select>
                   </label>
                   <label>
-                    <span className="motif-cs-visually-hidden">{coordinateSystem === 'alignment' ? 'Alignment column' : 'Template position'}</span>
+                    <span className="motif-cs-visually-hidden">{coordinateSystem === 'alignment' ? 'Alignment column' : activeReferenceCoordinates ? 'Reference position' : 'Template position'}</span>
                     <input
                       data-testid="msa-coordinate-input"
-                      type="number"
+                      type={coordinateSystem === 'template' && activeReferenceCoordinates ? 'text' : 'number'}
                       name="alignment-coordinate"
                       autoComplete="off"
-                      inputMode="numeric"
-                      min={1}
-                      max={coordinateSystem === 'alignment' ? activeAlignment.alignmentLength : activeTemplate?.aligned.replace(/-/g, '').length ?? 0}
-                      step={1}
+                      inputMode={coordinateSystem === 'template' && activeReferenceCoordinates ? 'text' : 'numeric'}
+                      min={coordinateSystem === 'template' && activeReferenceCoordinates ? undefined : 1}
+                      max={coordinateSystem === 'template' && activeReferenceCoordinates
+                        ? undefined
+                        : coordinateSystem === 'alignment'
+                          ? activeAlignment.alignmentLength
+                          : activeTemplate?.aligned.replace(/-/g, '').length ?? 0}
+                      step={coordinateSystem === 'template' && activeReferenceCoordinates ? undefined : 1}
+                      pattern={coordinateSystem === 'template' && activeReferenceCoordinates ? '[0-9]+[A-Za-z]*' : undefined}
+                      placeholder={coordinateSystem === 'template' && activeReferenceCoordinates ? '101 or 101A' : undefined}
                       value={columnDraft}
                       onChange={(event) => {
                         setColumnDraft(event.target.value);
                         setColumnError(null);
                         setColumnStatus('');
                       }}
-                      aria-label={coordinateSystem === 'alignment' ? 'Go to alignment column' : 'Go to template position'}
+                      aria-label={coordinateSystem === 'alignment' ? 'Go to alignment column' : activeReferenceCoordinates ? 'Go to reference position' : 'Go to template position'}
                       aria-invalid={columnError ? true : undefined}
                       aria-describedby={columnError ? 'motif-cs-msa-column-error' : undefined}
                     />
@@ -3988,6 +4395,7 @@ export function ClaudeScienceMsaViewer({
                   alignment={activeAlignment}
                   referenceRowId={referenceRowId}
                   sortMode={sortMode}
+                  strictDifferences={strictDifferences}
                   onSortModeChange={(nextSortMode) => updateViewPreferences({ sortMode: nextSortMode })}
                   onJump={jumpToRowDifference}
                 />
@@ -3996,6 +4404,7 @@ export function ClaudeScienceMsaViewer({
                 key={activeAlignment.id}
                 alignment={activeAlignment}
                 referenceRowId={referenceRowId}
+                referenceCoordinates={activeReferenceCoordinates}
                 emphasis={emphasis}
                 colorMode={colorMode}
                 colorScheme={colorScheme}
@@ -4011,6 +4420,7 @@ export function ClaudeScienceMsaViewer({
                 focusRequest={matrixFocusRequest}
                 searchActive={Boolean(searchQuery)}
                 sortMode={sortMode}
+                strictDifferences={strictDifferences}
                 visibility={matrixVisibility}
                 resetToken={viewResetToken}
                 onTemplateChange={selectTemplate}

--- a/src/artifacts/__tests__/ClaudeScienceMsaViewer.alphabet-warning.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceMsaViewer.alphabet-warning.jsdom.test.tsx
@@ -1,0 +1,60 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ClaudeScienceMsaViewer, type ClaudeScienceMsaViewerProps } from '../ClaudeScienceMsaViewer';
+import { normalizeArtifactAlignment, type ArtifactAlignment } from '../claude-science-msa';
+import { DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES } from '../claude-science-msa-view-preferences';
+
+function proteinAlignment(nucleotideLike: boolean): ArtifactAlignment {
+  return normalizeArtifactAlignment({
+    id: nucleotideLike ? 'nucleotide-like-protein' : 'protein',
+    name: 'Protein alignment',
+    molecule: 'protein',
+    rows: [
+      { id: 'first', name: 'First sequence', aligned: nucleotideLike ? 'ACGTUNACGTUN' : 'MKWVTFISLLFL' },
+      { id: 'second', name: 'Second sequence', aligned: 'MKYVTFISLLFL' },
+    ],
+  });
+}
+
+function renderViewer(alignment: ArtifactAlignment) {
+  const props: ClaudeScienceMsaViewerProps = {
+    records: [],
+    alignments: [alignment],
+    activeAlignmentId: alignment.id,
+    viewPreferences: DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES,
+    onActiveAlignmentChange: vi.fn(),
+    onViewPreferencesChange: vi.fn(),
+    onSaveAlignment: (nextAlignment) => nextAlignment,
+    onUpdateAlignmentTemplate: () => null,
+    onDeleteAlignment: vi.fn(),
+    onImportRecords: async () => ({ records: [], message: '', tone: 'status' }),
+    onCopy: async () => true,
+    onDownload: vi.fn(),
+  };
+  return render(<ClaudeScienceMsaViewer {...props} />);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ClaudeScienceMsaViewer alphabet warning', () => {
+  it('renders a non-fatal warning for nucleotide-like protein rows and dismisses it', () => {
+    renderViewer(proteinAlignment(true));
+
+    const warning = screen.getByTestId('msa-alphabet-warning');
+    expect(warning.getAttribute('role')).toBe('status');
+    expect(warning.textContent).toContain('1 of 2 sequences contain only nucleotide letters but are displayed as protein.');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss molecule type warning' }));
+    expect(screen.queryByTestId('msa-alphabet-warning')).toBeNull();
+  });
+
+  it('does not render the warning for ordinary protein content', () => {
+    renderViewer(proteinAlignment(false));
+    expect(screen.queryByTestId('msa-alphabet-warning')).toBeNull();
+  });
+});

--- a/src/artifacts/__tests__/ClaudeScienceMsaViewer.correctness.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceMsaViewer.correctness.jsdom.test.tsx
@@ -1,13 +1,17 @@
 /** @vitest-environment jsdom */
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ClaudeScienceMsaViewer,
+  ambiguousColumns,
   classifyMsaCell,
   differenceColumns,
   mismatchOverviewBins,
+  parseReferenceCoordinateColumn,
   pairwiseRowStats,
+  referenceCoordinateLabels,
   type ClaudeScienceMsaViewerProps,
 } from '../ClaudeScienceMsaViewer';
 import { normalizeArtifactAlignment, type ArtifactAlignment } from '../claude-science-msa';
@@ -41,6 +45,7 @@ function singleRowAlignment(): ArtifactAlignment {
 function renderViewer(
   alignment: ArtifactAlignment,
   viewPreferences = DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES,
+  overrides: Partial<ClaudeScienceMsaViewerProps> = {},
 ) {
   const props: ClaudeScienceMsaViewerProps = {
     records: [],
@@ -55,8 +60,37 @@ function renderViewer(
     onImportRecords: async () => ({ records: [], message: '', tone: 'status' }),
     onCopy: async () => true,
     onDownload: vi.fn(),
+    ...overrides,
   };
   return render(<ClaudeScienceMsaViewer {...props} />);
+}
+
+function ReferenceNumberingPersistenceHarness({ initialAlignment }: { initialAlignment: ArtifactAlignment }) {
+  const [alignments, setAlignments] = useState<ArtifactAlignment[]>([initialAlignment]);
+  const [activeAlignmentId, setActiveAlignmentId] = useState(initialAlignment.id);
+  const saveAlignment = (next: ArtifactAlignment): ArtifactAlignment => {
+    const saved = { ...next, id: `${initialAlignment.id}-saved-${alignments.length}` };
+    setAlignments((current) => [...current, saved]);
+    return saved;
+  };
+  return (
+    <ClaudeScienceMsaViewer
+      records={[]}
+      alignments={alignments}
+      activeAlignmentId={activeAlignmentId}
+      viewPreferences={DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES}
+      onActiveAlignmentChange={(alignmentId) => {
+        if (alignmentId) setActiveAlignmentId(alignmentId);
+      }}
+      onViewPreferencesChange={() => {}}
+      onSaveAlignment={saveAlignment}
+      onUpdateAlignmentTemplate={() => null}
+      onDeleteAlignment={() => {}}
+      onImportRecords={async () => ({ records: [], message: '', tone: 'status' })}
+      onCopy={async () => true}
+      onDownload={() => {}}
+    />
+  );
 }
 
 function expectComparisonUnavailable(): void {
@@ -91,6 +125,33 @@ function selectFirstColumn(): void {
   expect(screen.getByTestId('msa-selection-readout')).toBeTruthy();
 }
 
+function alignmentCell(column: number, rowId = 'reference'): HTMLElement {
+  const cell = screen.getByTestId('msa-alignment-view').querySelector<HTMLElement>(
+    `[data-msa-row-id="${rowId}"] [data-alignment-column="${column + 1}"]`,
+  );
+  if (!cell) throw new Error(`Expected alignment cell ${rowId}:${column + 1}.`);
+  return cell;
+}
+
+function selectColumnRangeWithKeyboard(startColumn: number, visibleSteps: number): void {
+  const start = alignmentCell(startColumn);
+  fireEvent.focus(start);
+  if (visibleSteps === 0) fireEvent.keyDown(start, { key: ' ' });
+  else {
+    for (let step = 0; step < visibleSteps; step += 1) {
+      fireEvent.keyDown(start, { key: 'ArrowRight', shiftKey: true });
+    }
+  }
+}
+
+function matrixGeometry(): { cellWidth: number; labelWidth: number } {
+  const frame = screen.getByTestId('msa-alignment-view');
+  return {
+    cellWidth: Number.parseFloat(frame.style.getPropertyValue('--motif-cs-msa-cell-width')),
+    labelWidth: Number.parseFloat(frame.style.getPropertyValue('--motif-cs-msa-label-width')),
+  };
+}
+
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
@@ -119,6 +180,7 @@ describe('ClaudeScienceMsaViewer comparison correctness', () => {
       ungappedLength: 3,
       comparableColumns: 3,
       mismatches: 0,
+      ambiguities: 0,
       identity: 100,
     });
     expect(differenceColumns(alignment, 'reference')).toEqual([]);
@@ -192,12 +254,264 @@ describe('ClaudeScienceMsaViewer comparison correctness', () => {
   });
 });
 
+describe('ClaudeScienceMsaViewer IUPAC-aware differences', () => {
+  it.each([
+    { reference: 'A', row: 'A', molecule: 'dna' as const, outcome: 'match' },
+    { reference: 'A', row: 'C', molecule: 'dna' as const, outcome: 'substitution' },
+    { reference: 'R', row: 'A', molecule: 'dna' as const, outcome: 'ambiguous' },
+    { reference: 'Y', row: 'A', molecule: 'dna' as const, outcome: 'substitution' },
+    { reference: 'N', row: 'N', molecule: 'dna' as const, outcome: 'ambiguous' },
+    { reference: 'T', row: 'U', molecule: 'dna' as const, outcome: 'match' },
+    { reference: 'B', row: 'D', molecule: 'protein' as const, outcome: 'ambiguous' },
+    { reference: 'B', row: 'Q', molecule: 'protein' as const, outcome: 'substitution' },
+    { reference: 'X', row: '*', molecule: 'protein' as const, outcome: 'substitution' },
+    { reference: '?', row: 'A', molecule: 'dna' as const, outcome: 'ambiguous' },
+  ])('classifies $reference versus $row as $outcome', ({ reference, row, molecule, outcome }) => {
+    expect(classifyMsaCell(reference, row, true, molecule)).toBe(outcome);
+  });
+
+  it('keeps gaps structural and makes strict mode use literal equality', () => {
+    expect(classifyMsaCell('N', '-', true, 'dna')).toBe('deletion');
+    expect(classifyMsaCell('-', 'N', true, 'dna')).toBe('insertion');
+    expect(classifyMsaCell('R', 'A', true, 'dna', true)).toBe('substitution');
+    expect(classifyMsaCell('N', 'N', true, 'dna', true)).toBe('match');
+  });
+
+  it('separates hard differences from compatible-only columns', () => {
+    const alignment = alignmentWithRows('iupac-columns', [
+      { id: 'reference', name: 'Reference', aligned: 'ACGT' },
+      { id: 'ambiguous', name: 'Ambiguous', aligned: 'RCGT' },
+      { id: 'hard', name: 'Hard', aligned: 'ACGA' },
+    ]);
+    expect(differenceColumns(alignment, 'reference')).toEqual([3]);
+    expect(ambiguousColumns(alignment, 'reference')).toEqual([0]);
+    expect(differenceColumns(alignment, 'reference', true)).toEqual([0, 3]);
+    expect(ambiguousColumns(alignment, 'reference', true)).toEqual([]);
+  });
+
+  it('keeps compatible calls in density and identity denominators without counting mismatches', () => {
+    const alignment = alignmentWithRows('iupac-overview', [
+      { id: 'reference', name: 'Reference', aligned: 'AA' },
+      { id: 'hard', name: 'Hard', aligned: 'CA' },
+      { id: 'compatible', name: 'Compatible', aligned: 'RA' },
+    ]);
+    expect(mismatchOverviewBins(alignment, 'reference', 2)).toEqual([0.5, 0]);
+    expect(mismatchOverviewBins(alignment, 'reference', 2, true)).toEqual([1, 0]);
+    expect(pairwiseRowStats('RCGT', 'ACGT', 'dna')).toEqual({
+      ungappedLength: 4,
+      comparableColumns: 4,
+      mismatches: 0,
+      ambiguities: 1,
+      identity: 75,
+    });
+  });
+
+  it('renders and counts compatible calls separately, then folds them under strict mode', () => {
+    const alignment = alignmentWithRows('iupac-render', [
+      { id: 'reference', name: 'Reference', aligned: 'ACGT' },
+      { id: 'read', name: 'Read', aligned: 'RCGT' },
+    ]);
+    const defaultView = renderViewer(alignment);
+    let cell = document.querySelector<HTMLElement>('[data-msa-row-id="read"] [data-alignment-column="1"]');
+    expect(cell?.dataset.cellOutcome).toBe('ambiguous');
+    expect(cell?.hasAttribute('data-difference')).toBe(false);
+    expect(screen.getByTestId('msa-stats-bar').textContent).toContain('0 differences in overlap');
+    expect(screen.getByTestId('msa-ambiguous-count').textContent).toContain('1 compatible');
+    defaultView.unmount();
+
+    renderViewer(alignment, { ...DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES, strictDifferences: true });
+    cell = document.querySelector<HTMLElement>('[data-msa-row-id="read"] [data-alignment-column="1"]');
+    expect(cell?.dataset.cellOutcome).toBe('substitution');
+    expect(cell?.hasAttribute('data-difference')).toBe(true);
+    expect(screen.queryByTestId('msa-ambiguous-count')).toBeNull();
+  });
+});
+
+describe('ClaudeScienceMsaViewer reference coordinates', () => {
+  it('labels residues and insertion columns from a pinned starting position', () => {
+    const coordinates = referenceCoordinateLabels('--AC--G-A', 100);
+    expect(coordinates.map((coordinate) => coordinate.label)).toEqual([
+      '99A', '99B', '100', '101', '101A', '101B', '102', '102A', '103',
+    ]);
+    const longInsertion = referenceCoordinateLabels(`A${'-'.repeat(28)}C`, 7);
+    expect(longInsertion[26].label).toBe('7Z');
+    expect(longInsertion[27].label).toBe('7AA');
+    expect(longInsertion[28].label).toBe('7AB');
+    expect(longInsertion[29].label).toBe('8');
+
+    const carry = referenceCoordinateLabels(`A${'-'.repeat(703)}C`, 100);
+    expect(carry[702]).toEqual({ referencePosition: 100, insertionCode: 'ZZ', label: '100ZZ' });
+    expect(carry[703]).toEqual({ referencePosition: 100, insertionCode: 'AAA', label: '100AAA' });
+  });
+
+  it('maps case-insensitive display coordinates back to alignment columns', () => {
+    const coordinates = referenceCoordinateLabels('AC--GT', 100);
+    expect(parseReferenceCoordinateColumn('100', coordinates)).toBe(0);
+    expect(parseReferenceCoordinateColumn('101a', coordinates)).toBe(2);
+    expect(parseReferenceCoordinateColumn('101B', coordinates)).toBe(3);
+    for (const invalid of ['101C', '101 A', 'A101', '101.5', '101A2', '-1', '', '999']) {
+      expect(parseReferenceCoordinateColumn(invalid, coordinates)).toBeNull();
+    }
+    const leading = referenceCoordinateLabels('-A', 1);
+    expect(parseReferenceCoordinateColumn('0A', leading)).toBe(0);
+  });
+
+  it('renders a reference axis and accepts insertion-code coordinate jumps', () => {
+    const alignment = normalizeArtifactAlignment({
+      id: 'reference-axis',
+      name: 'reference-axis',
+      molecule: 'dna',
+      referenceRowId: 'reference',
+      referenceNumbering: { rowId: 'reference', firstResiduePosition: 100 },
+      rows: [
+        { id: 'reference', name: 'Reference', aligned: 'AC--GT' },
+        { id: 'read', name: 'Read', aligned: 'ACTTGT' },
+      ],
+    });
+    renderViewer(alignment);
+
+    expect(screen.getByRole('row', { name: 'Reference positions for Reference' })).toBeTruthy();
+    expect(document.querySelector('[data-reference-coordinate="101A"]')).toBeTruthy();
+    const coordinateSystem = screen.getByTestId('msa-coordinate-system') as HTMLSelectElement;
+    fireEvent.change(coordinateSystem, { target: { value: 'template' } });
+    const input = screen.getByTestId('msa-coordinate-input') as HTMLInputElement;
+    const viewport = screen.getByTestId('msa-alignment-view').querySelector<HTMLElement>('.motif-cs-msa-matrix-scroll');
+    if (!viewport) throw new Error('Expected the alignment viewport.');
+    Object.defineProperty(viewport, 'scrollTo', { configurable: true, value: vi.fn() });
+    expect(input.type).toBe('text');
+    expect(input.placeholder).toBe('101 or 101A');
+    fireEvent.change(input, { target: { value: '101a' } });
+    fireEvent.submit(input.closest('form')!);
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('saves reference numbering as a new result without changing the comparison row', () => {
+    const alignment = alignmentWithRows('reference-editor', [
+      { id: 'comparison', name: 'Comparison', aligned: 'ACGT' },
+      { id: 'numbering', name: 'Numbering', aligned: 'A-GT' },
+    ]);
+    const onSaveAlignment = vi.fn((next: ArtifactAlignment) => ({ ...next, id: 'numbered-result' }));
+    const onActiveAlignmentChange = vi.fn();
+    renderViewer(alignment, DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES, {
+      onSaveAlignment,
+      onActiveAlignmentChange,
+    });
+
+    fireEvent.click(screen.getByTestId('msa-view-menu-button'));
+    fireEvent.change(screen.getByLabelText('Numbering reference row'), { target: { value: 'numbering' } });
+    fireEvent.change(screen.getByTestId('msa-reference-numbering-position'), { target: { value: '500' } });
+    fireEvent.click(screen.getByTestId('msa-apply-reference-numbering'));
+
+    expect(onSaveAlignment).toHaveBeenCalledWith(expect.objectContaining({
+      referenceRowId: 'comparison',
+      referenceNumbering: { rowId: 'numbering', firstResiduePosition: 500 },
+    }));
+    expect(onActiveAlignmentChange).toHaveBeenCalledWith('numbered-result');
+  });
+
+  it('clears numbering by saving a result without the metadata', () => {
+    const alignment = normalizeArtifactAlignment({
+      id: 'clear-reference-numbering',
+      name: 'Clear reference numbering',
+      molecule: 'dna',
+      referenceRowId: 'reference',
+      referenceNumbering: { rowId: 'reference', firstResiduePosition: 100 },
+      rows: [
+        { id: 'reference', name: 'Reference', aligned: 'A-C' },
+        { id: 'second', name: 'Second', aligned: 'ATC' },
+      ],
+    });
+    const onSaveAlignment = vi.fn((next: ArtifactAlignment) => ({ ...next, id: 'plain-result' }));
+    renderViewer(alignment, DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES, { onSaveAlignment });
+
+    fireEvent.click(screen.getByTestId('msa-view-menu-button'));
+    const clear = screen.getByTestId('msa-clear-reference-numbering') as HTMLButtonElement;
+    expect(clear.disabled).toBe(false);
+    fireEvent.click(clear);
+    expect(onSaveAlignment).toHaveBeenCalledTimes(1);
+    expect(onSaveAlignment.mock.calls[0][0]).not.toHaveProperty('referenceNumbering');
+  });
+
+  it('opens saved numbered and plain results while preserving status', async () => {
+    const alignment = alignmentWithRows('reference-numbering-persistence', [
+      { id: 'reference', name: 'Reference', aligned: 'A-C' },
+      { id: 'second', name: 'Second', aligned: 'ATC' },
+    ]);
+    render(<ReferenceNumberingPersistenceHarness initialAlignment={alignment} />);
+
+    fireEvent.click(screen.getByTestId('msa-view-menu-button'));
+    fireEvent.change(screen.getByTestId('msa-reference-numbering-position'), { target: { value: '100' } });
+    fireEvent.click(screen.getByTestId('msa-apply-reference-numbering'));
+    await waitFor(() => expect(screen.getByRole('row', { name: 'Reference positions for Reference' })).toBeTruthy());
+    expect(screen.getByTestId('msa-reference-numbering-editor').textContent).toContain('saved as a new session result');
+
+    fireEvent.click(screen.getByTestId('msa-clear-reference-numbering'));
+    await waitFor(() => expect(screen.getByRole('row', { name: 'Template positions for Reference' })).toBeTruthy());
+    expect(screen.getByTestId('msa-reference-numbering-editor').textContent).toContain('Plain 1-based');
+  });
+});
+
 describe('ClaudeScienceMsaViewer selection interactions', () => {
   const alignment = alignmentWithRows('selection-interactions', [
     { id: 'reference', name: 'Reference', aligned: 'ACGT' },
     { id: 'second', name: 'Second', aligned: 'ACGA' },
     { id: 'third', name: 'Third', aligned: 'ACGG' },
   ]);
+
+  it('defers pointer-drag statistics until settle while keeping coordinates live', () => {
+    renderViewer(alignment);
+    const view = screen.getByTestId('msa-alignment-view');
+    const viewport = view.querySelector<HTMLElement>('.motif-cs-msa-matrix-scroll');
+    const referenceRow = view.querySelector<HTMLElement>('[data-msa-row-id="reference"]');
+    const thirdRow = view.querySelector<HTMLElement>('[data-msa-row-id="third"]');
+    if (!viewport || !referenceRow || !thirdRow) throw new Error('Expected matrix pointer targets.');
+    vi.spyOn(viewport, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 800,
+      bottom: 400,
+      width: 800,
+      height: 400,
+      toJSON: () => ({}),
+    });
+    Object.defineProperty(document, 'elementFromPoint', {
+      configurable: true,
+      value: vi.fn((_clientX: number, clientY: number) => (clientY < 120 ? referenceRow : thirdRow)),
+    });
+    Object.defineProperty(viewport, 'setPointerCapture', { configurable: true, value: vi.fn() });
+    Object.defineProperty(viewport, 'hasPointerCapture', { configurable: true, value: vi.fn(() => false) });
+    const { cellWidth, labelWidth } = matrixGeometry();
+    const columnX = (column: number) => labelWidth + ((column + 0.5) * cellWidth);
+
+    fireEvent.pointerDown(viewport, { button: 0, buttons: 1, clientX: columnX(0), clientY: 90, pointerId: 8 });
+    expect(screen.getByTestId('msa-selection-readout').textContent).toContain('cols 1–1 (1)');
+    expect(screen.getByTestId('msa-selection-variable').textContent).toBe('· … variable');
+    expect(screen.getByTestId('msa-selection-identity').textContent).toBe('· … mean id');
+
+    fireEvent.pointerMove(viewport, { buttons: 1, clientX: columnX(1), clientY: 150, pointerId: 8 });
+    expect(screen.getByTestId('msa-selection-readout').textContent).toContain('cols 1–2 (2)· template 1–2· 3 rows');
+    expect(screen.getByTestId('msa-selection-variable').textContent).toBe('· … variable');
+
+    fireEvent.pointerMove(viewport, { buttons: 1, clientX: columnX(3), clientY: 150, pointerId: 8 });
+    expect(screen.getByTestId('msa-selection-readout').textContent).toContain('cols 1–4 (4)· template 1–4· 3 rows');
+    expect(screen.getByTestId('msa-selection-identity').textContent).toBe('· … mean id');
+
+    fireEvent.pointerUp(viewport, { button: 0, clientX: columnX(3), clientY: 150, pointerId: 8 });
+    expect(screen.getByTestId('msa-selection-variable').textContent).toBe('· 1 variable');
+    expect(screen.getByTestId('msa-selection-identity').textContent).toBe('· 83% mean id');
+  });
+
+  it('shows complete settled statistics immediately for keyboard selection', () => {
+    renderViewer(alignment);
+    selectColumnRangeWithKeyboard(1, 1);
+
+    expect(screen.queryByText('· … variable')).toBeNull();
+    expect(screen.getByTestId('msa-selection-readout').textContent).toBe(
+      'Selectedcols 2–3 (2)· template 2–3· 1 row· 0 variable· 100% mean idClear',
+    );
+  });
 
   it('preserves selection when a row grip is pressed and released without reordering', () => {
     renderViewer(alignment);

--- a/src/artifacts/__tests__/ClaudeScienceMsaViewer.row-stats-panel.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceMsaViewer.row-stats-panel.jsdom.test.tsx
@@ -84,16 +84,34 @@ describe('ClaudeScienceMsaViewer row statistics panel', () => {
     expect(screen.getAllByTestId('msa-row-stats-row')).toHaveLength(alignment.rows.length);
 
     const expected = {
-      template: ['0', '5 bp', '100.0%'],
-      zulu: ['2', '6 bp', '66.7%'],
-      alpha: ['0', '4 bp', '100.0%'],
-      middle: ['1', '5 bp', '80.0%'],
+      template: ['0', '5 bp', '100.0%', '0'],
+      zulu: ['2', '6 bp', '66.7%', '0'],
+      alpha: ['0', '4 bp', '100.0%', '0'],
+      middle: ['1', '5 bp', '80.0%', '0'],
     };
     for (const [rowId, values] of Object.entries(expected)) {
       const cells = panelRow(rowId).querySelectorAll('td');
       expect(Array.from(cells).slice(1).map((cell) => cell.textContent)).toEqual(values);
     }
     expect(panelRow('template').textContent).toContain('Template');
+  });
+
+  it('reports compatible ambiguity calls separately from hard differences', () => {
+    const sourceAlignment = normalizeArtifactAlignment({
+      id: 'compatible-row-statistics',
+      name: 'Compatible row statistics',
+      molecule: 'dna',
+      referenceRowId: 'template',
+      rows: [
+        { id: 'template', name: 'Template', aligned: 'ACGT' },
+        { id: 'compatible', name: 'Compatible', aligned: 'RCGT' },
+      ],
+    });
+    render(<StatefulViewer sourceAlignment={sourceAlignment} />);
+
+    expect(Array.from(panelRow('compatible').querySelectorAll('td')).slice(1).map((cell) => cell.textContent)).toEqual([
+      '0', '4 bp', '75.0%', '1',
+    ]);
   });
 
   it('uses the persisted sort mode for both the panel and matrix', () => {

--- a/src/artifacts/__tests__/claude-science-msa-analytics.test.ts
+++ b/src/artifacts/__tests__/claude-science-msa-analytics.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   computeMsaColumnStats,
   computeSequenceLogoColumns,
+  detectAlphabetAnomalies,
   msaShadeBucket,
   residueColorKey,
   sliceSelectionRows,
@@ -15,6 +16,62 @@ import {
   normalizeArtifactAlignment,
   type ArtifactAlignment,
 } from '../claude-science-msa';
+
+describe('detectAlphabetAnomalies', () => {
+  it('flags meaningful protein-declared rows containing only nucleotide letters', () => {
+    expect(detectAlphabetAnomalies([
+      { id: 'nucleotide-like', name: 'Nucleotide-like row', aligned: 'ACGTUNACGTUN' },
+      { id: 'protein', name: 'Protein row', aligned: 'MKWVTFISLLFL' },
+    ], 'protein')).toEqual([{
+      rowId: 'nucleotide-like',
+      label: 'Nucleotide-like row',
+      reason: 'only nucleotide letters (A/C/G/T/U/N)',
+    }]);
+  });
+
+  it('ignores gaps and unknowns but not short or non-protein inputs', () => {
+    expect(detectAlphabetAnomalies([{ id: 'gapped', aligned: 'AC-GT?UNAC.GT' }], 'protein'))
+      .toHaveLength(1);
+    expect(detectAlphabetAnomalies([{ id: 'short', aligned: 'ACGTUN' }], 'protein')).toEqual([]);
+    expect(detectAlphabetAnomalies([{ id: 'dna', aligned: 'ACGTUNACGTUN' }], 'dna')).toEqual([]);
+  });
+});
+
+describe('protein ambiguity matching', () => {
+  it('uses B, Z, J, and X consistently in motif search', () => {
+    const rows = [{ id: 'protein', name: 'Protein', aligned: 'DNEQILAFW' }];
+    const startsFor = (query: string) => findMsaMotifMatches(rows, query, { molecule: 'protein' })
+      .matches.map((match) => match.startColumn);
+
+    expect(startsFor('B')).toEqual([0, 1]);
+    expect(startsFor('Z')).toEqual([2, 3]);
+    expect(startsFor('J')).toEqual([4, 5]);
+    expect(startsFor('X')).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(startsFor('A')).toEqual([6]);
+  });
+
+  it.each([
+    { ambiguity: 'B', residue: 'D' },
+    { ambiguity: 'B', residue: 'N' },
+    { ambiguity: 'Z', residue: 'E' },
+    { ambiguity: 'Z', residue: 'Q' },
+    { ambiguity: 'J', residue: 'I' },
+    { ambiguity: 'J', residue: 'L' },
+    { ambiguity: 'X', residue: 'W' },
+  ])('keeps protein identity and search aligned for $ambiguity and $residue', ({ ambiguity, residue }) => {
+    const alignment = normalizeArtifactAlignment({
+      molecule: 'protein',
+      rows: [
+        { id: 'ambiguity', name: 'Ambiguity', aligned: ambiguity },
+        { id: 'residue', name: 'Residue', aligned: residue },
+      ],
+    });
+    expect(alignment.rows.map((row) => row.identity)).toEqual([100, 100]);
+    expect(findMsaMotifMatches([
+      { id: 'residue', name: 'Residue', aligned: residue },
+    ], ambiguity, { molecule: 'protein' }).matches).toHaveLength(1);
+  });
+});
 
 function dnaAlignment(): ArtifactAlignment {
   return normalizeArtifactAlignment({

--- a/src/artifacts/__tests__/claude-science-msa-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-msa-guards.test.ts
@@ -136,8 +136,9 @@ describe('Claude Science MSA interaction and rendering guards', () => {
     expect(coverageHelpers).toContain("if (rowResidue === '-' && !isColumnCoveredByRow) return 'uncovered';");
     expect(coverageHelpers).toContain('!coversColumn(referenceCoverage, column)');
     expect(coverageHelpers).toContain('coversColumn(rowCoverage.get(row.id) ?? null, column)');
-    expect(coverageHelpers).toContain('classifyMsaCell(templateSymbol, symbol, coversColumn(rowCoverage, column))');
-    expect(coverageHelpers).toContain('classifyMsaCell(templateSymbol, symbol, coversColumn(rowCoverage[rowIndex], column))');
+    expect(coverageHelpers).toContain('const outcome = classifyMsaCell(');
+    expect(coverageHelpers).toContain('coversColumn(rowCoverage[rowIndex], column),');
+    expect(coverageHelpers).toContain('alignment.molecule,');
   });
 
   it('runs browser alignment only from an explicit bounded action', () => {
@@ -237,7 +238,7 @@ describe('Claude Science MSA interaction and rendering guards', () => {
     expect(viewerSource).toContain('return template ? [template, ...nonTemplateRows] : nonTemplateRows;');
     expect(viewPreferencesSource).toContain("export type ClaudeScienceMsaRowSortMode = 'original' | 'name' | 'identity' | 'mismatches' | 'length';");
     expect(viewerSource).toContain('<option value="mismatches">Mismatches</option>');
-    expect(viewerSource).toContain('pairwiseRowStats(row.aligned, template?.aligned ?? \'\')');
+    expect(viewerSource).toContain("pairwiseRowStats(row.aligned, template?.aligned ?? '', alignment.molecule, strictDifferences)");
     expect(viewerSource).toContain('{stats.mismatches.toLocaleString()}Δ');
     expect(viewerSource).toContain('{stats.ungappedLength.toLocaleString()} {sequenceUnit(alignment.molecule)}');
     expect(viewerSource).toContain("Array.from(name.matchAll(/[^\\s_./-]+/g))");
@@ -246,7 +247,7 @@ describe('Claude Science MSA interaction and rendering guards', () => {
     expect(artifactCss).toMatch(/\.motif-cs-msa-row-name-trailing\s*\{[\s\S]*?flex:\s*0 0 auto/);
   });
 
-  it('adds exact dual-coordinate navigation and a gap-correct virtualized template axis', () => {
+  it('adds exact alignment, template, and optional reference navigation with a gap-correct virtualized axis', () => {
     const matrix = sliceBetween(viewerSource, 'function AlignmentMatrix({', 'export function ClaudeScienceMsaViewer({');
     expect(viewerSource).toContain('function templatePositionCoordinates(aligned: string): Array<number | null>');
     expect(viewerSource).toContain("if (aligned[column] === '-') coordinates[column] = null;");
@@ -259,9 +260,12 @@ describe('Claude Science MSA interaction and rendering guards', () => {
     expect(matrix).toContain('Alignment positions count gapped columns. Template positions count non-gap residues');
     expect(viewerSource).toContain('data-testid="msa-coordinate-system"');
     expect(viewerSource).toContain('data-testid="msa-coordinate-input"');
-    expect(viewerSource).toContain("coordinateSystem === 'alignment' ? 'Go to alignment column' : 'Go to template position'");
-    expect(viewerSource).toContain('min={1}');
+    expect(viewerSource).toContain("activeReferenceCoordinates ? 'Go to reference position' : 'Go to template position'");
+    expect(viewerSource).toContain("min={coordinateSystem === 'template' && activeReferenceCoordinates ? undefined : 1}");
     expect(viewerSource).toContain("templatePositionCoordinates(template?.aligned ?? '').findIndex((position) => position === requested)");
+    expect(viewerSource).toContain('parseReferenceCoordinateColumn(normalized, activeReferenceCoordinates)');
+    expect(matrix).toContain('data-reference-coordinate={referenceCoordinate?.label}');
+    expect(viewerSource).toContain('data-testid="msa-reference-numbering-editor"');
     expect(viewerSource).toContain('setJumpColumn(column);');
     expect(viewerSource).toContain('setJumpToken((token) => token + 1);');
     expect(viewerSource).toContain('role="status" aria-live="polite"');

--- a/src/artifacts/__tests__/claude-science-msa-view-preferences.test.ts
+++ b/src/artifacts/__tests__/claude-science-msa-view-preferences.test.ts
@@ -35,6 +35,7 @@ describe('Claude Science MSA view preferences', () => {
       showSequenceLogo: true,
       showTranslation: true,
       showAminoAcidIndices: false,
+      strictDifferences: true,
     })).toEqual({
       displayMode: 'text',
       emphasis: 'letters',
@@ -58,6 +59,7 @@ describe('Claude Science MSA view preferences', () => {
       showSequenceLogo: true,
       showTranslation: true,
       showAminoAcidIndices: false,
+      strictDifferences: true,
     });
   });
 
@@ -115,6 +117,12 @@ describe('Claude Science MSA view preferences', () => {
     expect(normalizeClaudeScienceMsaViewPreferences({ showAminoAcidIndices: false }).showAminoAcidIndices).toBe(false);
     expect(normalizeClaudeScienceMsaViewPreferences({ translationFrame: 2 }).translationFrame).toBe(2);
     expect(normalizeClaudeScienceMsaViewPreferences({ translationFrame: 5 }).translationFrame).toBe(0);
+  });
+
+  it('keeps strict differences opt-in so IUPAC-aware highlighting is the default', () => {
+    expect(normalizeClaudeScienceMsaViewPreferences({}).strictDifferences).toBe(false);
+    expect(normalizeClaudeScienceMsaViewPreferences({ strictDifferences: 'yes' }).strictDifferences).toBe(false);
+    expect(normalizeClaudeScienceMsaViewPreferences({ strictDifferences: true }).strictDifferences).toBe(true);
   });
 
   it('falls back to safe colour/shade defaults and keeps occupancy opt-in', () => {

--- a/src/artifacts/__tests__/claude-science-msa.test.ts
+++ b/src/artifacts/__tests__/claude-science-msa.test.ts
@@ -169,6 +169,40 @@ describe('Claude Science alignment normalization', () => {
     }), 'invalid_alignment');
   });
 
+  it('validates optional reference-numbering metadata against its pinned row and coordinate range', () => {
+    const base = {
+      molecule: 'dna' as const,
+      rows: [
+        { id: 'alpha', name: 'Alpha', aligned: 'A-CG' },
+        { id: 'beta', name: 'Beta', aligned: 'ATCG' },
+      ],
+    };
+    const invalidReferenceNumbering: unknown[] = [
+      null,
+      [],
+      'alpha:100',
+      {},
+      { rowId: '', firstResiduePosition: 100 },
+      { rowId: 'missing', firstResiduePosition: 100 },
+      { rowId: 'alpha', firstResiduePosition: '100' },
+      { rowId: 'alpha', firstResiduePosition: 0 },
+      { rowId: 'alpha', firstResiduePosition: 1.5 },
+      { rowId: 'alpha', firstResiduePosition: Number.MAX_SAFE_INTEGER },
+    ];
+    for (const referenceNumbering of invalidReferenceNumbering) {
+      expectAlignmentError(
+        () => normalizeArtifactAlignment({ ...base, referenceNumbering } as unknown),
+        'invalid_alignment',
+      );
+    }
+
+    expect(normalizeArtifactAlignment({
+      ...base,
+      referenceNumbering: { rowId: 'alpha', firstResiduePosition: 1 },
+    }).referenceNumbering).toEqual({ rowId: 'alpha', firstResiduePosition: 1 });
+    expect(normalizeArtifactAlignment(base)).not.toHaveProperty('referenceNumbering');
+  });
+
   it('rejects row and alignment names that could inject extra FASTA records', () => {
     expectAlignmentError(() => normalizeArtifactAlignment({
       name: 'review\n>forged-alignment',
@@ -448,6 +482,25 @@ describe('Claude Science alignment handoff formats', () => {
 
     if (typeof serialized.engine !== 'string' && serialized.engine?.parameters) serialized.engine.parameters[0] = '--changed';
     expect(alignment.engine.parameters).toEqual(['--auto']);
+  });
+
+  it('round-trips reference numbering defensively without changing FASTA or CLUSTAL bytes', () => {
+    const numbered = normalizeArtifactAlignment({
+      ...serializeArtifactAlignment(alignment),
+      referenceNumbering: { rowId: 'alpha', firstResiduePosition: 100 },
+    });
+    const serialized = serializeArtifactAlignment(numbered);
+
+    expect(serialized.referenceNumbering).toEqual({ rowId: 'alpha', firstResiduePosition: 100 });
+    expect(normalizeArtifactAlignment(serialized).referenceNumbering).toEqual({
+      rowId: 'alpha',
+      firstResiduePosition: 100,
+    });
+    expect(formatAlignedFasta(numbered)).toBe(formatAlignedFasta(alignment));
+    expect(formatClustal(numbered)).toBe(formatClustal(alignment));
+
+    if (serialized.referenceNumbering) serialized.referenceNumbering.firstResiduePosition = 250;
+    expect(numbered.referenceNumbering?.firstResiduePosition).toBe(100);
   });
 
   it('creates defensive MSA results and safe download names', () => {

--- a/src/artifacts/claude-science-msa-view-preferences.ts
+++ b/src/artifacts/claude-science-msa-view-preferences.ts
@@ -85,6 +85,8 @@ export type ClaudeScienceMsaViewPreferences = {
   showSequenceLogo: boolean;
   showTranslation: boolean;
   showAminoAcidIndices: boolean;
+  /** Treat every non-identical residue symbol as a hard difference. */
+  strictDifferences: boolean;
 };
 
 export const DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES: ClaudeScienceMsaViewPreferences = {
@@ -110,6 +112,7 @@ export const DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES: ClaudeScienceMsaViewPr
   showSequenceLogo: false,
   showTranslation: false,
   showAminoAcidIndices: true,
+  strictDifferences: false,
 };
 
 export function normalizeClaudeScienceMsaViewPreferences(value: unknown): ClaudeScienceMsaViewPreferences {
@@ -124,7 +127,7 @@ export function normalizeClaudeScienceMsaViewPreferences(value: unknown): Claude
     typeof source[key] === 'boolean' ? source[key] as boolean : true
   );
   // Toggles that default to off unless explicitly enabled.
-  const optional = (key: keyof Pick<ClaudeScienceMsaViewPreferences, 'showOccupancy' | 'showSequenceLogo' | 'showTranslation' | 'showRowStatsPanel'>) => (
+  const optional = (key: keyof Pick<ClaudeScienceMsaViewPreferences, 'showOccupancy' | 'showSequenceLogo' | 'showTranslation' | 'showRowStatsPanel' | 'strictDifferences'>) => (
     source[key] === true
   );
   return {
@@ -162,5 +165,6 @@ export function normalizeClaudeScienceMsaViewPreferences(value: unknown): Claude
     showSequenceLogo: optional('showSequenceLogo'),
     showTranslation: optional('showTranslation'),
     showAminoAcidIndices: visible('showAminoAcidIndices'),
+    strictDifferences: optional('strictDifferences'),
   };
 }

--- a/src/artifacts/claude-science-msa.css
+++ b/src/artifacts/claude-science-msa.css
@@ -10,6 +10,27 @@
 
 /* The matrix hosts absolutely-positioned selection/hover overlays. Each state
    owns a separate visual channel so stacked states remain readable. */
+.motif-cs-msa-workspace .motif-cs-msa-alphabet-warning {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 12px;
+  margin: 6px 0;
+  padding: 7px 10px;
+  border: 1px solid color-mix(in srgb, var(--amber) 48%, var(--border));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--amber) 10%, var(--bg-primary));
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.motif-cs-msa-workspace .motif-cs-msa-alphabet-warning > span {
+  min-width: 0;
+  flex: 1 1 320px;
+}
+.motif-cs-msa-workspace .motif-cs-msa-alphabet-warning strong { color: var(--text-primary); }
+.motif-cs-msa-workspace .motif-cs-msa-alphabet-warning .motif-cs-mini-button { margin-left: auto; }
+
 .motif-cs-msa-matrix {
   position: relative;
   --motif-cs-msa-selection-rule: color-mix(in srgb, var(--accent) 86%, var(--text-primary));
@@ -172,6 +193,15 @@
 }
 .motif-cs-msa-symbol[data-jump='true'][data-difference='true'] {
   background: color-mix(in srgb, var(--amber) 10%, transparent);
+}
+
+.motif-cs-msa-symbol[data-cell-outcome='ambiguous']:not([data-active-cell='true']) {
+  outline: 1px dashed color-mix(in srgb, var(--text-secondary) 55%, transparent);
+  outline-offset: -2px;
+}
+
+.motif-cs-msa-stats-ambiguous {
+  color: var(--text-secondary);
 }
 
 /* ===== Histogram tracks (conservation + occupancy) ===== */
@@ -354,6 +384,86 @@
 .motif-cs-msa-view-select select:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* ===== Alignment-owned reference numbering editor ===== */
+.motif-cs-msa-reference-numbering {
+  display: grid;
+  gap: 6px;
+  margin-top: 4px;
+  padding: 7px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--control-bg);
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+.motif-cs-msa-reference-numbering[data-active='true'] {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border-subtle));
+}
+.motif-cs-msa-reference-numbering-heading,
+.motif-cs-msa-reference-numbering-position,
+.motif-cs-msa-reference-numbering-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.motif-cs-msa-reference-numbering-heading > span {
+  color: var(--text-muted);
+  font: 9px/1 var(--font-mono);
+}
+.motif-cs-msa-reference-numbering-position .motif-cs-input {
+  width: 96px;
+  min-width: 0;
+  min-height: 26px;
+  padding: 3px 5px;
+  font: 10px/1 var(--font-mono);
+}
+.motif-cs-msa-reference-numbering > small {
+  color: var(--text-muted);
+  font-size: 9px;
+  line-height: 1.35;
+}
+.motif-cs-msa-reference-numbering-actions {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+.motif-cs-msa-reference-numbering-error {
+  color: var(--red);
+  font-size: 9px;
+  line-height: 1.3;
+}
+.motif-cs-msa-reference-numbering-status {
+  min-height: 12px;
+  color: var(--text-muted);
+  font-size: 9px;
+  line-height: 1.3;
+}
+.motif-cs-msa-reference-numbering-status[data-empty='true'] {
+  display: none;
+}
+
+.motif-cs-msa-column-jump input[type='text'] {
+  width: 82px;
+}
+
+.motif-cs-msa-ruler-cell[data-reference-coordinate] {
+  font-family: var(--font-mono);
+  font-size: 8px;
+}
+.motif-cs-msa-ruler-cell[data-reference-insertion] {
+  box-sizing: border-box;
+  align-items: flex-start;
+  padding-top: 1px;
+  font-size: 7.5px;
+  line-height: 1;
+}
+.motif-cs-msa-ruler-cell[data-reference-insertion][data-reference-label-lane='1'] {
+  padding-top: 9px;
+}
+.motif-cs-msa-ruler-cell[data-reference-insertion][data-reference-label-lane='2'] {
+  padding-top: 17px;
 }
 
 /* ===== Contextual residue colour key ===== */

--- a/src/artifacts/claude-science-msa.ts
+++ b/src/artifacts/claude-science-msa.ts
@@ -131,12 +131,18 @@ export type ArtifactAlignmentRowInput = {
   inputSha256?: string;
 };
 
+export type ArtifactAlignmentReferenceNumbering = {
+  rowId: string;
+  firstResiduePosition: number;
+};
+
 export type ArtifactAlignmentInput = {
   id?: string;
   name?: string;
   molecule?: SequenceType;
   type?: SequenceType;
   referenceRowId?: string;
+  referenceNumbering?: ArtifactAlignmentReferenceNumbering;
   rows?: ArtifactAlignmentRowInput[];
   sequences?: ArtifactAlignmentRowInput[];
   alignedFasta?: string;
@@ -169,6 +175,7 @@ export type ArtifactAlignment = {
   name: string;
   molecule: SequenceType;
   referenceRowId: string;
+  referenceNumbering?: ArtifactAlignmentReferenceNumbering;
   rows: ArtifactAlignmentRow[];
   engine: ArtifactAlignmentEngine;
   createdAt?: string;
@@ -256,8 +263,44 @@ function cleanAlignedSequence(value: unknown, field: string): string {
   return value.toUpperCase().replace(/\./g, '-').replace(/\s+/g, '');
 }
 
+const IUPAC_PROTEINS: Record<string, string> = {
+  B: 'DN', Z: 'EQ', J: 'IL', X: 'ACDEFGHIKLMNPQRSTVWY',
+};
+
+function proteinResiduesMatch(left: string, right: string): boolean {
+  const leftSet = IUPAC_PROTEINS[left] ?? left;
+  const rightSet = IUPAC_PROTEINS[right] ?? right;
+  for (const residue of leftSet) if (rightSet.includes(residue)) return true;
+  return false;
+}
+
+export type MsaAlphabetAnomaly = {
+  rowId: string;
+  label?: string;
+  reason: string;
+};
+
+const PROTEIN_NUCLEOTIDE_WARNING_MIN_RESIDUES = 10;
+
+export function detectAlphabetAnomalies(
+  rows: readonly { id: string; name?: string; aligned: string }[],
+  molecule: SequenceType,
+): MsaAlphabetAnomaly[] {
+  if (molecule !== 'protein') return [];
+  return rows.flatMap((row) => {
+    const residues = row.aligned.toUpperCase().replace(/[-.?]/g, '');
+    if (residues.length < PROTEIN_NUCLEOTIDE_WARNING_MIN_RESIDUES || !/^[ACGTUN]+$/.test(residues)) return [];
+    return [{
+      rowId: row.id,
+      label: row.name,
+      reason: 'only nucleotide letters (A/C/G/T/U/N)',
+    }];
+  });
+}
+
 function summarizeRows(
   rows: Array<Omit<ArtifactAlignmentRow, 'identity'>>,
+  molecule: SequenceType = 'dna',
 ): Pick<ArtifactAlignment, 'rows' | 'consensus' | 'conserved' | 'gapOnly' | 'alignmentLength'> {
   const alignmentLength = rows[0]?.aligned.length ?? 0;
   let consensus = '';
@@ -287,7 +330,9 @@ function summarizeRows(
     for (let column = 0; column < alignmentLength; column += 1) {
       if (consensus[column] === '-') continue;
       total += 1;
-      if (row.aligned[column] === consensus[column]) matches += 1;
+      if (molecule === 'protein'
+        ? proteinResiduesMatch(row.aligned[column], consensus[column])
+        : row.aligned[column] === consensus[column]) matches += 1;
     }
     return {
       ...row,
@@ -498,7 +543,7 @@ export function normalizeArtifactAlignment(
     }
   }
 
-  const summary = summarizeRows(rows);
+  const summary = summarizeRows(rows, molecule);
   const id = safeId(raw.id, `alignment-${index + 1}`, `alignments[${index}].id`);
   let referenceRowId = rows[0].id;
   if (raw.referenceRowId !== undefined) {
@@ -508,11 +553,36 @@ export function normalizeArtifactAlignment(
     }
     referenceRowId = requestedReference;
   }
+  let referenceNumbering: ArtifactAlignmentReferenceNumbering | undefined;
+  if (raw.referenceNumbering !== undefined) {
+    if (!plainObject(raw.referenceNumbering)) {
+      throw new ArtifactAlignmentError('invalid_alignment', `alignments[${index}].referenceNumbering must be an object.`);
+    }
+    const numberingRowId = safeId(
+      raw.referenceNumbering.rowId,
+      '',
+      `alignments[${index}].referenceNumbering.rowId`,
+    );
+    const numberingRow = rows.find((row) => row.id === numberingRowId);
+    if (!numberingRow) {
+      throw new ArtifactAlignmentError('invalid_alignment', `Alignment referenceNumbering rowId “${numberingRowId}” does not match a row id.`);
+    }
+    const firstResiduePosition = raw.referenceNumbering.firstResiduePosition;
+    if (!Number.isSafeInteger(firstResiduePosition) || firstResiduePosition < 1) {
+      throw new ArtifactAlignmentError('invalid_alignment', `alignments[${index}].referenceNumbering.firstResiduePosition must be a positive safe integer.`);
+    }
+    const residueCount = numberingRow.aligned.replace(/-/g, '').length;
+    if (!Number.isSafeInteger(firstResiduePosition + residueCount - 1)) {
+      throw new ArtifactAlignmentError('invalid_alignment', `alignments[${index}].referenceNumbering exceeds the safe integer coordinate range.`);
+    }
+    referenceNumbering = { rowId: numberingRowId, firstResiduePosition };
+  }
   return {
     id,
     name: normalizedHeaderText(raw.name, `Alignment ${index + 1}`, `alignments[${index}].name`),
     molecule,
     referenceRowId,
+    ...(referenceNumbering ? { referenceNumbering } : {}),
     ...summary,
     engine: normalizeEngine(raw.engine),
     createdAt: raw.createdAt === undefined ? undefined : normalizedText(raw.createdAt, '', `alignments[${index}].createdAt`) || undefined,
@@ -650,6 +720,9 @@ export function serializeArtifactAlignment(alignment: ArtifactAlignment): Artifa
     name: alignment.name,
     molecule: alignment.molecule,
     referenceRowId: alignment.referenceRowId,
+    ...(alignment.referenceNumbering
+      ? { referenceNumbering: { ...alignment.referenceNumbering } }
+      : {}),
     rows: alignment.rows.map((row) => ({
       id: row.id,
       name: row.name,
@@ -1139,8 +1212,27 @@ function nucleotidesMatch(query: string, target: string): boolean {
 }
 
 function residueMatch(query: string, target: string, molecule: SequenceType): boolean {
-  if (molecule === 'protein') return query === target || query === 'X' || target === 'X';
+  if (molecule === 'protein') return proteinResiduesMatch(query, target);
   return nucleotidesMatch(query, target);
+}
+
+function isWildcardResidue(symbol: string, molecule: SequenceType): boolean {
+  return symbol === '?' || symbol === (molecule === 'protein' ? 'X' : 'N');
+}
+
+/** Compare two present residues for difference highlighting without conflating
+ * compatible ambiguity codes with literal identity or hard substitutions. */
+export function classifyResidueDifference(
+  referenceResidue: string,
+  rowResidue: string,
+  molecule: SequenceType,
+): 'match' | 'ambiguous' | 'substitution' {
+  const reference = molecule !== 'protein' && referenceResidue === 'U' ? 'T' : referenceResidue;
+  const row = molecule !== 'protein' && rowResidue === 'U' ? 'T' : rowResidue;
+  if (reference === row && !isWildcardResidue(reference, molecule)) return 'match';
+  if (reference === '?' || row === '?') return 'ambiguous';
+  if (!residueMatch(reference, row, molecule)) return 'substitution';
+  return 'ambiguous';
 }
 
 function normalizeMotifResidue(symbol: string, molecule: SequenceType): string {


### PR DESCRIPTION
## Summary

- keep pointer-drag selection responsive by deferring block statistics until selection settles
- distinguish compatible IUPAC calls from hard differences, add strict comparison mode, and warn when protein alignments look nucleotide-only
- add durable reference-coordinate numbering with insertion labels, accessible ruler/readouts, coordinate jumps, and saved-result reset
- preserve existing fit-to-window, bounded motif search, responsive window geometry, and keyboard contracts

## Validation

- npm run typecheck
- npm run lint
- npm test — 1,026 tests
- npm run test:plugin
- npm run check:css-tokens
- npm run check:aria-controls
- npm run build:motif
- npm run validate:plugin
- npm run test:e2e
- npm run test:e2e:msa — 41 browser tests
- gitleaks scan of the publication diff
