### PR TITLE
Improve workspace, plasmid map, and alignment workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,13 @@ npm test
 npm run preview:motif
 ```
 
+Use `npm run typecheck`, never `npx tsc --noEmit`. The root `tsconfig.json` is
+solution-style (`"files": []` plus project references), so `--noEmit` finds no
+files and exits 0 unconditionally, while `tsc -b` follows the project
+references. It is not a weaker check; it does not check this repository.
+`scripts/__tests__/gate-parity.test.mjs` fails if the `typecheck` script drifts
+to `--noEmit`.
+
 For visible changes, open `preview/motif-artifact.html` in a real browser and
 exercise wide, narrow, light, dark, resized-panel, mouse, and keyboard states.
 A passing DOM assertion is not proof that a control is legible or reachable.
@@ -56,22 +63,24 @@ A passing DOM assertion is not proof that a control is legible or reachable.
 - Treat Database JSON and workspace ZIP as portable checkpoints, not encrypted
   durable storage.
 - Connector or remote-mutation changes require an explicit, separately
-  reviewed integration campaign. Keep model-facing tools narrow and typed;
+  reviewed integration change. Keep model-facing tools narrow and typed;
   never expose generic DOM, eval, shell, or filesystem bridges.
 
 ## Validation before handoff
 
 ```bash
-npm run typecheck
-npm run lint
-npm test
-npm run test:plugin
-npm run check:css-tokens
-npm run check:aria-controls
-npm run build:motif
-npm run test:e2e
-npm run test:e2e:msa
+npm run gate
 ```
+
+That runs the same checks as CI, in the same order. Keeping the sequence in one
+command avoids drift between contributor guidance and the workflow.
+`scripts/__tests__/gate-parity.test.mjs` fails if `gate` and the workflow stop
+agreeing in either direction.
+
+Read the `N passed / N failed` summary line, not only the exit code of a
+pipeline: `npm run test:e2e | tail -40` reports `tail`'s exit code. The browser
+specs also self-skip when their environment variable is unset, so an exit code
+of 0 can mean nothing ran.
 
 Also run `npm run validate:plugin` when the Claude CLI is available. Report any
 skips, external-tool assumptions, and generated output hashes explicitly.

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -322,13 +322,13 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('lacZ-alpha');
 
     await pUC19.click();
-    await page.getByRole('button', { name: 'Reverse complement', exact: true }).click();
+    await page.getByRole('button', { name: 'New rev comp record', exact: true }).click();
     expect(await page.evaluate(() => window.motifGetInventory().length)).toBe(inventoryCountBefore + 2);
     await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('reverse complement');
 
     await pUC19.click();
     await feature.click();
-    await page.getByRole('button', { name: 'Reverse complement', exact: true }).click();
+    await page.getByRole('button', { name: 'New rev comp record', exact: true }).click();
     expect(await page.evaluate(() => window.motifGetInventory().length)).toBe(inventoryCountBefore + 3);
     await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('reverse complement');
     await expect(page.getByTestId('session-durability-status')).toHaveText('unsaved changes');
@@ -484,6 +484,83 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(mapVisibility).toContainText('No enzymes match this filter.');
     await filter.fill('');
     expect(await mapVisibility.locator('.motif-cs-restriction-row input:checked').count()).toBe(visibleBefore);
+  });
+
+  test('a dense plasmid names its restriction clusters instead of drawing anonymous ticks', async ({ page }) => {
+    await openArtifact(page, 1600, 1000);
+
+    const clusters = page.locator('.motif-pm-restriction');
+    const names = page.locator('.motif-pm-restriction-label');
+    const readMap = async () => ({
+      clusters: await clusters.count(),
+      names: await names.count(),
+    });
+
+    // A sparse record: every cluster carries a name and nothing is withheld.
+    await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('pUC19');
+    const sparse = await readMap();
+    expect(sparse.clusters).toBe(22);
+    expect(sparse.names).toBe(22);
+    await expect(page.locator('.motif-pm-overflows text')).toHaveCount(0);
+
+    // A dense record: 149 sites over 31 clusters. The map cannot name all 31, but
+    // "cannot name all" is not "name none" — it used to draw 62 ticks and zero
+    // names because a site-count threshold switched labelling off wholesale.
+    await page.getByRole('tab', { name: 'pET-28a(+)' }).click();
+    await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('pET-28a(+)');
+
+    const mapVisibility = page.locator('details').filter({ hasText: 'Map Visibility' }).first();
+    await mapVisibility.locator(':scope > summary').click();
+    await expect(mapVisibility).toContainText('149/149 sites');
+
+    const dense = await readMap();
+    expect(dense.clusters).toBe(31);
+    expect(dense.names).toBeGreaterThanOrEqual(20);
+    expect(dense.names).toBeLessThanOrEqual(dense.clusters);
+
+    // Whatever it could not name, it says so rather than going quiet.
+    await expect(page.locator('.motif-pm-overflows text').filter({ hasText: /more sites$/ })).toHaveCount(1);
+
+    // Naming the cut sites must not cost the map its features. A rescue pass places
+    // grouped clusters over feature labels and deletes what it lands on; unbounded,
+    // it spent this vector's whole cloning site — promoter, operator, RBS, tag and
+    // terminator, five labels — to gain two enzyme names.
+    const featureNames = page.locator('.motif-pm-feature-label');
+    await expect(featureNames).toHaveCount(6);
+    for (const name of ['T7 prom.', 'RBS', '6xHis', 'T7 terminator']) {
+      await expect(featureNames.filter({ hasText: name })).toHaveCount(1);
+    }
+
+    // The labelling control reads the same on the dense record as on the sparse
+    // one — the density of a record is not a reason to flip a user-facing toggle.
+    const labelToggle = mapVisibility.getByRole('button', { name: /^Labels (On|Off)$/ });
+    await expect(labelToggle).toHaveText('Labels On');
+
+    // Shrink to a laptop-sized window. This is the case that used to fail hardest:
+    // the old threshold halved once the map's smaller dimension fell under 580px,
+    // and the sparsest bundled vector has 26 sites, so EVERY record lost EVERY
+    // name here — including the ones that looked healthy at 1600x1000.
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await expect
+      .poll(async () => {
+        const box = (await page.locator('.motif-pm-container').boundingBox())!;
+        return Math.min(box.width, box.height);
+      }, { message: 'map never re-laid out below the old 580px branch point' })
+      .toBeLessThan(580);
+
+    const denseSmall = await readMap();
+    expect(denseSmall.names).toBeGreaterThanOrEqual(15);
+    await expect(labelToggle).toHaveText('Labels On');
+
+    await page.getByRole('tab', { name: 'pUC19' }).click();
+    await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('pUC19');
+    const sparseSmall = await readMap();
+    expect(sparseSmall.clusters).toBe(22);
+    expect(sparseSmall.names).toBeGreaterThanOrEqual(15);
+
+    await page.setViewportSize({ width: 1600, height: 1000 });
+    await page.getByRole('tab', { name: 'pUC19' }).click();
+    await expect(labelToggle).toHaveText('Labels On');
   });
 
   test('digest recipes reject unknown enzymes and survive map-source changes', async ({ page }) => {
@@ -1226,6 +1303,53 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(page.getByRole('button', { name: 'Show sites' })).toBeDisabled();
   });
 
+  test('hiding restriction sites changes the map but not the exports or the summary', async ({ page }) => {
+    // "Hide sites" is a display control. It used to empty the record's enzyme
+    // sources as well, and the export and summary paths read those sources — so
+    // decluttering the map silently rewrote what a downloaded file said about
+    // the molecule. Everything downstream of the scan must be untouched.
+    await openArtifact(page);
+
+    const sitesCsvRowCount = async () => {
+      const panel = page.locator('.motif-cs-sequence-tools-panel');
+      // An open <details> reports open as "", which is falsy — testing truthiness
+      // here closes the panel on the second call.
+      if ((await panel.getAttribute('open')) === null) await panel.locator(':scope > summary').click();
+      await panel.locator('select[name="export-format"]').selectOption('sites-csv');
+      const downloadPromise = page.waitForEvent('download');
+      await panel.getByRole('button', { name: 'Download' }).click();
+      const file = await (await downloadPromise).path();
+      if (!file) throw new Error('restriction-site CSV download produced no file');
+      return (await readFile(file, 'utf8')).trim().split('\n').length - 1;
+    };
+    const cutterCounts = async () => page.evaluate(() => {
+      const text = window.motifDescribe?.()?.text ?? '';
+      return {
+        singleCutters: Number(text.match(/(\d+)\s+single cutters?/i)?.[1] ?? -1),
+        enzymesCut: Number(text.match(/(\d+)\s+enzymes? cut/i)?.[1] ?? -1),
+      };
+    });
+
+    const csvRowsBefore = await sitesCsvRowCount();
+    const countsBefore = await cutterCounts();
+    // Without sites to lose, "unchanged" would be true of a broken build too.
+    expect(csvRowsBefore).toBeGreaterThan(0);
+    expect(countsBefore.singleCutters).toBeGreaterThan(0);
+    expect(countsBefore.enzymesCut).toBeGreaterThan(0);
+
+    const mapVisibility = page.locator('details').filter({ hasText: 'Map visibility' }).first();
+    if (!(await mapVisibility.getAttribute('open'))) await mapVisibility.locator('summary').click();
+    const restrictionLabels = page.locator('.motif-cs-restriction-label');
+    expect(await restrictionLabels.count()).toBeGreaterThan(0);
+    await page.getByRole('button', { name: 'Hide sites' }).click();
+    // The control did its visible job — otherwise the assertions below pass on a
+    // click that never landed.
+    await expect(restrictionLabels).toHaveCount(0);
+
+    expect(await sitesCsvRowCount()).toBe(csvRowsBefore);
+    expect(await cutterCounts()).toEqual(countsBefore);
+  });
+
   test('primer edits clear invalid results and recompute valid pairs immediately', async ({ page }) => {
     await openArtifact(page, 1180, 900);
     const primerPanel = page.locator('details[data-rail-tool="primer-design"]');
@@ -1264,6 +1388,244 @@ test.describe('Claude Science artifact campaign', () => {
     await exportSummary.scrollIntoViewIfNeeded();
     await exportSummary.click();
     await expect(exportPanel).toHaveAttribute('open', '');
+  });
+
+  test('no Tools rail popover heading paints over the first line beneath it', async ({ page }) => {
+    await openArtifact(page, 1440, 900);
+    const toolsToggle = page.getByRole('button', { name: /Tools/ }).first();
+    if ((await toolsToggle.getAttribute('aria-pressed')) === 'true') await toolsToggle.click();
+
+    const tools = await page.locator('details[data-rail-tool]').evaluateAll((panels) =>
+      panels.map((panel) => (panel as HTMLElement).dataset.railTool!),
+    );
+    expect(tools.length).toBeGreaterThan(8);
+
+    const overprinting: string[] = [];
+    const measured: string[] = [];
+    for (const tool of tools) {
+      const panel = page.locator(`details[data-rail-tool="${tool}"]`);
+      if (!(await panel.getAttribute('open'))) await panel.locator(':scope > summary').click();
+
+      // The heading is sticky with an opaque background, so anything laid out above
+      // its bottom edge is painted over rather than merely crowded. A grid body that
+      // reserves less room for the heading than the heading renders swallows the
+      // panel's first line, with no scrollbar or any other signal that it did.
+      const overlap = await panel.evaluate((el) => {
+        const body = el.querySelector<HTMLElement>('.motif-cs-tool-panel-body');
+        const title = body?.querySelector<HTMLElement>(':scope > .motif-cs-rail-popover-title');
+        // The popover body is position:fixed, so offsetParent is always null here —
+        // ask for painted boxes instead. The heading is display:none while Tools is
+        // pinned, which is a different layout with no sticky overlap to check.
+        if (!body || !title || !body.getClientRects().length || !title.getClientRects().length) return null;
+        const next = [...body.children].find(
+          (child) => child !== title && getComputedStyle(child).position !== 'fixed',
+        );
+        if (!next) return null;
+        return Math.round(title.getBoundingClientRect().bottom - next.getBoundingClientRect().top);
+      });
+      if (overlap === null) continue;
+      measured.push(tool);
+      if (overlap > 0) overprinting.push(`${tool} by ${overlap}px`);
+    }
+
+    // Guard the guard: a fixture change that stopped these panels opening would
+    // otherwise turn this into a test that passes by measuring nothing.
+    expect(measured.length, `rail panels actually measured: ${measured.join(', ')}`).toBeGreaterThan(8);
+    expect(overprinting, `rail headings covering their own panel body: ${overprinting.join(', ')}`).toEqual([]);
+  });
+
+  test('no Tools rail popover covers the alignment window controls that would close it', async ({ page }) => {
+    await openArtifact(page, 1440, 980);
+    const toolsToggle = page.getByRole('button', { name: /Tools/ }).first();
+    if ((await toolsToggle.getAttribute('aria-pressed')) === 'true') await toolsToggle.click();
+
+    /** Where the open popover is, and whether it is sitting on the window's own controls. */
+    const readPlacement = () => page.evaluate(() => {
+      const body = document.querySelector<HTMLElement>('.motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel[open] > .motif-cs-tool-panel-body');
+      if (!body) return null;
+      const rect = body.getBoundingClientRect();
+      const covered: string[] = [];
+      for (const control of document.querySelectorAll<HTMLElement>('.motif-cs-window .motif-cs-window-head-actions button')) {
+        const box = control.getBoundingClientRect();
+        // Hit-test rather than compare boxes: this is the question the user asks
+        // of the pixel, and it accounts for stacking as well as geometry.
+        const hit = document.elementFromPoint(Math.round(box.x + box.width / 2), Math.round(box.y + box.height / 2));
+        if (!hit || !(control.contains(hit) || hit.contains(control))) covered.push(control.getAttribute('aria-label') ?? '?');
+      }
+      return {
+        top: Math.round(rect.top),
+        bottom: Math.round(rect.bottom),
+        left: Math.round(rect.left),
+        right: Math.round(rect.right),
+        height: Math.round(rect.height),
+        maxHeight: Number.parseFloat(getComputedStyle(body).maxHeight),
+        viewport: { width: window.innerWidth, height: window.innerHeight },
+        covered,
+      };
+    });
+
+    const railTools = await page.locator('.motif-cs-inspector[data-tools-pinned="false"] details[data-rail-tool]')
+      .evaluateAll((panels) => panels.map((panel) => (panel as HTMLElement).dataset.railTool!));
+    expect(railTools.length).toBeGreaterThan(8);
+
+    // The stylesheet's resting offset and its bottom gutter, read from the rule
+    // rather than restated here, so this test tracks a stylesheet edit.
+    const resting = await page.evaluate(() => {
+      const panel = document.querySelector('.motif-cs-inspector[data-tools-pinned="false"] details.motif-cs-panel');
+      return Number.parseFloat(getComputedStyle(panel!).getPropertyValue('--rail-popover-fixed-top'));
+    });
+    expect(resting).toBeGreaterThan(0);
+
+    // Nothing open to avoid: the popover must not move, and its height bound must
+    // still be the viewport bound the drag-resize reads its limit from.
+    const settings = page.locator('details[data-rail-tool="settings"]');
+    await settings.locator(':scope > summary').click();
+    const unobstructed = (await readPlacement())!;
+    expect(unobstructed.top).toBe(resting);
+    const gutter = unobstructed.viewport.height - unobstructed.top - unobstructed.maxHeight;
+    expect(gutter).toBeGreaterThan(0);
+    await settings.locator(':scope > summary').click();
+
+    await page.evaluate(() => {
+      window.motifAddAlignments({
+        id: 'popover-placement',
+        name: 'Popover placement fixture',
+        molecule: 'dna',
+        referenceRowId: 'placement-template',
+        rows: [
+          { id: 'placement-template', name: 'Template', aligned: 'ACGTACGTACGT' },
+          { id: 'placement-read-a', name: 'Read A', aligned: 'ACGTACGAACGT' },
+          { id: 'placement-read-b', name: 'Read B', aligned: 'ACGTACGTAAGT' },
+        ],
+        engine: { id: 'mafft', label: 'MAFFT', version: '7.526', mode: 'local-command' },
+      });
+    });
+    const alignmentWindow = page.locator('.motif-cs-window');
+    await expect(alignmentWindow).toBeVisible();
+    await expect(alignmentWindow.locator('.motif-cs-window-head-actions button')).not.toHaveCount(0);
+
+    // Park the window so its title bar lands under the popover column — the state
+    // that used to bury Maximize, Collapse and Close behind every one of these
+    // panels, with no way out because the popover is right-anchored and the
+    // control that would move it is the control it is covering.
+    const headBox = (await alignmentWindow.locator('.motif-cs-window-head').boundingBox())!;
+    const windowBox = (await alignmentWindow.boundingBox())!;
+    await page.mouse.move(headBox.x + 120, headBox.y + headBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(
+      headBox.x + 120 + (1432 - (windowBox.x + windowBox.width)),
+      headBox.y + headBox.height / 2 + (200 - windowBox.y),
+      { steps: 12 },
+    );
+    await page.mouse.up();
+
+    const placements = new Map<string, string>();
+    const covering: string[] = [];
+    const offscreen: string[] = [];
+    for (const tool of railTools) {
+      const panel = page.locator(`details[data-rail-tool="${tool}"]`);
+      if (!(await panel.getAttribute('open'))) await panel.locator(':scope > summary').click();
+      const placement = await readPlacement();
+      if (!placement) continue;
+      if (placement.covered.length > 0) covering.push(`${tool} covers ${placement.covered.join(' + ')}`);
+      if (placement.top < 0 || placement.left < 0
+        || placement.bottom > placement.viewport.height
+        || placement.right > placement.viewport.width) {
+        offscreen.push(`${tool} at ${placement.left},${placement.top}-${placement.right},${placement.bottom} in ${placement.viewport.width}x${placement.viewport.height}`);
+      }
+      // The bound has to follow wherever the popover landed, because the
+      // drag-resize takes its limit straight off the computed max-height.
+      expect(placement.top + placement.maxHeight,
+        `${tool} height bound runs past the viewport gutter`).toBeLessThanOrEqual(placement.viewport.height - gutter);
+      expect(placement.maxHeight, `${tool} height bound collapsed`).toBeGreaterThan(0);
+      placements.set(tool, `${placement.top}/${placement.maxHeight}`);
+      await panel.locator(':scope > summary').click();
+    }
+
+    expect(placements.size, `rail panels actually measured: ${[...placements.keys()].join(', ')}`).toBeGreaterThan(8);
+    expect(covering, `rail popovers burying the window controls: ${covering.join('; ')}`).toEqual([]);
+    expect(offscreen, `rail popovers off screen: ${offscreen.join('; ')}`).toEqual([]);
+    // A rail only works if the panel is in the same place every time. All of
+    // them share one answer for a given layout, and reopening does not move it.
+    expect(new Set(placements.values()).size,
+      `rail popovers disagreed about where to open: ${[...placements].map(([t, p]) => `${t}=${p}`).join(' ')}`).toBe(1);
+
+    const repeats: string[] = [];
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await settings.locator(':scope > summary').click();
+      const placement = (await readPlacement())!;
+      repeats.push(`${placement.top}/${placement.maxHeight}`);
+      await settings.locator(':scope > summary').click();
+    }
+    expect(new Set(repeats).size, `reopening moved the popover: ${repeats.join(' ')}`).toBe(1);
+    expect(repeats[0]).toBe(placements.get('settings'));
+
+    // Drag-resize must still reach the bound that goes with the solved position.
+    await settings.locator(':scope > summary').click();
+    const body = settings.locator('.motif-cs-tool-panel-body');
+    const handle = body.getByTestId('rail-popover-resize');
+    const handleBox = (await handle.boundingBox())!;
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(handleBox.x + handleBox.width / 2, 980 + 600, { steps: 16 });
+    await page.mouse.up();
+    const dragged = (await readPlacement())!;
+    expect(dragged.height).toBe(Math.round(dragged.maxHeight));
+    expect(dragged.bottom).toBeLessThanOrEqual(dragged.viewport.height);
+    expect(dragged.covered, `dragging the popover taller buried ${dragged.covered.join(' + ')}`).toEqual([]);
+  });
+
+  test('the annotations panel shows every feature it counts, and dragging it taller reveals more', async ({ page }) => {
+    await openArtifact(page, 1440, 980);
+    const toolsToggle = page.getByRole('button', { name: /Tools/ }).first();
+    if ((await toolsToggle.getAttribute('aria-pressed')) === 'true') await toolsToggle.click();
+
+    const panel = page.locator('details[data-rail-tool="annotations"]');
+    if (!(await panel.getAttribute('open'))) await panel.locator(':scope > summary').click();
+    const list = panel.locator('.motif-cs-feature-annotation-list');
+    await expect(list).toBeVisible();
+
+    // A row counts as shown only if the browser resolves it at its own centre.
+    // The list used to cap itself at min(24vh, 190px) — 190px at every viewport
+    // height above 792px — so it clipped 3 of 8 rows behind an overlay scrollbar
+    // that is invisible until you scroll, while the panel heading said "8 features".
+    const reach = async () => list.evaluate((el) => {
+      const rows = [...el.querySelectorAll<HTMLElement>(':scope > .motif-cs-row')];
+      const shown = rows.filter((row) => {
+        const rect = row.getBoundingClientRect();
+        const hit = document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2);
+        return !!hit && (hit === row || row.contains(hit));
+      });
+      return { total: rows.length, shown: shown.length, clientH: el.clientHeight, scrollH: el.scrollHeight };
+    });
+
+    const before = await reach();
+    // Guard the guard: with no rows this passes by checking nothing.
+    expect(before.total, 'feature rows rendered').toBeGreaterThan(5);
+    expect(before.shown, `feature rows reachable of ${before.total}`).toBe(before.total);
+    expect(before.scrollH - before.clientH, 'feature list content hidden inside its own cap').toBeLessThanOrEqual(1);
+
+    // The panel is well under the viewport bound here, so it grew to fit instead
+    // of scrolling — which is the whole point, but it means the assertion above
+    // would also pass if the list were merely tall enough by luck. Drag the
+    // popover taller and require the list to actually take the new space: a
+    // constant cap swallows it (measured 391px -> 598px moved the list 0px).
+    // The annotations details also contains the nested feature-editor panel, so
+    // `.motif-cs-tool-panel-body` alone matches two elements.
+    const body = panel.locator('.motif-cs-annotation-panel-body');
+    const handle = body.getByTestId('rail-popover-resize');
+    const handleBox = (await handle.boundingBox())!;
+    const listBefore = (await list.boundingBox())!.height;
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2 + 260, { steps: 8 });
+    await page.mouse.up();
+
+    const listAfter = (await list.boundingBox())!.height;
+    expect(listAfter, 'feature list height after dragging the popover 260px taller').toBeGreaterThan(listBefore + 150);
+    // The popover must stay on screen while doing it.
+    const grown = (await body.boundingBox())!;
+    expect(grown.y + grown.height).toBeLessThanOrEqual(980);
   });
 
   test('a Tools rail popover grows leftward, shrinks rightward, and docks without stale dimensions', async ({ page }) => {
@@ -1714,6 +2076,22 @@ test.describe('Claude Science artifact campaign', () => {
     await downloadPromise;
     await expect(exportPanel.getByText(/Download requested for motif-inventory\.json/)).toBeVisible();
     await expect(page.getByTestId('session-durability-status')).toHaveText('unsaved changes');
+
+    // Everything above dispatches a SYNTHETIC beforeunload, which proves the
+    // listener is registered and calls preventDefault. It cannot prove Chromium
+    // raises its dialog -- a synthetic event skips the browser's own machinery,
+    // so that assertion passes just as happily on a build where the user is
+    // never actually warned. Close the tab the way a user does and require the
+    // browser dialog itself.
+    const dialogs: string[] = [];
+    page.on('dialog', async (dialog) => {
+      dialogs.push(dialog.type());
+      await dialog.dismiss();
+    });
+    await page.close({ runBeforeUnload: true });
+    await expect.poll(() => dialogs, {
+      message: 'a real tab close with unsaved changes must raise the browser beforeunload dialog',
+    }).toContain('beforeunload');
   });
 
   test('250k records keep sequence and translation DOM bounded and an empty inventory exports only real data', async ({ page }) => {
@@ -2181,6 +2559,48 @@ test.describe('Claude Science artifact campaign', () => {
     expect(afterHeight).toBeLessThan(beforeHeight);
     await expect(rowResize).toHaveAttribute('aria-valuenow', String(afterHeight));
 
+    const main = page.locator('.motif-cs-main');
+    const dimensions = await main.evaluate((element) => ({ clientWidth: element.clientWidth, scrollWidth: element.scrollWidth }));
+    expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + 2);
+  });
+
+  test('the sequence pane keeps widening while the map still has width to give', async ({ page }) => {
+    await openArtifact(page, 1920, 1080);
+
+    const sequence = page.locator('.motif-cs-sequence-column');
+    const map = page.locator('.motif-cs-map-column');
+    const separator = page.getByRole('separator', { name: 'Resize sequence and map panes' });
+    await expect(separator).toBeVisible();
+
+    const startWidth = (await sequence.boundingBox())!.width;
+    const handle = (await separator.boundingBox())!;
+    const y = handle.y + handle.height / 2;
+    await page.mouse.move(handle.x + handle.width / 2, y);
+    await page.mouse.down();
+    // Well past any ceiling: this asserts where the drag STOPS, not where the pointer went.
+    await page.mouse.move(handle.x + handle.width / 2 + 900, y, { steps: 12 });
+    await page.mouse.up();
+
+    const widened = (await sequence.boundingBox())!.width;
+    const mapWidth = (await map.boundingBox())!.width;
+
+    // A flat 760px cap used to stop this drag at every viewport width, while the map
+    // sat on hundreds of pixels of unused slack. Both numbers matter: the pane has to
+    // clear the old cap, and it still must not eat into the map's 300px minimum.
+    expect(widened).toBeGreaterThan(startWidth);
+    expect(widened).toBeGreaterThan(800);
+    expect(mapWidth).toBeGreaterThanOrEqual(300);
+
+    // aria-valuenow reports the flex BASIS the drag committed, which is not always the
+    // rendered width: the map declines to shrink below its own content, so it can end
+    // up wider than the basis asked for and the sequence correspondingly narrower.
+    // Assert the invariant that is actually true rather than an equality that is not.
+    const valueMax = Number(await separator.getAttribute('aria-valuemax'));
+    const valueNow = Number(await separator.getAttribute('aria-valuenow'));
+    expect(valueNow).toBeGreaterThan(760);
+    expect(valueNow).toBeLessThanOrEqual(valueMax);
+
+    // Widening must not push the workspace into horizontal overflow.
     const main = page.locator('.motif-cs-main');
     const dimensions = await main.evaluate((element) => ({ clientWidth: element.clientWidth, scrollWidth: element.scrollWidth }));
     expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + 2);
@@ -2831,6 +3251,140 @@ test.describe('Claude Science artifact campaign', () => {
     expect(counterclockwise).not.toBe(clockwise);
   });
 
+  test('the map keeps saying what is selected while the view is zoomed', async ({ page }) => {
+    // The status corner reports two independent facts — the view transform and the
+    // selection — and they used to share one slot through a ternary the zoom badge
+    // always won. So zooming left the selection drawn on the map and unnamed, while
+    // the paths stayed live. A pan alone was enough; the badge could still read 100%.
+    await openArtifact(page, 1180, 900);
+    const mapFrame = page.locator('.motif-cs-map-frame');
+    const hint = mapFrame.locator('.motif-cs-map-hint');
+    const svg = mapFrame.locator('svg.motif-plasmid-map');
+    const svgBox = (await svg.boundingBox())!;
+    const centre = { x: svgBox.x + svgBox.width / 2, y: svgBox.y + svgBox.height / 2 };
+    const radius = Math.min(svgBox.width, svgBox.height) * 0.28;
+
+    await page.mouse.move(centre.x, centre.y - radius);
+    await page.mouse.down();
+    await page.mouse.move(centre.x + radius, centre.y, { steps: 8 });
+    await page.mouse.up();
+
+    const atFit = (await hint.textContent()) ?? '';
+    expect(atFit).toContain('range');
+    expect(atFit).not.toContain('%');
+    const selectionPaths = await mapFrame.locator('.motif-pm-selection').count();
+    expect(selectionPaths).toBeGreaterThan(0);
+
+    for (let i = 0; i < 4; i += 1) await page.getByRole('button', { name: 'Zoom in' }).click();
+    await expect(mapFrame.locator('.motif-pm-viewport')).toHaveAttribute('transform', /scale\((?!1\))/);
+
+    // Both facts, not one of them, joined in that order. The shape is written out
+    // literally rather than built from whatever produces the percentage — an
+    // expectation assembled from the same expression as the value under test moves
+    // with it and passes either way.
+    const zoomed = (await hint.textContent()) ?? '';
+    expect(zoomed).toMatch(/^\d+% · range \d/);
+    // ...and the range half is byte-identical to the fitted reading: zoom changes how
+    // the map is drawn, not what is selected. Restoring the ternary drops this half
+    // and fails here.
+    expect(zoomed.split(' · ')).toHaveLength(2);
+    expect(zoomed.split(' · ')[1]).toBe(atFit);
+    expect(await mapFrame.locator('.motif-pm-selection').count()).toBe(selectionPaths);
+  });
+
+  test('map clicks resolve the same base whether the view is fitted, panned, or zoomed', async ({ page }) => {
+    await openArtifact(page, 1180, 900);
+    const svg = page.locator('.motif-cs-map-frame svg.motif-plasmid-map');
+    const svgBox = (await svg.boundingBox())!;
+    const centre = { x: svgBox.x + svgBox.width / 2, y: svgBox.y + svgBox.height / 2 };
+
+    // Independent oracle: push the client point through the viewport group's OWN
+    // screen matrix and measure it against the backbone's rendered box. It shares
+    // no code with the handler under test, so it cannot fail in the same
+    // direction — which is the whole point, since the two coordinate spaces
+    // involved are numerically identical at the default fit.
+    // Read the record length rather than assuming one: an oracle that hardcodes
+    // a length reports the implementation as broken whenever the fixture changes.
+    const sequenceLength = await page.evaluate(() => {
+      const text = [...document.querySelectorAll('.motif-cs-panel-meta, .motif-cs-pane-title')]
+        .map((node) => node.textContent ?? '')
+        .find((value) => /[\d,]+\s*bp/.test(value));
+      const match = text?.match(/([\d,]+)\s*bp/);
+      return match ? Number(match[1].replace(/,/g, '')) : null;
+    });
+    expect(sequenceLength, 'could not read the record length for the oracle').toBeGreaterThan(100);
+
+    const baseUnderPoint = (client: { x: number; y: number }) => page.evaluate(([point, length]) => {
+      const root = document.querySelector<SVGSVGElement>('.motif-cs-map-frame svg.motif-plasmid-map');
+      const group = root?.querySelector<SVGGElement>('.motif-pm-viewport');
+      const backbone = group?.querySelector<SVGGraphicsElement>('.motif-pm-backbone');
+      if (!root || !group || !backbone) return null;
+      const svgPoint = root.createSVGPoint();
+      svgPoint.x = (point as { x: number; y: number }).x;
+      svgPoint.y = (point as { x: number; y: number }).y;
+      const local = svgPoint.matrixTransform(group.getScreenCTM()!.inverse());
+      const box = backbone.getBBox();
+      const centreX = box.x + (box.width / 2);
+      const centreY = box.y + (box.height / 2);
+      const degrees = ((Math.atan2(local.y - centreY, local.x - centreX) * 180 / Math.PI) + 90 + 360) % 360;
+      return Math.round((degrees / 360) * (length as number)) + 1;
+    }, [client, sequenceLength] as const);
+
+    const clickedBase = async () => {
+      const meta = await page.locator('.motif-cs-sequence-panel .motif-cs-panel-meta').textContent();
+      const match = (meta ?? '').trim().match(/^([\d,]+)-/);
+      return match ? Number(match[1].replace(/,/g, '')) : null;
+    };
+
+    const probe = { x: centre.x + (Math.min(svgBox.width, svgBox.height) * 0.3), y: centre.y };
+    const offCentre = { x: centre.x - 120, y: centre.y - 120 };
+
+    // Three viewports: a pristine fit; a pan with the zoom badge still reading
+    // 100%; and an off-centre zoom. The middle one matters most — a click can be
+    // hundreds of bases wrong while nothing on screen says the view has moved.
+    const seen: Array<{ label: string; expected: number; actual: number | null }> = [];
+    for (const step of [
+      { label: 'fit', prepare: async () => {} },
+      {
+        label: 'panned at fit',
+        prepare: async () => {
+          await svg.dispatchEvent('wheel', { deltaY: 180, clientX: centre.x, clientY: centre.y });
+        },
+      },
+      {
+        label: 'zoomed off centre',
+        prepare: async () => {
+          await svg.dispatchEvent('wheel', {
+            deltaY: -260, clientX: offCentre.x, clientY: offCentre.y, ctrlKey: true,
+          });
+        },
+      },
+    ]) {
+      await step.prepare();
+      await page.waitForTimeout(220);
+      const expected = await baseUnderPoint(probe);
+      expect(expected, `oracle failed to resolve a base at ${step.label}`).not.toBeNull();
+      await page.mouse.click(probe.x, probe.y);
+      await page.waitForTimeout(160);
+      seen.push({ label: step.label, expected: expected!, actual: await clickedBase() });
+    }
+
+    for (const { label, expected, actual } of seen) {
+      expect(actual, `no base was selected at ${label}`).not.toBeNull();
+      // Allow the half-base rounding at the seam and nothing else. The defect
+      // this guards against was 153-803 bp, so the tolerance has room to spare.
+      expect(
+        Math.min(Math.abs(actual! - expected), sequenceLength! - Math.abs(actual! - expected)),
+        `${label}: clicked the position of base ${expected} but the app selected ${actual}`,
+      ).toBeLessThanOrEqual(2);
+    }
+
+    // The view really did move between steps, so the three checks above were not
+    // three copies of the same easy case.
+    await expect(page.locator('.motif-cs-map-frame .motif-pm-viewport')).toHaveAttribute('transform', /scale\((?!1\))/);
+    expect(new Set(seen.map((entry) => entry.expected)).size).toBeGreaterThan(1);
+  });
+
   test('narrow linear maps keep the range readout clear of zoom controls', async ({ page }) => {
     await openArtifact(page, 640, 700);
     await page.evaluate(() => window.motifRenderInventory?.([{
@@ -2847,10 +3401,28 @@ test.describe('Claude Science artifact campaign', () => {
     const svgBox = await svg.boundingBox();
     expect(svgBox).toBeTruthy();
 
-    const y = svgBox!.y + svgBox!.height * 0.52;
-    await page.mouse.move(svgBox!.x + svgBox!.width * 0.28, y);
+    // Drag along a row that is actually the range-drag surface. A fixed fraction of
+    // the SVG height is not: enzyme labels are drawn across the middle of a short
+    // linear map, and a press that lands on one selects that cluster instead of
+    // starting a range — which leaves no range and no readout to place, so this
+    // test would fail describing the readout rather than the missed drag.
+    const startX = svgBox!.x + svgBox!.width * 0.28;
+    const endX = svgBox!.x + svgBox!.width * 0.55;
+    const y = await page.evaluate(([x0, x1, top, height]) => {
+      for (let step = 0; step <= 20; step += 1) {
+        const candidate = top + (height * (2 + step * 3)) / 100;
+        const onBackground = [x0, x1].every((x) => document
+          .elementFromPoint(x, candidate)
+          ?.classList.contains('motif-pm-bg'));
+        if (onBackground) return candidate;
+      }
+      return -1;
+    }, [startX, endX, svgBox!.y, svgBox!.height]);
+    expect(y, 'no row of the linear map accepts a range drag').toBeGreaterThan(0);
+
+    await page.mouse.move(startX, y);
     await page.mouse.down();
-    await page.mouse.move(svgBox!.x + svgBox!.width * 0.55, y, { steps: 8 });
+    await page.mouse.move(endX, y, { steps: 8 });
     await page.mouse.up();
 
     const hint = mapFrame.locator('.motif-cs-map-hint');
@@ -3136,7 +3708,7 @@ test.describe('Claude Science artifact campaign', () => {
     });
     const stats = page.getByTestId('msa-stats-bar');
     await expect(stats).toContainText('92.9% avg to template');
-    await expect(stats).toContainText('1 differences in overlap');
+    await expect(stats).toContainText('1 columns differ from template');
     await expect(page.getByRole('row', { name: /Read B; 0 mismatches; 6 ungapped bp; 100\.0 percent/ })).toBeVisible();
   });
 
@@ -3216,7 +3788,7 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(page.getByTestId('msa-run-button')).toBeEnabled();
     await page.getByTestId('msa-run-button').click();
     await expect(page.getByTestId('msa-stats-bar')).toBeVisible({ timeout: 15_000 });
-    await expect(windowPanel.locator('.motif-cs-msa-toolbar .motif-cs-chip')).toHaveText('Motif local preview');
+    await expect(windowPanel.getByTestId('msa-provenance')).toContainText('Motif local preview');
 
     const overview = page.getByTestId('msa-overview');
     const matrix = page.getByRole('region', { name: 'Scrollable alignment matrix viewport', exact: true });
@@ -3239,7 +3811,10 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(windowPanel.locator('.motif-cs-msa-matrix-row').first().getByRole('button')).toHaveAttribute('aria-label', templateButtonName!);
     await expect(windowPanel.locator('.motif-cs-msa-matrix-row').first()).toContainText('Template');
     await expect(windowPanel.locator('.motif-cs-msa-matrix-row').first()).toContainText('Δ');
+    // Row order lives in the View menu now, beside the other display preferences.
+    await windowPanel.getByTestId('msa-view-menu-button').click();
     await page.getByLabel('Sort').selectOption('mismatches');
+    await windowPanel.getByTestId('msa-view-menu-button').click();
     await expect(windowPanel.locator('.motif-cs-msa-matrix-row').first().getByRole('button')).toHaveAttribute('aria-label', templateButtonName!);
 
     const renderedSymbols = await page.locator('.motif-cs-msa-symbol').count();
@@ -3365,10 +3940,19 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(settings).not.toHaveAttribute('open', '');
     const body = dialog.locator('.motif-cs-window-body');
     const toolbar = dialog.getByTestId('msa-result-toolbar');
-    const exportRow = dialog.locator('.motif-cs-msa-export-row');
+    const exportTrigger = dialog.getByTestId('msa-export-menu-button');
+    // Scroll as far as this panel allows and assert the toolbar holds its place
+    // either way. The body used to be guaranteed to overflow at phone width, so
+    // this test could require scrollTop > 0; the controls now fit, and pinning a
+    // viewport that still overflows would be tuning the test to a magic number
+    // rather than testing the behaviour. What matters is unchanged: wherever the
+    // body ends up, the toolbar stays put, visible and clickable, and export
+    // rides along in it instead of sitting below a screenful of residues.
+    // (Asserting that scrollTop landed at scrollHeight - clientHeight would be a
+    // tautology — the platform clamps it there for every element, scrollable or
+    // not. The assertions below carry the actual claim.)
     await body.evaluate((element) => { element.scrollTop = element.scrollHeight; });
-    await expect.poll(() => body.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
-    await expect(exportRow).toBeVisible();
+    await expect(exportTrigger).toBeVisible();
     await expect(toolbar).toBeVisible();
 
     const toolbarGeometry = await toolbar.evaluate((element) => {
@@ -3596,15 +4180,24 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(windowPanel).toBeVisible();
     await picker.selectOption('view-state-second');
     await windowPanel.getByRole('button', { name: 'All letters' }).click();
-    await windowPanel.getByLabel('Sort').selectOption('name');
+    // Row order and the export format now live inside the View and Export
+    // menus, so each has to be opened before its control is reachable. The
+    // preferences under test are unchanged.
     const viewButton = windowPanel.getByTestId('msa-view-menu-button');
     await viewButton.click();
+    await windowPanel.getByLabel('Sort').selectOption('name');
     await windowPanel.getByTestId('msa-view-menu').getByRole('checkbox', { name: 'Residue colors' }).check();
     await windowPanel.getByRole('button', { name: 'Increase alignment font size' }).click();
     await windowPanel.getByRole('button', { name: 'Text' }).click();
+    const exportMenuButton = windowPanel.getByTestId('msa-export-menu-button');
+    await exportMenuButton.click();
     const exportFormat = windowPanel.getByRole('combobox', { name: 'Export', exact: true });
     await exportFormat.selectOption('json');
 
+    // With a menu open, the first Escape dismisses the menu; only once nothing
+    // is covering the window does Escape reach the window itself.
+    await page.keyboard.press('Escape');
+    await expect(windowPanel.getByTestId('msa-export-menu')).toBeHidden();
     await page.keyboard.press('Escape');
     await expect(windowPanel).toBeHidden();
     await expect(alignmentSummary).toBeFocused();
@@ -3613,11 +4206,14 @@ test.describe('Claude Science artifact campaign', () => {
 
     await expect(picker).toHaveValue('view-state-second');
     await expect(windowPanel.getByRole('button', { name: 'Text' })).toHaveAttribute('aria-pressed', 'true');
+    await exportMenuButton.click();
+    await expect(windowPanel.getByTestId('msa-export-menu')).toBeVisible();
     await expect(exportFormat).toHaveValue('json');
+    await page.keyboard.press('Escape');
     await windowPanel.getByRole('button', { name: 'Viewer' }).click();
     await expect(windowPanel.getByRole('button', { name: 'All letters' })).toHaveAttribute('aria-pressed', 'true');
-    await expect(windowPanel.getByLabel('Sort')).toHaveValue('name');
     await viewButton.click();
+    await expect(windowPanel.getByLabel('Sort')).toHaveValue('name');
     await expect(windowPanel.getByTestId('msa-view-menu').getByRole('checkbox', { name: 'Residue colors' })).toBeChecked();
     await expect(windowPanel.locator('.motif-cs-msa-view-font-row > span')).toHaveText('Aa 12 px');
   });
@@ -3783,6 +4379,7 @@ test.describe('Claude Science artifact campaign', () => {
     const copyStatus = windowPanel.getByTestId('msa-copy-status');
     await expect(copyStatus).toHaveAttribute('role', 'status');
     await expect(copyStatus).toHaveAttribute('aria-live', 'polite');
+    await windowPanel.getByTestId('msa-export-menu-button').click();
     await windowPanel.locator('.motif-cs-msa-export-row').getByRole('button', { name: 'Copy', exact: true }).click();
     await expect(copyStatus).toBeVisible();
     await expect(copyStatus).toHaveText('Aligned FASTA copied');
@@ -3820,6 +4417,7 @@ test.describe('Claude Science artifact campaign', () => {
     ));
     expect(templatePositions).toEqual(['gap', 'gap', '1', '2', 'gap', '3', '4', 'gap', 'gap']);
 
+    await windowPanel.getByTestId('msa-goto-menu-button').click();
     const columnInput = windowPanel.getByRole('spinbutton', { name: 'Go to alignment column' });
     await columnInput.fill('6');
     await columnInput.press('Enter');
@@ -3863,6 +4461,7 @@ test.describe('Claude Science artifact campaign', () => {
     }));
 
     const dialog = page.getByRole('dialog', { name: 'Multiple Sequence Alignment' });
+    await dialog.getByTestId('msa-goto-menu-button').click();
     const coordinateSystem = dialog.getByTestId('msa-coordinate-system');
     const coordinateInput = dialog.getByTestId('msa-coordinate-input');
     await expect(coordinateSystem).toBeVisible();
@@ -3976,10 +4575,16 @@ test.describe('Claude Science artifact campaign', () => {
     await page.keyboard.up('Shift');
     await expect.poll(() => matrix.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0);
 
+    // At this size the window body must not scroll at all: the matrix sizes to
+    // the panel and owns its own scrolling, so nothing is left underneath to
+    // slide. A vertical wheel must also leave the pan position alone — the
+    // dominant axis is vertical, and this test is about the pan rail.
     const windowBody = windowPanel.locator('.motif-cs-window-body');
-    await windowBody.evaluate((element) => { element.scrollTop = 0; });
+    expect(await windowBody.evaluate((element) => element.scrollHeight - element.clientHeight)).toBeLessThanOrEqual(1);
+    const panBefore = await matrix.evaluate((element) => element.scrollLeft);
     await page.mouse.wheel(0, 700);
-    await expect.poll(() => windowBody.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+    expect(await windowBody.evaluate((element) => element.scrollTop)).toBe(0);
+    expect(await matrix.evaluate((element) => element.scrollLeft)).toBe(panBefore);
 
     await page.screenshot({ path: path.join(msaCampaignOutputDir, `msa-pan-rail-${browserName}-1440x900.png`) });
   });
@@ -4002,7 +4607,7 @@ test.describe('Claude Science artifact campaign', () => {
     await page.locator('.motif-cs-msa-import-fields select').nth(1).selectOption('clustal-omega');
     await page.locator('.motif-cs-msa-import-fields input').last().fill('1.2.4');
     await page.getByTestId('msa-import-button').click();
-    await expect(page.getByTestId('msa-result-toolbar').getByText('Clustal Omega 1.2.4', { exact: true })).toBeVisible();
+    await expect(page.getByTestId('msa-provenance')).toContainText('Clustal Omega 1.2.4');
     await expect(page.getByTestId('msa-stats-bar')).toContainText('10 columns');
 
     const saved = await page.evaluate(() => window.motifGetAlignments());
@@ -4010,17 +4615,22 @@ test.describe('Claude Science artifact campaign', () => {
     expect(saved[0].engine).toMatchObject({ id: 'clustal-omega', label: 'Clustal Omega', version: '1.2.4', mode: 'local-command' });
 
     await page.getByRole('button', { name: 'Text' }).click();
+    await page.getByTestId('msa-export-menu-button').click();
     await page.getByTestId('msa-workspace').getByRole('combobox', { name: 'Export', exact: true }).selectOption('clustal');
+    await page.getByTestId('msa-export-menu-button').click();
+    await expect(page.getByTestId('msa-export-menu')).toBeHidden();
     const exportedClustal = await page.getByLabel('CLUSTAL alignment text').inputValue();
     expect(exportedClustal).toMatch(/sample_A\s+ACGT--ACGT/);
-    await page.locator('.motif-cs-msa-source > summary').click();
+    // Once a result exists the source banner collapses out of the way, and
+    // "Edit inputs" is the affordance that brings it back.
+    await page.getByTestId('msa-edit-inputs').click();
     await page.getByTestId('msa-workspace').getByRole('button', { name: 'Aligned file' }).click();
     await page.locator('.motif-cs-msa-import-fields input').first().fill('Round-tripped CLUSTAL');
     await page.locator('.motif-cs-msa-import-fields select').nth(1).selectOption('imported');
     await page.locator('.motif-cs-msa-import-fields input').last().fill('');
     await input.fill(exportedClustal);
     await page.getByTestId('msa-import-button').click();
-    await expect(page.locator('.motif-cs-msa-toolbar .motif-cs-chip')).toHaveText('Imported alignment');
+    await expect(page.getByTestId('msa-provenance')).toContainText('Imported alignment');
     const roundTripped = await page.evaluate(() => window.motifGetAlignments());
     expect(roundTripped).toHaveLength(2);
     expect(roundTripped[1].rows.map((row: { aligned: string }) => row.aligned)).toEqual(roundTripped[0].rows.map((row: { aligned: string }) => row.aligned));
@@ -4077,7 +4687,14 @@ test.describe('Claude Science artifact campaign', () => {
     await page.setViewportSize({ width: 390, height: 760 });
     const windowPanel = page.locator('.motif-cs-window').filter({ has: page.getByTestId('msa-workspace') });
     await expect(windowPanel).toBeVisible();
-    await expect(windowPanel.locator('.motif-cs-msa-source > summary .motif-cs-chip')).toHaveText('MAFFT');
+    // The engine has to be READABLE, not merely present in the DOM. The source
+    // summary that used to be asserted here is display:none in exactly the state
+    // where its chip renders the engine label, so toHaveText passed against
+    // markup nobody can see — inside the test named for staying accessible at
+    // phone width. The provenance summary is where a reader actually finds it.
+    const provenance = windowPanel.getByTestId('msa-provenance').locator('summary');
+    await expect(provenance).toBeVisible();
+    await expect(provenance).toContainText('MAFFT');
     expect(await page.evaluate(() => window.motifGetAlignments()[0]?.engine.version)).toBe('7.526');
     await expect(windowPanel.locator('.motif-cs-msa-row-name-trailing')).toHaveText(['reference', 'ins3', 'del3']);
 
@@ -4096,6 +4713,7 @@ test.describe('Claude Science artifact campaign', () => {
     await page.screenshot({ path: path.join(msaCampaignOutputDir, 'msa-claude-dark-viewer-390x760.png') });
     await page.getByRole('button', { name: 'Text' }).click();
     await expect(page.getByLabel('Aligned FASTA alignment text')).toHaveValue(/>Campaign2_reference/);
+    await windowPanel.getByTestId('msa-export-menu-button').click();
     await windowPanel.getByRole('combobox', { name: 'Export', exact: true }).selectOption('clustal');
     await expect(page.getByLabel('CLUSTAL alignment text')).toHaveValue(/CLUSTAL W/);
 
@@ -4104,7 +4722,7 @@ test.describe('Claude Science artifact campaign', () => {
     await page.screenshot({ path: path.join(msaCampaignOutputDir, 'msa-claude-dark-390x760.png') });
   });
 
-  test('MSA 100-row density preserves suffixes, semantics, and chained scrolling', async ({ page }) => {
+  test('MSA 100-row density preserves suffixes, semantics, and panel-owned scrolling', async ({ page }) => {
     test.setTimeout(120_000);
     await openArtifact(page, 1180, 820);
     await page.evaluate(() => {
@@ -4178,7 +4796,13 @@ test.describe('Claude Science artifact campaign', () => {
     });
     await page.mouse.move(visibleMatrixPoint.x, visibleMatrixPoint.y);
     await page.mouse.wheel(0, 700);
-    await expect.poll(() => windowBody.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+    // A hundred rows are reachable inside the matrix, so the wheel scrolls the
+    // matrix and the window body stays put. It used to be the other way round:
+    // the matrix was capped short, the workspace overflowed, and reaching row
+    // 100 meant scrolling the entire UI — controls and all — off the top.
+    await expect.poll(() => matrixViewport.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+    expect(await windowBody.evaluate((element) => element.scrollTop)).toBe(0);
+    await matrixViewport.evaluate((element) => { element.scrollTop = element.scrollHeight; });
 
     const lastRowVisible = await windowPanel.locator('.motif-cs-msa-matrix-row').nth(99).evaluate((row) => {
       const rowRect = row.getBoundingClientRect();
@@ -4186,7 +4810,13 @@ test.describe('Claude Science artifact campaign', () => {
       return rowRect.top >= viewportRect.top - 1 && rowRect.bottom <= viewportRect.bottom + 1;
     });
     expect(lastRowVisible).toBe(true);
+    // Export stays reachable at this density without scrolling anywhere: it is
+    // a toolbar menu now rather than a strip below a hundred rows of residues.
+    await expect(windowPanel.getByTestId('msa-export-menu-button')).toBeInViewport();
+    await windowPanel.getByTestId('msa-export-menu-button').click();
     await expect(windowPanel.locator('.motif-cs-msa-export-row')).toBeInViewport();
+    await windowPanel.getByTestId('msa-export-menu-button').click();
+    await expect(windowPanel.getByTestId('msa-export-menu')).toBeHidden();
 
     const accessibility = await new AxeBuilder({ page }).include('.motif-cs-window').analyze();
     expect(accessibility.violations).toEqual([]);
@@ -4360,7 +4990,11 @@ test.describe('Claude Science artifact campaign', () => {
   });
 
   test('eight AB1 reads stay synchronized, virtualized, and reviewable at compact sizes', async ({ page }) => {
-    await openArtifact(page, 1180, 820);
+    // 750 tall, not 820: the alignment window opens at viewportHeight - 150, so
+    // this is the viewport that still yields the compact 600px panel this test
+    // is named for. Left at 820 the panel is roomy, everything fits, and the
+    // scroll hand-off below would never be exercised at all.
+    await openArtifact(page, 1180, 750);
     await page.locator('select[name="artifact-theme"]').selectOption('claude-light');
     await page.evaluate(() => {
       const template = 'ACGTTGCA'.repeat(45);

--- a/e2e/claude-science-feature-semantics.spec.ts
+++ b/e2e/claude-science-feature-semantics.spec.ts
@@ -197,7 +197,7 @@ test.describe('Claude Science multipart feature semantics', () => {
     if ((await detail.getAttribute('data-active')) !== 'true') await detail.click();
     await page.locator('.motif-cs-feature-block').filter({ hasText: 'ordered CDS' }).first().click();
     await expect.poll(() => page.evaluate(() => window.motifDescribe?.()?.data.selection ?? null)).toBeNull();
-    await expect(page.getByRole('group', { name: 'Selection actions' }).getByRole('button', { name: 'Reverse complement' })).toBeDisabled();
+    await expect(page.getByRole('group', { name: 'Selection actions' }).getByRole('button', { name: 'New rev comp record' })).toBeDisabled();
 
     const translation = page.locator('details[data-rail-tool="translation"]');
     if ((await translation.getAttribute('open')) === null) await translation.locator(':scope > summary').click();

--- a/e2e/claude-science-msa-interactions.spec.ts
+++ b/e2e/claude-science-msa-interactions.spec.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { expect, test, type Page } from '@playwright/test';
 
 // Real-mouse interaction coverage for the MSA viewer: selection, hover readout,
@@ -115,6 +116,7 @@ test.describe('Motif MSA viewer interactions', () => {
     await expect(compatibleCell).toHaveAttribute('data-cell-outcome', 'ambiguous');
     await expect(compatibleCell).toHaveAttribute('aria-label', /reference position 100/);
 
+    await page.getByTestId('msa-goto-menu-button').click();
     await page.getByTestId('msa-coordinate-system').selectOption('template');
     const coordinateInput = page.getByTestId('msa-coordinate-input');
     await expect(coordinateInput).toHaveAttribute('type', 'text');
@@ -143,6 +145,28 @@ test.describe('Motif MSA viewer interactions', () => {
     await expect(moved).toBeFocused();
     await expect(moved).toHaveAttribute('data-alignment-column', '2');
     await expect(moved).toHaveAttribute('aria-label', 'Residue I, alignment column 2, row ref');
+  });
+
+  test('clicking a residue leaves the keyboard able to move from it', async ({ page }) => {
+    await setup(page);
+    // Deliberately no .focus() call anywhere in this test — that is the whole point.
+    // Every other keyboard test here focuses the cell first, which is exactly why the
+    // grid could ship with arrows dead after a click: the click left DOM focus on the
+    // window container, keydown never reached the matrix, and getting back in by
+    // keyboard took 30 tab stops.
+    const target = page.locator('[data-msa-grid-cell="true"]').nth(120);
+    const column = await target.getAttribute('data-alignment-column');
+    await target.click();
+
+    const clicked = activeGridCell(page);
+    await expect(clicked).toBeFocused();
+    await expect(clicked).toHaveAttribute('data-alignment-column', column!);
+
+    await page.keyboard.press('ArrowRight');
+    await expect(activeGridCell(page)).toHaveAttribute(
+      'data-alignment-column',
+      String(Number(column) + 1),
+    );
   });
 
   test('Shift plus Arrow extends the keyboard selection from its anchor', async ({ page }) => {
@@ -219,6 +243,79 @@ test.describe('Motif MSA viewer interactions', () => {
     await page.keyboard.press('Escape');
     await expect(page.locator('.motif-cs-msa-selection-band')).toHaveCount(0);
     await expect(page.getByTestId('msa-alignment-view')).toBeVisible();
+  });
+
+  test('Escape dismisses a covering tools panel before the window underneath', async ({ page }) => {
+    // The window listens in capture on window and stops propagation, so without
+    // an explicit guard it closed itself and left the panel covering the space.
+    await setup(page);
+    const panel = page.locator('.motif-cs-inspector details[name="motif-cs-tools"]').first();
+    await panel.locator(':scope > summary').click();
+    await expect(panel).toHaveAttribute('open', '');
+
+    await page.keyboard.press('Escape');
+    await expect(panel).not.toHaveAttribute('open', '');
+    // The window — and the view state inside it — survives the first press.
+    await expect(page.getByTestId('msa-alignment-view')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.motif-cs-window')).toHaveCount(0);
+  });
+
+  test('the position axes share one row until the template gains a gap', async ({ page }) => {
+    // An ungapped template prints the same number as the alignment axis in every
+    // column, so two rows carry one row of information.
+    await setup(page);
+    const rulerRows = page.locator('.motif-cs-msa-ruler-row');
+    await expect(rulerRows).toHaveCount(1);
+    await expect(rulerRows.locator('.motif-cs-msa-ruler-label')).toContainText('Alignment / template');
+
+    // Turning the template axis off leaves the row, minus the template's name —
+    // the View menu checkbox must never become a control with no visible effect.
+    await page.getByTestId('msa-view-menu-button').click();
+    await page.getByRole('checkbox', { name: /Template axis/i }).setChecked(false);
+    await expect(rulerRows).toHaveCount(1);
+    await expect(rulerRows.locator('.motif-cs-msa-ruler-label')).toHaveText('Alignment position');
+    await page.getByRole('checkbox', { name: /Template axis/i }).setChecked(true);
+    await expect(rulerRows.locator('.motif-cs-msa-ruler-label')).toContainText('Alignment / template');
+  });
+
+  test('a gapped template keeps its own position axis', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.addInitScript(() => { window.localStorage.clear(); window.sessionStorage.clear(); });
+    await page.goto('/motif.html');
+    await expect(page.locator('.motif-cs-shell')).toBeVisible();
+    await page.evaluate(() => {
+      const api = (window as unknown as { motifAddAlignments?: (a: unknown) => number }).motifAddAlignments;
+      if (!api) throw new Error('motifAddAlignments unavailable');
+      // The template's gap makes its coordinates diverge from the alignment's.
+      api({
+        name: 'Gapped template',
+        molecule: 'protein',
+        alignedFasta: '>ref\nACDE----FGHIKLMNPQRS\n>v1\nACDEWWWWFGHIKLMNPQRS\n>v2\nACDEWWWWFGHIKLMNPQRA\n',
+      });
+    });
+    await page.getByTestId('msa-open-button').dispatchEvent('click');
+    await expect(page.getByTestId('msa-alignment-view')).toBeVisible();
+
+    await expect(page.locator('.motif-cs-msa-ruler-row')).toHaveCount(2);
+    await expect(page.locator('.motif-cs-msa-template-ruler-row')).toBeVisible();
+  });
+
+  test('Escape still closes the window when Tools is docked beside it', async ({ page }) => {
+    // Docked tools use the same markup as the rail popover but sit beside the
+    // window rather than over it, and their own Escape handler is not registered.
+    // Deferring to them there would leave Escape doing nothing at all.
+    await setup(page);
+    await page.locator('[data-pane-toggle="tools"]').click();
+    await expect(page.locator('.motif-cs-inspector')).toHaveAttribute('data-tools-pinned', 'true');
+
+    const docked = page.locator('.motif-cs-inspector details[name="motif-cs-tools"]').first();
+    await docked.locator(':scope > summary').click();
+    await expect(docked).toHaveAttribute('open', '');
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.motif-cs-window')).toHaveCount(0);
   });
 
   test('grid drag past the right edge auto-scrolls into far columns', async ({ page }) => {
@@ -393,7 +490,10 @@ test.describe('Motif MSA viewer interactions', () => {
   });
 
   test('a near-vertical wheel gesture is not hijacked into horizontal scroll', async ({ page }) => {
-    await setupDna(page);
+    // Enough rows that the matrix overflows vertically. The matrix sizes to its
+    // panel and owns the vertical scroll, so the gesture is absorbed here rather
+    // than delegated to a scrolling window body.
+    await setup(page, 1440, 980, 120, 30);
     const scroll = page.locator('.motif-cs-msa-matrix-scroll');
     const spot = await center(page, 1, 10);
     await page.mouse.move(spot.x, spot.y);
@@ -401,15 +501,11 @@ test.describe('Motif MSA viewer interactions', () => {
     await page.mouse.wheel(180, 6);
     await expect.poll(() => scroll.evaluate((el) => el.scrollLeft)).toBeGreaterThan(0);
     const afterHorizontal = await scroll.evaluate((el) => el.scrollLeft);
-    const body = page.locator('.motif-cs-window-body');
-    const bodyBefore = await body.evaluate((el) => el.scrollTop);
+    const verticalBefore = await scroll.evaluate((el) => el.scrollTop);
     // A near-vertical gesture (tiny deltaX) must not change horizontal scroll —
     // its vertical delta is honoured instead of being swallowed as horizontal.
     await page.mouse.wheel(6, 160);
-    await expect.poll(() => scroll.evaluate((el) => el.scrollLeft)).toBe(afterHorizontal);
-    // ...and the vertical delta actually scrolled (the matrix has no vertical
-    // overflow here, so it delegates to the scrollable window body).
-    await expect.poll(() => body.evaluate((el) => el.scrollTop)).toBeGreaterThan(bodyBefore);
+    await expect.poll(() => scroll.evaluate((el) => el.scrollTop)).toBeGreaterThan(verticalBefore);
     expect(await scroll.evaluate((el) => el.scrollLeft)).toBe(afterHorizontal);
   });
 
@@ -675,6 +771,68 @@ test.describe('Motif MSA viewer interactions', () => {
     await expect(page.getByTestId('msa-zoom-reset')).toBeVisible();
   });
 
+  test('panning to the end brings the final column fully into view', async ({ page }) => {
+    // The scroller reserves a stable scrollbar gutter outside its content box.
+    // Content sized to the columns alone stops with its right edge against the
+    // OUTER edge, parking the last column underneath that reservation where no
+    // amount of scrolling retrieves it. Measured against the CONTENT box — the
+    // border box counts the gutter as visible and passes while the column is
+    // hidden.
+    await setup(page, 900, 860, 1000);
+    const pan = page.getByTestId('msa-horizontal-scroll');
+    await expect(pan).toBeVisible();
+    const max = await pan.evaluate((element) => (element as HTMLInputElement).max);
+    await pan.fill(max);
+
+    // Scrolling is immediate, while the virtualized column window is deliberately
+    // updated on the next animation frame. Wait for that render boundary before
+    // measuring the final cell; the geometry assertions below remain exact.
+    await expect(
+      page.locator('.motif-cs-msa-matrix-row').first().locator('[data-alignment-column="1000"]'),
+    ).toBeAttached();
+
+    const tail = await page.evaluate((lastColumn) => {
+      const scroller = document.querySelector('.motif-cs-msa-matrix-scroll');
+      const cell = document.querySelector(`.motif-cs-msa-matrix-row [data-alignment-column="${lastColumn}"]`);
+      const gutter = document.querySelector('.motif-cs-msa-sticky-label');
+      if (!scroller || !cell || !gutter) return null;
+      const box = scroller.getBoundingClientRect();
+      const contentRight = box.left + scroller.clientLeft + scroller.clientWidth;
+      const clipLeft = Math.max(box.left, gutter.getBoundingClientRect().right);
+      const rect = cell.getBoundingClientRect();
+      return {
+        width: rect.width,
+        visibleWidth: Math.max(0, Math.min(rect.right, contentRight) - Math.max(rect.left, clipLeft)),
+        scrollLeft: scroller.scrollLeft,
+      };
+    }, 1000);
+
+    if (!tail) {
+      // This null has fired under machine load, and "matrix tail geometry
+      // missing" names neither which of the three lookups came back empty nor
+      // what the scroller had settled on — so the failure could only be re-run,
+      // never read. Gathered on the failing path alone, so the passing path is
+      // unchanged.
+      const why = await page.evaluate(() => {
+        const scroller = document.querySelector('.motif-cs-msa-matrix-scroll');
+        const columns = [...document.querySelectorAll('.motif-cs-msa-matrix-row:first-of-type [data-alignment-column]')]
+          .map((cell) => cell.getAttribute('data-alignment-column'));
+        return [
+          `scroller=${Boolean(scroller)}`,
+          `stickyLabel=${Boolean(document.querySelector('.motif-cs-msa-sticky-label'))}`,
+          `renderedColumns=${columns.length} (${columns[0] ?? 'none'}…${columns[columns.length - 1] ?? 'none'})`,
+          `scrollLeft=${scroller?.scrollLeft ?? '?'} of ${scroller ? scroller.scrollWidth - scroller.clientWidth : '?'}`,
+        ].join(' ');
+      });
+      throw new Error(`matrix tail geometry missing: ${why}`);
+    }
+    expect(tail.width).toBeGreaterThan(0);
+    // Fully visible, not merely intersecting: the defect left 0 of 10.6px.
+    expect(tail.visibleWidth).toBeGreaterThan(tail.width - 0.5);
+    // The scroller reaches the range the pan control advertises, not 15px short.
+    expect(tail.scrollLeft).toBeGreaterThan(Number(max) - 1);
+  });
+
   test('very long alignments offer an honest minimum zoom instead of claiming to fit', async ({ page }) => {
     await setup(page, 900, 860, 1000);
     const control = page.getByTestId('msa-zoom-fit');
@@ -886,5 +1044,436 @@ test.describe('Motif MSA viewer interactions', () => {
     // The crowded set wrapped onto a second line rather than overflowing.
     const row = await page.getByTestId('msa-zoom-row').boundingBox();
     expect(row!.height).toBeGreaterThan(40);
+  });
+
+  test('zoom and the visible-column readout share one status line', async ({ page }) => {
+    await setup(page, 1280, 900, 400, 6);
+    const zoom = await page.getByTestId('msa-zoom-row').boundingBox();
+    const note = await page.locator('.motif-cs-msa-window-note').boundingBox();
+    if (!zoom || !note) throw new Error('status line missing');
+    // Same line: their vertical centres coincide, and the readout sits to the right.
+    expect(Math.abs((zoom.y + zoom.height / 2) - (note.y + note.height / 2))).toBeLessThanOrEqual(2);
+    expect(note.x).toBeGreaterThan(zoom.x + zoom.width - 1);
+  });
+
+  test('the export menu holds every export control and closes before the window', async ({ page }) => {
+    await setup(page, 1280, 900);
+    const trigger = page.getByTestId('msa-export-menu-button');
+    const panel = page.getByTestId('msa-export-menu');
+    await expect(trigger).toBeVisible();
+    await expect(panel).toBeHidden();
+
+    await trigger.click();
+    await expect(panel).toBeVisible();
+    for (const name of ['Copy', 'Download', 'Save PNG', 'Save SVG']) {
+      await expect(panel.getByRole('button', { name, exact: true })).toBeVisible();
+    }
+    await expect(panel.getByRole('combobox', { name: 'Export', exact: true })).toBeVisible();
+    await expect(page.getByTestId('msa-export-image-scope')).toBeVisible();
+
+    // Escape dismisses the menu and returns focus to its trigger; the window
+    // beneath must survive, and only a second Escape may close it.
+    await page.keyboard.press('Escape');
+    await expect(panel).toBeHidden();
+    await expect(page.getByTestId('msa-alignment-view')).toBeVisible();
+    await expect(trigger).toBeFocused();
+  });
+
+  // Residue fills are the only <rect> elements the image renderers emit per cell;
+  // the page background and the label gutter are emitted without x/y.
+  const svgCellFills = (svg: string) => [...svg.matchAll(
+    /<rect x="[^"]*" y="[^"]*" width="[^"]*" height="[^"]*" fill="([^"]+)"\/>/g,
+  )].map((match) => match[1]);
+
+  async function savedSvg(page: Page) {
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByTestId('msa-export-svg').click(),
+    ]);
+    const path = await download.path();
+    if (!path) throw new Error('the SVG export produced no file — nothing below was measured');
+    return readFileSync(path, 'utf8');
+  }
+
+  test('stepping back off the first difference returns to neutral instead of the far end', async ({ page }) => {
+    // Regression: both ends wrapped by modular arithmetic with nothing said, so
+    // three Prev presses from the start read "N of N" and threw the view to the
+    // opposite end of the alignment — and Prev from the neutral state did it
+    // before the user had gone anywhere. One round trip would not show this.
+    await setup(page);
+    const counter = page.locator('.motif-cs-msa-difference-nav span').first();
+    const previous = page.getByLabel('Previous variable column').first();
+    const next = page.getByLabel('Next variable column').first();
+    const total = (await counter.textContent())?.match(/of\s+([\d,]+)/)?.[1];
+    if (!total) throw new Error('no difference total on the counter — nothing below was measured');
+    expect(Number(total.replaceAll(',', ''))).toBeGreaterThan(3);
+
+    await expect(counter).toHaveText(`Difference — of ${total}`);
+    await previous.click();
+    await expect(counter).toHaveText(`Difference — of ${total}`);
+
+    for (const step of [1, 2, 3]) {
+      await next.click();
+      await expect(counter).toHaveText(`Difference ${step} of ${total}`);
+    }
+    for (const step of [2, 1]) {
+      await previous.click();
+      await expect(counter).toHaveText(`Difference ${step} of ${total}`);
+    }
+    await previous.click();
+    await expect(counter).toHaveText(`Difference — of ${total}`);
+  });
+
+  test('the search readout says what its number is before a match is stepped to', async ({ page }) => {
+    // A bare "36" beside two step arrows reads as "match 36".
+    await setup(page);
+    const readout = page.getByTestId('msa-search-count');
+    await page.getByTestId('msa-search-input').fill('AIR');
+    await expect(readout).toHaveText(/^\d+ matches$/);
+    await page.getByTestId('msa-search-input').press('Enter');
+    await expect(readout).toHaveText(/^1 of \d+$/);
+  });
+
+  test('the exported image follows the residue-colour toggle, and stays legible without it', async ({ page }) => {
+    // Regression: the export read only `colorScheme` and never `colorMode`, so
+    // turning colours off changed nothing — and since the scheme select is
+    // disabled while colours are off, the file was coloured by a setting the UI
+    // was preventing the user from inspecting.
+    await setup(page);
+    await page.getByTestId('msa-view-menu-button').click();
+    await page.getByLabel('Colour scheme').isDisabled();
+    await page.keyboard.press('Escape');
+
+    await page.getByTestId('msa-export-menu-button').click();
+    await expect(page.getByTestId('msa-export-image-scope')).toBeVisible();
+    const mono = svgCellFills(await savedSvg(page));
+    await page.keyboard.press('Escape');
+
+    await page.getByTestId('msa-view-menu-button').click();
+    await page.getByRole('checkbox', { name: 'Residue colors' }).check();
+    await page.getByLabel('Colour scheme').selectOption('taylor');
+    await page.keyboard.press('Escape');
+    await page.getByTestId('msa-export-menu-button').click();
+    const coloured = svgCellFills(await savedSvg(page));
+    await page.keyboard.press('Escape');
+
+    // Colours on: every cell painted, in the scheme that was chosen. Taylor is
+    // used rather than clustal because 'auto' resolves TO clustal for a protein,
+    // so comparing those two compares a scheme with itself.
+    expect(coloured.length).toBeGreaterThan(300);
+    expect(new Set(coloured).size).toBeGreaterThan(9);
+    // Colours off: no residue fills at all, and the letters are still there — the
+    // image is monochrome, not empty.
+    expect(mono.length).toBeLessThan(coloured.length / 10);
+    expect(new Set(mono).size).toBeLessThanOrEqual(1);
+
+    // The exception, and the reason this is not simply "skip the fills": once the
+    // alignment is too wide to draw letters, colour is all that is left carrying
+    // the sequence, so a monochrome whole-alignment export must still be painted.
+    await setup(page, 1440, 980, 6000);
+    await page.getByTestId('msa-export-menu-button').click();
+    await page.getByTestId('msa-export-image-scope').selectOption('all');
+    const dense = await savedSvg(page);
+    const denseFills = svgCellFills(dense);
+    // Precondition: this really is the letters-dropped regime. The document
+    // always carries a title and axis ticks, so "no <text> at all" would be the
+    // wrong test — what marks birdseye is text becoming negligible against cells.
+    expect((dense.match(/<text /g) ?? []).length).toBeLessThan(denseFills.length / 10);
+    expect(denseFills.length).toBeGreaterThan(1000);
+  });
+
+  test('resetting the alignment view keeps the export format and the pane you are in', async ({ page }) => {
+    // Regression: the reset spread the whole defaults object, so a control called
+    // "Reset alignment view" silently changed the chosen export format and threw
+    // a user reading the Text pane back into the Viewer.
+    await setup(page);
+    await page.getByTestId('msa-export-menu-button').click();
+    const format = page.getByTestId('msa-export-menu').locator('select').first();
+    await format.selectOption('clustal');
+    await page.keyboard.press('Escape');
+    await page.getByRole('button', { name: 'Text', exact: true }).click();
+    const pane = page.getByRole('button', { name: 'Text', exact: true });
+    await expect(pane).toHaveAttribute('aria-pressed', 'true');
+
+    // Move something the reset SHOULD restore, so this proves narrowing rather
+    // than a reset that no longer does anything.
+    await page.getByTestId('msa-view-menu-button').click();
+    await page.getByRole('checkbox', { name: 'Residue colors' }).check();
+    await page.getByRole('button', { name: 'Reset alignment view' }).click();
+
+    await expect(page.getByRole('checkbox', { name: 'Residue colors' })).not.toBeChecked();
+    await expect(pane).toHaveAttribute('aria-pressed', 'true');
+    await page.keyboard.press('Escape');
+    await page.getByTestId('msa-export-menu-button').click();
+    await expect(format).toHaveValue('clustal');
+  });
+
+  test('cycling reference numbering leaves one result per state, with stable names', async ({ page }) => {
+    // Regression: "Use plain 1-based" forked instead of going back, and the name
+    // it asked for was already suffixed, so the suffix concatenated. Three round
+    // trips left seven results ending in "REVIEW 2 2 2 2 2 2". A single round trip
+    // would not have shown either problem.
+    await setup(page, 1440, 1100);
+    await page.getByTestId('msa-view-menu-button').click();
+    const savedResults = () => page.locator('.motif-cs-msa-alignment-picker select option').allTextContents();
+    const numberingIsOn = () => page.getByTestId('msa-reference-numbering-editor').evaluate((el) => el.getAttribute('data-active') === 'true');
+
+    expect(await savedResults()).toEqual(['E2E protein panel']);
+    await page.getByTestId('msa-apply-reference-numbering').click();
+    await expect.poll(numberingIsOn).toBe(true);
+    const afterFirstApply = await savedResults();
+    expect(afterFirstApply).toHaveLength(2);
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      await page.getByTestId('msa-clear-reference-numbering').click();
+      await expect.poll(numberingIsOn).toBe(false);
+      expect(await savedResults()).toEqual(afterFirstApply);
+
+      await page.getByTestId('msa-apply-reference-numbering').click();
+      await expect.poll(numberingIsOn).toBe(true);
+      expect(await savedResults()).toEqual(afterFirstApply);
+    }
+    // No name may be a suffix pile-up, and no two may collide.
+    for (const name of afterFirstApply) expect(name).not.toMatch(/\s\d+\s+\d+$/);
+    expect(new Set(afterFirstApply).size).toBe(afterFirstApply.length);
+
+    // A genuinely different numbering IS a new result, and it counts up from the
+    // root rather than gluing another suffix on.
+    await page.getByTestId('msa-reference-numbering-position').fill('250');
+    await page.getByTestId('msa-apply-reference-numbering').click();
+    await expect.poll(async () => (await savedResults()).length).toBe(3);
+    const names = await savedResults();
+    expect(names[2]).toBe(`${names[0]} 3`);
+  });
+
+  test('the view menu grows with the window instead of stopping at a constant', async ({ page }) => {
+    // Regression: the cap was `min(430px, <window expression>)`. Every window
+    // taller than 540px made min() pick the constant, so the menu showed 428px of
+    // an 807px list at every window size — and dragging the window taller changed
+    // nothing, leaving 852px of window unused beside 379px of hidden menu.
+    await setup(page, 1440, 1300);
+    await page.getByTestId('msa-view-menu-button').click();
+    const panel = page.getByTestId('msa-view-menu');
+    await expect(panel).toBeVisible();
+
+    const read = () => panel.evaluate((el) => {
+      const host = el.closest('.motif-cs-window');
+      if (!host) throw new Error('the view menu is not inside a window — this measures nothing');
+      const panelBox = el.getBoundingClientRect();
+      const windowBox = host.getBoundingClientRect();
+      if (panelBox.height <= 0) throw new Error('the view menu panel has no box — this measures nothing');
+      return {
+        windowHeight: Math.round(windowBox.height),
+        visible: el.clientHeight,
+        content: el.scrollHeight,
+        hidden: el.scrollHeight - el.clientHeight,
+        pastWindowBottom: Math.round(panelBox.bottom - windowBox.bottom),
+        // Minus the panel's own two 1px borders; what is left is scrollbar.
+        gutter: el.offsetWidth - el.clientWidth - 2,
+      };
+    });
+
+    const handle = page.locator('.motif-cs-window-resize').first();
+    await handle.focus();
+    for (let step = 0; step < 40; step += 1) await handle.press('Shift+ArrowUp');
+    const samples = [await read()];
+    for (let batch = 0; batch < 4; batch += 1) {
+      for (let step = 0; step < 10; step += 1) await handle.press('Shift+ArrowDown');
+      samples.push(await read());
+    }
+
+    // The window really did grow each time; without this the heights below would
+    // agree for the most boring possible reason.
+    for (let index = 1; index < samples.length; index += 1) {
+      expect(samples[index].windowHeight).toBeGreaterThan(samples[index - 1].windowHeight);
+    }
+    // The menu grew with it, and monotonically.
+    expect(new Set(samples.map((sample) => sample.visible)).size).toBeGreaterThan(1);
+    for (let index = 1; index < samples.length; index += 1) {
+      expect(samples[index].visible).toBeGreaterThanOrEqual(samples[index - 1].visible);
+    }
+    // Given room, it stops hiding anything at all.
+    const tallest = samples[samples.length - 1];
+    expect(tallest.hidden).toBe(0);
+    expect(tallest.visible).toBe(tallest.content);
+    // It never outgrows the window, which is overflow: hidden and would clip it.
+    // The first sample is the 180px window floor, where the menu's own 120px floor
+    // legitimately wins.
+    for (const sample of samples.slice(1)) expect(sample.pastWindowBottom).toBeLessThanOrEqual(0);
+    // And whatever is still hidden is signalled rather than left silent.
+    for (const sample of samples) expect(sample.gutter).toBeGreaterThan(0);
+  });
+
+  test('toolbar menu panels stay inside the window at a narrow width', async ({ page }) => {
+    // Regression: the panels were anchored to their own trigger and right-aligned
+    // to it, so a panel wider than the gap to the left edge hung off-screen — at
+    // this width the export panel began 106px past it, unreachable.
+    await setup(page, 760, 820);
+    for (const [triggerId, panelId] of [
+      ['msa-export-menu-button', 'msa-export-menu'],
+      ['msa-view-menu-button', 'msa-view-menu'],
+      ['msa-goto-menu-button', 'msa-goto-menu'],
+    ]) {
+      await page.getByTestId(triggerId).click();
+      const box = await page.getByTestId(panelId).boundingBox();
+      if (!box) throw new Error(`${panelId} missing`);
+      expect(box.x).toBeGreaterThanOrEqual(0);
+      expect(box.x + box.width).toBeLessThanOrEqual(760);
+      await page.keyboard.press('Escape');
+    }
+  });
+
+  test('the window corner grip still takes the mouse at the smallest window size', async ({ page }) => {
+    // Regression: the grip declared no z-index, so it only outranked content
+    // stacking at auto. Narrow the window and the sticky toolbar wraps taller
+    // than a short body, so it covers the bottom-right corner; at z-index 10 it
+    // then painted over the grip and took the press itself. Mouse resizing died
+    // completely at 280x180, with 82% of the body below the fold and no
+    // scrollbar, so nothing but the keyboard could get the window back.
+    await setup(page, 1440, 900);
+    const grip = page.getByRole('button', { name: /^Resize .* window in 2 dimensions/ });
+    const size = async () => page.evaluate(() => {
+      const box = document.querySelector('.motif-cs-window')!.getBoundingClientRect();
+      return { w: Math.round(box.width), h: Math.round(box.height) };
+    });
+
+    // Reach the minimum through the keyboard path, which never depended on paint
+    // order — so the state under test is reached even when the grip is buried.
+    await grip.focus();
+    for (let step = 0; step < 200; step += 1) {
+      const now = await size();
+      if (now.w <= 280 && now.h <= 180) break;
+      await page.keyboard.press(now.w > 280 ? 'ArrowLeft' : 'ArrowUp');
+    }
+    expect(await size()).toEqual({ w: 280, h: 180 });
+
+    // The grip is window chrome: it has to be the element under its own centre.
+    const centre = await page.evaluate(() => {
+      const box = document.querySelector('.motif-cs-window-resize')!.getBoundingClientRect();
+      const x = box.x + box.width / 2;
+      const y = box.y + box.height / 2;
+      const hit = document.elementFromPoint(x, y);
+      return { x, y, hit: hit ? `${hit.tagName}.${hit.className}` : 'none' };
+    });
+    expect(centre.hit).toBe('BUTTON.motif-cs-window-resize');
+
+    // And a real mouse drag from there resizes. Pinned to the absolute size the
+    // drag has to produce, so a partly working drag cannot pass either.
+    await page.mouse.move(centre.x, centre.y);
+    await page.mouse.down();
+    for (let step = 1; step <= 10; step += 1) {
+      await page.mouse.move(centre.x + step * 20, centre.y + step * 20);
+    }
+    await page.mouse.up();
+    expect(await size()).toEqual({ w: 480, h: 380 });
+  });
+
+  test('"Reset display" restores a shrunken alignment window that reopening deliberately does not', async ({ page }) => {
+    // Two behaviours that look like one bug and are not. Keeping a dragged size
+    // across a close and reopen is correct — a size chosen by dragging a corner
+    // is a choice, and closing a window is not a request to forget it. What was
+    // missing is the way back: the seven floating tool windows keep their
+    // geometry in state that "Reset display" never touched, so the button put
+    // the panes right and left the window exactly as small as it found it.
+    //
+    // The half that is easy to get wrong is the OPEN window. `initial` is read
+    // once, in a useState initialiser, so resetting the parent's rect alone
+    // moves nothing on screen — measured, that leaves the window at 280x180
+    // while silently fixing only the NEXT open, which is the one moment the
+    // user is guaranteed not to be looking. Both states are asserted below.
+    await setup(page, 1440, 900);
+    const size = async () => page.evaluate(() => {
+      const box = document.querySelector('.motif-cs-window')!.getBoundingClientRect();
+      return { w: Math.round(box.width), h: Math.round(box.height) };
+    });
+    const reopen = async () => {
+      await page.locator('.motif-cs-window-close').first().click();
+      await expect(page.getByTestId('msa-alignment-view')).toBeHidden();
+      await page.getByTestId('msa-open-button').dispatchEvent('click');
+      await expect(page.getByTestId('msa-alignment-view')).toBeVisible();
+    };
+
+    // min(940, 1440 - 40) x min(820, 900 - 150). Pinned, so a change to either
+    // cap has to come past this test rather than through it.
+    const defaultSize = { w: 940, h: 750 };
+    expect(await size()).toEqual(defaultSize);
+
+    const grip = await page.evaluate(() => {
+      const box = document.querySelector('.motif-cs-window-resize')!.getBoundingClientRect();
+      return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+    });
+    await page.mouse.move(grip.x, grip.y);
+    await page.mouse.down();
+    for (let step = 1; step <= 20; step += 1) {
+      await page.mouse.move(grip.x - step * 40, grip.y - step * 32, { steps: 2 });
+    }
+    await page.mouse.up();
+    // The floor. Asserted rather than assumed: everything below is about
+    // recovering from this state, so a drag that never reached it would leave
+    // the rest of this test proving nothing.
+    expect(await size()).toEqual({ w: 280, h: 180 });
+
+    await reopen();
+    expect(await size(), 'a deliberately chosen window size must survive a reopen').toEqual({ w: 280, h: 180 });
+
+    const settings = page.locator('details[data-rail-tool="settings"]');
+    await settings.locator(':scope > summary').click();
+    await settings.getByRole('button', { name: 'Reset display' }).click();
+    await expect.poll(size, { message: 'Reset display left the OPEN window at its floor' }).toEqual(defaultSize);
+
+    await reopen();
+    expect(await size(), 'the reset must clear the remembered size, not just the rendered one').toEqual(defaultSize);
+  });
+
+  test('Escape dismisses a toolbar menu opened a moment earlier instead of closing the window', async ({ page }) => {
+    // Regression: the window deferred to an open menu by looking for a rendered
+    // data-motif-cs-escape-scope attribute, but for a native <details> that
+    // attribute only arrives with React's `toggle` handler — measured at ~52ms
+    // after the browser had already opened the menu on screen. An Escape inside
+    // that interval found no scope, so the window closed and took the alignment
+    // with it. On a loaded machine the interval is far longer, which is how the
+    // artifact suite hit this about one run in six while passing in isolation.
+    //
+    // Click and key both go through CDP, back to back: real trusted input, with
+    // only the automation round trip removed — which is what a busy machine
+    // removes as well.
+    await page.addInitScript(() => {
+      (window as unknown as { __escapeState?: unknown }).__escapeState = null;
+      window.addEventListener('keydown', (event) => {
+        if (event.key !== 'Escape') return;
+        const host = document.querySelector<HTMLDetailsElement>('details.motif-cs-msa-export-menu');
+        const shell = document.querySelector('.motif-cs-window');
+        (window as unknown as { __escapeState?: unknown }).__escapeState = {
+          isTrusted: event.isTrusted,
+          menuOpen: host ? host.open : null,
+          renderedScope: !!shell?.querySelector('[data-motif-cs-escape-scope="true"]'),
+        };
+      }, true);
+    });
+    await setup(page, 1280, 900);
+
+    const client = await page.context().newCDPSession(page);
+    const box = await page.getByTestId('msa-export-menu-button').boundingBox();
+    if (!box) throw new Error('export menu trigger has no box');
+    const x = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+    const mouse = (type: string, buttons: number) => client.send('Input.dispatchMouseEvent', { type, x, y, button: 'left', clickCount: 1, buttons });
+    const key = (type: string) => client.send('Input.dispatchKeyEvent', { type, key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27, nativeVirtualKeyCode: 27 });
+    await Promise.all([mouse('mousePressed', 1), mouse('mouseReleased', 0), key('keyDown'), key('keyUp')]);
+    await page.waitForTimeout(400);
+
+    // The state under test has to have been reached: menu open on screen while
+    // the rendered scope attribute is still absent. Without this the test would
+    // keep passing if that interval ever closed, while checking nothing at all.
+    type EscapeState = { isTrusted: boolean; menuOpen: boolean | null; renderedScope: boolean };
+    const observed = await page.evaluate(() => (window as unknown as { __escapeState?: EscapeState | null }).__escapeState);
+    expect(observed, 'no Escape reached the page').toBeTruthy();
+    expect(observed!.isTrusted, 'the key must be real input, not a dispatched event').toBe(true);
+    expect(observed!.menuOpen, 'the menu must be open when Escape lands').toBe(true);
+    expect(observed!.renderedScope, 'the race window was never entered — this test no longer tests anything').toBe(false);
+
+    // The window survives, and the key does what the user meant by it.
+    await expect(page.getByTestId('msa-alignment-view')).toBeVisible();
+    await expect(page.locator('details.motif-cs-msa-export-menu')).not.toHaveAttribute('open', /.*/);
   });
 });

--- a/e2e/claude-science-pane-placement.spec.ts
+++ b/e2e/claude-science-pane-placement.spec.ts
@@ -120,4 +120,169 @@ test.describe('state-preserving pane placement', () => {
     await expect(sequenceCollapse).toHaveAttribute('title', 'Keep one content pane docked in the workspace');
     await expect(page.locator('.motif-cs-main')).toHaveAttribute('data-content-pane-count', '1');
   });
+
+  test('the circular map keeps its status readout inside the part of the column it shows', async ({ page }) => {
+    // Regression: the readout hung off the map frame's BOTTOM edge, and between
+    // 768px and 1535px that frame is floored taller than its column can display —
+    // 504px of frame in a 442px column at 1440x900, 141px scrolled away. The
+    // readout was inside that 141px at every size in the band, at rest and zoomed
+    // alike, because the clip is static rather than a zoom artefact. It was
+    // reachable by scrolling the map pane, which nothing invites.
+    //
+    // Measured against the column's clip rect, NOT with a hit test: the readout
+    // computes `pointer-events: none`, so elementFromPoint at its own centre
+    // returns the map container beneath it at every size — including the sizes
+    // where nothing is wrong, which is what makes that instrument useless here.
+    for (const [width, height] of [[1440, 900], [1280, 900], [1024, 768]] as const) {
+      await openArtifact(page, width, height);
+
+      // The readout only exists once something has zoomed or selected — it renders
+      // from a string that is empty at rest. Zoom, then assert it is really there,
+      // so an absent element can never read as "not below the fold".
+      const zoomIn = page.locator('button[aria-label="Zoom in"]').first();
+      for (let step = 0; step < 4; step += 1) await zoomIn.click();
+      const hint = page.locator('.motif-cs-map-hint');
+      await expect(hint, `no readout to measure at ${width}x${height}`).toBeVisible();
+
+      const geometry = await page.evaluate(() => {
+        const node = document.querySelector('.motif-cs-map-hint')!;
+        const column = document.querySelector('.motif-cs-map-column')!;
+        const box = node.getBoundingClientRect();
+        const columnBox = column.getBoundingClientRect();
+        return {
+          belowBy: Math.round(box.bottom - (columnBox.top + column.clientHeight)),
+          aboveBy: Math.round(columnBox.top - box.top),
+          columnHides: Math.round(column.scrollHeight - column.clientHeight),
+          mode: document.querySelector('[data-map-mode]')?.getAttribute('data-map-mode'),
+        };
+      });
+
+      expect(geometry.mode, 'this test is about the circular map').toBe('circular');
+      // The precondition that makes the assertion meaningful: the column really is
+      // clipping something here. If it ever stops overflowing, the readout being
+      // visible proves nothing and this test should be re-derived rather than
+      // quietly kept.
+      expect(geometry.columnHides, `column stopped overflowing at ${width}x${height}`).toBeGreaterThan(0);
+      expect(geometry.belowBy, `readout below the column's visible edge at ${width}x${height}`).toBeLessThan(0);
+      expect(geometry.aboveBy, `readout above the column's visible edge at ${width}x${height}`).toBeLessThan(0);
+    }
+  });
+
+  test('the map dock heads stay on screen as a column footer wherever the column scrolls', async ({ page }) => {
+    // The end of the map workflow — Map Visibility and Digest Preview — sat below the
+    // fold at every desktop size under 1536: measured 138px past the column's visible
+    // edge at 900x700, 133 at 1024x768, 131 at 1280x900 and 1440x900, 85 at 1440x1200.
+    // Reachable by scrolling the map pane, which nothing invites.
+    //
+    // REFUTED on the way, recorded so it is not retried: reviving the dead
+    // `.motif-cs-map-column { max-width: min(900px, 62vw) }` does NOT fix this. Applying
+    // it narrows the column from 1377px to 878px at 1440x900 and moves the fold by
+    // exactly 0px, because the frame's height comes from `min-height: clamp(410px, 56vh,
+    // 620px)` — a pure viewport-height expression that column width never enters. The
+    // discriminating pair is 1280x900 against 1440x900: 160px of column width apart,
+    // frame height identical at 504px.
+    const heads = async () => page.evaluate(() => {
+      const column = document.querySelector('.motif-cs-map-column')!;
+      const columnBox = column.getBoundingClientRect();
+      const visibleBottom = columnBox.top + column.clientHeight;
+      const named = (text: string) => [...document.querySelectorAll('summary.motif-cs-panel-head')]
+        .find((node) => node.textContent!.trim().startsWith(text));
+      const belowBy = (node?: Element) => (node ? Math.round(node.getBoundingClientRect().bottom - visibleBottom) : null);
+      const strip = document.querySelector('.motif-cs-map-dock-strip')!;
+      const stripBox = strip.getBoundingClientRect();
+      const hit = document.elementFromPoint(Math.round(stripBox.left + 30), Math.round(stripBox.top + stripBox.height / 2));
+      const readout = document.querySelector('.motif-cs-map-hint');
+      const readoutBox = readout?.getBoundingClientRect();
+      return {
+        columnHides: Math.round(column.scrollHeight - column.clientHeight),
+        mapVisibility: belowBy(named('Map Visibility')),
+        digestPreview: belowBy(named('Digest Preview')),
+        // These heads are buttons, so unlike the readout a hit test IS the right
+        // instrument — it is what decides whether a press reaches them.
+        pressReachesStrip: !!hit && strip.contains(hit),
+        overlapsReadout: !!readoutBox && !(stripBox.bottom < readoutBox.top || stripBox.top > readoutBox.bottom),
+      };
+    });
+
+    for (const [width, height] of [[900, 700], [1280, 900], [1440, 900]] as const) {
+      await openArtifact(page, width, height);
+      const zoomIn = page.locator('button[aria-label="Zoom in"]').first();
+      for (let step = 0; step < 4; step += 1) await zoomIn.click();
+
+      const result = await heads();
+      // Precondition: without overflow a sticky footer is inert, and this would pass on
+      // a column that simply fits.
+      expect(result.columnHides, `column does not overflow at ${width}x${height}`).toBeGreaterThan(0);
+      expect(result.mapVisibility, `Map Visibility below the fold at ${width}x${height}`).toBeLessThanOrEqual(0);
+      expect(result.digestPreview, `Digest Preview below the fold at ${width}x${height}`).toBeLessThanOrEqual(0);
+      expect(result.pressReachesStrip, `a press at the dock strip does not reach it at ${width}x${height}`).toBe(true);
+      expect(result.overlapsReadout, `the footer covers the map readout at ${width}x${height}`).toBe(false);
+    }
+
+    // Where the column already fits, the footer must change nothing: `bottom` only
+    // engages while an ancestor scrolls, so this is the no-overflow control.
+    await openArtifact(page, 1920, 1080);
+    const settled = await heads();
+    expect(settled.columnHides, 'expected no overflow at 1920x1080').toBe(0);
+    expect(settled.mapVisibility).toBeLessThan(0);
+    expect(settled.digestPreview).toBeLessThan(0);
+  });
+
+  test('the annotations list reaches every feature in all three Tools placements', async ({ page }) => {
+    // Regression, and a SCOPING one rather than a plain miss. `max-height: min(24vh,
+    // 190px)` resolves to a flat 190px at every viewport height above 792px. It was
+    // fixed once, but as an addition under
+    // `.motif-cs-inspector[data-tools-pinned="false"]` — so the unpinned rail popover
+    // came right while the pinned docked column and the floated Tools pane kept the
+    // whole defect, and nothing looked wrong because a fix was on record. Measured in
+    // the pinned state: clientHeight 189 against scrollHeight 288, 3 of 8 rows
+    // unreachable, identically at 900, 980, 1080 and 1400 tall — constant across
+    // viewport height, which is the signature of the constant winning.
+    //
+    // All three placements are exercised, because the bug was exactly that one of
+    // them was checked and the other two were not.
+    await openArtifact(page, 1440, 980);
+
+    const annotations = page.locator('details[data-rail-tool="annotations"]');
+    const list = page.locator('.motif-cs-feature-annotation-list');
+    const openPanel = async () => {
+      if ((await annotations.getAttribute('open')) === null) {
+        await annotations.locator(':scope > summary').click();
+      }
+      await expect(list).toBeVisible();
+    };
+
+    const reachable = async (label: string) => {
+      const result = await page.evaluate(() => {
+        const node = document.querySelector('.motif-cs-feature-annotation-list')!;
+        const rows = [...node.querySelectorAll('.motif-cs-row')];
+        const box = node.getBoundingClientRect();
+        // A row scrolled out of a scroller still has a real rect, so geometry alone
+        // proves nothing — intersect with the list's own client box.
+        const visible = rows.filter((row) => {
+          const rowBox = row.getBoundingClientRect();
+          return rowBox.top >= box.top - 1 && rowBox.bottom <= box.top + node.clientHeight + 1;
+        }).length;
+        return { rows: rows.length, visible, hidden: node.scrollHeight - node.clientHeight };
+      });
+      // Precondition: a list short enough to fit under a 190px cap would pass this
+      // whether or not the cap was ever removed.
+      expect(result.rows, `${label}: too few features for this to test anything`).toBeGreaterThan(6);
+      expect(result.hidden, `${label}: the list still clips its own content`).toBe(0);
+      expect(result.visible, `${label}: rows unreachable inside the list`).toBe(result.rows);
+    };
+
+    await openPanel();
+    await reachable('unpinned rail popover');
+
+    await page.locator('[data-pane-toggle="tools"]').click();
+    await expect(page.locator('.motif-cs-inspector')).toHaveAttribute('data-tools-pinned', 'true');
+    await openPanel();
+    await reachable('pinned docked column');
+
+    await page.locator('[data-pane-key="tools"]').getByRole('button', { name: 'Pop out Tools pane' }).click();
+    await expect(page.locator('[data-pane-key="tools"]')).toHaveAttribute('data-pane-placement', 'floating');
+    await openPanel();
+    await reachable('floated Tools pane');
+  });
 });

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "claude-science:remove-local": "node scripts/configure-motif-claude-science-local.mjs --remove",
     "claude-science:setup": "npm run claude-science:build && npm run claude-science:doctor:unregistered && npm run claude-science:install-local && npm run claude-science:check-local",
     "check:css-tokens": "node scripts/check-css-tokens.mjs",
-    "check:aria-controls": "node scripts/check-aria-controls.mjs"
+    "check:aria-controls": "node scripts/check-aria-controls.mjs",
+    "gate": "npm run typecheck && npm run lint && npm test && npm run test:plugin && npm run test:connector && npm run check:css-tokens && npm run check:aria-controls && npm run build:motif && npm run test:e2e && npm run test:e2e:msa"
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "1.7.4",

--- a/scripts/__tests__/gate-parity.test.mjs
+++ b/scripts/__tests__/gate-parity.test.mjs
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// `npm run gate` is the canonical local check sequence. This test turns any
+// drift between that sequence and CI into a local failure.
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const workflow = readFileSync(resolve(root, '.github/workflows/ci.yml'), 'utf8');
+const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+
+// Steps that set the machine up rather than check the source. `npm ci` installs
+// dependencies and `npx playwright install` fetches a browser; neither is
+// something a local run should repeat on every commit.
+const SETUP_ONLY = new Set(['npm ci']);
+
+function npmCommands(script) {
+  return script
+    .split('&&')
+    .map((part) => part.trim())
+    .filter((part) => /^npm (run |test\b)/.test(part) && !SETUP_ONLY.has(part));
+}
+
+const ciCommands = [
+  ...workflow.matchAll(/^\s*run:\s*(.+)$/gm),
+].flatMap((match) => npmCommands(match[1]));
+
+const gateCommands = npmCommands(pkg.scripts.gate ?? '');
+
+describe('npm run gate matches CI', () => {
+  it('reads a non-trivial list out of both sides', () => {
+    // Guard the guard: a regex that stopped matching would make every
+    // assertion below pass by comparing two empty lists.
+    expect(ciCommands.length).toBeGreaterThan(5);
+    expect(gateCommands.length).toBeGreaterThan(5);
+  });
+
+  it('runs every check CI runs', () => {
+    const missing = ciCommands.filter((command) => !gateCommands.includes(command));
+    expect(missing, 'in CI but not in `npm run gate`').toEqual([]);
+  });
+
+  it('runs nothing CI does not', () => {
+    // The other direction matters too: a gate that checks more than CI turns
+    // green CI into an unreliable signal about what the gate proved.
+    const extra = gateCommands.filter((command) => !ciCommands.includes(command));
+    expect(extra, 'in `npm run gate` but not in CI').toEqual([]);
+  });
+});
+
+// The root tsconfig is solution-style: `{"files": [], "references": [...]}`.
+// `tsc --noEmit` reads it, finds no files and exits 0, while `tsc -b` follows
+// the project references. Build mode is therefore required for a meaningful
+// repository-wide typecheck.
+describe('the typecheck script builds the project references', () => {
+  const typecheck = pkg.scripts.typecheck ?? '';
+
+  it('uses build mode', () => {
+    expect(typecheck).toMatch(/\btsc\b.*\s-b\b/);
+  });
+
+  it('does not use --noEmit, which is vacuous against a solution-style root', () => {
+    expect(typecheck).not.toContain('--noEmit');
+  });
+
+  it('still has the empty root file list that makes --noEmit vacuous', () => {
+    // Guard the guard. If the root config ever gains its own files/include then
+    // --noEmit starts checking something, and the two tests above are defending
+    // against a hazard that no longer exists. Fail here so someone re-reads the
+    // comment rather than leaving a stale prohibition in place.
+    const rootConfig = JSON.parse(readFileSync(resolve(root, 'tsconfig.json'), 'utf8'));
+    expect(rootConfig.files).toEqual([]);
+    expect(rootConfig.include).toBeUndefined();
+    expect(rootConfig.references?.length ?? 0).toBeGreaterThan(0);
+  });
+});

--- a/src/artifacts/ClaudeScienceMsaViewer.tsx
+++ b/src/artifacts/ClaudeScienceMsaViewer.tsx
@@ -11,9 +11,10 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
+  type RefObject,
 } from 'react';
 import './claude-science-msa.css';
-import { ChevronDown, ChevronLeft, ChevronRight, GripVertical, Play, Search, SlidersHorizontal, Trash2, UploadCloud } from 'lucide-react';
+import { ChevronDown, ChevronLeft, ChevronRight, Crosshair, Download, GripVertical, Play, Search, SlidersHorizontal, Trash2, UploadCloud } from 'lucide-react';
 import { MSA_MAX_SEQ_LEN } from '../bio/msa';
 import type { SangerTraceData } from '../bio/abi-import';
 import { reverseComplement } from '../bio/reverse-complement';
@@ -55,6 +56,7 @@ import {
   type AlignmentImageLayout,
   type AlignmentImageScope,
   type ArtifactAlignment,
+  type ArtifactAlignmentReferenceNumbering,
   type ArtifactMsaRecord,
   type MsaColorScheme,
   type MsaColumnStats,
@@ -230,6 +232,56 @@ export function parseReferenceCoordinateColumn(
   return column < 0 ? null : column;
 }
 
+function sameOptionalStrings(a: readonly string[] | undefined, b: readonly string[] | undefined): boolean {
+  if (!a || !b) return !a && !b;
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function sameBooleans(a: readonly boolean[], b: readonly boolean[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+// A saved numbering variant receives a fresh id and name, but every scientific
+// and provenance field is preserved. Treat results as the same lineage only when
+// all of those preserved fields agree; identical residue text can legitimately
+// come from distinct engines, inputs, or analysis runs.
+function sameAlignmentApartFromNumbering(a: ArtifactAlignment, b: ArtifactAlignment): boolean {
+  return a.molecule === b.molecule
+    && a.referenceRowId === b.referenceRowId
+    && a.alignmentLength === b.alignmentLength
+    && a.centerIdx === b.centerIdx
+    && a.createdAt === b.createdAt
+    && a.outputSha256 === b.outputSha256
+    && a.note === b.note
+    && a.consensus === b.consensus
+    && sameBooleans(a.conserved, b.conserved)
+    && sameBooleans(a.gapOnly, b.gapOnly)
+    && a.engine.id === b.engine.id
+    && a.engine.label === b.engine.label
+    && a.engine.mode === b.engine.mode
+    && a.engine.version === b.engine.version
+    && a.engine.usedFallback === b.engine.usedFallback
+    && sameOptionalStrings(a.engine.parameters, b.engine.parameters)
+    && a.rows.length === b.rows.length
+    && a.rows.every((row, index) => {
+      const other = b.rows[index];
+      return row.id === other.id
+        && row.name === other.name
+        && row.aligned === other.aligned
+        && row.identity === other.identity
+        && row.sourceRecordId === other.sourceRecordId
+        && row.inputSha256 === other.inputSha256;
+    });
+}
+
+function sameReferenceNumbering(
+  a: ArtifactAlignmentReferenceNumbering | undefined,
+  b: ArtifactAlignmentReferenceNumbering | undefined,
+): boolean {
+  if (!a || !b) return !a && !b;
+  return a.rowId === b.rowId && a.firstResiduePosition === b.firstResiduePosition;
+}
+
 export type ClaudeScienceMsaViewerProps = {
   records: readonly ViewerRecord[];
   alignments: readonly ArtifactAlignment[];
@@ -399,11 +451,15 @@ function downloadBlobFile(filename: string, blob: Blob) {
   window.setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
-/** Draw the alignment onto an off-DOM canvas sized from the layout. */
+/**
+ * Draw the alignment onto an off-DOM canvas sized from the layout. A null scheme
+ * means the caller asked for no residue colouring, and cells are left as
+ * background — the export's equivalent of the matrix's monochrome mode.
+ */
 function renderAlignmentImageCanvas(
   rows: readonly ImageExportRow[],
   molecule: SequenceType,
-  scheme: MsaColorScheme,
+  scheme: MsaColorScheme | null,
   layout: AlignmentImageLayout,
   title: string,
 ): HTMLCanvasElement | null {
@@ -455,7 +511,7 @@ function renderAlignmentImageCanvas(
     const row = rows[rowIndex];
     const y = layout.headerHeight + rowIndex * layout.cellHeight;
     // Cell backgrounds (+0.5 overdraw removes hairline seams between tiles).
-    for (let index = 0; index < layout.columnCount; index += 1) {
+    for (let index = 0; scheme && index < layout.columnCount; index += 1) {
       const symbol = row.aligned[layout.startColumn + index] ?? '-';
       const fill = resolveResidueCellColor(symbol, molecule, scheme, bg);
       if (!fill) continue;
@@ -493,11 +549,14 @@ function canvasToPngBlob(canvas: HTMLCanvasElement): Promise<Blob | null> {
   });
 }
 
-/** Build a self-contained SVG document for the alignment (vector alternative). */
+/**
+ * Build a self-contained SVG document for the alignment (vector alternative).
+ * A null scheme means no residue colouring, as in the canvas renderer above.
+ */
 function renderAlignmentImageSvg(
   rows: readonly ImageExportRow[],
   molecule: SequenceType,
-  scheme: MsaColorScheme,
+  scheme: MsaColorScheme | null,
   layout: AlignmentImageLayout,
   title: string,
 ): string {
@@ -531,7 +590,7 @@ function renderAlignmentImageSvg(
     const row = rows[rowIndex];
     const y = layout.headerHeight + rowIndex * layout.cellHeight;
     // Cell backgrounds.
-    for (let index = 0; index < layout.columnCount; index += 1) {
+    for (let index = 0; scheme && index < layout.columnCount; index += 1) {
       const symbol = row.aligned[layout.startColumn + index] ?? '-';
       const fill = resolveResidueCellColor(symbol, molecule, scheme, bg);
       if (!fill) continue;
@@ -814,6 +873,57 @@ export function ambiguousColumns(
   return columns;
 }
 
+// The shared prefix is CHOSEN by a case-insensitive comparison, so it has to be
+// RECOGNISED by one too. Mixed-case accession or chromosome prefixes — "Chr1_"
+// beside "chr1_", "sp|" beside "SP|" — otherwise leave exactly one row holding
+// its full name while every sibling loses theirs, and that longer row is then
+// the one a narrow control truncates. Precisely backwards.
+function startsWithSharedPrefix(name: string, prefix: string): boolean {
+  return prefix.length > 0
+    && name.length >= prefix.length
+    && name.slice(0, prefix.length).toLocaleLowerCase() === prefix.toLocaleLowerCase();
+}
+
+// Drop a prefix every row shares, keeping the whole name if nothing would be
+// left. Used wherever a narrow control has to tell rows apart by their text.
+function withoutSharedPrefix(name: string, prefix: string): string {
+  if (!startsWithSharedPrefix(name, prefix)) return name;
+  return name.slice(prefix.length).replace(/^[\s_./-]+/u, '') || name;
+}
+
+// Width of the sticky row-name gutter, and therefore the x origin of the
+// residue grid. Names are the index; residues are the subject. At the previous
+// 30% of viewport width this gutter cost as much as both app rails combined, so
+// it is biased back toward the alignment while keeping rows tellable apart.
+// eslint-disable-next-line react-refresh/only-export-components -- pure MSA helper exported for unit tests
+export function msaRowLabelWidth(viewportWidth: number): number {
+  return Math.max(136, Math.min(216, Math.round(viewportWidth * 0.22)));
+}
+
+// Rows in one alignment routinely share a gene or project prefix ("PAL — ")
+// that repeats on every label and so does nothing to tell them apart. The name
+// gutter is narrow and truncates from the right, which spends its width on that
+// shared text and elides the species that actually differs. Returns the prefix
+// worth hiding, or '' when there is none; the full name stays in the row
+// button's title and aria-label either way.
+function sharedNamePrefix(allNames: readonly string[]): string {
+  if (allNames.length < 2) return '';
+  // Keep separators attached so a prefix is never cut mid-word.
+  const tokenise = (name: string) => Array.from(name.matchAll(/[^\s_./-]+[\s_./-]*/gu), (match) => match[0]);
+  const tokenLists = allNames.map(tokenise);
+  const [first] = tokenLists;
+  // Always leave one token, so no row can render an empty label.
+  const limit = Math.min(...tokenLists.map((tokens) => tokens.length)) - 1;
+  let shared = 0;
+  while (
+    shared < limit
+    && tokenLists.every((tokens) => tokens[shared].toLocaleLowerCase() === first[shared].toLocaleLowerCase())
+  ) shared += 1;
+  const prefix = first.slice(0, shared).join('');
+  // Hiding one or two characters is not worth the ambiguity it introduces.
+  return prefix.trim().length >= 3 ? prefix : '';
+}
+
 function rowNameParts(name: string, allNames: readonly string[]): { leading: string; trailing: string } {
   const tokens = Array.from(name.matchAll(/[^\s_./-]+/g));
   if (tokens.length < 2) return { leading: name, trailing: '' };
@@ -963,19 +1073,32 @@ export function mismatchOverviewBins(
   return bins;
 }
 
+/**
+ * Content width of the observed element, plus the width its scrollbar gutter
+ * reserves. The matrix scroller keeps a `scrollbar-gutter: stable` reservation,
+ * which sits outside the content box and cannot be scrolled out from under; the
+ * content has to be widened by it or its tail is unreachable. Measured rather
+ * than assumed because the reservation is 11px where the styled webkit
+ * scrollbar applies and the platform default elsewhere.
+ */
 function useObservedWidth<T extends HTMLElement>(fallback = 720) {
   const ref = useRef<T>(null);
   const [width, setWidth] = useState(fallback);
+  const [scrollbarGutter, setScrollbarGutter] = useState(0);
   useEffect(() => {
     const element = ref.current;
     if (!element || typeof ResizeObserver === 'undefined') return undefined;
     const observer = new ResizeObserver(([entry]) => {
       if (entry.contentRect.width > 0) setWidth(Math.floor(entry.contentRect.width));
+      // offsetWidth − clientWidth is the gutter plus any horizontal border; the
+      // scroller carries no border, and an extra border's worth of trailing
+      // space would only ever be blank.
+      setScrollbarGutter(Math.max(0, element.offsetWidth - element.clientWidth));
     });
     observer.observe(element);
     return () => observer.disconnect();
   }, []);
-  return [ref, width] as const;
+  return [ref, width, scrollbarGutter] as const;
 }
 
 /** Inclusive rectangular block: column and (ordered-row) index ranges. */
@@ -1006,6 +1129,91 @@ const MSA_LETTER_MIN = 6.5;
 // Overlay geometry mirrors the fixed row heights in the viewer stylesheet.
 const MSA_MATRIX_ROW_HEIGHT = 30;
 const MSA_RULER_ROW_HEIGHT = 27;
+/** Mirrors `.motif-cs-msa-overview-row { min-height }` in motif-artifact.css. */
+const MSA_OVERVIEW_ROW_HEIGHT = 30;
+/**
+ * Mirrors `.motif-cs-msa-matrix-scroll { min-height }`. This predates the shell and
+ * already encodes what the residue viewport refuses to go below.
+ */
+const MSA_MATRIX_SCROLL_MIN_HEIGHT = 142;
+/**
+ * Floor for the clipped matrix frame: the sum of the floors its own two children
+ * already declare. Not a chosen number — a frame shorter than this clips content that
+ * has refused to shrink, which is the same defect the shell exists to remove, just
+ * one box further in. Deriving it from ruler + N rows instead gave 147 and lost
+ * exactly 25px to the clip, measured.
+ *
+ * The floor is what lets the body scroll again on a short panel: below it the frame
+ * would collapse and take the residue viewport with it, while above it the frame
+ * shrinks normally, so at 1024x768 (415px available) and 1280x900 (547px) it never
+ * binds and those sizes keep zero body overflow. It is deliberately NOT
+ * `min-height: min-content`, which computes to ~469px and forces whole-UI scrolling.
+ *
+ * Slightly conservative when the overview row is hidden, which over-reserves its 30px.
+ * The alternative is a floor that moves as tracks are toggled, and a viewport that
+ * resizes when you hide something is the defect class this whole change is about.
+ */
+const MSA_MATRIX_FRAME_MIN_HEIGHT = MSA_OVERVIEW_ROW_HEIGHT + MSA_MATRIX_SCROLL_MIN_HEIGHT;
+/**
+ * Fallback for the bottom chrome before it has been measured, and the floor under
+ * `.motif-cs-msa-statusbar`'s own declaration: one unwrapped status line. The real
+ * height is measured at runtime, because this strip WRAPS at narrow widths — an
+ * existing e2e expectation has the zoom row past 40px at 440x760.
+ */
+const MSA_STATUSBAR_HEIGHT = 33;
+/** `.motif-cs-msa-selection-readout`: 40px plus its 6px top margin, in flow. */
+const MSA_SELECTION_READOUT_HEIGHT = 46;
+/**
+ * The same readout while FLOATING — absolutely positioned, so no margin. The bottom
+ * chrome must be at least this tall for the float to sit over it without overhanging
+ * into the residue grid.
+ */
+const MSA_SELECTION_READOUT_FLOAT_HEIGHT = 40;
+/** The shell's own 1px border, top and bottom. */
+const MSA_MATRIX_SHELL_BORDERS = 2;
+/**
+ * Floor for the shell: the frame's floor plus every row currently mounted beneath it.
+ *
+ * Without a floor the shell is a flex item with `min-height: 0`, free to be shorter
+ * than its own content — and a border wraps the BORDER BOX, not the overflow. At
+ * 1100x420 the shell measured 97px against 233px of content, so its bottom border
+ * painted a hairline straight across the residue grid, 8px into row 2, reading as a
+ * row divider that is not one.
+ *
+ * It has to be COMPUTED rather than constant, because three of the four rows are
+ * conditional and this box's whole problem is the rows that are not always there. A
+ * constant covering only the permanent rows left the shell short by 45px once a
+ * selection settled, and 77px with the order note as well: the border then drew
+ * correctly around everything else and left those rows orphaned just below it.
+ * Padding the constant unconditionally would instead waste 78px at exactly the panel
+ * size that cannot spare it.
+ *
+ * The readout counts only when it is IN FLOW. While the pointer is still down it is
+ * absolutely positioned (see its `data-live` rule) and contributes no layout height,
+ * so reserving for it mid-drag would shrink the residue viewport at the one moment
+ * this change exists to hold steady.
+ *
+ * `min-height: auto` on the shell is the intuitive alternative and is WRONG — the
+ * expectation being that `overflow: hidden` on the frame clamps its contribution to
+ * its own floor. Measured, it resolves to 469px, identical to `min-content` and
+ * `fit-content`, because the frame contributes its full matrix height to a
+ * content-based minimum regardless. All three bind at 1024x768 and take body overflow
+ * from 0 to 40px, introducing whole-interface scrolling.
+ *
+ * If the status line ever wraps, this falls short by the extra line and the border
+ * cuts the status line rather than the grid: chrome instead of data, which is the
+ * right way round for it to fail.
+ */
+function msaMatrixShellMinHeight(rows: {
+  /** MEASURED height of the in-flow strip: pan row, status line, order note. */
+  chromeHeight: number;
+  readoutInFlow: boolean;
+}): number {
+  return MSA_MATRIX_FRAME_MIN_HEIGHT
+    + rows.chromeHeight
+    + (rows.readoutInFlow ? MSA_SELECTION_READOUT_HEIGHT : 0)
+    + MSA_MATRIX_SHELL_BORDERS;
+}
 // Sequence-logo track: plotting height (must match .motif-cs-msa-logo-row in
 // the CSS) and the smallest glyph, in px, still worth drawing in a segment.
 const MSA_LOGO_TRACK_HEIGHT = 46;
@@ -1199,7 +1407,7 @@ function AlignmentMatrix({
   onZoomChange: (zoom: number) => void;
   onVisibleColumnsChange: (range: { start: number; end: number }) => void;
 }) {
-  const [viewportRef, viewportWidth] = useObservedWidth<HTMLDivElement>();
+  const [viewportRef, viewportWidth, viewportScrollbarGutter] = useObservedWidth<HTMLDivElement>();
   const initialViewport = useMemo(() => msaMatrixViewportSession.get(alignment.id), [alignment.id]);
   const [scrollLeft, setScrollLeft] = useState(initialViewport?.left ?? 0);
   const scrollFrameRef = useRef<number | null>(null);
@@ -1225,6 +1433,56 @@ function AlignmentMatrix({
   const [reorderStatus, setReorderStatus] = useState('');
   const selectionAnchorRef = useRef<{ column: number; rowIndex: number } | null>(null);
   const frameRef = useRef<HTMLDivElement>(null);
+  const chromeRef = useRef<HTMLDivElement>(null);
+  /**
+   * MEASURED height of the in-flow rows under the frame — pan slider, status line,
+   * order note — rather than a sum of constants.
+   *
+   * Two things depend on it and a constant 33 had both wrong. The shell's floor was
+   * short whenever the status line wrapped, and `claude-science-msa-interactions`
+   * already asserts the zoom row exceeds 40px at 440x760, so that was demonstrated
+   * rather than theoretical. And the mid-drag readout floats over exactly this strip,
+   * so whether it FITS turns on the same number: with no pan row the strip is a single
+   * status line and a 40px readout overhangs it into the residue grid.
+   *
+   * It cannot oscillate. These rows are sized by the shell's WIDTH, which no height
+   * floor affects, so the measurement never feeds back into itself.
+   */
+  const [chromeHeight, setChromeHeight] = useState(MSA_STATUSBAR_HEIGHT);
+  const readoutRef = useRef<HTMLDivElement>(null);
+  /**
+   * MEASURED height of the readout itself. The float gate compares this against the
+   * chrome strip, and BOTH wrap: at 520px the strip grows to 44px and the readout to
+   * 61px, so gating on a 40px constant let it float and cover a residue row by 17px.
+   * Measured-against-measured is the only version that holds at every width.
+   */
+  const [readoutHeight, setReadoutHeight] = useState(MSA_SELECTION_READOUT_FLOAT_HEIGHT);
+  useEffect(() => {
+    const node = readoutRef.current;
+    if (!node || typeof ResizeObserver === 'undefined') return undefined;
+    const sync = () => setReadoutHeight((prev) => {
+      const next = Math.round(node.getBoundingClientRect().height);
+      return next > 0 && next !== prev ? next : prev;
+    });
+    sync();
+    const observer = new ResizeObserver(sync);
+    observer.observe(node);
+    return () => observer.disconnect();
+  });
+  useEffect(() => {
+    const node = chromeRef.current;
+    if (!node || typeof ResizeObserver === 'undefined') return undefined;
+    const sync = () => setChromeHeight((prev) => {
+      const next = Math.round(node.getBoundingClientRect().height);
+      return next > 0 && next !== prev ? next : prev;
+    });
+    sync();
+    const observer = new ResizeObserver(sync);
+    observer.observe(node);
+    return () => observer.disconnect();
+    // The wrapper itself is always rendered; its conditional children change its
+    // height, which the observer sees. Re-subscribing per render would be churn.
+  }, []);
   const baseCellWidth = Math.max(MSA_BASE_CELL_MIN, Math.min(MSA_BASE_CELL_MAX, fontSize * 0.78 + 2));
   const cellWidth = Math.round(Math.max(MSA_CELL_MIN, Math.min(MSA_CELL_MAX, baseCellWidth * zoom)) * 10) / 10;
   const blocks = cellWidth < MSA_LETTER_MIN;
@@ -1233,7 +1491,7 @@ function AlignmentMatrix({
   // the chosen font size when zooming in.
   const renderFontSize = blocks ? fontSize : Math.min(fontSize, Math.max(7, Math.round(cellWidth * 1.32)));
   const prevCellWidthRef = useRef(cellWidth);
-  const labelWidth = Math.max(150, Math.min(260, Math.round(viewportWidth * 0.3)));
+  const labelWidth = msaRowLabelWidth(viewportWidth);
   const sequenceViewportWidth = Math.max(120, viewportWidth - labelWidth);
   const overscan = 24;
   const visibleStartColumn = Math.max(0, Math.min(
@@ -1273,6 +1531,18 @@ function AlignmentMatrix({
     () => templatePositionCoordinates(template?.aligned ?? ''),
     [template],
   );
+  // With an ungapped template and no reference numbering, the template axis
+  // prints the same number as the alignment axis in every column, so the two
+  // rows are one row's worth of information in two rows' worth of height.
+  // Decided across the whole alignment rather than the visible window: a
+  // template gapped only near the end would otherwise make the row appear and
+  // disappear as you pan, which is worse than the duplication.
+  const axesAreIdentical = useMemo(() => (
+    !referenceCoordinates
+    && templateCoordinates.length > 0
+    && templateCoordinates[templateCoordinates.length - 1] === templateCoordinates.length
+  ), [referenceCoordinates, templateCoordinates]);
+  const mergeAxisRows = axesAreIdentical && visibility.showAlignmentAxis && visibility.showTemplateAxis;
   // Amino-acid translation of the reference row (nucleotide alignments only),
   // codons positioned against alignment columns; empty when the track is off.
   const translationCodons = useMemo(
@@ -1332,10 +1602,21 @@ function AlignmentMatrix({
     && activeCell.column < endColumn,
   );
   const allRowNames = useMemo(() => alignment.rows.map((row) => row.name), [alignment.rows]);
-  const rowLabelsById = useMemo(() => new Map(alignment.rows.map((row) => [
-    row.id,
-    rowNameParts(row.name, allRowNames),
-  ])), [alignment.rows, allRowNames]);
+  const commonNamePrefix = useMemo(() => sharedNamePrefix(allRowNames), [allRowNames]);
+  const rowLabelsById = useMemo(() => {
+    // rowNameParts trims trailing separators off `leading`, while the shared
+    // prefix carries its own. Compare on the trimmed form, or names whose
+    // distinguishing text sits entirely in the tail ("Homo sapiens hemoglobin
+    // alpha 1/2/3") never match and keep every shared character.
+    const prefix = commonNamePrefix.trimEnd();
+    return new Map(alignment.rows.map((row) => {
+      const parts = rowNameParts(row.name, allRowNames);
+      if (!startsWithSharedPrefix(parts.leading, prefix)) return [row.id, parts];
+      const leading = parts.leading.slice(prefix.length).replace(/^[\s_./-]+/u, '');
+      // Never leave a row with nothing to render.
+      return [row.id, leading || parts.trailing ? { ...parts, leading } : parts];
+    }));
+  }, [alignment.rows, allRowNames, commonNamePrefix]);
   const overviewBinCount = Math.min(512, Math.max(1, alignment.alignmentLength));
   const overviewBins = useMemo(
     () => mismatchOverviewBins(alignment, template?.id ?? referenceRowId, overviewBinCount, strictDifferences),
@@ -1357,7 +1638,11 @@ function AlignmentMatrix({
     Math.max(0, alignment.alignmentLength - 1),
     Math.floor((visibleStartColumn + Math.max(visibleStartColumn, visibleEndColumn - 1)) / 2),
   );
-  const axisRows = Number(visibility.showAlignmentAxis) + Number(visibility.showTemplateAxis);
+  // When the two position axes are identical they render as ONE row, so the
+  // template axis must not be counted here — otherwise every sequence row's
+  // aria-rowindex is one too high, aria-rowcount overshoots, and index 2 is
+  // never emitted, which assistive tech reads as a hole in the grid.
+  const axisRows = Number(visibility.showAlignmentAxis) + Number(visibility.showTemplateAxis && !mergeAxisRows);
   const firstSequenceRow = axisRows + 1;
   const tableRowCount = axisRows
     + orderedRows.length
@@ -1794,6 +2079,17 @@ function AlignmentMatrix({
     setContextMenu(null);
     setHoverCell(null);
     activateCell({ column: cell.column, rowId: cell.rowId }, false);
+    // A click has to leave DOM focus on the cell it selected. The preventDefault above
+    // suppresses the browser's own mousedown focus, so without this focus stays where it
+    // was — the window container — and arrow keys are swallowed there instead of reaching
+    // handleMatrixKeyDown on the viewport beneath it. Recovering by keyboard costs 30 tab
+    // stops, because Tab restarts from the window's first stop.
+    //
+    // Focus the element directly rather than passing focus=true to activateCell: that
+    // routes through the layout effect, which scrolls a partially visible cell into view.
+    // On the leftmost clipped column it would shift the content under the cursor at the
+    // exact moment a drag-selection begins, changing the resulting selection.
+    findGridCellElement({ rowId: cell.rowId, column: cell.column })?.focus({ preventScroll: true });
     if (!(event.shiftKey && selectionAnchorRef.current)) {
       selectionAnchorRef.current = { column: cell.column, rowIndex: cell.rowIndex };
     }
@@ -1846,6 +2142,12 @@ function AlignmentMatrix({
     setHoverCell(null);
     selectWholeColumn(column);
     rulerSelectingRef.current = true;
+    // Mirrors the grid path. `isSelecting` is what floats the selection readout out of
+    // the flow and defers the block statistics while the pointer is down. Without it a
+    // ruler drag mounted the readout as a row mid-gesture and took 46px — one whole
+    // residue row — out of the viewport, measured at 1100x640. A ruler drag selects
+    // every row, so it is the case where losing one hurts most.
+    setIsSelecting(true);
     stopDragAutoScroll();
     try { event.currentTarget.setPointerCapture(event.pointerId); } catch { /* capture is best-effort */ }
   };
@@ -1881,6 +2183,7 @@ function AlignmentMatrix({
       }
     }
     rulerSelectingRef.current = false;
+    setIsSelecting(false);
     if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId);
   };
 
@@ -2230,14 +2533,55 @@ function AlignmentMatrix({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [clearSelection, contextMenu, searchActive, selection]);
 
+  /**
+   * Where the selection readout sits. It FLOATS over the bottom chrome only while the
+   * pointer is down AND that chrome is tall enough to hold it — otherwise it takes a
+   * row like anything else.
+   *
+   * The height test is the whole point. The float is anchored to the shell's bottom
+   * and grows upward, so it covers the chrome strip; when that strip is a lone status
+   * line (no pan row, which happens whenever the alignment fits horizontally) a 40px
+   * readout overhangs it and paints an opaque panel across the last residue row —
+   * measured at 7px, over the very rows the pointer is aiming at. Covering data is
+   * worse than the viewport shrink the float exists to avoid, so in that case the
+   * float is declined and the pre-existing in-flow behaviour stands.
+   */
+  const readoutVisible = !!selection && !!selectionCoordinates;
+  const readoutPlacement: 'none' | 'flow' | 'float' = !readoutVisible
+    ? 'none'
+    : isSelecting && chromeHeight >= readoutHeight
+      ? 'float'
+      : 'flow';
+
   const frameStyle = {
     '--motif-cs-msa-label-width': `${labelWidth}px`,
     '--motif-cs-msa-cell-width': `${cellWidth}px`,
     '--motif-cs-msa-font-size': `${renderFontSize}px`,
+    // Derived from the row-height constants above, so the floors cannot drift away
+    // from the rows they exist to hold. The shell's floor tracks what is actually
+    // mounted — three of its four rows come and go — and drops the readout while the
+    // pointer is down, when it floats instead of taking a row.
+    '--motif-cs-msa-frame-min-height': `${MSA_MATRIX_FRAME_MIN_HEIGHT}px`,
+    '--motif-cs-msa-shell-min-height': `${msaMatrixShellMinHeight({
+      chromeHeight,
+      readoutInFlow: readoutPlacement === 'flow',
+    })}px`,
   } as CSSProperties;
 
   const matrixStyle = {
-    width: totalWidth,
+    /**
+     * The scroller reserves a stable scrollbar gutter on its inline end, and
+     * scrolling stops with the content's right edge against the OUTER edge of
+     * the box — so content sized to `totalWidth` alone leaves its last gutter's
+     * worth of columns permanently underneath the reservation. Measured at
+     * 1440x980: the tail stopped 15px short at 120, 500, 5,000, 50,000 and
+     * 100x20,000 columns alike, hiding the final column completely and 64% of
+     * the one before it, through every route into the tail. Reserving the same
+     * width as trailing space lands the scroll exactly on maxHorizontalScroll.
+     * Only while the alignment overflows: adding it to one that already fits
+     * would manufacture the overflow it exists to correct.
+     */
+    width: totalWidth + (maxHorizontalScroll > 0 ? viewportScrollbarGutter : 0),
   } as CSSProperties;
 
   const navigateOverviewPointer = (element: HTMLElement, clientX: number) => {
@@ -2425,13 +2769,53 @@ function AlignmentMatrix({
   const hoverColumnLeft = hoverCell ? labelWidth + (hoverCell.column * cellWidth) : 0;
 
   return (
+    /*
+     * Two boxes, on purpose. The SHELL owns the visible enclosure and the layout
+     * vars; the FRAME is the clipped residue viewport and holds only the overview
+     * and the matrix.
+     *
+     * Everything that does not scroll — the pan slider, the status line, the order
+     * note, the selection readout — is a sibling of the frame rather than a child.
+     * Inside the frame those rows were squeezed out of a box that clips, with the
+     * window body no longer overflowing, so on a short panel they were unreachable:
+     * no scrollbar anywhere led to them. As siblings they keep their own height, the
+     * frame absorbs the shrink instead, and once the frame hits its floor the shell
+     * outgrows the body and the body scrolls again.
+     *
+     * frameStyle is declared on BOTH boxes, deliberately, but for two different
+     * reasons — and only one of them is about production.
+     *
+     * The SHELL genuinely needs it: --motif-cs-msa-label-width sizes the pan row's
+     * grid, and the pan row is now a sibling of the frame, so without it the slider
+     * falls back to 180px and stops lining up with the residue columns it scrolls.
+     *
+     * The FRAME's copy is redundant to the browser. Nothing in production reads these
+     * properties — they are consumed by CSS, which inherits, so the shell alone would
+     * serve the whole subtree. The frame keeps its own copy solely because two jsdom
+     * tests read them as INLINE style off `data-testid="msa-alignment-view"`
+     * (ClaudeScienceMsaViewer.overlays and .correctness); the e2e spec uses
+     * getComputedStyle and would be fine either way. Removing it would mean repointing
+     * those tests at a different element to accommodate a layout change, which is how
+     * a suite quietly stops testing what it says it does. It is the same object on
+     * both elements, so the two cannot drift.
+     *
+     * The cursor channel stays declared on the frame in CSS — both widgets that read
+     * it (active cell, overview viewport) are inside it.
+     */
+    <div
+      className="motif-cs-msa-matrix-shell"
+      style={frameStyle}
+      /* On the shell, not the frame: the host swallows Escape for whatever the
+         target sits inside, and the selection readout's Clear button is now a
+         sibling of the frame. Scoped to the frame it would fall outside, and
+         Escape there would close the whole window instead of the selection. */
+      data-motif-cs-escape-scope={selection ? 'true' : undefined}
+    >
     <div
       ref={frameRef}
       className="motif-cs-msa-matrix-frame"
       data-testid="msa-alignment-view"
       style={frameStyle}
-      data-has-selection={selection ? true : undefined}
-      data-motif-cs-escape-scope={selection ? 'true' : undefined}
     >
       {visibility.showOverview ? <div className="motif-cs-msa-overview-row">
         <span className="motif-cs-msa-overview-label">Overview</span>
@@ -2543,8 +2927,28 @@ function AlignmentMatrix({
           {hoverCell ? (
             <div className="motif-cs-msa-hover-column" style={{ left: hoverColumnLeft, width: cellWidth }} aria-hidden="true" />
           ) : null}
-          {visibility.showAlignmentAxis ? <div className="motif-cs-msa-ruler-row" role="row" aria-rowindex={1}>
-            <div className="motif-cs-msa-sticky-label motif-cs-msa-ruler-label" role="columnheader">Alignment position</div>
+          {visibility.showAlignmentAxis ? <div
+            className="motif-cs-msa-ruler-row"
+            role="row"
+            aria-rowindex={1}
+            aria-label={mergeAxisRows
+              ? `Alignment positions, matching template positions for ${template?.name ?? 'template'}`
+              : undefined}
+          >
+            <div
+              // When merged this label carries a name in a <small>, which is the
+              // template ruler's two-part shape — it needs that class or the name
+              // inherits the ruler's uppercase mono styling with no ellipsis and
+              // overflows the sticky gutter onto the residues.
+              className={`motif-cs-msa-sticky-label motif-cs-msa-ruler-label${mergeAxisRows ? ' motif-cs-msa-template-ruler-label' : ''}`}
+              role="columnheader"
+              title={mergeAxisRows
+                ? `Alignment position · identical to template position for ${template?.name ?? 'Template'}, which has no gaps`
+                : undefined}
+            >
+              <span>{mergeAxisRows ? 'Alignment / template' : 'Alignment position'}</span>
+              {mergeAxisRows ? <small translate="no">{template?.name ?? 'Template'}</small> : null}
+            </div>
             <div
               className="motif-cs-msa-ruler-window motif-cs-msa-ruler-window-clickable"
               style={{ left: labelWidth + (startColumn * cellWidth) }}
@@ -2571,7 +2975,7 @@ function AlignmentMatrix({
             </div>
           </div> : null}
 
-          {visibility.showTemplateAxis ? <div
+          {visibility.showTemplateAxis && !mergeAxisRows ? <div
             className="motif-cs-msa-ruler-row motif-cs-msa-template-ruler-row"
             data-alignment-axis={visibility.showAlignmentAxis || undefined}
             role="row"
@@ -2749,6 +3153,41 @@ function AlignmentMatrix({
           </div> : null}
         </div>
       </div>
+      </div>
+      {/* Every in-flow row under the frame, in one box so its real height can be
+          MEASURED. The floor and the mid-drag float both depend on how tall this
+          strip actually is, and both were wrong while it was assumed to be 33px:
+          the status line wraps at narrow widths, and with no pan row the strip is
+          too short for the floating readout to sit over. */}
+      <div className="motif-cs-msa-matrix-chrome" ref={chromeRef}>
+      {/* The pan slider is the alignment's horizontal scrollbar, so it sits
+          directly against the matrix and stays aligned to the residue columns
+          rather than joining the status line below. It is a SIBLING of the frame,
+          not a child: inside the clipped frame it was the first thing squeezed off
+          a short panel, with nothing to scroll to reach it. */}
+      {maxHorizontalScroll > 0 ? (
+        <div className="motif-cs-msa-pan-row" data-testid="msa-horizontal-scroll-row">
+          <span className="motif-cs-msa-pan-label" aria-hidden="true">Columns</span>
+          <input
+            className="motif-cs-msa-pan-range"
+            data-testid="msa-horizontal-scroll"
+            type="range"
+            min={0}
+            max={Math.max(1, Math.ceil(maxHorizontalScroll))}
+            step={1}
+            value={Math.min(Math.ceil(maxHorizontalScroll), Math.round(scrollLeft))}
+            onChange={(event) => setHorizontalScroll(Number(event.target.value))}
+            aria-label="Horizontal alignment scroll"
+            aria-valuetext={`Columns ${visibleStartColumn + 1}–${Math.max(visibleStartColumn + 1, visibleEndColumn)} of ${alignment.alignmentLength}`}
+            title="Drag to pan alignment columns"
+            style={{ '--motif-cs-msa-pan-thumb-width': `${panThumbWidth}px` } as CSSProperties}
+          />
+        </div>
+      ) : null}
+      {/* Zoom and the visible-column readout answer the same question — what am
+          I looking at, and how closely — so they share one status line instead
+          of taking a strip each under the alignment. */}
+      <div className="motif-cs-msa-statusbar">
       <div className="motif-cs-msa-zoom-row" data-testid="msa-zoom-row">
         <span className="motif-cs-msa-zoom-label" aria-hidden="true">Zoom</span>
         <input
@@ -2783,30 +3222,12 @@ function AlignmentMatrix({
         ) : null}
         {blocks ? <span className="motif-cs-chip motif-cs-msa-blocks-chip" data-testid="msa-blocks-chip" title="Columns are compressed past letter legibility; residues render as coloured blocks">Blocks</span> : null}
       </div>
-      {maxHorizontalScroll > 0 ? (
-        <div className="motif-cs-msa-pan-row" data-testid="msa-horizontal-scroll-row">
-          <span className="motif-cs-msa-pan-label" aria-hidden="true">Columns</span>
-          <input
-            className="motif-cs-msa-pan-range"
-            data-testid="msa-horizontal-scroll"
-            type="range"
-            min={0}
-            max={Math.max(1, Math.ceil(maxHorizontalScroll))}
-            step={1}
-            value={Math.min(Math.ceil(maxHorizontalScroll), Math.round(scrollLeft))}
-            onChange={(event) => setHorizontalScroll(Number(event.target.value))}
-            aria-label="Horizontal alignment scroll"
-            aria-valuetext={`Columns ${visibleStartColumn + 1}–${Math.max(visibleStartColumn + 1, visibleEndColumn)} of ${alignment.alignmentLength}`}
-            title="Drag to pan alignment columns"
-            style={{ '--motif-cs-msa-pan-thumb-width': `${panThumbWidth}px` } as CSSProperties}
-          />
-        </div>
-      ) : null}
       <span id="motif-cs-msa-matrix-help" className="motif-cs-visually-hidden">{referenceCoordinates
         ? 'Alignment positions count gapped columns. Reference positions use the saved first-residue coordinate; reference-gap columns append stable insertion letters, and leading gaps use the preceding coordinate. Choose any row header button to make that row the comparison template. In the grid, use Arrow keys to move the active residue, Shift plus Arrow keys to extend a selection, Home and End for row boundaries, Control or Command plus Home or End for grid boundaries, Page Up and Page Down to move by a viewport, Space to select a column, and Shift plus F10 or the Context Menu key for selection actions. The Columns slider and Shift plus wheel also pan the alignment. Switch to Text to read or copy the complete aligned sequences with assistive technology.'
         : 'Alignment positions count gapped columns. Template positions count non-gap residues in the chosen template; blank template-axis cells are gaps. Choose any row header button to make that row the template. In the grid, use Arrow keys to move the active residue, Shift plus Arrow keys to extend a selection, Home and End for row boundaries, Control or Command plus Home or End for grid boundaries, Page Up and Page Down to move by a viewport, Space to select a column, and Shift plus F10 or the Context Menu key for selection actions. The Columns slider and Shift plus wheel also pan the alignment. Switch to Text to read or copy the complete aligned sequences with assistive technology.'}</span>
       <div className="motif-cs-msa-window-note" aria-live="polite">
         Alignment columns {visibleStartColumn + 1}–{Math.max(visibleStartColumn + 1, visibleEndColumn)} of {alignment.alignmentLength.toLocaleString()}
+      </div>
       </div>
       {manualOrder ? (
         <div className="motif-cs-msa-order-note" data-testid="msa-order-note">
@@ -2816,8 +3237,22 @@ function AlignmentMatrix({
         </div>
       ) : null}
       <span className="motif-cs-visually-hidden" data-testid="msa-reorder-status" role="status" aria-live="polite">{reorderStatus}</span>
+      </div>
       {selection && selectionCoordinates ? (
-        <div className="motif-cs-msa-selection-readout" data-testid="msa-selection-readout" role="status" aria-live="polite">
+        <div
+          ref={readoutRef}
+          className="motif-cs-msa-selection-readout"
+          data-testid="msa-selection-readout"
+          /* While the pointer is still down the readout floats instead of claiming a
+             row. Taking one mid-drag shrinks the residue viewport by 46px under the
+             pointer — measured at 1 to 2 rows cut off between 1100x600 and 1100x768 —
+             which moves the rows you are dragging toward away from you. It settles
+             into the flow on pointer-up, when nothing is being aimed at. Same
+             reasoning as selectionSummary, which already waits for the settle. */
+          data-live={readoutPlacement === 'float' || undefined}
+          role="status"
+          aria-live="polite"
+        >
           <strong>Selected</strong>
           <span>cols {selection.colStart + 1}–{selection.colEnd + 1} ({selectionCoordinates.columns.toLocaleString()})</span>
           {selectionReferenceRange
@@ -2857,6 +3292,69 @@ function AlignmentMatrix({
       ) : null}
     </div>
   );
+}
+
+/**
+ * Shared dismissal behaviour for the toolbar's `<details>` menus: an outside
+ * pointerdown closes the menu, and Escape closes it and returns focus to its own
+ * summary. Both listeners are capture-phase on purpose — the floating window's
+ * own Escape handler also listens on capture, so a bubble-phase listener here
+ * would never see the key first and Escape would close the whole window.
+ *
+ * Returns the focus-restoring close, for callers that dismiss the menu directly.
+ */
+function useDismissableMenu(
+  open: boolean,
+  setOpen: (next: boolean) => void,
+  menuRef: RefObject<HTMLDetailsElement | null>,
+  buttonRef: RefObject<HTMLElement | null>,
+): () => void {
+  // The browser opens a <details> during the click and only tells React later,
+  // through the `toggle` event — measured at ~52ms. Inside that gap the menu is
+  // open on screen while `open` here is still false, so `setOpen(false)` alone
+  // is a no-op and the dismissal is silently dropped. Closing the element itself
+  // is what actually shuts it; the toggle that follows settles the state.
+  const shut = useCallback(() => {
+    if (menuRef.current?.open) menuRef.current.open = false;
+    setOpen(false);
+  }, [menuRef, setOpen]);
+
+  const close = useCallback(() => {
+    shut();
+    window.requestAnimationFrame(() => buttonRef.current?.focus({ preventScroll: true }));
+  }, [buttonRef, shut]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const closeFromOutside = (event: Event) => {
+      if (menuRef.current?.contains(event.target as Node)) return;
+      shut();
+    };
+    document.addEventListener('pointerdown', closeFromOutside, true);
+    // focusin as well as pointerdown: a <summary> activated from the keyboard
+    // fires click but never pointerdown, so tabbing to a sibling trigger and
+    // pressing Enter would otherwise leave both menus open, stacked in the same
+    // right-anchored rectangle with their Escape handlers racing.
+    document.addEventListener('focusin', closeFromOutside, true);
+    return () => {
+      document.removeEventListener('pointerdown', closeFromOutside, true);
+      document.removeEventListener('focusin', closeFromOutside, true);
+    };
+  }, [menuRef, open, shut]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const closeFromEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      event.stopPropagation();
+      close();
+    };
+    window.addEventListener('keydown', closeFromEscape, true);
+    return () => window.removeEventListener('keydown', closeFromEscape, true);
+  }, [close, open]);
+
+  return close;
 }
 
 export function ClaudeScienceMsaViewer({
@@ -2922,6 +3420,8 @@ export function ClaudeScienceMsaViewer({
   const [copyStatus, setCopyStatus] = useState<{ label: string; message: string; tone: 'status' | 'error' } | null>(null);
   const [imageScope, setImageScope] = useState<AlignmentImageScope>('view');
   const [viewMenuOpen, setViewMenuOpen] = useState(false);
+  const [exportMenuOpen, setExportMenuOpen] = useState(false);
+  const [gotoMenuOpen, setGotoMenuOpen] = useState(false);
   const [viewResetStatus, setViewResetStatus] = useState('');
   const alignmentFileInputRef = useRef<HTMLInputElement>(null);
   const recordFileInputRef = useRef<HTMLInputElement>(null);
@@ -2933,6 +3433,10 @@ export function ClaudeScienceMsaViewer({
   const copyStatusTimerRef = useRef<number | null>(null);
   const viewMenuRef = useRef<HTMLDetailsElement>(null);
   const viewMenuButtonRef = useRef<HTMLElement>(null);
+  const exportMenuRef = useRef<HTMLDetailsElement>(null);
+  const exportMenuButtonRef = useRef<HTMLElement>(null);
+  const gotoMenuRef = useRef<HTMLDetailsElement>(null);
+  const gotoMenuButtonRef = useRef<HTMLElement>(null);
   const pendingReferenceNumberingStatusRef = useRef<{ alignmentId: string; message: string } | null>(null);
   const explicitlySelectedTemplateIdRef = useRef<string | null>(null);
   // Latest visible column window reported by the matrix, for "Visible view" export.
@@ -2974,6 +3478,15 @@ export function ClaudeScienceMsaViewer({
     // reports a fresh range on mount (undefined until then falls back to whole).
     visibleColumnsRef.current = null;
   }, [activeAlignment]);
+
+  // Only the matrix reports a visible column window, but Export now lives in the
+  // toolbar and is offered in every mode. Without this, leaving the Viewer would
+  // leave the last window behind, and "Image · Visible view" from Traces or Text
+  // would silently export columns the user is no longer looking at. Clearing it
+  // falls through to the whole-alignment path.
+  useEffect(() => {
+    if (displayMode !== 'viewer') visibleColumnsRef.current = null;
+  }, [displayMode]);
 
   // Reset the sequence search only when switching to a different alignment, not
   // when the same alignment yields a new object (e.g. a template change), so a
@@ -3020,16 +3533,6 @@ export function ClaudeScienceMsaViewer({
     const frame = window.requestAnimationFrame(() => cancelDeleteRef.current?.focus());
     return () => window.cancelAnimationFrame(frame);
   }, [pendingDeleteId]);
-
-  useEffect(() => {
-    if (!viewMenuOpen) return undefined;
-    const closeFromOutside = (event: PointerEvent) => {
-      if (viewMenuRef.current?.contains(event.target as Node)) return;
-      setViewMenuOpen(false);
-    };
-    document.addEventListener('pointerdown', closeFromOutside, true);
-    return () => document.removeEventListener('pointerdown', closeFromOutside, true);
-  }, [viewMenuOpen]);
 
   const selectedRecords = useMemo(
     () => records.filter((record) => selectedIds.has(record.id)),
@@ -3113,14 +3616,31 @@ export function ClaudeScienceMsaViewer({
     ? comparisonStats.reduce((sum, stats) => sum + stats.identity, 0) / comparisonStats.length
     : null;
   const differenceNavigationDisabled = !hasComparableRows || differences.length === 0;
+  // One phrasing in both states. Reading "717 differences" before stepping and
+  // "Difference 1 of 717" after made the same control look like two controls.
   const differenceNavigationLabel = !hasComparableRows
     ? 'No comparable rows'
     : differenceIndex >= 0
       ? `Difference ${differenceIndex + 1} of ${differences.length}`
-      : `${differences.length} differences`;
+      : `Difference — of ${differences.length}`;
+  // Reserve the widest label this alignment can produce. The counter gains
+  // digits as you step, and a box that grows with it walks the "next" button
+  // out from under the cursor clicking it.
+  const differenceNavigationWidth = Math.max(
+    'No comparable rows'.length,
+    `Difference ${differences.length} of ${differences.length}`.length,
+  );
   const textContent = activeAlignment ? formatAlignment(activeAlignment, textFormat) : '';
   const selectedExport = formatExtension(textFormat);
   const pickerLabels = useMemo(() => alignmentPickerLabels(alignments), [alignments]);
+  // The template picker is a narrow control listing rows that often differ only
+  // in their tail, so a shared prefix pushes the distinguishing text past the
+  // ellipsis and every option renders alike. Strip it here too.
+  const compareRowLabels = useMemo(() => {
+    const rows = activeAlignment?.rows ?? [];
+    const prefix = sharedNamePrefix(rows.map((row) => row.name)).trimEnd();
+    return new Map(rows.map((row) => [row.id, withoutSharedPrefix(row.name, prefix)]));
+  }, [activeAlignment]);
   const matrixVisibility = useMemo<MsaMatrixVisibility>(() => ({
     showOverview: viewPreferences.showOverview,
     showAlignmentAxis: viewPreferences.showAlignmentAxis,
@@ -3197,15 +3717,27 @@ export function ClaudeScienceMsaViewer({
     });
     const rows = imageExportRows(activeAlignment, referenceRowId);
     const title = activeAlignment.name;
+    // Mirror what the matrix paints rather than the scheme alone. The export used
+    // to read only `colorScheme`, so turning "Residue colors" off changed nothing
+    // about the image — and because the scheme select is disabled while colours
+    // are off, the saved file was coloured by a setting the UI was preventing the
+    // user from inspecting. The exception is the same one the matrix makes: when
+    // cells are too narrow to carry glyphs, colour is the only thing left holding
+    // the sequence, so a monochrome birdseye would export a blank rectangle. In
+    // that case the matrix falls back to the automatic tone scheme, not to the
+    // user's stored one, so this does too.
+    const exportScheme: MsaColorScheme | null = colorMode === 'residue'
+      ? colorScheme
+      : layout.drawLetters ? null : 'auto';
     try {
       if (format === 'svg') {
-        const svg = renderAlignmentImageSvg(rows, activeAlignment.molecule, colorScheme, layout, title);
+        const svg = renderAlignmentImageSvg(rows, activeAlignment.molecule, exportScheme, layout, title);
         const filename = safeAlignmentFilename(activeAlignment, 'svg');
         downloadBlobFile(filename, new Blob([svg], { type: 'image/svg+xml' }));
         flashStatus('Image export', layout.clamped ? `Saved ${filename} (scaled to fit)` : `Saved ${filename}`, 'status');
         return;
       }
-      const canvas = renderAlignmentImageCanvas(rows, activeAlignment.molecule, colorScheme, layout, title);
+      const canvas = renderAlignmentImageCanvas(rows, activeAlignment.molecule, exportScheme, layout, title);
       const blob = canvas ? await canvasToPngBlob(canvas) : null;
       if (!blob) {
         flashStatus('Image export', 'PNG export is unavailable here. Try Save SVG.', 'error');
@@ -3217,7 +3749,7 @@ export function ClaudeScienceMsaViewer({
     } catch {
       flashStatus('Image export', 'Image export failed. Try Save SVG or the Visible view scope.', 'error');
     }
-  }, [activeAlignment, colorScheme, fontSize, imageScope, referenceRowId, flashStatus]);
+  }, [activeAlignment, colorMode, colorScheme, fontSize, imageScope, referenceRowId, flashStatus]);
 
   const hydrateInputsFromAlignment = useCallback((alignment: ArtifactAlignment) => {
     const linked = alignment.rows.map((row) => (
@@ -3522,8 +4054,21 @@ export function ClaudeScienceMsaViewer({
 
   const jumpDifference = (direction: -1 | 1) => {
     if (differenceNavigationDisabled) return;
+    // Stepping back off the front returns to the neutral "— of N" state rather
+    // than teleporting to the far end. Both ends used to wrap by modular
+    // arithmetic with nothing said about it, so three Prev presses from the start
+    // read "130 of 130" and threw the view to the opposite end of the alignment —
+    // and Prev from neutral did the same, before the user had gone anywhere.
+    // Forward still wraps, because there is no neutral state past the last one to
+    // land on, and that wrap is at least announced by the counter returning to 1.
+    if (direction < 0 && differenceIndex <= 0) {
+      setDifferenceIndex(-1);
+      setJumpColumn(null);
+      setJumpRowId(null);
+      return;
+    }
     const nextIndex = differenceIndex < 0
-      ? direction > 0 ? 0 : differences.length - 1
+      ? 0
       : (differenceIndex + direction + differences.length) % differences.length;
     setDifferenceIndex(nextIndex);
     setJumpColumn(differences[nextIndex]);
@@ -3605,6 +4150,37 @@ export function ClaudeScienceMsaViewer({
       : activeReferenceCoordinates
         ? `Reference position ${activeReferenceCoordinates[column].label} in ${activeNumberingReference?.name ?? 'reference'} shown at alignment column ${(column + 1).toLocaleString()}.`
         : `Template position ${requested.toLocaleString()} in ${template?.name ?? 'template'} shown at alignment column ${(column + 1).toLocaleString()}.`);
+    // Deliberately does NOT close the menu. The jump issues no focus request, so
+    // nothing dismisses the panel and it stays over the stats row it just
+    // changed — which reads like an oversight until you try closing it: looking
+    // up a run of positions is the normal use of this box, and auto-close makes
+    // every position after the first cost a reopen. The residues themselves are
+    // below the panel, so what it covers is re-readable metadata. Staying open
+    // is the cheaper of the two costs.
+  };
+
+  // The saved result that is this alignment in the numbering state asked for, if
+  // the session already holds one. Both buttons used to save unconditionally,
+  // which made "Use plain 1-based" a third result rather than a way back to the
+  // first: three round trips left seven results named up to "REVIEW 2 2 2 2 2 2".
+  // Reopening the state the user already has keeps one result per distinct
+  // numbering, which is what "save as a new session result" was always meant to
+  // mean.
+  const savedResultWithNumbering = (numbering: ArtifactAlignmentReferenceNumbering | undefined) => (
+    activeAlignment
+      ? alignments.find((candidate) => (
+        candidate.id !== activeAlignment.id
+        && sameAlignmentApartFromNumbering(candidate, activeAlignment)
+        && sameReferenceNumbering(candidate.referenceNumbering, numbering)
+      )) ?? null
+      : null
+  );
+
+  const openSavedResult = (alignment: ArtifactAlignment, message: string) => {
+    pendingReferenceNumberingStatusRef.current = { alignmentId: alignment.id, message };
+    setReferenceNumberingError(null);
+    setReferenceNumberingStatus(message);
+    onActiveAlignmentChange(alignment.id);
   };
 
   const applyReferenceNumbering = () => {
@@ -3637,12 +4213,15 @@ export function ClaudeScienceMsaViewer({
       setReferenceNumberingStatus('Reference numbering is already applied.');
       return;
     }
+    const numbering = { rowId: numberingRow.id, firstResiduePosition };
+    const alreadySaved = savedResultWithNumbering(numbering);
+    if (alreadySaved) {
+      openSavedResult(alreadySaved, `Opened “${alreadySaved.name}”, the saved result that already uses this numbering.`);
+      return;
+    }
     const successMessage = 'Reference numbering saved as a new session result and opened.';
     try {
-      const saved = onSaveAlignment({
-        ...activeAlignment,
-        referenceNumbering: { rowId: numberingRow.id, firstResiduePosition },
-      });
+      const saved = onSaveAlignment({ ...activeAlignment, referenceNumbering: numbering });
       pendingReferenceNumberingStatusRef.current = { alignmentId: saved.id, message: successMessage };
       setReferenceNumberingError(null);
       setReferenceNumberingStatus(successMessage);
@@ -3655,6 +4234,11 @@ export function ClaudeScienceMsaViewer({
 
   const clearReferenceNumbering = () => {
     if (!activeAlignment?.referenceNumbering) return;
+    const plainResult = savedResultWithNumbering(undefined);
+    if (plainResult) {
+      openSavedResult(plainResult, `Reopened “${plainResult.name}”, which is this alignment on plain 1-based numbering.`);
+      return;
+    }
     const plainAlignment = { ...activeAlignment };
     delete plainAlignment.referenceNumbering;
     const successMessage = 'Plain 1-based numbering saved as a new session result and opened.';
@@ -3671,7 +4255,18 @@ export function ClaudeScienceMsaViewer({
   };
 
   const resetAlignmentView = useCallback(() => {
-    onViewPreferencesChange({ ...DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES });
+    // Everything about how the alignment is DRAWN goes back to its default, which
+    // is what the button offers. Two stored preferences are deliberately carried
+    // through rather than reset, because neither describes the drawing:
+    // `textFormat` decides the bytes Copy and Download write, and resetting it
+    // silently changed a chosen export format; `displayMode` is which pane is
+    // open, and resetting it threw a user reading the Text pane back into the
+    // Viewer. Both controls live outside the View menu this button sits in.
+    onViewPreferencesChange({
+      ...DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES,
+      displayMode: viewPreferences.displayMode,
+      textFormat: viewPreferences.textFormat,
+    });
     setDifferenceIndex(-1);
     setJumpColumn(null);
     setCoordinateSystem('alignment');
@@ -3679,25 +4274,12 @@ export function ClaudeScienceMsaViewer({
     setColumnError(null);
     setColumnStatus('');
     setViewResetToken((token) => token + 1);
-    setViewResetStatus('Alignment view reset. Result and comparison template kept.');
-  }, [onViewPreferencesChange]);
+    setViewResetStatus('Alignment view reset. Result, comparison template and export format kept.');
+  }, [onViewPreferencesChange, viewPreferences.displayMode, viewPreferences.textFormat]);
 
-  const closeViewMenu = useCallback(() => {
-    setViewMenuOpen(false);
-    window.requestAnimationFrame(() => viewMenuButtonRef.current?.focus({ preventScroll: true }));
-  }, []);
-
-  useEffect(() => {
-    if (!viewMenuOpen) return undefined;
-    const closeFromEscape = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return;
-      event.preventDefault();
-      event.stopPropagation();
-      closeViewMenu();
-    };
-    window.addEventListener('keydown', closeFromEscape, true);
-    return () => window.removeEventListener('keydown', closeFromEscape, true);
-  }, [closeViewMenu, viewMenuOpen]);
+  const closeViewMenu = useDismissableMenu(viewMenuOpen, setViewMenuOpen, viewMenuRef, viewMenuButtonRef);
+  const closeExportMenu = useDismissableMenu(exportMenuOpen, setExportMenuOpen, exportMenuRef, exportMenuButtonRef);
+  const closeGotoMenu = useDismissableMenu(gotoMenuOpen, setGotoMenuOpen, gotoMenuRef, gotoMenuButtonRef);
 
   const deleteActiveAlignment = () => {
     if (!activeAlignment) return;
@@ -3753,6 +4335,9 @@ export function ClaudeScienceMsaViewer({
       <details
         className="motif-cs-msa-source"
         open={sourceOpen}
+        /* Once a result exists the toolbar's "Edit inputs" button is the way in,
+           so this banner is redundant chrome; it only re-appears while open. */
+        data-redundant={activeAlignment && !sourceOpen ? 'true' : undefined}
         onToggle={(event) => handleSourceToggle(event.currentTarget.open)}
       >
         <summary ref={sourceSummaryRef}>
@@ -3982,13 +4567,11 @@ export function ClaudeScienceMsaViewer({
                 {!alignments.some((alignment) => alignment.id === activeAlignment.id) ? <option value={activeAlignment.id}>{pickerLabels.get(activeAlignment.id) ?? activeAlignment.name}</option> : null}
               </select>
             </label>
-            <span
-              className="motif-cs-chip motif-cs-msa-engine-chip"
-              data-fallback={activeAlignment.engine.usedFallback || undefined}
-              title={`${activeAlignment.engine.label}${activeAlignment.engine.version ? ` ${activeAlignment.engine.version}` : ''}${activeAlignment.engine.usedFallback ? ' · fallback used' : ''}`}
-            >
-              {activeAlignment.engine.label}{activeAlignment.engine.version ? ` ${activeAlignment.engine.version}` : ''}{activeAlignment.engine.usedFallback ? ' · fallback' : ''}
-            </span>
+            {/* The engine chip used to sit here repeating what the Provenance
+                summary one row below already says — same label, same version,
+                same fallback note — and it cost 134px of a row that had none to
+                spare. Provenance says strictly more (it adds how the engine was
+                executed), so nothing is lost by letting it be the one voice. */}
             <button
               className="motif-cs-mini-button motif-cs-msa-edit-inputs"
               type="button"
@@ -4006,9 +4589,106 @@ export function ClaudeScienceMsaViewer({
               {traceAvailable ? <button type="button" data-active={displayMode === 'trace' || undefined} aria-pressed={displayMode === 'trace'} onClick={() => updateViewPreferences({ displayMode: 'trace' })}>Traces</button> : null}
               <button type="button" data-active={displayMode === 'text' || undefined} aria-pressed={displayMode === 'text'} onClick={() => updateViewPreferences({ displayMode: 'text' })}>Text</button>
             </div>
+            {/* Jumping to a coordinate is a deliberate "take me there" action, not
+                something read while scanning residues, and as a permanent form it
+                was the control that forced the row below onto a second line. */}
+            {displayMode === 'viewer' ? (
+              <details
+                ref={gotoMenuRef}
+                className="motif-cs-msa-goto-menu"
+                // Static, and read together with the element's own `open`: the
+                // panel's data-motif-cs-escape-scope below cannot be trusted for
+                // the ~52ms between the browser opening this menu and React
+                // hearing about it, which is long enough for the host window to
+                // take an Escape meant for the menu and close itself.
+                data-motif-cs-escape-scope-when-open="true"
+                open={gotoMenuOpen}
+                onToggle={(event) => setGotoMenuOpen(event.currentTarget.open)}
+                onKeyDown={(event) => {
+                  if (event.key !== 'Escape') return;
+                  event.preventDefault();
+                  event.stopPropagation();
+                  closeGotoMenu();
+                }}
+              >
+                <summary ref={gotoMenuButtonRef} data-testid="msa-goto-menu-button" aria-label="Go to a position in the alignment" aria-expanded={gotoMenuOpen}>
+                  <Crosshair size={13} strokeWidth={2.1} aria-hidden="true" />
+                  {coordinateSystem === 'alignment'
+                    ? 'Go to'
+                    : activeReferenceCoordinates ? 'Go to \u00b7 reference' : 'Go to \u00b7 template'}
+                  <ChevronDown size={12} aria-hidden="true" />
+                </summary>
+                <div className="motif-cs-msa-goto-menu-panel" data-testid="msa-goto-menu" data-motif-cs-escape-scope={gotoMenuOpen || undefined}>
+                    <form
+                      className="motif-cs-msa-column-jump"
+                      data-invalid={columnError ? true : undefined}
+                      noValidate
+                      onSubmit={(event) => {
+                        event.preventDefault();
+                        goToCoordinate();
+                      }}
+                    >
+                      <label className="motif-cs-msa-coordinate-system">
+                        <span className="motif-cs-visually-hidden">Coordinate system</span>
+                        <select
+                          data-testid="msa-coordinate-system"
+                          name="alignment-coordinate-system"
+                          value={coordinateSystem}
+                          aria-label="Coordinate system"
+                          onChange={(event) => {
+                            setCoordinateSystem(event.target.value as CoordinateSystem);
+                            setColumnDraft('');
+                            setColumnError(null);
+                            setColumnStatus('');
+                          }}
+                        >
+                          <option value="alignment">Alignment column</option>
+                          <option value="template">{activeReferenceCoordinates ? 'Reference position' : 'Template position'}</option>
+                        </select>
+                      </label>
+                      <label>
+                        <span className="motif-cs-visually-hidden">{coordinateSystem === 'alignment' ? 'Alignment column' : activeReferenceCoordinates ? 'Reference position' : 'Template position'}</span>
+                        <input
+                          data-testid="msa-coordinate-input"
+                          type={coordinateSystem === 'template' && activeReferenceCoordinates ? 'text' : 'number'}
+                          name="alignment-coordinate"
+                          autoComplete="off"
+                          inputMode={coordinateSystem === 'template' && activeReferenceCoordinates ? 'text' : 'numeric'}
+                          min={coordinateSystem === 'template' && activeReferenceCoordinates ? undefined : 1}
+                          max={coordinateSystem === 'template' && activeReferenceCoordinates
+                            ? undefined
+                            : coordinateSystem === 'alignment'
+                              ? activeAlignment.alignmentLength
+                              : activeTemplate?.aligned.replace(/-/g, '').length ?? 0}
+                          step={coordinateSystem === 'template' && activeReferenceCoordinates ? undefined : 1}
+                          pattern={coordinateSystem === 'template' && activeReferenceCoordinates ? '[0-9]+[A-Za-z]*' : undefined}
+                          placeholder={coordinateSystem === 'template' && activeReferenceCoordinates ? '101 or 101A' : undefined}
+                          value={columnDraft}
+                          onChange={(event) => {
+                            setColumnDraft(event.target.value);
+                            setColumnError(null);
+                            setColumnStatus('');
+                          }}
+                          aria-label={coordinateSystem === 'alignment' ? 'Go to alignment column' : activeReferenceCoordinates ? 'Go to reference position' : 'Go to template position'}
+                          aria-invalid={columnError ? true : undefined}
+                          aria-describedby={columnError ? 'motif-cs-msa-column-error' : undefined}
+                        />
+                      </label>
+                      <button className="motif-cs-mini-button" type="submit">Go</button>
+                      {columnError ? <span id="motif-cs-msa-column-error" className="motif-cs-msa-column-error" role="alert">{columnError}</span> : null}
+                      {/* Safe inside the panel only because the panel stays open
+                          after a jump (see goToCoordinate). Anyone adding
+                          auto-close must move this out first, or the success is
+                          announced into a closed <details> and never heard. */}
+                      <span className="motif-cs-visually-hidden" role="status" aria-live="polite">{columnStatus}</span>
+                    </form>
+                </div>
+              </details>
+            ) : null}
             <details
               ref={viewMenuRef}
               className="motif-cs-msa-view-menu"
+              data-motif-cs-escape-scope-when-open="true"
               open={viewMenuOpen}
               onToggle={(event) => setViewMenuOpen(event.currentTarget.open)}
               onKeyDown={(event) => {
@@ -4082,6 +4762,19 @@ export function ClaudeScienceMsaViewer({
                     ) : null}
                   </>
                 ) : null}
+                {/* Row order is a display preference like the tracks above it, and
+                    it is set once and left alone — it does not earn 155px of the
+                    control row it used to sit in. */}
+                <label className="motif-cs-msa-view-select">
+                  <span>Sort</span>
+                  <select value={sortMode} onChange={(event) => updateViewPreferences({ sortMode: event.target.value as RowSortMode })}>
+                    <option value="original">Original order</option>
+                    <option value="name">Name</option>
+                    <option value="identity">Identity</option>
+                    <option value="mismatches">Mismatches</option>
+                    <option value="length">Ungapped length</option>
+                  </select>
+                </label>
                 <label>
                   <input
                     type="checkbox"
@@ -4128,7 +4821,7 @@ export function ClaudeScienceMsaViewer({
                         setReferenceNumberingStatus('');
                       }}
                     >
-                      {activeAlignment.rows.map((row) => <option key={row.id} value={row.id}>{row.name}</option>)}
+                      {activeAlignment.rows.map((row) => <option key={row.id} value={row.id} title={row.name}>{compareRowLabels.get(row.id) ?? row.name}</option>)}
                     </select>
                   </label>
                   <label className="motif-cs-msa-reference-numbering-position">
@@ -4184,6 +4877,58 @@ export function ClaudeScienceMsaViewer({
                 <span className="motif-cs-msa-view-menu-status" data-testid="msa-view-menu-status" data-empty={!viewResetStatus || undefined} role="status" aria-live="polite">{viewResetStatus}</span>
               </div>
             </details>
+            {/* Export used to be a permanent 49px strip under the alignment, most
+                of it a sentence of guidance nobody rereads. It is an end-of-look
+                action, so it belongs beside the other toolbar menus. */}
+            <details
+              ref={exportMenuRef}
+              className="motif-cs-msa-export-menu"
+              data-motif-cs-escape-scope-when-open="true"
+              open={exportMenuOpen}
+              onToggle={(event) => setExportMenuOpen(event.currentTarget.open)}
+              onKeyDown={(event) => {
+                if (event.key !== 'Escape') return;
+                event.preventDefault();
+                event.stopPropagation();
+                closeExportMenu();
+              }}
+            >
+              <summary ref={exportMenuButtonRef} data-testid="msa-export-menu-button" aria-label="Export alignment" aria-expanded={exportMenuOpen}>
+                <Download size={13} strokeWidth={2.1} aria-hidden="true" />
+                Export
+                <ChevronDown size={12} aria-hidden="true" />
+              </summary>
+              <div className="motif-cs-msa-export-row motif-cs-msa-export-menu-panel" data-testid="msa-export-menu" data-motif-cs-escape-scope={exportMenuOpen || undefined}>
+                <label>
+                  <span>Export</span>
+                  <select value={textFormat} onChange={(event) => updateViewPreferences({ textFormat: event.target.value as TextFormat })}>
+                    <option value="fasta">Aligned FASTA</option>
+                    <option value="clustal">CLUSTAL</option>
+                    <option value="consensus">Consensus FASTA</option>
+                    <option value="json">Alignment JSON</option>
+                  </select>
+                </label>
+                <button className="motif-cs-mini-button" type="button" onClick={() => void copyFromViewer(selectedExport.label, textContent)}>{copyStatus?.label === selectedExport.label && copyStatus.tone === 'status' ? 'Copied' : 'Copy'}</button>
+                <button className="motif-cs-mini-button" type="button" onClick={() => onDownload(safeAlignmentFilename(activeAlignment, selectedExport.extension), textContent, selectedExport.mime)}>Download</button>
+                <div className="motif-cs-msa-export-image" data-testid="msa-export-image">
+                  <label className="motif-cs-msa-image-scope">
+                    <span>Image</span>
+                    <select
+                      value={imageScope}
+                      data-testid="msa-export-image-scope"
+                      aria-label="Image export scope"
+                      onChange={(event) => setImageScope(event.target.value as AlignmentImageScope)}
+                    >
+                      <option value="view">Visible view</option>
+                      <option value="all">Whole alignment</option>
+                    </select>
+                  </label>
+                  <button className="motif-cs-mini-button" type="button" data-testid="msa-export-png" onClick={() => void exportAlignmentImage('png')}>Save PNG</button>
+                  <button className="motif-cs-mini-button" type="button" data-testid="msa-export-svg" onClick={() => void exportAlignmentImage('svg')}>Save SVG</button>
+                </div>
+                <span className="motif-cs-muted">In session · Export a workspace backup before reload. To restore a ZIP export, unzip it and choose inventory.json in Settings. {activeAlignment.note}</span>
+              </div>
+            </details>
             {pendingDeleteId === activeAlignment.id ? (
               <div className="motif-cs-msa-delete-confirm" role="group" aria-label="Confirm alignment deletion">
                 <span>Delete?</span>
@@ -4217,6 +4962,9 @@ export function ClaudeScienceMsaViewer({
             </div>
           ) : null}
 
+          {/* Counts and provenance are both read-once metadata, so they share a
+              row instead of each taking a full strip above the residues. */}
+          <div className="motif-cs-msa-meta-row">
           <details
             className="motif-cs-msa-provenance"
             data-testid="msa-provenance"
@@ -4255,13 +5003,26 @@ export function ClaudeScienceMsaViewer({
             <span><strong>{activeAlignment.rows.length}</strong> rows</span>
             <span><strong>{activeAlignment.alignmentLength.toLocaleString()}</strong> columns</span>
             <span><strong>{conservedPct}%</strong> conserved</span>
-            <span><strong>{avgIdentity === null ? 'N/A' : `${formatIdentity(avgIdentity)}%`}</strong> avg to template</span>
-            <span><strong>{differences.length.toLocaleString()}</strong> differences in overlap</span>
+            <span title="Mean of each row's identity to the template, over the columns the template spans, ignoring the ragged ends where a row has not started or has already finished. A column where one side has an internal gap counts as comparable and not matching.">
+              <strong>{avgIdentity === null ? 'N/A' : `${formatIdentity(avgIdentity)}%`}</strong> avg to template
+            </span>
+            {/* This said "differences in overlap", which named a population it
+                does not count: a column where a row has an internal gap facing a
+                template residue is an indel, not overlap, and it is counted.
+                An alignment with no substitutions at all and one 20-column
+                internal gap printed "20 differences in overlap". Both this and
+                the average beside it use the SAME rule — template span, ragged
+                ends excluded, internal indels counted — so the fix is to name
+                that rule rather than to change either number. */}
+            <span title="Columns inside the template's span where at least one row's call differs from the template — substitutions and internal gaps alike. Ragged ends, where a row has not started or has already finished, are not counted.">
+              <strong>{differences.length.toLocaleString()}</strong> columns differ from template
+            </span>
             {ambiguities.length > 0 ? (
               <span className="motif-cs-msa-stats-ambiguous" data-testid="msa-ambiguous-count" title="Columns with compatible ambiguity-code calls, counted separately from hard differences">
                 <strong>{ambiguities.length.toLocaleString()}</strong> compatible
               </span>
             ) : null}
+          </div>
           </div>
 
           {displayMode === 'viewer' ? (
@@ -4274,22 +5035,12 @@ export function ClaudeScienceMsaViewer({
                 <label className="motif-cs-msa-reference-picker">
                   <span>Compare against</span>
                   <select value={referenceRowId} disabled={!hasComparableRows} onChange={(event) => selectTemplate(event.target.value)}>
-                    {activeAlignment.rows.map((row) => <option key={row.id} value={row.id}>{row.name}</option>)}
-                  </select>
-                </label>
-                <label className="motif-cs-msa-sort-picker">
-                  <span>Sort</span>
-                  <select value={sortMode} onChange={(event) => updateViewPreferences({ sortMode: event.target.value as RowSortMode })}>
-                    <option value="original">Original order</option>
-                    <option value="name">Name</option>
-                    <option value="identity">Identity</option>
-                    <option value="mismatches">Mismatches</option>
-                    <option value="length">Ungapped length</option>
+                    {activeAlignment.rows.map((row) => <option key={row.id} value={row.id} title={row.name}>{compareRowLabels.get(row.id) ?? row.name}</option>)}
                   </select>
                 </label>
                 <div className="motif-cs-msa-difference-nav" role="group" aria-label="Variable column navigation">
                   <button className="motif-cs-mini-button" type="button" disabled={differenceNavigationDisabled} onClick={() => jumpDifference(-1)} aria-label="Previous variable column"><ChevronLeft size={13} /></button>
-                  <span>{differenceNavigationLabel}</span>
+                  <span style={{ minWidth: `${differenceNavigationWidth}ch` }}>{differenceNavigationLabel}</span>
                   <button className="motif-cs-mini-button" type="button" disabled={differenceNavigationDisabled} onClick={() => jumpDifference(1)} aria-label="Next variable column"><ChevronRight size={13} /></button>
                 </div>
                 <form
@@ -4310,7 +5061,15 @@ export function ClaudeScienceMsaViewer({
                     spellCheck={false}
                     maxLength={MSA_MOTIF_SEARCH_MAX_QUERY_LENGTH}
                     value={searchQuery}
+                    // Degenerate codes are honoured and nothing said so, which
+                    // made a correct count look like a bug: typing ZZ into a
+                    // protein alignment containing no literal Z returns every
+                    // adjacent E/Q pair, and that is right. The rule is in the
+                    // title rather than the placeholder because the box is 146px
+                    // and every phrasing naming IUPAC needs 151px or more — a
+                    // placeholder that says it and then clips says nothing.
                     placeholder="Find sequence…"
+                    title="Case-insensitive, and IUPAC ambiguity codes match the residues they stand for — N matches any base, Z matches E or Q."
                     aria-label="Find a sequence motif in the alignment"
                     onChange={(event) => setSearchQuery(event.target.value)}
                     onKeyDown={(event) => {
@@ -4324,70 +5083,17 @@ export function ClaudeScienceMsaViewer({
                         ? 'Searching…'
                         : searchMatches.length === 0
                           ? searchResult.truncated ? 'Search limit reached' : 'No matches'
-                          : `${searchIndex >= 0 ? `${Math.min(searchIndex, searchMatches.length - 1) + 1} of ` : ''}${searchMatches.length.toLocaleString()}${searchResult.truncated ? '+' : ''}`
+                          // Before anything has been stepped to there is no
+                          // current match, and a bare "13" beside a pair of
+                          // step arrows reads as "match 13 of something". The
+                          // noun says which number this is.
+                          : searchIndex >= 0
+                            ? `${Math.min(searchIndex, searchMatches.length - 1) + 1} of ${searchMatches.length.toLocaleString()}${searchResult.truncated ? '+' : ''}`
+                            : `${searchMatches.length.toLocaleString()}${searchResult.truncated ? '+' : ''} ${searchMatches.length === 1 ? 'match' : 'matches'}`
                       : ''}
                   </span>
                   <button type="button" className="motif-cs-mini-button" data-testid="msa-search-prev" disabled={searchMatches.length === 0} onClick={() => stepSearch(-1)} aria-label="Previous match"><ChevronLeft size={13} /></button>
                   <button type="submit" className="motif-cs-mini-button" data-testid="msa-search-next" disabled={searchMatches.length === 0} aria-label="Next match"><ChevronRight size={13} /></button>
-                </form>
-                <form
-                  className="motif-cs-msa-column-jump"
-                  data-invalid={columnError ? true : undefined}
-                  noValidate
-                  onSubmit={(event) => {
-                    event.preventDefault();
-                    goToCoordinate();
-                  }}
-                >
-                  <label className="motif-cs-msa-coordinate-system">
-                    <span className="motif-cs-visually-hidden">Coordinate system</span>
-                    <select
-                      data-testid="msa-coordinate-system"
-                      name="alignment-coordinate-system"
-                      value={coordinateSystem}
-                      aria-label="Coordinate system"
-                      onChange={(event) => {
-                        setCoordinateSystem(event.target.value as CoordinateSystem);
-                        setColumnDraft('');
-                        setColumnError(null);
-                        setColumnStatus('');
-                      }}
-                    >
-                      <option value="alignment">Alignment column</option>
-                      <option value="template">{activeReferenceCoordinates ? 'Reference position' : 'Template position'}</option>
-                    </select>
-                  </label>
-                  <label>
-                    <span className="motif-cs-visually-hidden">{coordinateSystem === 'alignment' ? 'Alignment column' : activeReferenceCoordinates ? 'Reference position' : 'Template position'}</span>
-                    <input
-                      data-testid="msa-coordinate-input"
-                      type={coordinateSystem === 'template' && activeReferenceCoordinates ? 'text' : 'number'}
-                      name="alignment-coordinate"
-                      autoComplete="off"
-                      inputMode={coordinateSystem === 'template' && activeReferenceCoordinates ? 'text' : 'numeric'}
-                      min={coordinateSystem === 'template' && activeReferenceCoordinates ? undefined : 1}
-                      max={coordinateSystem === 'template' && activeReferenceCoordinates
-                        ? undefined
-                        : coordinateSystem === 'alignment'
-                          ? activeAlignment.alignmentLength
-                          : activeTemplate?.aligned.replace(/-/g, '').length ?? 0}
-                      step={coordinateSystem === 'template' && activeReferenceCoordinates ? undefined : 1}
-                      pattern={coordinateSystem === 'template' && activeReferenceCoordinates ? '[0-9]+[A-Za-z]*' : undefined}
-                      placeholder={coordinateSystem === 'template' && activeReferenceCoordinates ? '101 or 101A' : undefined}
-                      value={columnDraft}
-                      onChange={(event) => {
-                        setColumnDraft(event.target.value);
-                        setColumnError(null);
-                        setColumnStatus('');
-                      }}
-                      aria-label={coordinateSystem === 'alignment' ? 'Go to alignment column' : activeReferenceCoordinates ? 'Go to reference position' : 'Go to template position'}
-                      aria-invalid={columnError ? true : undefined}
-                      aria-describedby={columnError ? 'motif-cs-msa-column-error' : undefined}
-                    />
-                  </label>
-                  <button className="motif-cs-mini-button" type="submit">Go</button>
-                  {columnError ? <span id="motif-cs-msa-column-error" className="motif-cs-msa-column-error" role="alert">{columnError}</span> : null}
-                  <span className="motif-cs-visually-hidden" role="status" aria-live="polite">{columnStatus}</span>
                 </form>
               </div>
               {viewPreferences.showRowStatsPanel ? (
@@ -4435,12 +5141,12 @@ export function ClaudeScienceMsaViewer({
                 <label className="motif-cs-msa-reference-picker">
                   <span>Compare against</span>
                   <select value={referenceRowId} disabled={!hasComparableRows} onChange={(event) => selectTemplate(event.target.value)}>
-                    {activeAlignment.rows.map((row) => <option key={row.id} value={row.id}>{row.name}</option>)}
+                    {activeAlignment.rows.map((row) => <option key={row.id} value={row.id} title={row.name}>{compareRowLabels.get(row.id) ?? row.name}</option>)}
                   </select>
                 </label>
                 <div className="motif-cs-msa-difference-nav" role="group" aria-label="Variable column navigation">
                   <button className="motif-cs-mini-button" type="button" disabled={differenceNavigationDisabled} onClick={() => jumpDifference(-1)} aria-label="Previous variable column"><ChevronLeft size={13} /></button>
-                  <span>{differenceNavigationLabel}</span>
+                  <span style={{ minWidth: `${differenceNavigationWidth}ch` }}>{differenceNavigationLabel}</span>
                   <button className="motif-cs-mini-button" type="button" disabled={differenceNavigationDisabled} onClick={() => jumpDifference(1)} aria-label="Next variable column"><ChevronRight size={13} /></button>
                 </div>
                 <span className="motif-cs-muted">Click a call, drag the position slider, or use arrow keys inside the trace.</span>
@@ -4459,37 +5165,6 @@ export function ClaudeScienceMsaViewer({
               <textarea className="motif-cs-textarea" readOnly value={textContent} aria-label={`${selectedExport.label} alignment text`} />
             </div>
           )}
-
-          <div className="motif-cs-msa-export-row">
-            <label>
-              <span>Export</span>
-              <select value={textFormat} onChange={(event) => updateViewPreferences({ textFormat: event.target.value as TextFormat })}>
-                <option value="fasta">Aligned FASTA</option>
-                <option value="clustal">CLUSTAL</option>
-                <option value="consensus">Consensus FASTA</option>
-                <option value="json">Alignment JSON</option>
-              </select>
-            </label>
-            <button className="motif-cs-mini-button" type="button" onClick={() => void copyFromViewer(selectedExport.label, textContent)}>{copyStatus?.label === selectedExport.label && copyStatus.tone === 'status' ? 'Copied' : 'Copy'}</button>
-            <button className="motif-cs-mini-button" type="button" onClick={() => onDownload(safeAlignmentFilename(activeAlignment, selectedExport.extension), textContent, selectedExport.mime)}>Download</button>
-            <div className="motif-cs-msa-export-image" data-testid="msa-export-image">
-              <label className="motif-cs-msa-image-scope">
-                <span>Image</span>
-                <select
-                  value={imageScope}
-                  data-testid="msa-export-image-scope"
-                  aria-label="Image export scope"
-                  onChange={(event) => setImageScope(event.target.value as AlignmentImageScope)}
-                >
-                  <option value="view">Visible view</option>
-                  <option value="all">Whole alignment</option>
-                </select>
-              </label>
-              <button className="motif-cs-mini-button" type="button" data-testid="msa-export-png" onClick={() => void exportAlignmentImage('png')}>Save PNG</button>
-              <button className="motif-cs-mini-button" type="button" data-testid="msa-export-svg" onClick={() => void exportAlignmentImage('svg')}>Save SVG</button>
-            </div>
-            <span className="motif-cs-muted">In session · Export a workspace backup before reload. To restore a ZIP export, unzip it and choose inventory.json in Settings. {activeAlignment.note}</span>
-          </div>
         </>
       ) : (
         <div className="motif-cs-msa-empty" data-testid="msa-empty-state">

--- a/src/artifacts/__tests__/ClaudeScienceMsaViewer.correctness.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceMsaViewer.correctness.jsdom.test.tsx
@@ -120,8 +120,13 @@ function selectFirstColumn(): void {
   Object.defineProperty(document, 'elementFromPoint', { configurable: true, value: vi.fn(() => null) });
   Object.defineProperty(ruler, 'setPointerCapture', { configurable: true, value: vi.fn() });
   Object.defineProperty(ruler, 'hasPointerCapture', { configurable: true, value: vi.fn(() => false) });
-  fireEvent.pointerDown(ruler, { button: 0, clientX: 220, clientY: 20, pointerId: 1 });
-  fireEvent.pointerUp(ruler, { button: 0, clientX: 220, clientY: 20, pointerId: 1 });
+  // Aim at the centre of the first residue column using the geometry the frame
+  // actually rendered, so resizing the row-label gutter or the cells cannot
+  // silently move this click into a different column.
+  const { cellWidth, labelWidth } = matrixGeometry();
+  const rulerX = labelWidth + (cellWidth / 2);
+  fireEvent.pointerDown(ruler, { button: 0, clientX: rulerX, clientY: 20, pointerId: 1 });
+  fireEvent.pointerUp(ruler, { button: 0, clientX: rulerX, clientY: 20, pointerId: 1 });
   expect(screen.getByTestId('msa-selection-readout')).toBeTruthy();
 }
 
@@ -196,11 +201,38 @@ describe('ClaudeScienceMsaViewer comparison correctness', () => {
     expect(partialRow?.getAttribute('aria-label')).toContain('100.0 percent identity');
     expect(terminalCell?.dataset.cellOutcome).toBe('uncovered');
     expect(terminalCell?.hasAttribute('data-difference')).toBe(false);
-    expect(screen.getByTestId('msa-stats-bar').textContent).toContain('0 differences in overlap');
-    expect(screen.getByText('0 differences')).toBeTruthy();
+    expect(screen.getByTestId('msa-stats-bar').textContent).toContain('0 columns differ from template');
+    expect(screen.getByText('Difference — of 0')).toBeTruthy();
     expect((screen.getByLabelText('Next variable column') as HTMLButtonElement).disabled).toBe(true);
     expect(screen.getByTestId('msa-overview')
       .querySelector('.motif-cs-msa-overview-mismatches')?.getAttribute('d')).toBe('');
+  });
+
+  it('names the population the stats bar counts, which is not the overlap', () => {
+    // Regression: the count was labelled "differences in overlap" while counting
+    // internal indels, which are by definition not overlap. This fixture has NO
+    // substitution anywhere — every difference is a gap facing a residue — so the
+    // count and the word are forced apart, which a fixture with mismatches in it
+    // could not do.
+    const alignment = alignmentWithRows('gap-only-differences', [
+      { id: 'reference', name: 'Reference', aligned: 'ACGTACGTAC' },
+      { id: 'identical', name: 'Identical', aligned: 'ACGTACGTAC' },
+      { id: 'gapped', name: 'Gapped', aligned: 'ACG---GTAC' },
+    ]);
+    // Independently: columns 3, 4 and 5 have a residue in the template and a gap
+    // in one row; no column has two residues that disagree.
+    expect(differenceColumns(alignment, 'reference')).toEqual([3, 4, 5]);
+
+    renderViewer(alignment);
+    const bar = screen.getByTestId('msa-stats-bar');
+    expect(bar.textContent).toContain('3 columns differ from template');
+    // The number is right; the old label was not. Pin the claim, not the phrasing:
+    // nothing in this bar may call an indel column part of an overlap.
+    expect(bar.textContent).not.toMatch(/overlap/i);
+    // The average beside it uses the same rule, so the two cannot drift apart:
+    // each row scores over the template's span with the indel columns comparable
+    // — 100% for the identical row and 7/10 for the gapped one.
+    expect(bar.textContent).toContain('85.0% avg to template');
   });
 
   it('keeps an internal deletion counted across grid, stats, navigation, and overview', () => {
@@ -222,8 +254,8 @@ describe('ClaudeScienceMsaViewer comparison correctness', () => {
     expect(deletionRow?.getAttribute('aria-label')).toContain('1 mismatches');
     expect(deletionCell?.dataset.cellOutcome).toBe('deletion');
     expect(deletionCell?.hasAttribute('data-difference')).toBe(true);
-    expect(screen.getByTestId('msa-stats-bar').textContent).toContain('1 differences in overlap');
-    expect(screen.getByText('1 differences')).toBeTruthy();
+    expect(screen.getByTestId('msa-stats-bar').textContent).toContain('1 columns differ from template');
+    expect(screen.getByText('Difference — of 1')).toBeTruthy();
     expect((screen.getByLabelText('Next variable column') as HTMLButtonElement).disabled).toBe(false);
     expect(screen.getByTestId('msa-overview')
       .querySelector('.motif-cs-msa-overview-mismatches')?.getAttribute('d')).toContain('M1 22V2H2V22Z');
@@ -315,7 +347,7 @@ describe('ClaudeScienceMsaViewer IUPAC-aware differences', () => {
     let cell = document.querySelector<HTMLElement>('[data-msa-row-id="read"] [data-alignment-column="1"]');
     expect(cell?.dataset.cellOutcome).toBe('ambiguous');
     expect(cell?.hasAttribute('data-difference')).toBe(false);
-    expect(screen.getByTestId('msa-stats-bar').textContent).toContain('0 differences in overlap');
+    expect(screen.getByTestId('msa-stats-bar').textContent).toContain('0 columns differ from template');
     expect(screen.getByTestId('msa-ambiguous-count').textContent).toContain('1 compatible');
     defaultView.unmount();
 
@@ -449,6 +481,76 @@ describe('ClaudeScienceMsaViewer reference coordinates', () => {
     await waitFor(() => expect(screen.getByRole('row', { name: 'Template positions for Reference' })).toBeTruthy());
     expect(screen.getByTestId('msa-reference-numbering-editor').textContent).toContain('Plain 1-based');
   });
+
+  it('keeps one result per numbering state instead of forking on every click', async () => {
+    // Regression: both buttons saved unconditionally, so "Use plain 1-based" was
+    // a third result rather than a way back to the first. Three round trips left
+    // seven results. One round trip would not have caught it — the count has to
+    // be watched across several.
+    const alignment = alignmentWithRows('reference-numbering-cycle', [
+      { id: 'reference', name: 'Reference', aligned: 'A-C' },
+      { id: 'second', name: 'Second', aligned: 'ATC' },
+    ]);
+    render(<ReferenceNumberingPersistenceHarness initialAlignment={alignment} />);
+    fireEvent.click(screen.getByTestId('msa-view-menu-button'));
+    fireEvent.change(screen.getByTestId('msa-reference-numbering-position'), { target: { value: '100' } });
+
+    const savedResultCount = () => {
+      const picker = document.querySelector('.motif-cs-msa-alignment-picker select');
+      if (!picker) throw new Error('the alignment picker is absent — the count below would measure nothing');
+      return picker.querySelectorAll('option').length;
+    };
+    const numberingIsOn = () => screen.getByTestId('msa-reference-numbering-editor').getAttribute('data-active') === 'true';
+
+    fireEvent.click(screen.getByTestId('msa-apply-reference-numbering'));
+    await waitFor(() => expect(numberingIsOn()).toBe(true));
+    expect(savedResultCount()).toBe(2);
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      fireEvent.click(screen.getByTestId('msa-clear-reference-numbering'));
+      await waitFor(() => expect(numberingIsOn()).toBe(false));
+      expect(savedResultCount()).toBe(2);
+
+      // Opening the plain result resets the editor to its defaults, so ask for
+      // the same numbering again the way a user toggling between the two would.
+      fireEvent.change(screen.getByTestId('msa-reference-numbering-position'), { target: { value: '100' } });
+      fireEvent.click(screen.getByTestId('msa-apply-reference-numbering'));
+      await waitFor(() => expect(numberingIsOn()).toBe(true));
+      expect(savedResultCount()).toBe(2);
+    }
+  });
+
+  it('does not reuse a numbering result from a provenance-distinct alignment', () => {
+    const alignment = {
+      ...alignmentWithRows('reference-numbering-provenance', [
+        { id: 'reference', name: 'Reference', aligned: 'A-C' },
+        { id: 'second', name: 'Second', aligned: 'ATC' },
+      ]),
+      outputSha256: 'a'.repeat(64),
+    };
+    const foreignNumbered = {
+      ...alignment,
+      id: 'foreign-numbered-result',
+      name: 'Foreign numbered result',
+      outputSha256: 'b'.repeat(64),
+      referenceNumbering: { rowId: 'reference', firstResiduePosition: 100 },
+    };
+    const onSaveAlignment = vi.fn((next: ArtifactAlignment) => ({ ...next, id: 'new-numbered-result' }));
+    const onActiveAlignmentChange = vi.fn();
+    renderViewer(alignment, DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES, {
+      alignments: [alignment, foreignNumbered],
+      onSaveAlignment,
+      onActiveAlignmentChange,
+    });
+
+    fireEvent.click(screen.getByTestId('msa-view-menu-button'));
+    fireEvent.change(screen.getByTestId('msa-reference-numbering-position'), { target: { value: '100' } });
+    fireEvent.click(screen.getByTestId('msa-apply-reference-numbering'));
+
+    expect(onSaveAlignment).toHaveBeenCalledTimes(1);
+    expect(onActiveAlignmentChange).toHaveBeenCalledWith('new-numbered-result');
+    expect(onActiveAlignmentChange).not.toHaveBeenCalledWith('foreign-numbered-result');
+  });
 });
 
 describe('ClaudeScienceMsaViewer selection interactions', () => {
@@ -536,5 +638,26 @@ describe('ClaudeScienceMsaViewer selection interactions', () => {
 
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(screen.queryByTestId('msa-selection-readout')).toBeNull();
+  });
+
+  it('strips a shared prefix from every row even when the rows disagree about its case', () => {
+    // The prefix is picked by a case-insensitive comparison. If it is then
+    // stripped case-sensitively, the one row spelling it differently keeps its
+    // full name while its siblings lose theirs — and it is the long one a narrow
+    // control truncates. Mixed-case accession and chromosome prefixes are the
+    // realistic source ("Chr1_" beside "chr1_", "sp|" beside "SP|").
+    renderViewer(alignmentWithRows('mixed-case-prefix', [
+      { id: 'a', name: 'PAL_Prunus_avium', aligned: 'ACGT' },
+      { id: 'b', name: 'pal_Pisum_sativum', aligned: 'ACGA' },
+      { id: 'c', name: 'PAL_Zea_mays', aligned: 'ACGC' },
+    ]));
+
+    const compare = screen.getByLabelText('Compare against') as HTMLSelectElement;
+    const labels = [...compare.options].map((option) => option.textContent ?? '');
+    expect(labels).toContain('Prunus_avium');
+    expect(labels).toContain('Zea_mays');
+    expect(labels).toContain('Pisum_sativum');
+    // No option may still be carrying the shared prefix in any casing.
+    expect(labels.filter((label) => /^pal[\s_./-]/i.test(label))).toEqual([]);
   });
 });

--- a/src/artifacts/__tests__/ClaudeScienceMsaViewer.frame-structure.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceMsaViewer.frame-structure.jsdom.test.tsx
@@ -1,0 +1,335 @@
+// @vitest-environment jsdom
+
+/**
+ * The matrix frame clips (`overflow: hidden`) and the window body no longer
+ * overflows, so anything squeezed out of the frame used to be unreachable — there
+ * was no scrollbar anywhere that led to it. On a 300px-tall panel that was the pan
+ * slider, the zoom line and the selection readout: present in the DOM, drawn at a
+ * real size, and impossible to get to.
+ *
+ * The fix is structural, so the guard has to be structural too: only the overview
+ * and the residue viewport may live inside the clipped box. Everything that does not
+ * scroll is a sibling, held by a shell that can grow and push the body into
+ * scrolling. jsdom has no layout, so these tests pin the STRUCTURE and the token
+ * plumbing that the structure depends on; the pixel behaviour is measured on the
+ * live app (bodyOverflow 106 -> 118 at 1100x420 with the pan row reachable after
+ * scrolling, and 0 at 1024x768 and 1280x900 with 9/9 rows).
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { act } from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  ClaudeScienceMsaViewer,
+  type ClaudeScienceMsaViewerProps,
+} from '../ClaudeScienceMsaViewer';
+import { normalizeArtifactAlignment } from '../claude-science-msa';
+import { DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES } from '../claude-science-msa-view-preferences';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const viewerSource = readFileSync(resolve(here, '..', 'ClaudeScienceMsaViewer.tsx'), 'utf8');
+const msaCss = readFileSync(resolve(here, '..', 'claude-science-msa.css'), 'utf8');
+/**
+ * BOTH stylesheets that style the frame. motif-artifact.css carries its own bare
+ * `.motif-cs-msa-matrix-frame` rule, and a guard that reads only the file it was
+ * written beside is the failure this branch has already hit once — a value declared
+ * twice, one copy fixed, the guard watching the fixed copy.
+ */
+const hostCss = readFileSync(resolve(here, '..', 'motif-artifact.css'), 'utf8');
+const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, '');
+
+/** Every rule block, in either sheet, whose selector targets the frame. */
+function frameRules(): { sheet: string; selector: string; body: string }[] {
+  const out: { sheet: string; selector: string; body: string }[] = [];
+  for (const [sheet, css] of [['claude-science-msa.css', msaCss], ['motif-artifact.css', hostCss]] as const) {
+    for (const match of stripComments(css).matchAll(/([^{}]+)\{([^}]*)\}/g)) {
+      const selector = match[1].trim();
+      if (/\.motif-cs-msa-matrix-frame\b/.test(selector)) out.push({ sheet, selector, body: match[2] });
+    }
+  }
+  return out;
+}
+
+/**
+ * Rendered, not read from source. A first cut of this file sliced the JSX from the
+ * frame's opening tag to the pan row's comment and asserted on the text between —
+ * which cannot see where the frame actually CLOSES. Deleting the frame's closing tag
+ * put every row back inside the clipped box and all six tests still passed. Only the
+ * DOM knows what contains what.
+ */
+function renderViewer() {
+  const alignment = normalizeArtifactAlignment({
+    id: 'frame-structure',
+    name: 'Frame structure',
+    molecule: 'dna',
+    referenceRowId: 'reference',
+    rows: [
+      { id: 'reference', name: 'Reference', aligned: 'ACGTACGT' },
+      { id: 'second', name: 'Second', aligned: 'ACGAACGT' },
+      { id: 'third', name: 'Third', aligned: 'ACGGACGT' },
+    ],
+  });
+  const props: ClaudeScienceMsaViewerProps = {
+    records: [],
+    alignments: [alignment],
+    activeAlignmentId: alignment.id,
+    viewPreferences: DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES,
+    onActiveAlignmentChange: vi.fn(),
+    onViewPreferencesChange: vi.fn(),
+    onSaveAlignment: (next) => next,
+    onUpdateAlignmentTemplate: () => null,
+    onDeleteAlignment: vi.fn(),
+    onImportRecords: async () => ({ records: [], message: '', tone: 'status' }),
+    onCopy: async () => true,
+    onDownload: vi.fn(),
+  };
+  return render(<ClaudeScienceMsaViewer {...props} />);
+}
+
+/**
+ * jsdom has no layout and no ResizeObserver, so the measured chrome height stays at its
+ * fallback and the readout never floats — the float is gated on the strip being tall
+ * enough to hold it. Stub both, so the tests exercise the real gate instead of a
+ * degenerate "no measurement, therefore no float" path.
+ */
+function stubChromeHeight(container: HTMLElement, height: number): void {
+  const chrome = container.querySelector<HTMLElement>('.motif-cs-msa-matrix-chrome');
+  if (!chrome) throw new Error('chrome strip missing');
+  vi.spyOn(chrome, 'getBoundingClientRect').mockReturnValue({
+    x: 0, y: 0, left: 0, top: 0, right: 800, bottom: height, width: 800, height,
+    toJSON: () => ({}),
+  } as DOMRect);
+}
+
+/**
+ * Records its callbacks instead of firing on observe. The viewer runs more than one
+ * ResizeObserver, and another reads `entry.contentRect` — a stub that fires with an
+ * empty entry list crashes THAT one, which is how the first version of this helper
+ * broke two unrelated tests.
+ */
+const resizeCallbacks: ResizeObserverCallback[] = [];
+class StubResizeObserver {
+  constructor(cb: ResizeObserverCallback) { resizeCallbacks.push(cb); }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+/** Re-runs every observer with a well-formed entry, after the rects are stubbed. */
+function flushResizeObservers(width = 800, height = 60): void {
+  const entry = { contentRect: { width, height } } as ResizeObserverEntry;
+  for (const cb of resizeCallbacks) cb([entry], {} as ResizeObserver);
+}
+
+afterEach(() => {
+  resizeCallbacks.length = 0;
+  vi.unstubAllGlobals();
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('only scrolling content lives inside the clipped matrix frame', () => {
+  it('keeps the overview and the residue viewport inside the frame', () => {
+    renderViewer();
+    const frame = screen.getByTestId('msa-alignment-view');
+
+    // Both must stay: the cursor channel is declared on the frame precisely because
+    // the overview viewport is the matrix's sibling and has to inherit it too.
+    expect(frame.querySelector('.motif-cs-msa-overview-row')).not.toBeNull();
+    expect(frame.querySelector('.motif-cs-msa-matrix')).not.toBeNull();
+    expect(frame.closest('.motif-cs-msa-matrix-shell')).not.toBeNull();
+  });
+
+  it('holds every non-scrolling row outside the frame, as a sibling', () => {
+    renderViewer();
+    const frame = screen.getByTestId('msa-alignment-view');
+    const shell = frame.closest('.motif-cs-msa-matrix-shell');
+    expect(shell).not.toBeNull();
+
+    // The statusbar always mounts, and every row moved out of the frame shares the
+    // frame's single closing tag — so this one assertion is what catches the boundary
+    // moving back. The pan slider only mounts when there is something to scroll,
+    // which needs real layout; its position is measured on the live app instead.
+    const statusbar = shell!.querySelector('.motif-cs-msa-statusbar');
+    expect(statusbar, 'statusbar is missing entirely').not.toBeNull();
+    expect(frame.contains(statusbar), 'statusbar is still inside the clipped frame').toBe(false);
+
+    const panRow = shell!.querySelector('[data-testid="msa-horizontal-scroll-row"]');
+    if (panRow) expect(frame.contains(panRow), 'pan row is still inside the frame').toBe(false);
+  });
+
+  it('floats the readout on BOTH drag paths, not just the grid', () => {
+    // The ruler drag is a second, independent route into a selection, and it used to
+    // set only its own ref — never `isSelecting` — so the readout mounted as a row
+    // mid-gesture and took 46px out of the residue viewport. Measured at 1100x640:
+    // scroller 195 -> 149 with the pointer still down and one row lost, where the grid
+    // path held at 195. A ruler drag selects EVERY row, so it is the worst case.
+    vi.stubGlobal('ResizeObserver', StubResizeObserver);
+    const { container } = renderViewer();
+    stubChromeHeight(container, 60);   // pan row + status line: room for the float
+    act(() => flushResizeObservers());
+    const frame = screen.getByTestId('msa-alignment-view');
+    const ruler = frame.querySelector<HTMLElement>('.motif-cs-msa-ruler-window-clickable');
+    expect(ruler, 'ruler drag target missing').not.toBeNull();
+
+    const labelWidth = Number.parseFloat(frame.style.getPropertyValue('--motif-cs-msa-label-width'));
+    const cellWidth = Number.parseFloat(frame.style.getPropertyValue('--motif-cs-msa-cell-width'));
+    expect(Number.isFinite(labelWidth) && Number.isFinite(cellWidth)).toBe(true);
+
+    // jsdom hands back a zero rect for everything, and the column is resolved against
+    // the scroller's box — so without this the press lands on no column and makes no
+    // selection. Same stub the overlays suite uses to drive this element.
+    const viewport = frame.querySelector<HTMLElement>('.motif-cs-msa-matrix-scroll')!;
+    vi.spyOn(viewport, 'getBoundingClientRect').mockReturnValue({
+      x: 0, y: 0, left: 0, top: 0, right: 800, bottom: 400, width: 800, height: 400,
+      toJSON: () => ({}),
+    } as DOMRect);
+    Object.defineProperty(ruler!, 'setPointerCapture', { configurable: true, value: vi.fn() });
+    Object.defineProperty(ruler!, 'hasPointerCapture', { configurable: true, value: vi.fn(() => false) });
+    // The press bubbles to the grid's own pointerdown handler, which calls
+    // document.elementFromPoint — absent in jsdom, and it throws OUTSIDE the
+    // assertions, so vitest reports "11 passed, 1 error" and exits non-zero.
+    Object.defineProperty(document, 'elementFromPoint', { configurable: true, value: vi.fn(() => null) });
+
+    fireEvent.pointerDown(ruler!, {
+      button: 0,
+      buttons: 1,
+      clientX: labelWidth + (cellWidth * 1.5),
+      clientY: 10,
+      pointerId: 3,
+    });
+
+    const shell = frame.closest('.motif-cs-msa-matrix-shell')!;
+    const readout = shell.querySelector('[data-testid="msa-selection-readout"]');
+    // Guard against the false pass: no selection means the press missed, and "no
+    // readout in the flow" would then be true for the wrong reason.
+    expect(readout, 'the ruler press produced no selection — the path was not exercised').not.toBeNull();
+    expect(readout!.getAttribute('data-live'), 'ruler drag left the readout in the flow').toBe('true');
+  });
+
+  it('keeps the rows that mount later outside the frame too', () => {
+    renderViewer();
+    const frame = screen.getByTestId('msa-alignment-view');
+    const shell = frame.closest('.motif-cs-msa-matrix-shell')!;
+
+    // The selection readout only exists once there is a selection; it is the child
+    // whose arrival used to shrink the residue viewport mid-drag.
+    fireEvent.keyDown(screen.getByTestId('msa-alignment-view'), { key: 'ArrowRight' });
+    const grid = shell.querySelector('.motif-cs-msa-matrix-scroll') ?? shell;
+    fireEvent.keyDown(grid, { key: ' ' });
+    const readout = shell.querySelector('[data-testid="msa-selection-readout"]');
+    if (readout) expect(frame.contains(readout)).toBe(false);
+    // Not asserting the readout exists: the point is only that if it does, it is a
+    // sibling. Its mounting path is covered by the correctness suite.
+  });
+
+  it('gives the shell a floor to grow against, not min-content, in either sheet', () => {
+    const rules = frameRules();
+    const shellScoped = rules.find((r) => r.selector.includes('.motif-cs-msa-matrix-shell >'));
+    expect(shellScoped, 'no shell-scoped frame rule in either stylesheet').toBeTruthy();
+
+    // The floor is derived in the viewer and passed down; the literal is the fallback.
+    expect(shellScoped!.body).toMatch(/min-height:\s*var\(--motif-cs-msa-frame-min-height,\s*\d+px\)/);
+
+    // Neither rejected approach may appear on the frame in EITHER sheet. min-content
+    // computes to ~469px and forces whole-UI scrolling at 1024x768; flex-shrink:0
+    // fixes the mid-drag shrink but costs 39px of the same at the same size.
+    for (const rule of rules) {
+      expect(rule.body, `${rule.sheet} ${rule.selector} uses min-content`).not.toContain('min-content');
+      expect(rule.body, `${rule.sheet} ${rule.selector} pins flex-shrink to 0`).not.toMatch(/flex-shrink:\s*0/);
+    }
+  });
+
+  it('stops the shell being shorter than the box it draws a border around', () => {
+    // A border wraps the border box, not the overflow. With `min-height: 0` the shell
+    // measured 97px against 233px of content on a 300px panel, so its bottom border
+    // painted a hairline across the residue grid, 8px into row 2.
+    const code = stripComments(msaCss);
+    const at = code.indexOf('.motif-cs-msa-matrix-shell {');
+    const shellRule = code.slice(at, code.indexOf('}', at));
+
+    expect(shellRule).toMatch(/min-height:\s*var\(--motif-cs-msa-shell-min-height,\s*\d+px\)/);
+    expect(shellRule, 'a zero floor is what let the border cut the grid').not.toMatch(/min-height:\s*0/);
+    // auto / min-content / fit-content all measure 469px here and take 1024x768 from
+    // 0 to 40px of body overflow, so none may stand in for the derived floor.
+    expect(shellRule).not.toMatch(/min-height:\s*(auto|min-content|fit-content)/);
+  });
+
+  it('derives both floors from the row constants rather than hard-coding them', () => {
+    // The frame's floor is the sum of its own children's floors; the shell's is the
+    // frame's plus the rows beneath it. Both are computed in the viewer and passed
+    // down, so changing a row height cannot leave a floor behind.
+    expect(viewerSource).toContain(
+      'const MSA_MATRIX_FRAME_MIN_HEIGHT = MSA_OVERVIEW_ROW_HEIGHT + MSA_MATRIX_SCROLL_MIN_HEIGHT;',
+    );
+    expect(viewerSource).toContain("'--motif-cs-msa-frame-min-height': `${MSA_MATRIX_FRAME_MIN_HEIGHT}px`");
+
+    // The shell's floor is COMPUTED from what is mounted, not constant: three of its
+    // four rows are conditional, and a constant left it 45px short once a selection
+    // settled and 77px short with the order note too.
+    expect(viewerSource).toContain('function msaMatrixShellMinHeight(');
+    // The chrome strip is MEASURED, not summed from constants — it wraps at narrow
+    // widths, and an existing e2e expectation already has the zoom row past 40px.
+    for (const term of [
+      '+ rows.chromeHeight',
+      '(rows.readoutInFlow ? MSA_SELECTION_READOUT_HEIGHT : 0)',
+      'new ResizeObserver(sync)',
+    ]) expect(viewerSource).toContain(term);
+    // ...and the readout counts only in flow — floating, it takes no layout height.
+    expect(viewerSource).toContain("readoutInFlow: readoutPlacement === 'flow'");
+  });
+
+  it('keeps the enclosure on the shell, so the two sheets cannot both draw it', () => {
+    // motif-artifact.css still declares the old border/background on the bare
+    // selector as the unwrapped fallback. What must hold is that the shell-scoped
+    // rule cancels them, or the frame paints a second border inside the shell's.
+    const shellScoped = frameRules().find((r) => r.selector.includes('.motif-cs-msa-matrix-shell >'))!;
+
+    expect(shellScoped.body).toMatch(/border:\s*0/);
+    expect(shellScoped.body).toMatch(/background:\s*transparent/);
+    // Specificity, not source order, is what makes that reliable: 0,2,0 vs 0,1,0.
+    const bare = frameRules().filter((r) => r.selector === '.motif-cs-msa-matrix-frame');
+    expect(bare.length, 'expected the bare frame rules to still exist as fallbacks').toBeGreaterThan(0);
+    for (const rule of bare) expect(rule.selector.split(/\s+/).length).toBeLessThan(shellScoped.selector.split(/\s+/).length);
+  });
+
+  it('passes the column geometry to the rows that moved out of the frame', () => {
+    // The pan row's grid is sized by --motif-cs-msa-label-width. As a sibling it can
+    // only inherit that from the shell; left on the frame alone the slider falls back
+    // to 180px and stops lining up with the residue columns it scrolls.
+    const shellOpen = viewerSource.indexOf('className="motif-cs-msa-matrix-shell"');
+    expect(shellOpen).toBeGreaterThan(-1);
+    expect(viewerSource.slice(shellOpen, shellOpen + 200)).toContain('style={frameStyle}');
+  });
+
+  it('floats the selection readout while the pointer is still down', () => {
+    // Claiming a row mid-drag shrinks the residue viewport by 46px and cuts 1-2 rows
+    // off the bottom — the rows being dragged toward.
+    expect(viewerSource).toContain("data-live={readoutPlacement === 'float' || undefined}");
+    // The float is declined when the strip below cannot hold it: anchored to the
+    // shell's bottom it would otherwise overhang into the last residue row (7px,
+    // measured, whenever the alignment fits horizontally and no pan row mounts).
+    // Measured against measured, not against a constant: BOTH the chrome strip and the
+    // readout wrap at narrow widths (44px and 61px at 520), and a constant-40 gate let
+    // it float over a strip too short for it and cover a residue row by 17px.
+    expect(viewerSource).toContain('chromeHeight >= readoutHeight');
+    expect(viewerSource).toContain('const [readoutHeight, setReadoutHeight]');
+    const liveRule = msaCss.slice(
+      msaCss.indexOf('.motif-cs-msa-selection-readout[data-live]'),
+      msaCss.indexOf('}', msaCss.indexOf('.motif-cs-msa-selection-readout[data-live]')),
+    );
+    expect(liveRule).toContain('position: absolute;');
+    expect(msaCss).toMatch(/\.motif-cs-msa-matrix-shell\s*\{[^}]*position:\s*relative/);
+  });
+
+  it('leaves the cursor channel on the element both widgets sit inside', () => {
+    // 517db34's coupling, restated here because this change moves the boundary it
+    // depends on: the channel must stay on the frame, and the frame must stay the
+    // alignment view. A new wrapper redeclaring these names would silently break the
+    // accent/ink split with nothing rendering differently.
+    const owner = /(\.[a-zA-Z0-9_-]+)\s*\{[^}]*--motif-cs-msa-cursor-rule:/.exec(msaCss)?.[1];
+    expect(owner).toBe('.motif-cs-msa-matrix-frame');
+    expect(msaCss).not.toMatch(/\.motif-cs-msa-matrix-shell\s*\{[^}]*--motif-cs-msa-cursor-rule/);
+  });
+});

--- a/src/artifacts/__tests__/ClaudeScienceMsaViewer.overlays.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceMsaViewer.overlays.jsdom.test.tsx
@@ -14,6 +14,15 @@ import { DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES } from '../claude-science-m
 
 const here = dirname(fileURLToPath(import.meta.url));
 const overlayCss = readFileSync(resolve(here, '..', 'claude-science-msa.css'), 'utf8');
+const artifactCss = readFileSync(resolve(here, '..', 'motif-artifact.css'), 'utf8');
+const viewerSource = readFileSync(resolve(here, '..', 'ClaudeScienceMsaViewer.tsx'), 'utf8');
+
+/** Body of the rule block for `selector` that carries `needle`. */
+function ruleBlockContaining(css: string, selector: string, needle: string): string | null {
+  const re = new RegExp(`${selector.replace(/[.[\]]/g, '\\$&')}\\s*\\{([^}]*)\\}`, 'g');
+  for (const match of css.matchAll(re)) if (match[1].includes(needle)) return match[1];
+  return null;
+}
 
 function renderViewer() {
   const alignment = normalizeArtifactAlignment({
@@ -87,13 +96,22 @@ describe('ClaudeScienceMsaViewer interaction-state overlays', () => {
     expect(stackedCell.dataset.searchActive).toBe('true');
     expect(stackedCell.dataset.jump).toBe('true');
 
-    const secondColumnX = 232;
+    // Centre of the second residue column, derived from the geometry the frame
+    // actually rendered, so resizing the row-label gutter or the cells cannot
+    // silently move this click into a different column.
+    const labelWidth = Number.parseFloat(view.style.getPropertyValue('--motif-cs-msa-label-width'));
+    const cellWidth = Number.parseFloat(view.style.getPropertyValue('--motif-cs-msa-cell-width'));
+    const secondColumnX = labelWidth + (cellWidth * 1.5);
     Object.defineProperty(document, 'elementFromPoint', { configurable: true, value: vi.fn(() => null) });
     fireEvent.pointerDown(ruler, { button: 0, clientX: secondColumnX, clientY: 20, pointerId: 1 });
     fireEvent.pointerUp(ruler, { button: 0, clientX: secondColumnX, clientY: 20, pointerId: 1 });
 
     const selection = view.querySelector<HTMLElement>('.motif-cs-msa-selection-band');
-    expect(selection?.style.top).toBe('54px');
+    // ONE ruler row, so one row's offset. This fixture's reference is ungapped,
+    // which makes the template axis identical to the alignment axis and merges
+    // the two into a single row. Reserving 54px here reserved space for a ruler
+    // that is not rendered and drew the band a full row below its columns.
+    expect(selection?.style.top).toBe('27px');
     expect(selection?.style.height).toBe('90px');
 
     Object.defineProperty(document, 'elementFromPoint', { configurable: true, value: vi.fn(() => stackedCell) });
@@ -108,6 +126,49 @@ describe('ClaudeScienceMsaViewer interaction-state overlays', () => {
     expect(overlayCss).toMatch(/\.motif-cs-msa-symbol\[data-search-match\][\s\S]*?inset 0 -3px 0 var\(--amber\)/);
     expect(overlayCss).toMatch(/\.motif-cs-msa-symbol\[data-search-active\][\s\S]*?inset 0 0 0 2px var\(--amber\)/);
     expect(overlayCss).toContain('--motif-cs-msa-jump-rule: var(--purple);');
-    expect(overlayCss).toMatch(/\.motif-cs-msa-symbol\[data-jump='true'\]::after[\s\S]*?width:\s*3px;[\s\S]*?background:\s*var\(--motif-cs-msa-jump-rule\)/);
+    // Width is capped at 3px but shrinks with the cell, so zooming out cannot
+    // leave the tick wider than the column it marks.
+    expect(overlayCss).toMatch(/\.motif-cs-msa-symbol\[data-jump='true'\]::after[\s\S]*?width:\s*min\(3px,[\s\S]*?background:\s*var\(--motif-cs-msa-jump-rule\)/);
+    // The roving cursor used to be the one state this test's own title excludes:
+    // raw var(--accent), no token, which put it within 1.2:1 of the selection
+    // rule it sits on top of by default.
+    expect(overlayCss).toContain('--motif-cs-msa-cursor-rule: var(--text-primary);');
+    expect(overlayCss).toContain('--motif-cs-msa-cursor-keyline: var(--bg-primary);');
+    expect(overlayCss).toMatch(/\.motif-cs-msa-symbol\[data-active-cell='true'\]\s*\{[\s\S]*?outline:\s*2px solid var\(--motif-cs-msa-cursor-rule\)/);
+    // Geometry channels stay disjoint: the cursor may never take box-shadow or
+    // ::after, because search and the jump tick own those and one cell can
+    // legitimately be all three at once.
+    expect(overlayCss).toMatch(/\.motif-cs-msa-symbol\[data-active-cell='true'\]::before\s*\{[\s\S]*?border:\s*1px solid var\(--motif-cs-msa-cursor-keyline\)/);
+  });
+
+  it('keeps the overview viewport off the selection colour', () => {
+    // The viewport rectangle and the selection band are the viewer's only two
+    // region outlines, one strip apart. While both were accent-derived they
+    // measured ΔE 1.9-3.3 apart in all four themes — one colour saying two
+    // things. The viewport marks where the system is looking, which is the
+    // cursor's statement, so it takes the cursor's channel; accent is then left
+    // to mean the selection and nothing else.
+    const viewport = ruleBlockContaining(artifactCss, '.motif-cs-msa-overview-viewport', 'min-width');
+    expect(viewport).toBeTruthy();
+    expect(viewport).toMatch(/border:[^;]*var\(--motif-cs-msa-cursor-rule/);
+    expect(viewport).not.toMatch(/border[^;]*var\(--accent\)/);
+    // The other half of the split: the selection rule stays accent-derived, so
+    // the two cannot converge again from the opposite direction. It is the
+    // theme's accent UNDILUTED — the invariant, not a byte string. Any mix
+    // toward ink drags the band back onto the cursor's own channel, which is
+    // exactly what this test exists to prevent; see
+    // claude-science-msa-colour-guards.test.ts for the shape guard.
+    expect(overlayCss).toMatch(/--motif-cs-msa-selection-rule:\s*var\(--accent\)\s*;/);
+  });
+
+  it('declares the cursor channel on an element both widgets sit inside', () => {
+    // The overview viewport is the matrix's SIBLING, not its child, so a token
+    // scoped to .motif-cs-msa-matrix never reaches it. Whichever class owns the
+    // channel has to be the alignment view itself.
+    const owner = /(\.[a-zA-Z0-9_-]+)\s*\{[^}]*--motif-cs-msa-cursor-rule:/.exec(overlayCss)?.[1];
+    expect(owner).toBeTruthy();
+    const mount = viewerSource.indexOf(`className="${(owner as string).slice(1)}"`);
+    expect(mount).toBeGreaterThan(-1);
+    expect(viewerSource.slice(mount, mount + 200)).toContain('data-testid="msa-alignment-view"');
   });
 });

--- a/src/artifacts/__tests__/claude-science-accessibility-interaction-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-accessibility-interaction-guards.test.ts
@@ -7,6 +7,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 const artifactSource = readFileSync(resolve(here, '..', 'motif-artifact.tsx'), 'utf8');
 const artifactCss = readFileSync(resolve(here, '..', 'motif-artifact.css'), 'utf8');
 const primerWorkspaceSource = readFileSync(resolve(here, '..', 'ClaudeSciencePrimerWorkspace.tsx'), 'utf8');
+const plasmidMapCss = readFileSync(
+  resolve(here, '..', '..', 'components', 'plasmid-map', 'plasmid-map.css'),
+  'utf8',
+);
 
 function sliceBetween(startNeedle: string, endNeedle: string): string {
   const start = artifactSource.indexOf(startNeedle);
@@ -32,6 +36,79 @@ describe('Claude Science accessibility and interaction guards', () => {
     expect(artifactSource).toContain("aria-label={payload.records.length === 0 ? 'Sequence workspace; no records open' : undefined}");
     expect(artifactSource).toContain("role={payload.records.length > 0 ? 'tablist' : undefined}");
     expect(artifactCss).toContain('.motif-cs-skip-link:focus-visible');
+  });
+
+  it('gives the Tools rail a skip link, because sequential Tab prices it out of reach', () => {
+    // Measured at 1440x900 with real Tab keys: the first rail tool was stop 124
+    // of 139, behind the entire workspace. That cost is effectively unreachable
+    // for a keyboard user. Via this link the
+    // cost is 2 Tab + Enter + 2 Tab, and all fifteen tools then follow in order.
+    expect(artifactSource).toContain('<a className="motif-cs-skip-link" href="#motif-cs-tools-pane">Skip to tools</a>');
+
+    // The href and the id must agree. They did not in the first draft of this
+    // fix -- the link pointed at #motif-cs-tools while the pane was
+    // #motif-cs-tools-pane -- and nothing failed anywhere. Enter simply moved
+    // focus nowhere: no console error, no missing target, the link still looked
+    // right in the DOM. Only walking the focus afterwards caught it, so pin the
+    // pair rather than the two strings independently.
+    const skipHref = artifactSource.match(/className="motif-cs-skip-link" href="#([\w-]+)">Skip to tools/)?.[1];
+    expect(skipHref, 'Skip to tools link is missing its href').toBeTruthy();
+    expect(artifactSource, `no element carries id="${skipHref}" -- the skip link points at nothing`)
+      .toContain(`id="${skipHref}"`);
+
+    // An href jump moves focus only if the target is focusable, so the rail
+    // needs tabIndex -1 in EVERY placement. It previously had one only while
+    // floating, which is the placement the link is least needed in.
+    const railPane = sliceBetween('key="tools-pane"', 'className="motif-cs-pane-title"');
+    expect(railPane).toContain('id="motif-cs-tools-pane"');
+    expect(railPane).toContain('tabIndex={-1}');
+    expect(railPane, 'the landing target needs a name to announce on arrival')
+      .toContain("aria-label={toolsFloating ? 'Tools pane' : 'Tools'}");
+  });
+
+  it('keeps both pane splitters and map features visibly focusable', () => {
+    // The filed premise was that these show NO focus indicator because they
+    // compute `outline: none 0px`. That reading is right and the conclusion is
+    // wrong: every one of them sets `outline: none` deliberately and paints its
+    // indicator into background / ::after / stroke instead. Measured by pixel
+    // diff between rest and a real Tab, at 1440x900:
+    //   vertical splitter   23.13% of its pixels repaint  -- was already fine
+    //   stacked splitter     1.65% -> 9.36% after this fix
+    //   map feature arc      1.08% -> 27.46% after this fix
+    // So only the latter two were real, and a probe reading outline and
+    // box-shadow alone cannot tell any of the three apart.
+
+    // Vertical splitter: full-length accent stripe plus accent grip. Unchanged,
+    // guarded so the refutation does not get "fixed" by a later reviewer.
+    expect(artifactCss).toMatch(
+      /\.motif-cs-resize-handle:hover,\s*\.motif-cs-resize-handle:focus-visible,[\s\S]*?background:\s*\n?\s*linear-gradient\(to right, transparent 0 2px, var\(--accent\) 2px 4px/,
+    );
+
+    // Stacked splitter: its grip is 34px wide on a handle that spans the whole
+    // workspace, so a grip-only recolour is invisible at that scale. Both
+    // stacked rules take the full-length line.
+    const stackedFocusRules = artifactCss.match(
+      /\.motif-cs-stacked-resize-handle(\[data-pane="sequence"\])?:focus-visible \{[^}]*\}/g,
+    ) ?? [];
+    expect(stackedFocusRules.length, 'expected a focus rule per stacked-handle layout').toBe(3);
+    for (const rule of stackedFocusRules) {
+      expect(rule, 'stacked handle focus must light the whole separator, not just its grip')
+        .toContain('linear-gradient(to bottom, transparent 0 3px, var(--accent) 3px 5px, transparent 5px 100%)');
+    }
+
+    // Map feature arcs: undiluted accent at the app's 2px, not a 0.7px stroke
+    // mixed 30% into the feature's own colour. The dilution is what made it
+    // read as absent -- against a coloured arc, 70% accent is barely a shift.
+    const mapFeatureFocus = plasmidMapCss.match(
+      /\.motif-pm-feature:focus-visible \.motif-pm-feature-body \{[^}]*\}/,
+    )?.[0] ?? '';
+    expect(mapFeatureFocus, 'map features lost their focus rule').toBeTruthy();
+    expect(mapFeatureFocus).toContain('stroke: var(--accent, #0169cc)');
+    expect(mapFeatureFocus, 'a diluted focus stroke is what made this look like no indicator at all')
+      .not.toContain('color-mix');
+    const focusWidth = Number(mapFeatureFocus.match(/stroke-width:\s*([\d.]+)/)?.[1]);
+    // Must also stay clear of hover (0.55), so focus is not the quieter signal.
+    expect(focusWidth).toBeGreaterThanOrEqual(2);
   });
 
   it('returns focus to the corresponding top control when a pane disappears', () => {

--- a/src/artifacts/__tests__/claude-science-inventory-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-inventory-guards.test.ts
@@ -15,6 +15,38 @@ function sliceBetween(source: string, startNeedle: string, endNeedle: string): s
   return source.slice(start, end);
 }
 
+/**
+ * Return the `@media` block opened by `condition` that contains `marker`,
+ * brace-matched to its own close.
+ *
+ * `sliceBetween` takes the FIRST occurrence of its start needle and runs to the
+ * next end needle, which silently spans unrelated rules once a second block
+ * shares a media condition — and a stylesheet is free to carry several. Matching
+ * braces keeps a block's assertions about that block.
+ */
+function mediaBlockContaining(css: string, condition: string, marker: string): string {
+  for (let from = 0; ; ) {
+    const open = css.indexOf(condition, from);
+    expect(open, `no ${condition} block contains ${marker}`).toBeGreaterThanOrEqual(0);
+    let depth = 0;
+    let end = -1;
+    for (let i = css.indexOf('{', open); i < css.length; i += 1) {
+      if (css[i] === '{') depth += 1;
+      else if (css[i] === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    expect(end, `unbalanced braces after ${condition}`).toBeGreaterThan(open);
+    const block = css.slice(open, end + 1);
+    if (block.includes(marker)) return block;
+    from = open + condition.length;
+  }
+}
+
 describe('Claude Science Inventory regression guards', () => {
   it('renders no record rows while an Inventory group is collapsed', () => {
     const inventoryList = sliceBetween(
@@ -96,10 +128,19 @@ describe('Claude Science Inventory regression guards', () => {
   });
 
   it('keeps Inventory vertical and record tabs visible in the split workspace', () => {
-    const splitWorkspace = sliceBetween(
+    // The stylesheet carries MORE THAN ONE `@media (min-width: 768px) and
+    // (max-width: 1535px)` block, so slicing from the first opener to the 1536
+    // breakpoint spans everything in between — including the `max-width: 767px`
+    // phone block, which is exactly where the record-tab overrides legitimately
+    // live. That made the negative assertion below fail on a stylesheet whose
+    // split-workspace rules were untouched. Select the block that actually
+    // carries the split-workspace inventory rules and brace-match to its own
+    // close, so this guard is immune to how many such blocks exist or where
+    // they sit.
+    const splitWorkspace = mediaBlockContaining(
       artifactCss,
       '@media (min-width: 768px) and (max-width: 1535px) {',
-      '@media (min-width: 1536px) {',
+      '.motif-cs-sidebar .motif-cs-inventory-groups',
     );
 
     expect(splitWorkspace).toContain('flex-wrap: nowrap;');
@@ -113,6 +154,28 @@ describe('Claude Science Inventory regression guards', () => {
       '.motif-cs-shell:has(> .motif-cs-record-tabs[data-inventory-visible="true"])',
     );
     expect(artifactCss).toMatch(/@media \(max-width: 767px\)[\s\S]*?data-inventory-visible="true"\]\)\s*\{\s*grid-template-rows:\s*auto 1fr/);
+  });
+
+  it('gives the inventory scroller a themed scrollbar rather than the platform default', () => {
+    // At laptop sizes this list is the only place a session meets its whole
+    // vector inventory, and it hides 237px of it at 1440x900 and 303px at
+    // 1024x768. `scrollbar-gutter: stable` reserves the lane; without a colour
+    // the bar fell through to the platform default and measured 1.72:1 against
+    // its own track in BOTH light themes and 2.66:1 in both dark ones, under the
+    // 3.0 non-text floor. Identical rgb across all four themes is the tell that
+    // it was never themed rather than themed badly. Measured HEADED — headless
+    // macOS Chromium reports a 0px gutter and no bar at all.
+    const list = sliceBetween(artifactCss, '.motif-cs-inventory-groups {', '}');
+    expect(list).toContain('overflow: auto');
+    expect(list).toContain('scrollbar-gutter: stable');
+    expect(list, 'inventory scroller left on the platform default scrollbar').toContain('scrollbar-color:');
+
+    // One scrollbar for the app, not two: the same two tokens the alignment
+    // matrix's scroller already uses.
+    const matrix = sliceBetween(artifactCss, '.motif-cs-msa-matrix-scroll {', '}');
+    const colourOf = (rule: string) => /scrollbar-color:\s*([^;]+);/.exec(rule)?.[1].replace(/\s+/g, ' ').trim();
+    expect(colourOf(list)).toBeTruthy();
+    expect(colourOf(list)).toBe(colourOf(matrix));
   });
 
   it('keeps the extreme-width topbar on one row without hiding stateful controls', () => {

--- a/src/artifacts/__tests__/claude-science-map-workspace-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-map-workspace-guards.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const artifactSource = readFileSync(resolve(here, '..', 'motif-artifact.tsx'), 'utf8');
+const artifactCss = readFileSync(resolve(here, '..', 'motif-artifact.css'), 'utf8');
 
 function sliceBetween(source: string, startNeedle: string, endNeedle: string): string {
   const start = source.indexOf(startNeedle);
@@ -33,6 +34,19 @@ describe('Claude Science map workspace regression guards', () => {
     );
   });
 
+  it('defaults restriction labels on instead of pre-judging them by site count', () => {
+    // A site-count threshold here switched labelling off wholesale on any record
+    // past it, which on the bundled vectors meant 8 of 13 drew every tick and
+    // named none. Site count is the wrong quantity — labels are per CLUSTER, and
+    // the layout engine already caps candidates (maxRestrictionLabels), culls by
+    // geometry, and reports the remainder through the "+N more sites" chip. Only
+    // the per-record user override may decide this.
+    expect(artifactSource).toContain(
+      'const showRestrictionLabels = restrictionLabelsByRecord[recordId] ?? true;',
+    );
+    expect(artifactSource).not.toMatch(/visibleRestrictionSites\.length\s*<=/);
+  });
+
   it('reveals an explicitly added enzyme without enabling a source group', () => {
     const addCustomEnzyme = sliceBetween(
       artifactSource,
@@ -43,5 +57,79 @@ describe('Claude Science map workspace regression guards', () => {
     expect(addCustomEnzyme).toContain('hidden.delete(enzyme.name)');
     expect(addCustomEnzyme).toContain('}, [recordId]);');
     expect(addCustomEnzyme).not.toContain('setEnzymeSourcesByRecord');
+  });
+
+  it('anchors the circular map readout to the edge its column actually shows', () => {
+    // Between 768px and 1535px the circular map frame is floored taller than the
+    // column can display — measured 504px of frame in a 442px column at 1440x900,
+    // 141px of it scrolled away — so anything anchored to the frame's BOTTOM is
+    // off-screen in every state. The readout was; the zoom controls were not, and
+    // the only difference between them was which edge they hang off.
+    const base = sliceBetween(artifactCss, '.motif-cs-map-hint {', '}');
+    const toolbar = sliceBetween(artifactCss, '.motif-cs-map-toolbar {', '}');
+    // The premise the fix rests on: the top edge is the safe one, because that is
+    // where the controls that survived are anchored. If the toolbar ever moves to
+    // the bottom this reasoning is void and this test should fail.
+    expect(toolbar, 'the zoom controls no longer anchor to the safe top edge').toMatch(/top:\s*12px/);
+    expect(base).toMatch(/bottom:\s*12px/);
+
+    const circular = sliceBetween(
+      artifactCss,
+      '.motif-cs-map-frame[data-map-mode="circular"] .motif-cs-map-hint {',
+      '}',
+    );
+    expect(circular).toMatch(/top:\s*12px/);
+    // Clearing `bottom` is what actually moves it: the base rule's `bottom: 12px`
+    // would otherwise combine with a `top` and stretch the element across the
+    // whole frame rather than relocating it.
+    expect(circular).toMatch(/bottom:\s*auto/);
+
+    // Scope. The rule must not reach 1536px and up, where the column does fit its
+    // frame and the lower-left corner is both reachable and quieter — and it must
+    // not reach the linear map, which has its own placement for its own reason.
+    const scoped = sliceBetween(
+      artifactCss,
+      '@media (min-width: 768px) and (max-width: 1535px) {\n  .motif-cs-map-frame[data-map-mode="circular"] .motif-cs-map-hint {',
+      '}',
+    );
+    expect(scoped, 'the circular readout override escaped its breakpoint band').toMatch(/top:\s*12px/);
+    const linear = sliceBetween(
+      artifactCss,
+      '.motif-cs-map-frame[data-map-mode="linear"] .motif-cs-map-hint {',
+      '}',
+    );
+    expect(linear, 'the linear readout must keep its own corner').toMatch(/right:\s*12px/);
+    expect(linear).not.toMatch(/top:\s*12px/);
+  });
+
+  it('pins the map dock heads as a column footer only while they are collapsed', () => {
+    // These two heads are the end of the map workflow and sat below the column's visible
+    // edge at every desktop size under 1536 — 138px at 900x700 down to 85px at 1440x1200.
+    // The app's first sticky FOOTER; the ten that already exist are headers at `top: 0`.
+    const footer = sliceBetween(
+      artifactCss,
+      '.motif-cs-map-dock-strip:not(:has(> details[open])) {',
+      '}',
+    );
+    expect(footer).toMatch(/position:\s*sticky/);
+    expect(footer).toMatch(/bottom:\s*-10px/);
+    // Opaque, or the map scrolls through the footer that is meant to end it.
+    expect(footer, 'a transparent sticky footer lets the map show through').toMatch(/background:\s*var\(--bg-primary\)/);
+    expect(footer).toMatch(/z-index:/);
+
+    // The `:not(...)` is load-bearing, not decoration. Open, this element IS the whole
+    // panel body — pinning that to the bottom would cover the map rather than finish it.
+    const openState = sliceBetween(artifactCss, '.motif-cs-map-dock-strip:has(> details[open]) {', '}');
+    expect(openState, 'the open dock strip must not be sticky').not.toMatch(/position:\s*sticky/);
+
+    // No breakpoint, deliberately: `bottom` engages only while an ancestor scrolls, so
+    // 1920 — where the column hides 0px — needs no exemption and must not be given one.
+    const stickyIndex = artifactCss.indexOf('.motif-cs-map-dock-strip:not(:has(> details[open]))');
+    const enclosingMedia = artifactCss.lastIndexOf('@media', stickyIndex);
+    const enclosingClose = artifactCss.lastIndexOf('\n}', stickyIndex);
+    expect(
+      enclosingClose > enclosingMedia,
+      'the dock footer was wrapped in a media query; it should engage from overflow alone',
+    ).toBe(true);
   });
 });

--- a/src/artifacts/__tests__/claude-science-msa-colour-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-msa-colour-guards.test.ts
@@ -1,0 +1,280 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Colour guards for the MSA viewer's accent-derived marks.
+ *
+ * Two failure modes live here, and both are silent — they change a number
+ * nobody is looking at and leave the pixels looking roughly the same:
+ *
+ *  1. The selection band gets re-mixed toward `--text-primary`. That reads like
+ *     free contrast (ink is by definition the highest-contrast colour against
+ *     the background) but the band's real neighbour is the roving CURSOR, which
+ *     IS ink — a drag-select parks the cursor on the band's own corner. Mixing
+ *     toward ink spends surplus (band vs backdrop) to buy a shortage (band vs
+ *     cursor) backwards.
+ *
+ *  2. The Template badge drifts below WCAG AA. It clears 4.50 by roughly 0.04 in
+ *     claude-dark, so any nudge to `--accent`, to `--bg-primary`, or to the
+ *     badge's own mix ratio breaks it with no visible symptom.
+ *
+ * Everything below is derived from the stylesheets on disk, so a token edit is
+ * caught wherever it happens. The FLOORS are absolute constants and must stay
+ * that way: a floor expressed in terms of the tokens under test moves with the
+ * change and passes it.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const overlayCss = readFileSync(resolve(here, '..', 'claude-science-msa.css'), 'utf8');
+const artifactCss = readFileSync(resolve(here, '..', 'motif-artifact.css'), 'utf8');
+
+/** WCAG 2.x AA floor for normal-size text. Absolute. Never derive this. */
+const AA_NORMAL_TEXT = 4.5;
+/** WCAG 2.x 1.4.11 floor for a non-text UI boundary against its backdrop. */
+const NON_TEXT_UI = 3;
+/**
+ * WCAG "large text" starts at 18.66px when bold (14pt) or 24px otherwise, and
+ * only large text may fall back to the 3.00 floor. The Template badge is 8px at
+ * weight 760 — nowhere near it — so 4.50 is the floor that applies, and dropping
+ * this guard to 3.00 would not be a fix, it would be an exemption the badge does
+ * not qualify for. `badgeIsLargeText` below re-checks that premise from the
+ * stylesheet rather than trusting this comment.
+ */
+const LARGE_TEXT_MIN_PX_BOLD = 18.66; // 14pt
+const LARGE_TEXT_MIN_PX = 24; // 18pt
+const BOLD_THRESHOLD = 700;
+
+type Rgb = readonly [number, number, number];
+
+const THEME_SELECTORS: Record<string, string> = {
+  light: 'html\\[data-theme="light"\\]',
+  dark: 'html\\[data-theme="dark"\\]',
+  'claude-light': 'html\\[data-theme="claude-light"\\]',
+  'claude-dark': 'html\\[data-theme="claude-dark"\\]',
+};
+
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+interface CssRule {
+  selectors: string;
+  body: string;
+  /** True when the rule sits inside `@media`/`@supports`/any other at-rule. */
+  conditional: boolean;
+}
+
+/**
+ * Brace-depth scan of a stylesheet into flat rules. A plain regex cannot do this:
+ * `.motif-cs-msa-template-badge` is declared in two adjacent blocks, and a regex
+ * that anchors on the preceding `}` consumes that brace on the first match and
+ * then cannot find a delimiter for the second — it silently returns one rule
+ * where there are two, which is exactly the kind of quiet under-read this file
+ * exists to prevent.
+ */
+function parseRules(css: string): CssRule[] {
+  const rules: CssRule[] = [];
+  const stack: { prelude: string; atRule: boolean }[] = [];
+  let buffer = '';
+  for (const part of stripComments(css).split(/([{}])/)) {
+    if (part === '{') {
+      const prelude = buffer.trim();
+      stack.push({ prelude, atRule: prelude.startsWith('@') });
+      buffer = '';
+    } else if (part === '}') {
+      const frame = stack.pop();
+      if (frame && !frame.atRule) {
+        rules.push({
+          selectors: frame.prelude,
+          body: buffer,
+          conditional: stack.some((entry) => entry.atRule),
+        });
+      }
+      buffer = '';
+    } else {
+      buffer += part;
+    }
+  }
+  return rules;
+}
+
+const ARTIFACT_RULES = parseRules(artifactCss);
+const OVERLAY_RULES = parseRules(overlayCss);
+
+/**
+ * Rules whose selector list mentions `selectorPattern`, in source order, split
+ * into the unconditional ones and any that sit inside an at-rule. Callers read
+ * the unconditional list last-wins — the order the cascade applies — and assert
+ * the conditional list is empty, so a `@media` override cannot appear later and
+ * change the answer without anyone noticing.
+ */
+function matchingRules(rules: CssRule[], selectorPattern: string): { plain: CssRule[]; conditional: CssRule[] } {
+  // `(?![\w-])` stops `.motif-cs-msa-matrix` from also matching
+  // `.motif-cs-msa-matrix-frame`/`-row`/`-scroll`/`-shell`.
+  const re = new RegExp(`${selectorPattern}(?![\\w-])`);
+  const hit = rules.filter((rule) => re.test(rule.selectors));
+  return {
+    plain: hit.filter((rule) => !rule.conditional),
+    conditional: hit.filter((rule) => rule.conditional),
+  };
+}
+
+/** Last-wins lookup for a property across every unconditional rule for the selector. */
+function declaredValue(rules: CssRule[], selectorPattern: string, property: string): string | null {
+  const { plain, conditional } = matchingRules(rules, selectorPattern);
+  if (conditional.length > 0) {
+    throw new Error(
+      `${selectorPattern} is also styled inside an at-rule (${conditional.length} block(s)). ` +
+        'This guard only reads the unconditional cascade — extend it before relying on it again.',
+    );
+  }
+  let found: string | null = null;
+  for (const rule of plain) {
+    const re = new RegExp(`(?:^|;)\\s*${property}\\s*:([^;]*)`, 'g');
+    for (const match of rule.body.matchAll(re)) found = match[1].trim();
+  }
+  return found;
+}
+
+function themeTokens(theme: string): Record<string, string> {
+  const { plain, conditional } = matchingRules(ARTIFACT_RULES, THEME_SELECTORS[theme]);
+  if (plain.length === 0) throw new Error(`No rule block found for theme "${theme}"`);
+  if (conditional.length > 0) {
+    // Same contract as declaredValue: a `@media (prefers-contrast: more)` block
+    // that re-points --accent would change the answer for a viewer this guard
+    // never measured. Refuse rather than read half the cascade.
+    throw new Error(`Theme "${theme}" is also redefined inside an at-rule — extend this guard before trusting it.`);
+  }
+  const tokens: Record<string, string> = {};
+  for (const rule of plain) {
+    for (const match of rule.body.matchAll(/(--[a-zA-Z0-9_-]+)\s*:([^;]*)/g)) {
+      tokens[match[1]] = match[2].trim();
+    }
+  }
+  return tokens;
+}
+
+function parseHex(value: string): Rgb {
+  const hex = /^#([0-9a-f]{6})$/i.exec(value.trim());
+  if (!hex) throw new Error(`Expected a 6-digit hex colour, got "${value}"`);
+  const n = Number.parseInt(hex[1], 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+/**
+ * Resolve a declaration to an RGB triple. Understands a bare `var(--token)`, a
+ * literal hex, and the single `color-mix(in srgb, var(--a) N%, var(--b))` shape
+ * the badge uses. Anything else THROWS rather than guessing — an unparsed
+ * declaration must fail this suite, not slip through it.
+ */
+function resolveColour(declaration: string, tokens: Record<string, string>): Rgb {
+  const value = declaration.trim();
+
+  const varOnly = /^var\(\s*(--[a-zA-Z0-9_-]+)\s*\)$/.exec(value);
+  if (varOnly) {
+    const token = tokens[varOnly[1]];
+    if (!token) throw new Error(`Token ${varOnly[1]} is not defined for this theme`);
+    return resolveColour(token, tokens);
+  }
+
+  if (value.startsWith('#')) return parseHex(value);
+
+  const mix = /^color-mix\(\s*in\s+srgb\s*,\s*(.+?)\s+([\d.]+)%\s*,\s*(.+?)\s*\)$/.exec(value);
+  if (mix) {
+    const a = resolveColour(mix[1], tokens);
+    const b = resolveColour(mix[3], tokens);
+    const weight = Number(mix[2]) / 100;
+    // Chrome interpolates in gamma-encoded sRGB for `in srgb` and does NOT
+    // quantise the result to 8 bits, so this stays in continuous space too.
+    // That is also the stricter reading: the 8-bit-rounded claude-dark badge
+    // measures 4.553 where the continuous value measures 4.544.
+    return [0, 1, 2].map((i) => a[i] * weight + b[i] * (1 - weight)) as unknown as Rgb;
+  }
+
+  throw new Error(`Unrecognised colour declaration "${value}" — extend resolveColour rather than skipping it`);
+}
+
+function relativeLuminance([r, g, b]: Rgb): number {
+  const channel = (raw: number): number => {
+    const c = raw / 255;
+    return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrastRatio(a: Rgb, b: Rgb): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+const THEMES = Object.keys(THEME_SELECTORS);
+
+describe('MSA selection band stays undiluted accent', () => {
+  it('declares the selection rule as the theme accent with no mix toward ink', () => {
+    const declaration = declaredValue(OVERLAY_RULES, '\\.motif-cs-msa-matrix', '--motif-cs-msa-selection-rule');
+    expect(declaration).toBe('var(--accent)');
+  });
+
+  it('never re-mixes the selection rule toward the cursor colour', () => {
+    // The shape guard, independent of the exact value above: a mix toward
+    // `--text-primary` is the specific regression, because `--text-primary` is
+    // what `--motif-cs-msa-cursor-rule` resolves to. Re-mixing pulls the band
+    // and the cursor back onto one channel.
+    const cursorRule = declaredValue(OVERLAY_RULES, '\\.motif-cs-msa-matrix-frame', '--motif-cs-msa-cursor-rule');
+    expect(cursorRule).toBe('var(--text-primary)');
+
+    const declaration = declaredValue(OVERLAY_RULES, '\\.motif-cs-msa-matrix', '--motif-cs-msa-selection-rule') ?? '';
+    expect(declaration).not.toMatch(/color-mix/);
+    expect(declaration).not.toMatch(/--text-primary/);
+  });
+
+  it.each(THEMES)('keeps the band readable against its backdrop in %s', (theme) => {
+    const tokens = themeTokens(theme);
+    const band = resolveColour(
+      declaredValue(OVERLAY_RULES, '\\.motif-cs-msa-matrix', '--motif-cs-msa-selection-rule') ?? '',
+      tokens,
+    );
+    const backdrop = resolveColour('var(--bg-primary)', tokens);
+    // The band is a region boundary, not text, so 1.4.11's 3.00 is the correct
+    // floor here. Measured in Chrome after the de-mix: 5.29-5.76 in the four
+    // themes, so this has real headroom and is not a rubber stamp.
+    expect(contrastRatio(band, backdrop)).toBeGreaterThanOrEqual(NON_TEXT_UI);
+  });
+});
+
+describe('Template badge holds WCAG AA', () => {
+  const badgeSelector = '\\.motif-cs-msa-template-badge';
+
+  it('is still small text, so the 4.50 floor is the one that applies', () => {
+    // If this fails the badge grew into WCAG "large text" territory. That is a
+    // real design decision, not licence to drop the floor below — re-derive it
+    // deliberately, do not delete this test.
+    const font = declaredValue(ARTIFACT_RULES, badgeSelector, 'font') ?? '';
+    const weightDecl = declaredValue(ARTIFACT_RULES, badgeSelector, 'font-weight') ?? '';
+    const sizePx = Number(/(\d+(?:\.\d+)?)px/.exec(font)?.[1]);
+    const weight = Number(/(\d+)/.exec(weightDecl)?.[1]);
+    expect(Number.isFinite(sizePx)).toBe(true);
+    expect(Number.isFinite(weight)).toBe(true);
+    const badgeIsLargeText =
+      weight >= BOLD_THRESHOLD ? sizePx >= LARGE_TEXT_MIN_PX_BOLD : sizePx >= LARGE_TEXT_MIN_PX;
+    expect(badgeIsLargeText).toBe(false);
+  });
+
+  it.each(THEMES)('clears 4.50:1 in %s', (theme) => {
+    const tokens = themeTokens(theme);
+    const foreground = resolveColour(declaredValue(ARTIFACT_RULES, badgeSelector, 'color') ?? '', tokens);
+    const background = resolveColour(declaredValue(ARTIFACT_RULES, badgeSelector, 'background') ?? '', tokens);
+    const ratio = contrastRatio(foreground, background);
+    // Reported to 3dp so a failure states the margin instead of just "false".
+    expect(
+      ratio,
+      `Template badge in ${theme} measures ${ratio.toFixed(3)}:1 against a ${AA_NORMAL_TEXT} floor. ` +
+        'Darken --accent (or deepen the badge background) until it clears; do NOT lower the floor — ' +
+        '8px at weight 760 does not qualify for the 3.00 large-text exemption.',
+    ).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+  });
+
+});

--- a/src/artifacts/__tests__/claude-science-msa-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-msa-guards.test.ts
@@ -94,6 +94,23 @@ describe('Claude Science MSA integration guards', () => {
 });
 
 describe('Claude Science MSA interaction and rendering guards', () => {
+  it('marks every dismissable toolbar menu so its host window can see it open', () => {
+    // The window's Escape handler defers to an open menu. It cannot use the
+    // panel's rendered scope attribute for a native <details>, because React
+    // only learns the menu opened from its `toggle` event ~52ms later; it reads
+    // the element's own `open` instead, keyed on this marker. A menu added
+    // without the marker would silently take the whole window down with it, so
+    // the two counts are derived separately and have to agree.
+    const menus = viewerSource.match(/= useDismissableMenu\(/g) ?? [];
+    const marked = viewerSource.match(/data-motif-cs-escape-scope-when-open="true"/g) ?? [];
+    expect(menus.length).toBe(3);
+    expect(marked.length).toBe(menus.length);
+    expect(artifactSource).toContain("querySelector('details[data-motif-cs-escape-scope-when-open][open]')");
+    // Dismissal has to close the element, not just the state that mirrors it:
+    // inside that same interval `setOpen(false)` is a no-op and the key is lost.
+    expect(viewerSource).toContain('if (menuRef.current?.open) menuRef.current.open = false;');
+  });
+
   it('never auto-pairs the active record with an unrelated hidden workspace record', () => {
     const defaults = sliceBetween(viewerSource, 'function compatibleDefaultIds(', 'function engineMetadata(');
     expect(defaults).toContain("const activeGroup = active.group?.trim().toLocaleLowerCase();");
@@ -258,6 +275,7 @@ describe('Claude Science MSA interaction and rendering guards', () => {
     expect(matrix).toContain('aria-rowcount={tableRowCount}');
     expect(matrix).toContain('aria-rowindex={firstSequenceRow + rowIndex}');
     expect(matrix).toContain('Alignment positions count gapped columns. Template positions count non-gap residues');
+    expect(viewerSource).toContain('data-testid="msa-goto-menu-button"');
     expect(viewerSource).toContain('data-testid="msa-coordinate-system"');
     expect(viewerSource).toContain('data-testid="msa-coordinate-input"');
     expect(viewerSource).toContain("activeReferenceCoordinates ? 'Go to reference position' : 'Go to template position'");
@@ -279,12 +297,46 @@ describe('Claude Science MSA interaction and rendering guards', () => {
     expect(viewerSource).toContain('data-testid="msa-view-menu-button"');
     expect(viewerSource).toContain('data-testid="msa-view-menu-status"');
     expect(viewerSource).toContain('Reset alignment view');
-    expect(viewerSource).toContain('const axisRows = Number(visibility.showAlignmentAxis) + Number(visibility.showTemplateAxis);');
+    // Must exclude a template axis that has been merged into the alignment axis.
+    // This count drives aria-rowindex, the selection band's pixel offset, and the
+    // keyboard scroll-into-view origin at once, so over-counting it draws the
+    // band a whole row low and leaves a hole in the grid's row indices.
+    expect(viewerSource).toContain('const axisRows = Number(visibility.showAlignmentAxis) + Number(visibility.showTemplateAxis && !mergeAxisRows);');
     expect(viewerSource).toContain('const tableRowCount = axisRows');
     expect(viewerSource).toContain('Number(visibility.showConservation)');
     expect(viewerSource).toContain('Number(visibility.showConsensus)');
     expect(artifactSource).toContain("const MSA_VIEW_STORAGE_KEY = 'motif.claude-science.msa-view.v1';");
     expect(artifactCss).toMatch(/\.motif-cs-msa-toolbar\s*\{[\s\S]*?position:\s*sticky/);
+  });
+
+  it('caps the view menu against the window it lives in, with nothing constant in the ceiling', () => {
+    const panel = sliceBetween(artifactCss, '.motif-cs-msa-view-menu-panel {', '.motif-cs-msa-view-menu-panel > strong');
+    const capMatch = /max-height:\s*([^;]+);/.exec(panel);
+    expect(capMatch, 'view menu panel declares no max-height').not.toBeNull();
+    const cap = capMatch![1];
+    // Bound by the window this viewer floats in, not the browser viewport: a
+    // 240px window on a 1400px display is where the two disagree, and the window
+    // is overflow: hidden, so a panel past its bottom edge is gone rather than
+    // scrolled to.
+    expect(cap).toContain('var(--motif-cs-window-height');
+    // The ceiling has to be an expression in that variable and nothing else. A
+    // `min(<constant>, <window expression>)` reads as responsive and behaves as a
+    // constant the moment the window clears the constant — which is every
+    // ordinary window, and is how 379px of this menu stayed hidden at every size.
+    // Asserted as "no numeric term may cap it" rather than as the text of the
+    // rule, because pinning the text pins the very line a correct change deletes.
+    expect(cap).not.toMatch(/min\(\s*\d+(\.\d+)?px/);
+    expect(cap).not.toMatch(/min\(\s*calc\([^)]*\)\s*,\s*\d/);
+    // A floor is still wanted, so the menu stays usable in a tiny window.
+    expect(cap).toMatch(/max\(\s*\d+(\.\d+)?px/);
+    // And whatever still overflows has to be signalled. Naming a scrollbar-color
+    // is what forces a painted bar on a platform that would otherwise draw an
+    // overlay one, i.e. nothing at rest.
+    expect(panel).toMatch(/scrollbar-gutter:\s*stable/);
+    expect(panel).toMatch(/scrollbar-color:/);
+    // `scrollbar-width` must stay auto: any other value changes the reserved
+    // gutter that the panel's own width is sized around.
+    expect(panel).toMatch(/scrollbar-width:\s*auto/);
   });
 
   it('offers a bounded mismatch overview with viewport, pointer drag, and keyboard navigation', () => {
@@ -333,5 +385,121 @@ describe('Claude Science MSA interaction and rendering guards', () => {
     expect(artifactCss).toMatch(/\.motif-cs-msa-pan-row\s*\{[\s\S]*?grid-template-columns:\s*var\(--motif-cs-msa-label-width, 180px\) minmax\(0, 1fr\)/);
     expect(artifactCss).toMatch(/\.motif-cs-msa-pan-range\s*\{[\s\S]*?height:\s*24px/);
     expect(artifactCss).toContain('var(--motif-cs-msa-pan-thumb-width, 36px)');
+  });
+
+  it('keeps the pan lane trough drawn at a boundary strong enough to read as a scrollbar', () => {
+    // The empty trough is the part that states how much alignment lies beyond
+    // the edge. Diluting its border to 72% measured 2.14:1 in light and dark and
+    // 2.28:1 in the claude themes against the row behind it — under the 3.0
+    // non-text floor — while the fill sat at 1.03-1.05, so the lane rendered as a
+    // thumb floating on flat chrome. Two reviewers read those pixels and both
+    // reported the alignment as having no horizontal scroll affordance at all.
+    const webkitTrack = sliceBetween(artifactCss, '.motif-cs-msa-pan-range::-webkit-slider-runnable-track {', '}');
+    const mozTrack = sliceBetween(artifactCss, '.motif-cs-msa-pan-range::-moz-range-track {', '}');
+    const borderOf = (rule: string) => /border:\s*1px solid ([^;]+);/.exec(rule)?.[1];
+    for (const [engine, rule] of [['webkit', webkitTrack], ['moz', mozTrack]] as const) {
+      expect(borderOf(rule), `${engine} track declares no 1px border`).toBeTruthy();
+      expect(borderOf(rule), `${engine} trough boundary is diluted toward transparent`).not.toMatch(/transparent/);
+      expect(rule, `${engine} track fill must separate from the pan row behind it`)
+        .toMatch(/background:\s*color-mix\(in srgb, var\(--bg-primary\) 88%, var\(--text-muted\)\)/);
+    }
+    // Both engines must draw the same trough; this pair is a hand-kept duplicate.
+    expect(borderOf(mozTrack)).toBe(borderOf(webkitTrack));
+    // The thumb stays the strongest thing in the lane and is not part of this
+    // change — it already measured 4.56-5.94 against the row.
+    expect(artifactCss).toMatch(/::-webkit-slider-thumb\s*\{[\s\S]*?background:\s*color-mix\(in srgb, var\(--text-muted\) 82%, var\(--border-strong\)\)/);
+  });
+
+  it('marks the collapsed Tools rail when the session actually holds alignments', () => {
+    // The rail is the default state and it hides `.motif-cs-chip` on every tool
+    // head. Of the fifteen heads, Alignment's is the only chip that reports
+    // session content rather than a fixed label — measured empty vs loaded, it
+    // is the only one whose text changes at all — so hiding it left the rail
+    // identical whether the session held no alignments or twenty.
+    const head = sliceBetween(artifactSource, 'data-rail-label="M"', '</summary>');
+    expect(head).toContain('data-rail-count={payload.alignments.length || undefined}');
+    expect(head).toMatch(/\$\{payload\.alignments\.length\} in session/);
+    // Absent at zero: a session that never aligns anything gains no mark.
+    expect(head).toContain('|| undefined');
+
+    const dot = sliceBetween(
+      artifactCss,
+      '.motif-cs-inspector[data-tools-pinned="false"] summary.motif-cs-panel-head[data-rail-count]::after {',
+      '}',
+    );
+    // Chrome folds ::after content into the accessible name. Printing the count
+    // here replaced the head's whole name with the bare number, measured over
+    // CDP; the empty alternative text is what keeps the name intact.
+    expect(dot).toMatch(/content:\s*""\s*\/\s*""/);
+    expect(dot).toContain('background: var(--accent)');
+    expect(dot).toContain('pointer-events: none');
+    // The rail is icon-only by design; the mark must not reintroduce text that
+    // can outgrow the 38px head.
+    expect(dot).not.toMatch(/content:\s*attr\(/);
+    expect(dot).not.toMatch(/font-size/);
+  });
+
+  it('records why the matrix hides its own horizontal scrollbar', () => {
+    // The rule carried no rationale on a branch where nearly every decision
+    // does, and `overflow-x: hidden` next to a surface with 2801px of hidden
+    // extent got re-litigated as a bug twice. The scroll is real; the bar is
+    // hand-drawn one box below as .motif-cs-msa-pan-row.
+    const scrollRule = sliceBetween(artifactCss, '.motif-cs-msa-matrix-scroll {', '}');
+    expect(scrollRule).toContain('overflow-x: hidden');
+    expect(scrollRule).toMatch(/motif-cs-msa-pan-row/);
+  });
+
+  it('never pairs a scrollbar-color with ::-webkit-scrollbar rules on the same element', () => {
+    // Naming a `scrollbar-color` makes Chromium ignore every ::-webkit-scrollbar
+    // pseudo-element on that element, so the two cannot be combined: whichever
+    // half is written second is dead text that still reads as intent. The matrix
+    // scroller carried both for a long time — an 11px inset pill with an accent
+    // hover tint that never painted a pixel. Measured headed (offsetWidth minus
+    // clientWidth plus screenshot hashes of the gutter strip), the element
+    // rendered byte-identical with those five rules present and absent, while the
+    // same five rules WITHOUT the scrollbar-color rendered visibly different —
+    // which is what proves the colour is the thing disabling them.
+    //
+    // Asserted over the whole stylesheet rather than over the matrix alone,
+    // because the failure mode is someone reaching for ::-webkit-scrollbar on the
+    // next themed scroller and getting no feedback that it did nothing.
+    const withoutComments = artifactCss.replace(/\/\*[\s\S]*?\*\//g, '');
+    // Innermost blocks only: an @media wrapper cannot match, since a selector may
+    // not contain a brace, so its nested rules are what get captured.
+    const blocks = [...withoutComments.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((match) => ({
+      selectors: match[1].split(',').map((one) => one.trim().replace(/\s+/g, ' ')).filter(Boolean),
+      body: match[2],
+    }));
+    // The parse has to be shown to see both halves, or an empty intersection is
+    // just an empty parse. Both counts are asserted non-zero below.
+    const colouredElements = new Set<string>();
+    const webkitStyledElements = new Map<string, string>();
+    for (const block of blocks) {
+      for (const selector of block.selectors) {
+        if (selector.includes('::-webkit-scrollbar')) {
+          const owner = selector.slice(0, selector.indexOf('::-webkit-scrollbar'));
+          if (!webkitStyledElements.has(owner)) webkitStyledElements.set(owner, selector);
+        } else if (/(^|[\s;])scrollbar-color\s*:/.test(block.body)) {
+          colouredElements.add(selector);
+        }
+      }
+    }
+    expect(colouredElements.size, 'parsed no scrollbar-color rules at all').toBeGreaterThan(0);
+    expect(webkitStyledElements.size, 'parsed no ::-webkit-scrollbar rules at all').toBeGreaterThan(0);
+
+    const combined = [...colouredElements].filter((element) => webkitStyledElements.has(element));
+    expect(
+      combined,
+      `these elements declare scrollbar-color AND ::-webkit-scrollbar rules, so the ` +
+        `pseudo-elements are inert: ${combined.map((one) => webkitStyledElements.get(one)).join(', ')}`,
+    ).toEqual([]);
+
+    // And the matrix specifically keeps the half that paints. Deleting the colour
+    // to revive the pseudo-elements would restore the defect the colour was added
+    // for: on a system drawing overlay scrollbars nothing is painted at rest, so
+    // the scroller reads as simply ending.
+    const scrollRule = sliceBetween(artifactCss, '.motif-cs-msa-matrix-scroll {', '}');
+    expect(scrollRule).toMatch(/scrollbar-color:/);
+    expect(artifactCss).not.toMatch(/\.motif-cs-msa-matrix-scroll::-webkit-scrollbar/);
   });
 });

--- a/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
@@ -49,6 +49,35 @@ describe('Claude Science rail popover regression guards', () => {
     expect(featureList).toContain('more translations');
   });
 
+  it('caps the features list at nothing, in every Tools placement rather than one', () => {
+    // `c999493` removed a `max-height: min(24vh, 190px)` from this list — but as an
+    // ADDITION at higher specificity, under
+    // `.motif-cs-inspector[data-tools-pinned="false"]`. The base rule stayed in force
+    // for every state that selector does not match, so the pinned docked column and
+    // the floated Tools pane kept the entire defect while a fix was on record.
+    // Measured in the pinned state before this change: clientHeight 189 against
+    // scrollHeight 288, 3 of 8 rows unreachable, identically at 1440x900, 1440x980,
+    // 1920x1080 and 2560x1400 — the same numbers the earlier fix's own comment
+    // records as already solved.
+    const baseRule = artifactCss.slice(
+      artifactCss.indexOf('.motif-cs-feature-annotation-list {'),
+      artifactCss.indexOf('}', artifactCss.indexOf('.motif-cs-feature-annotation-list {')),
+    );
+    expect(baseRule, 'the features list base rule is missing').toBeTruthy();
+    // Asserted as "no height cap of any kind", not as the absence of one literal
+    // string: re-adding the constant in another shape is the same defect.
+    expect(baseRule, 'a height cap is back on the base rule, so it binds in every state the overrides miss')
+      .not.toMatch(/max-height/);
+    // The list still scrolls rather than clipping when the popover is dragged shorter
+    // than its content, which is the one state where it can be squeezed.
+    expect(baseRule).toMatch(/overflow:\s*auto/);
+    // The popover's own flex treatment stays: there it has a definite height to take
+    // the remainder of, which the docked and floated columns do not.
+    expect(artifactCss).toMatch(
+      /\.motif-cs-inspector\[data-tools-pinned="false"\][^{]*\.motif-cs-feature-annotation-list\s*\{[\s\S]*?flex:\s*1 1 auto/,
+    );
+  });
+
   it('keeps the close control visible while a long editor scrolls', () => {
     expect(artifactCss).toMatch(
       /\.motif-cs-inspector\[data-tools-pinned="false"\] \.motif-cs-rail-popover-title\s*\{[\s\S]*?position:\s*sticky;[\s\S]*?top:\s*0;/,
@@ -267,7 +296,18 @@ describe('Claude Science rail popover regression guards', () => {
     expect(artifactSource).toContain("window.addEventListener('pointercancel', endPointerResize);");
     expect(artifactSource).toContain("handle.addEventListener('lostpointercapture', endLostPointerCapture);");
     expect(artifactSource).toContain('widthDelta = event.key === \'ArrowLeft\' ? step');
-    expect(artifactCss).toMatch(/@media \(max-width: 1280px\)[\s\S]*?max-height:\s*min\(calc\(100vh - var\(--rail-popover-fixed-top\) - 22px\), 600px\)/);
+    // The popover is bounded by the viewport and the rail offset, and nothing else.
+    // This used to assert a second copy of the declaration inside the 1280px block,
+    // which was byte-identical to the base rule and did nothing — the base rule reads
+    // the offset through var(), so it re-resolves on its own. Assert the two halves
+    // that carry the behaviour instead: the bound itself, and the breakpoint moving
+    // the offset it is measured from.
+    expect(railBody).toMatch(/max-height:\s*calc\(100vh - var\(--rail-popover-fixed-top\) - 22px\)/);
+    // A constant term would have to come back as min(viewport, Npx), and it would cap
+    // the drag below the viewport at every size — the drag reads its limit straight off
+    // the computed max-height, so a flat 600px was what stopped the pointer.
+    expect(railBody).not.toMatch(/max-height:\s*min\(/);
+    expect(artifactCss).toMatch(/@media \(max-width: 1280px\)[\s\S]*?--rail-popover-fixed-top:\s*132px/);
   });
 
   it('cleans up floating-window pointer listeners when a drag is interrupted', () => {

--- a/src/artifacts/__tests__/claude-science-runtime-integrity.test.ts
+++ b/src/artifacts/__tests__/claude-science-runtime-integrity.test.ts
@@ -19,12 +19,14 @@ import {
   createDefensiveRuntimeSnapshot,
   describePayloadSnapshot,
   inventoryReportHtml,
+  normalizeRecord,
   normalizeSequence,
   omitUndefinedObjectProperties,
   parseImportedRecords,
   prepareArtifactDatabaseRestore,
   prepareInventoryReplacement,
   prepareRecordsOnlyWorkspaceReplacement,
+  toGenBankLite,
   validateRuntimeRecordInputs,
 } from '../motif-artifact';
 
@@ -837,6 +839,45 @@ describe('Claude Science runtime data-integrity behavior', () => {
     }));
   });
 
+  // The truncation checks above all run on hand-written GenBank. These cases run
+  // Motif's exporter and reader against each other so the exported LOCUS length
+  // remains actionable during truncation checks.
+  it('declares an exported length the reader can act on, for nucleotides and protein alike', () => {
+    const dna = normalizeRecord({ id: 'unit-dna', name: 'unit-dna', molecule: 'dna', seq: 'GAATTC'.repeat(100) }, 0);
+    const protein = normalizeRecord({ id: 'unit-aa', name: 'unit-aa', molecule: 'protein', seq: 'MKVLAAGIVGLNLGGK'.repeat(10) }, 0);
+    expect(dna).not.toBeNull();
+    expect(protein).not.toBeNull();
+
+    expect(toGenBankLite(dna!, 'linear')).toContain('600 bp ');
+    expect(toGenBankLite(protein!, 'linear')).toContain('160 aa');
+  });
+
+  it('catches a truncated copy of its own GenBank export instead of importing a fragment', () => {
+    const sequence = 'GAATTC'.repeat(100);
+    const record = normalizeRecord({ id: 'roundtrip', name: 'roundtrip', molecule: 'dna', seq: sequence }, 0);
+    expect(record).not.toBeNull();
+    const genbank = toGenBankLite(record!, 'linear');
+
+    // An intact export still round-trips, so the guard below is not simply
+    // refusing everything this exporter writes.
+    const reimported = parseImportedRecords(genbank, '', 'auto', 'linear');
+    expect(reimported).toHaveLength(1);
+    expect((reimported[0].seq ?? '').toUpperCase()).toBe(sequence);
+    expect(sequence).toHaveLength(600);
+
+    // Keep ORIGIN plus its first two rows: 120 residues of a declared 600.
+    const lines = genbank.split('\n');
+    const originAt = lines.indexOf('ORIGIN');
+    expect(originAt).toBeGreaterThan(-1);
+    const truncated = lines.slice(0, originAt + 3).join('\n');
+    expect(truncated).not.toBe(genbank);
+    expect(truncated.split('\n')).toHaveLength(originAt + 3);
+
+    expect(() => parseImportedRecords(truncated, '', 'auto', 'linear')).toThrowError(
+      expect.objectContaining({ code: 'MOTIF_TRUNCATED_GENBANK_IMPORT' }),
+    );
+  });
+
   it('builds an immediate description from a fresh restriction scan', () => {
     const payload = prepareInventoryReplacement([
       { id: 'eco-ri-record', name: 'EcoRI record', type: 'dna', topology: 'linear', sequence: 'TTTGAATTCAAA' },
@@ -900,8 +941,18 @@ describe('Claude Science runtime data-integrity behavior', () => {
     expect(analysisPanel).toContain('const allOrfs = useMemo(');
     expect(analysisPanel).toContain('const visibleOrfs = useMemo(() => allOrfs.slice(0, 8), [allOrfs]);');
     expect(analysisPanel).toContain('orfCount: allOrfs.length');
-    expect(analysisPanel).toContain('Showing the 8 longest of {allOrfs.length} detected ORFs.');
-    expect(analysisPanel).toContain('`${allOrfs.length} ORFs`');
+    // Both readouts still publish the COMPLETE total while only eight rows
+    // render, which is what this guard exists for. The wording moved because
+    // "ORFs" was doing two jobs: this panel counts start-to-stop intervals at a
+    // 10 aa floor while the record summary counts at 30 aa, and the two
+    // published 221 and 96 for the same record in the same session under the
+    // same word. Each count now names its own floor, so assert the floor
+    // travels WITH the number rather than pinning the prose around it.
+    expect(analysisPanel).toContain('Showing the 8 longest of {allOrfs.length} start-to-stop intervals');
+    expect(analysisPanel).toContain('≥{ANALYSIS_ORF_MIN_AA} aa');
+    expect(analysisPanel).toContain('`${allOrfs.length} ORFs ≥${ANALYSIS_ORF_MIN_AA} aa`');
+    // A bare count with no floor beside it is the defect this replaced.
+    expect(analysisPanel).not.toContain('`${allOrfs.length} ORFs`');
   });
 
   it('labels lossy interchange exports and session durability honestly', () => {

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -54,6 +54,66 @@ describe('Claude Science workspace layout guards', () => {
     expect(dataSettingsSource).toContain('Reset display');
   });
 
+  it('lets "Reset display" reach every floating tool window, including one already open', () => {
+    // The seven tool windows keep their geometry in plain state, deliberately: a
+    // size dragged onto a corner survives closing and reopening that window. What
+    // was missing is the way back — the button reset the panes and left every
+    // window exactly as small as it found it, which is the state a user presses
+    // it in.
+    const resetRects = sliceBetween(
+      artifactSource,
+      'const resetToolWindowRects = useCallback',
+      'const resetDisplayPreferences = useCallback',
+    );
+    const resetDisplay = sliceBetween(
+      artifactSource,
+      'const resetDisplayPreferences = useCallback',
+      'const downloadWorkspaceBackup',
+    );
+    expect(resetDisplay).toContain('resetToolWindowRects();');
+
+    // Named one at a time. A window left off this list is not reset and says
+    // nothing about it; the entire failure mode here is a silent omission.
+    for (const tool of ['Translations', 'Primer', 'Alignment', 'Gel', 'Assembly', 'CloningDesign', 'ConstructVerification']) {
+      expect(resetRects, `the ${tool} window is not restored by "Reset display"`)
+        .toContain(`set${tool}Win(default${tool}WindowRect());`);
+    }
+    expect(resetRects).toContain('setWindowResetSignal((value) => value + 1);');
+
+    // Resetting that state is only half of it. `initial` is read once, in a
+    // useState initialiser, so a window that is already open when the button is
+    // pressed never sees the new rect — measured on the live app, it sat at
+    // 280x180 while only the NEXT open came up correct, which is the one moment
+    // the user is guaranteed not to be watching. Every window must be handed the
+    // signal or it is one of the ones that does not move.
+    const windowElements = artifactSource.split('<FloatingWindow').slice(1)
+      .map((chunk) => chunk.slice(0, chunk.search(/\n\s*>\n/)));
+    expect(windowElements, 'expected seven floating tool windows').toHaveLength(7);
+    for (const element of windowElements) {
+      const rect = /initial=\{(\w+)\}/.exec(element)?.[1];
+      expect(rect, 'a FloatingWindow is rendered without an initial rect').toBeTruthy();
+      expect(element, `the ${rect} window is never told that a display reset happened`)
+        .toContain('resetSignal={windowResetSignal}');
+    }
+
+    // And the receiving end adopts it. Keyed on the counter rather than on
+    // `initial` changing identity, because `onCommit` writes every finished drag
+    // back into that same prop: adopting on identity would fire against the very
+    // gesture that produced it.
+    const adopt = sliceBetween(
+      artifactSource,
+      'const lastResetSignalRef = useRef(resetSignal);',
+      'const restoreWindow = useCallback',
+    );
+    expect(adopt).toContain('if (resetSignal === lastResetSignalRef.current) return;');
+    expect(adopt).toContain('clampWindowRect(initial, window.innerWidth, window.innerHeight, rightInset)');
+    expect(adopt).toContain('setRect(next);');
+    // A reset that restored the size but left the window maximized would not
+    // show the user the thing it had just fixed.
+    expect(adopt).toContain('setMaximized(false);');
+    expect(adopt).toContain('setCollapsed(false);');
+  });
+
   it('does not count the permanent Tools rail as workspace content', () => {
     expect(artifactSource).toContain(
       "const CONTENT_PANE_KEYS: readonly Exclude<PaneKey, 'tools'>[] = ['inventory', 'sequence', 'map'];",
@@ -86,6 +146,123 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toContain('ref={recordTabsRef}');
     expect(artifactSource).toContain("tabs?.querySelector<HTMLElement>('.motif-cs-record-tab[data-active=\"true\"]')");
     expect(artifactSource).toContain("tabs.scrollTo({ left: tabRight - tabs.clientWidth, behavior: 'auto' })");
+  });
+
+  it('makes every ORF count name the population it counted', () => {
+    // Measured on the app's own pUC19 (2,578 bp, circular) with the real
+    // detector. "221 ORFs" is true and points the wrong way: it is 221
+    // start-to-stop intervals at a 10 aa floor over six frames, counting the
+    // standard table's ATG/TTG/CTG starts — only 76 of the 221 begin ATG — and
+    // findORFs emits one entry per START, so the 221 sit on just 159 distinct
+    // (strand, stop) reading frames. Four of the eight rows the panel lists are
+    // the same reverse-strand frame entered at four different starts.
+    //
+    // The sharper defect the filing did not have: the record summary reports
+    // the SAME word for a 30 aa population — 96 on this record — so the app
+    // published 221 and 96 as "ORFs" with nothing to tell them apart, because
+    // only the summary's EMPTY branch named its floor. Both are legitimate
+    // populations, so both now say which they are; unifying them would have
+    // moved a number somebody may already be quoting.
+    expect(artifactSource).toContain('const ANALYSIS_ORF_MIN_AA = 10;');
+    expect(artifactSource).toContain('const SUMMARY_ORF_MIN_AA = 30;');
+
+    // The floor in the label must be the floor that was scanned, so the two
+    // cannot drift: both call sites take the constant, not a literal.
+    expect(artifactSource).toContain('findORFs(record.sequence, ANALYSIS_ORF_MIN_AA, translationCode.table, { topology })');
+    expect(artifactSource).toContain('findORFs(record.sequence, SUMMARY_ORF_MIN_AA, translationCode.table, { topology })');
+    expect(artifactSource).not.toMatch(/findORFs\(record\.sequence,\s*\d/);
+
+    // Chip and rail-popover meta both carry the floor.
+    expect(
+      artifactSource.match(/\$\{allOrfs\.length\} ORFs ≥\$\{ANALYSIS_ORF_MIN_AA\} aa/g),
+      'both the summary chip and the popover meta must name the floor',
+    ).toHaveLength(2);
+
+    // The record summary names its floor in the non-empty branch too, not only
+    // when the count is zero.
+    expect(artifactSource).toContain('`ORFs: ${orfs.length} ≥${SUMMARY_ORF_MIN_AA} aa (longest ');
+    expect(artifactSource).toContain('`ORFs: none ≥${SUMMARY_ORF_MIN_AA} aa`');
+    // ...and the machine-readable copy carries it as data.
+    expect(artifactSource).toContain('minAminoAcids: SUMMARY_ORF_MIN_AA,');
+
+    // The panel states the definition next to the count, including the
+    // denominator that explains the inflation. Derived from the SAME array the
+    // rows render from so the two cannot disagree about one quantity.
+    expect(artifactSource).toContain('new Set(allOrfs.map((orf) => `${orf.strand}:${orf.end}`)).size');
+    expect(artifactSource).toContain('start-to-stop intervals ≥{ANALYSIS_ORF_MIN_AA} aa');
+    expect(artifactSource).toContain('across {orfReadingFrameCount} distinct reading frames');
+    // The start set comes from the table the scan used, because the panel has a
+    // "Record genetic code" select and the tables disagree — standard initiates
+    // at ATG/TTG/CTG, vertebrate mitochondrial at ATT/ATC/ATA/ATG/GTG. A fixed
+    // list here would be one more readout true of some other configuration.
+    expect(artifactSource).toContain('translationCode.table.starts');
+    expect(artifactSource).toContain('starting at {orfStartCodons}');
+    // The bare noun is what misled; it must not come back.
+    expect(artifactSource).not.toContain('detected ORFs.');
+  });
+
+  it('renders no chip that the stylesheet unconditionally hides', () => {
+    // Four chips — a record count and a length in the topbar, a type and a
+    // length in the sequence title — were rendered on every load and hidden by
+    // BASE-block rules, so no viewport, record type, pane placement or media
+    // mode could reveal them. Measured at 225 widths from 320 to 2560 and across
+    // 0/1/13 records, protein records, every pane toggled and print /
+    // forced-colors / prefers-contrast / dark: `display: none`, 0x0, every time.
+    // Deleting them changed 0 of 462 element rects across 7 widths.
+    //
+    // The filing supposed the base rule had been added later and the
+    // media-query one left behind as redundant; `git log -S` refutes that —
+    // both, and the sequence-title rule, arrived in the initial commit.
+    const topbarMeta = sliceBetween(
+      artifactSource,
+      '<div className="motif-cs-topbar-meta">',
+      '</header>',
+    );
+    expect(topbarMeta, 'topbar chip is hidden by the stylesheet; do not render it').not.toContain('motif-cs-chip');
+
+    const titleActions = sliceBetween(
+      artifactSource,
+      '<div className="motif-cs-title-actions">',
+      '</div>',
+    );
+    expect(titleActions, 'sequence-title chip is hidden by the stylesheet; do not render it').not.toContain('motif-cs-chip');
+
+    // ...and the rules that hid them are gone rather than left to hide markup
+    // that no longer exists.
+    expect(artifactCss).not.toContain('.motif-cs-topbar-meta > .motif-cs-chip');
+    expect(artifactCss).not.toContain('.motif-cs-sequence-title .motif-cs-title-actions .motif-cs-chip');
+    // This one never matched anything: the topbar's only children are
+    // .motif-cs-brand and .motif-cs-topbar-meta, so a direct-child chip
+    // selector had nothing to style even before the chips were removed.
+    expect(artifactCss).not.toContain('.motif-cs-topbar > .motif-cs-chip');
+  });
+
+  it('gives the record tab strip a themed scrollbar and no inert webkit rules', () => {
+    // Thirteen records need 1137px, so the strip scrolls from 1024 down: at
+    // 1024 pCDFDuet-1 is entirely off-strip, at 900 pRSFDuet-1 goes with it.
+    // The edge fades work (measured headed: 1.15:1 against the field, and the
+    // shadow swaps ends with scroll position), but the bar is what says how
+    // much is left, and with no colour it fell through to the platform default
+    // at 1.72:1 in BOTH light themes and 2.66:1 in both dark ones — identical
+    // rgb across themes, the tell that it was never themed at all. Now 4.30,
+    // 5.38, 4.59 and 4.50, measured HEADED because headless Chromium paints no
+    // scrollbar for a non-root scroller and would show nothing to measure.
+    const strip = sliceBetween(artifactCss, '.motif-cs-record-tabs {', '}');
+    expect(strip).toContain('overflow-x: auto');
+    expect(strip, 'record tab strip left on the platform default scrollbar').toContain('scrollbar-color:');
+
+    // One scrollbar for the app: the same two tokens the inventory list and the
+    // alignment matrix already use.
+    const inventory = sliceBetween(artifactCss, '.motif-cs-inventory-groups {', '}');
+    const colourOf = (rule: string) => /scrollbar-color:\s*([^;]+);/.exec(rule)?.[1].replace(/\s+/g, ' ').trim();
+    expect(colourOf(strip)).toBeTruthy();
+    expect(colourOf(strip)).toBe(colourOf(inventory));
+
+    // `scrollbar-width` above is a standard property, so Chromium ignores these
+    // pseudo-elements entirely. The pair that used to sit here declared a 5px
+    // bar and a border-strong thumb and delivered neither — 11px, Chromium's
+    // own thumb. Dead text that reads like live styling is worse than none.
+    expect(artifactCss).not.toContain('.motif-cs-record-tabs::-webkit-scrollbar');
   });
 
   it('only advertises pane reordering where the rendered layout can honor it', () => {
@@ -182,7 +359,7 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toContain("const STACKED_LAYOUT_MEDIA = '(max-width: 767px)';");
     expect(artifactSource).toContain("const TWO_ROW_LAYOUT_MEDIA = '(min-width: 640px) and (max-width: 1535px)';");
     expect(artifactSource).toContain("const OVERLAY_TOOLS_LAYOUT_MEDIA = '(max-width: 1535px)';");
-    expect(artifactSource).toContain("sequence: { min: 240, max: 760 }");
+    expect(artifactSource).toContain("sequence: { min: 240, max: 2000 }");
     expect(artifactSource).toContain("map: { min: 300, max: 900 }");
     expect(artifactCss).toMatch(/\.motif-cs-resize-handle\[data-pane="sequence"\]\s*\{[\s\S]*?display:\s*block/);
     expect(artifactCss).toMatch(/@media \(min-width: 768px\) and \(max-width: 1535px\)[\s\S]*?\.motif-cs-resize-handle\[data-pane="inventory"\],[\s\S]*?\.motif-cs-resize-handle\[data-pane="sequence"\][\s\S]*?display:\s*block/);
@@ -336,9 +513,24 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toContain('addTranslationLayer();');
     expect(artifactSource).toContain('onTranslationTrackSelect={handleTranslationTrackSelectAndReveal}');
     expect(artifactSource).toMatch(/>\s*\+ Feature\s*<\/button>/);
-    expect(artifactSource).toContain('<span className="motif-cs-label-full">Rev comp</span>');
-    expect(artifactSource).toContain('<span className="motif-cs-label-short">RC</span>');
-    expect(artifactSource).toMatch(/>\s*Protein\s*<\/button>/);
+
+    // Both controls in this bar that add a record to the inventory say so. They
+    // used to be spelled like the "Copy" beside them, so pressing "Rev comp"
+    // took a session from 13 records to 14 and opened a new Derived group with
+    // nothing in the label to warn of it — and with no selection it is the only
+    // enabled control here, so it was the one thing the resting bar invited.
+    // "New" is the word the Export panel already uses to tell "Copy rev comp"
+    // from "New rev comp"; reusing it keeps the two surfaces agreeing.
+    expect(artifactSource).toContain('<span className="motif-cs-label-full">New rev comp</span>');
+    expect(artifactSource).toContain('<span className="motif-cs-label-short">+ RC</span>');
+    expect(artifactSource).toContain('<span className="motif-cs-label-full">New protein</span>');
+    expect(artifactSource).toContain('<span className="motif-cs-label-short">+ Prot</span>');
+    expect(artifactSource).toContain('aria-label="New rev comp record"');
+    expect(artifactSource).toContain('aria-label="New protein record"');
+    // The rule is decoration; the labels carry the meaning, so it stays hidden
+    // from assistive tech and must never become the only signal.
+    expect(artifactSource).toContain('<span className="motif-cs-selection-action-rule" aria-hidden="true" />');
+    expect(artifactCss).toMatch(/\.motif-cs-selection-actions \.motif-cs-selection-action-rule\s*\{[\s\S]*?width:\s*1px/);
     expect(artifactSource).toContain("onClick={() => setSequenceViewMode('standard')}");
     expect(artifactSource).toContain("onClick={() => setSequenceViewMode('detail')}");
     expect(artifactSource).toContain('if (selectionSummary) {');
@@ -461,6 +653,29 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactCss).not.toContain('.motif-cs-window-resize {\n    right: 58px;');
   });
 
+  it('keeps the window corner grip above anything the window body stacks', () => {
+    // The grip used to declare no z-index, so it lost to the MSA toolbar's
+    // sticky z-index: 10 wherever the two overlapped — which is the whole
+    // bottom-right corner once the toolbar wraps taller than a short body. The
+    // press then went to the toolbar and the window could not be mouse-resized.
+    const declared = (selector: string) => {
+      const rule = artifactCss.match(new RegExp(`\\n${selector.replace('.', '\\.')}\\s*\\{([\\s\\S]*?)\\n\\}`));
+      const found = rule?.[1].match(/\n\s*z-index:\s*(\d+);/);
+      return found ? Number(found[1]) : null;
+    };
+    const grip = declared('.motif-cs-window-resize');
+    const toolbar = declared('.motif-cs-msa-toolbar');
+    const dropOverlay = declared('.motif-cs-msa-drop-overlay');
+    // Absolute floors as well as the comparison: a guard that only checks
+    // "higher than the others" still passes if every number drifts together.
+    expect(grip).toBe(20);
+    expect(toolbar).toBe(10);
+    expect(dropOverlay).toBe(12);
+    expect(grip!).toBeGreaterThan(Math.max(toolbar!, dropOverlay!));
+    // Scoped to the window, so the raised value cannot reorder anything outside it.
+    expect(artifactCss).toMatch(/\.motif-cs-window\s*\{[\s\S]*?isolation:\s*isolate;/);
+  });
+
   it('limits floating-window drags to the initiating primary pointer', () => {
     expect(artifactSource).toContain('if (!event.isPrimary || event.button !== 0) return;');
     expect(artifactSource).toContain('pointerId: event.pointerId,');
@@ -538,9 +753,15 @@ describe('Claude Science workspace layout guards', () => {
 
   it('exports each record with its own restriction-enzyme source settings', () => {
     expect(artifactSource).toContain('const itemSources = enzymeSourcesByRecord[item.id] ?? DEFAULT_ENZYME_SOURCES;');
-    expect(artifactSource).toContain('resolveEnzymeUnion(itemSources)');
+    expect(artifactSource).toContain('restrictionEnzymesForSources(itemSources, customEnzymes)');
     expect(artifactSource).toContain('[customEnzymes, enzymeSourcesByRecord, exportRecords, needsInventoryExport]');
     expect(artifactSource).not.toContain('recordSitesForExport(item, scanEnzymes)');
+    // Resolve through the shared helper, never a second inline union. Calling
+    // resolveEnzymeUnion directly skips the empty-source check the helper
+    // carries, and it answers an empty list with the Common working set — so
+    // the export listed sites for enzymes every other surface reported as not
+    // selected.
+    expect(artifactSource).not.toContain('resolveEnzymeUnion(itemSources)');
   });
 
   it('collapses absent intermediate-width pane tracks and preserves wider-layout preferences', () => {
@@ -552,5 +773,44 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactCss).toContain('.motif-cs-main[data-content-pane-count="1"]');
     expect(artifactCss).toMatch(/\.motif-cs-sidebar \.motif-cs-import-slot\s*\{\s*min-height:\s*0/);
     expect(artifactCss).toContain('clamp(160px, var(--motif-cs-inventory-pane-width, 210px), 38vw)');
+  });
+
+  it('lets the collapsed Tools rail scroll once its fifteen tools stop fitting', () => {
+    // Below 695px of viewport the rail's tools do not fit and used to simply
+    // leave the screen -- Settings and Alignment unreachable, with wheel,
+    // touch-drag and 120 presses of Tab all measured as no-ops. Only page zoom
+    // under 100% recovered them.
+    const rule = sliceBetween(
+      artifactCss,
+      '@media (max-height: 694px) {',
+      '\n}',
+    );
+    expect(rule).toContain('.motif-cs-inspector[data-tools-pinned="false"]');
+    expect(rule).toContain('overflow-y: auto');
+    // pointer-events must be restored INSIDE the query. Without it the wheel
+    // targets whatever sits beneath the rail, so scrolling works only while the
+    // pointer is over an icon and is dead in the 3px gaps between them, and the
+    // thumb cannot be dragged at all. Measured: 103 over an icon, 0 in a gap.
+    expect(rule, 'scroll without pointer-events is a mirage -- dead in the gaps').toContain('pointer-events: auto');
+    // One scrollbar for the app: same pair as the matrix and the inventory.
+    expect(rule).toMatch(/scrollbar-color:\s*color-mix\(in srgb, var\(--text-muted\) 68%, var\(--border-strong\)\)\s*color-mix\(in srgb, var\(--bg-secondary\) 78%, var\(--bg-primary\)\)/);
+
+    // The rail must stay pointer-events:none OUTSIDE the query, because above
+    // this height there IS empty rail space and it must keep passing clicks
+    // through to a floating workspace underneath (measured empty space: 205px
+    // at 900, 65px at 760, 5px at 700, 0px at 694 and below).
+    const collapsed = sliceBetween(artifactCss, '.motif-cs-inspector[data-tools-pinned="false"] {', '}');
+    expect(collapsed).toContain('pointer-events: none');
+
+    // 694 is derived, not chosen: 15 heads x 34px + 14 gaps x 3px + title and
+    // 8px padding = 625px of content under a 70px top bar, so 695 is the last
+    // height that fits. These are the inputs -- if any moves, re-derive.
+    expect(collapsed).toContain('padding: 8px 5px');
+    expect(collapsed).toContain('gap: 3px');
+    expect(artifactCss).toMatch(/\.motif-cs-inspector\[data-tools-pinned="false"\] \.motif-cs-panel-head\s*\{[\s\S]*?min-height:\s*34px/);
+    // Tool count is the other input. 16 rail labels exist in the artifact, 15 of
+    // them in this rail; adding one moves the breakpoint and must fail here.
+    expect((artifactSource.match(/data-rail-label="/g) ?? []).length,
+      'rail tool count changed -- re-derive the 694px breakpoint').toBe(16);
   });
 });

--- a/src/artifacts/__tests__/rail-popover-placement.test.ts
+++ b/src/artifacts/__tests__/rail-popover-placement.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RAIL_POPOVER_MIN_HEIGHT,
+  chooseRailPopoverPlacement,
+  type PlacementObstacle,
+  type RailPopoverPlacementInput,
+} from '../rail-popover-placement';
+
+/*
+ * Every number below was measured in the running app at 1440x980 with the
+ * alignment window open: topbar 0-38, record tabs 38-70, window at (250, 80)
+ * 940x820, its title bar 81-124, its control row 134-178, and the popover
+ * docked at x 1038-1382 with a resting offset of 84 and a 22px bottom gutter.
+ */
+const VIEWPORT_HEIGHT = 980;
+const COLUMN = { left: 1038, right: 1382 };
+const HOME_TOP = 84;
+const BOTTOM_GUTTER = 22;
+const SAFE_BOTTOM = VIEWPORT_HEIGHT - BOTTOM_GUTTER;
+
+const TOP_CHROME: PlacementObstacle = { id: 'top-chrome', priority: 'hard', left: 0, top: 0, width: 1440, height: 70 };
+
+/** The hard + soft zones a window at `top` contributes, at its measured proportions. */
+function windowAt(top: number, { height = 820, left = 250, width = 940 } = {}): PlacementObstacle[] {
+  return [
+    { id: 'window', priority: 'soft', left, top, width, height },
+    { id: 'window-head', priority: 'hard', left: left + 1, top: top + 1, width: width - 2, height: 43 },
+    { id: 'window-controls', priority: 'hard', left: left + 11, top: top + 54, width: width - 22, height: 44 },
+  ];
+}
+
+function place(overrides: Partial<RailPopoverPlacementInput> = {}) {
+  return chooseRailPopoverPlacement({
+    column: COLUMN,
+    homeTop: HOME_TOP,
+    desiredHeight: 874,
+    viewportHeight: VIEWPORT_HEIGHT,
+    bottomGutter: BOTTOM_GUTTER,
+    obstacles: [TOP_CHROME],
+    ...overrides,
+  });
+}
+
+/** Does the placement, at the height it will actually render, sit on a hard zone? */
+function coversHard(placement: { top: number; maxHeight: number }, obstacles: PlacementObstacle[], desiredHeight = 874) {
+  const height = Math.min(desiredHeight, placement.maxHeight);
+  return obstacles.filter((o) => o.priority === 'hard').some((o) => (
+    o.left < COLUMN.right && o.left + o.width > COLUMN.left
+    && o.top < placement.top + height && o.top + o.height > placement.top
+  ));
+}
+
+describe('chooseRailPopoverPlacement', () => {
+  it('leaves the popover at the stylesheet offset when nothing is under it', () => {
+    const placement = place();
+    expect(placement.top).toBe(HOME_TOP);
+    expect(placement.strategy).toBe('home');
+    // The stylesheet's own bound: 100vh - offset - 22.
+    expect(placement.maxHeight).toBe(VIEWPORT_HEIGHT - HOME_TOP - BOTTOM_GUTTER);
+  });
+
+  it('drops below the title bar and control row of a window parked at the top', () => {
+    const obstacles = [TOP_CHROME, ...windowAt(80)];
+    const placement = place({ obstacles });
+    // Control row ends at 80 + 54 + 44 = 178, plus RAIL_POPOVER_GAP of breathing room.
+    expect(placement.top).toBe(186);
+    expect(placement.strategy).toBe('shifted-down');
+    expect(placement.clearsHard).toBe(true);
+    expect(coversHard(placement, obstacles)).toBe(false);
+  });
+
+  it('re-derives the height bound from where it actually landed', () => {
+    const placement = place({ obstacles: [TOP_CHROME, ...windowAt(80)] });
+    // Not the stylesheet's 100vh - 84 - 22: the popover is no longer at 84.
+    expect(placement.maxHeight).toBe(SAFE_BOTTOM - placement.top);
+    expect(placement.maxHeight).toBe(VIEWPORT_HEIGHT - placement.top - BOTTOM_GUTTER);
+    expect(placement.maxHeight).toBeLessThan(VIEWPORT_HEIGHT - HOME_TOP - BOTTOM_GUTTER);
+  });
+
+  it('stays home and shortens when the window sits low enough to leave room above it', () => {
+    const obstacles = [TOP_CHROME, ...windowAt(500)];
+    const placement = place({ obstacles });
+    expect(placement.top).toBe(HOME_TOP);
+    expect(placement.strategy).toBe('home');
+    // Bounded by the title bar above it (501), less the gap, less the offset —
+    // not by the bottom of the screen.
+    expect(placement.maxHeight).toBe(409);
+    expect(coversHard(placement, obstacles)).toBe(false);
+  });
+
+  it('ignores a window that does not reach the docked column', () => {
+    const obstacles = [TOP_CHROME, ...windowAt(80, { left: 20, width: 600 })];
+    const placement = place({ obstacles });
+    expect(placement.top).toBe(HOME_TOP);
+    expect(placement.strategy).toBe('home');
+  });
+
+  it('clears both title bars when two windows are stacked', () => {
+    // The band between the windows is 441 - 8 - (178 + 8) = 247px: big enough to
+    // be worth using, and nearer home than the band below the lower window.
+    const obstacles = [TOP_CHROME, ...windowAt(80, { height: 300 }), ...windowAt(440, { height: 400 })];
+    const placement = place({ obstacles });
+    expect(placement.clearsHard).toBe(true);
+    expect(coversHard(placement, obstacles)).toBe(false);
+    expect(placement.top).toBe(186);
+    expect(placement.maxHeight).toBe(247);
+  });
+
+  it('passes over a band too small to be worth using and takes the roomier one', () => {
+    // The same layout 20px higher squeezes the middle band to 227px. Under the
+    // stylesheet's bare 96px minimum that band wins on nearness alone and the
+    // panel opens into it; a usable band exists further down, so take that
+    // instead of reserving less room than the panel needs and hiding the rest.
+    const obstacles = [TOP_CHROME, ...windowAt(80, { height: 300 }), ...windowAt(420, { height: 400 })];
+    const placement = place({ obstacles });
+    expect(placement.clearsHard).toBe(true);
+    expect(coversHard(placement, obstacles)).toBe(false);
+    expect(placement.top).toBe(526);
+    expect(placement.maxHeight).toBe(432);
+    // Drop the floor back to the stylesheet minimum and the sliver returns.
+    const sliver = place({ obstacles, minUsableHeight: RAIL_POPOVER_MIN_HEIGHT });
+    expect(sliver.top).toBe(186);
+    expect(sliver.maxHeight).toBe(227);
+  });
+
+  it('goes below a window rather than open 109px above it', () => {
+    // The measured regression: window dragged to y=200 leaves a 115px band above
+    // its title bar, and the popover sitting at home inside it gets 109px — which
+    // renders one of the fourteen rail panels whole.
+    const obstacles = [TOP_CHROME, ...windowAt(200)];
+    const placement = place({ obstacles });
+    expect(placement.top).toBe(306);
+    expect(placement.maxHeight).toBe(652);
+    expect(coversHard(placement, obstacles)).toBe(false);
+    expect(place({ obstacles, minUsableHeight: RAIL_POPOVER_MIN_HEIGHT }).maxHeight).toBe(109);
+  });
+
+  it('will not wedge into a band the popover cannot physically fit in', () => {
+    // Two clear bands, neither usable: 56px nearer home and 142px further away.
+    // 56 is under the stylesheet's own min-height, so a popover put there would
+    // overflow its band and land back on the hard zone it was avoiding.
+    const obstacles: PlacementObstacle[] = [
+      TOP_CHROME,
+      { id: 'window-head', priority: 'hard', left: 250, top: 142, width: 940, height: 60 },
+      { id: 'window-head-2', priority: 'hard', left: 250, top: 360, width: 940, height: 598 },
+    ];
+    const placement = place({ obstacles });
+    expect(placement.top).toBe(210);
+    expect(placement.maxHeight).toBe(142);
+    expect(placement.maxHeight).toBeGreaterThanOrEqual(RAIL_POPOVER_MIN_HEIGHT);
+    expect(coversHard(placement, obstacles)).toBe(false);
+  });
+
+  it('still takes an undersized band when it is the only way to clear a hard zone', () => {
+    // Never covering the window controls is the rule that does not bend: a 149px
+    // band beats staying home on top of Close, even though 149 is under the floor.
+    const obstacles: PlacementObstacle[] = [
+      TOP_CHROME,
+      ...windowAt(240),
+      { id: 'window-head-2', priority: 'hard', left: 250, top: 346, width: 940, height: 612 },
+    ];
+    const placement = place({ obstacles });
+    expect(placement.clearsHard).toBe(true);
+    expect(coversHard(placement, obstacles)).toBe(false);
+    expect(placement.top).toBe(84);
+    expect(placement.maxHeight).toBe(149);
+  });
+
+  it('refuses a band too small to hold the popover', () => {
+    // Window head at 150 leaves 150 - 8 - 78 = 64px above it, under the minimum.
+    const obstacles = [TOP_CHROME, ...windowAt(149)];
+    const placement = place({ obstacles });
+    expect(placement.top).toBeGreaterThan(149);
+    expect(placement.maxHeight).toBeGreaterThanOrEqual(RAIL_POPOVER_MIN_HEIGHT);
+    expect(coversHard(placement, obstacles)).toBe(false);
+  });
+
+  it('places a short panel and a tall panel identically', () => {
+    const obstacles = [TOP_CHROME, ...windowAt(280)];
+    const short = place({ obstacles, desiredHeight: 96 });
+    const tall = place({ obstacles, desiredHeight: 1344 });
+    expect(short.top).toBe(tall.top);
+    expect(short.maxHeight).toBe(tall.maxHeight);
+    // Only the reported shortfall differs — that is what the height is for.
+    expect(short.hiddenHeight).toBe(0);
+    expect(tall.hiddenHeight).toBeGreaterThan(0);
+  });
+
+  it('is a pure function of the layout — same input, same pixel', () => {
+    const obstacles = [TOP_CHROME, ...windowAt(80)];
+    const answers = Array.from({ length: 8 }, () => JSON.stringify(place({ obstacles })));
+    expect(new Set(answers).size).toBe(1);
+  });
+
+  it('never lets the popover run off the bottom of the viewport', () => {
+    for (let windowTop = 72; windowTop <= 900; windowTop += 1) {
+      const placement = place({ obstacles: [TOP_CHROME, ...windowAt(windowTop)] });
+      expect(placement.top).toBeGreaterThanOrEqual(0);
+      expect(placement.top + placement.maxHeight).toBeLessThanOrEqual(SAFE_BOTTOM);
+    }
+  });
+
+  it('clears the hard zones at every window position it can be dragged to', () => {
+    const failures: number[] = [];
+    for (let windowTop = 72; windowTop <= 900; windowTop += 1) {
+      const obstacles = [TOP_CHROME, ...windowAt(windowTop)];
+      if (coversHard(place({ obstacles }), obstacles)) failures.push(windowTop);
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it('honours the 132px offset the narrow-viewport media query switches to', () => {
+    const obstacles = [TOP_CHROME, ...windowAt(600)];
+    const placement = place({ homeTop: 132, obstacles, viewportHeight: 800 });
+    expect(placement.top).toBe(132);
+    expect(placement.maxHeight).toBe(461);
+  });
+
+  it('reports the overlap it could not avoid rather than pretending it cleared', () => {
+    // A window tall enough that its hard zones leave no band anywhere.
+    const obstacles: PlacementObstacle[] = [
+      TOP_CHROME,
+      { id: 'window-head', priority: 'hard', left: 0, top: 60, width: 1440, height: 900 },
+    ];
+    const placement = place({ obstacles });
+    expect(placement.clearsHard).toBe(false);
+    expect(placement.strategy).toBe('no-clear-band');
+    expect(placement.hardOverlap).toBeGreaterThan(0);
+  });
+
+  it('prefers the band that covers less of the window body when travel ties', () => {
+    // One hard zone at 408-592 leaves bands [0, 400] and [600, 958] after the
+    // breathing room. Their nearest-to-home positions are 160 and 600 — exactly
+    // 220px either side of a home of 380, so only soft overlap tells them apart.
+    const hardZone: PlacementObstacle = { id: 'window-head', priority: 'hard', left: 1000, top: 408, width: 400, height: 184 };
+    const softOver = (top: number, height: number): PlacementObstacle => ({ id: 'window', priority: 'soft', left: 1000, top, width: 400, height });
+
+    const softAbove = place({ homeTop: 380, obstacles: [hardZone, softOver(160, 240)] });
+    expect(softAbove.top).toBe(600);
+    expect(softAbove.softOverlap).toBe(0);
+
+    const softBelow = place({ homeTop: 380, obstacles: [hardZone, softOver(600, 358)] });
+    expect(softBelow.top).toBe(160);
+    expect(softBelow.softOverlap).toBe(0);
+  });
+});

--- a/src/artifacts/claude-science-msa.css
+++ b/src/artifacts/claude-science-msa.css
@@ -31,9 +31,110 @@
 .motif-cs-msa-workspace .motif-cs-msa-alphabet-warning strong { color: var(--text-primary); }
 .motif-cs-msa-workspace .motif-cs-msa-alphabet-warning .motif-cs-mini-button { margin-left: auto; }
 
+/* The cursor channel is declared on the frame rather than the matrix because the
+   overview viewport is the matrix's sibling and draws on this same channel: "the
+   window you are looking at" and "the cell the keyboard is on" are one statement
+   about where the system is pointing, made by two widgets that never abut.
+   Accent is left to mean one thing only — the region you committed to. */
+.motif-cs-msa-matrix-frame {
+  /* The cursor has to stay legible ON TOP of the selection rule, because its
+     default position is the selection's own corner: a drag-select leaves it
+     there, and a single click makes a 1x1 band pixel-coincident with it. Accent
+     cannot do that — every accent variant lands within 1.3:1 of the rule. Ink
+     puts the cursor on the luminance axis, which no other overlay uses and which
+     red-green colour vision deficiency does not compress. */
+  --motif-cs-msa-cursor-rule: var(--text-primary);
+  --motif-cs-msa-cursor-keyline: var(--bg-primary);
+}
+
+/* ===== Matrix shell: the frame's clip boundary is not the visible box =====
+   The frame clips, so anything it cannot fit disappears with no scrollbar leading
+   to it. Only the overview and the residue viewport belong in a box like that.
+   The pan slider, status line, order note and selection readout are siblings held
+   by this shell, so they keep their height while the frame absorbs the shrink.
+
+   The shell also carries the enclosure the frame used to draw, so moving those
+   rows out of the clipped box does not move them out of the bordered one — the
+   assembly looks exactly as it did, and the rows' own border-tops still read as
+   dividers within it. */
+.motif-cs-msa-matrix-shell {
+  position: relative; /* containing block for the mid-drag selection readout */
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-width: 0;
+  /* The shell must never be shorter than what it holds, because a border wraps the
+     BORDER BOX and not the overflow. At `min-height: 0` this box measured 97px
+     against 233px of content on a 300px panel, so its bottom border painted a
+     hairline across the residue grid, 8px into row 2 — reading as a row divider that
+     is not one. MSA_MATRIX_SHELL_MIN_HEIGHT derives the floor from the frame's floor,
+     the rows below it, and this border.
+
+     NOT `min-height: auto`, and not min-content or fit-content: measured, all three
+     resolve identically to 469px, because the frame contributes its whole matrix
+     height to a content-based minimum rather than its own floor. All three bind at
+     1024x768 and take body overflow from 0 to 40px, introducing whole-interface
+     scrolling. */
+  min-height: var(--motif-cs-msa-shell-min-height, 234px);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+}
+
+.motif-cs-msa-matrix-shell > .motif-cs-msa-matrix-frame {
+  /* The floor is what makes the body scroll again. At 0 the frame collapses and
+     nothing ever overflows, so the residue viewport just vanishes on a short panel;
+     with a floor the shell outgrows the workspace, the workspace does not clip, and
+     the body's overflow:auto finally has something to scroll.
+
+     The value is DERIVED, not chosen: MSA_MATRIX_FRAME_MIN_HEIGHT in the viewer sums
+     the floors this frame's own two children already declare — the overview row's
+     30px and .motif-cs-msa-matrix-scroll's 142px — for 172px today. A frame shorter
+     than that clips content that has refused to shrink one box further in;
+     deriving it as ruler + 3 rows instead gave 147 and measurably
+     lost 25px to the clip. The literal below is only the fallback for a render that
+     somehow arrives without the variable.
+
+     Not `min-height: min-content`, which computes to ~469px and forces whole-UI
+     scrolling at 1024x768.
+
+     This rule out-specifies (0,2,0 vs 0,1,0) the bare .motif-cs-msa-matrix-frame in
+     motif-artifact.css that still sets min-height:0 and the old enclosure, so the
+     outcome does not depend on which stylesheet loads first. Verified by measurement,
+     not by arithmetic: computed min-height 172px, border-top-width 0px, background
+     rgba(0,0,0,0) on the frame; 1px / rgb(231,231,231) / rgb(255,255,255) on the
+     shell — one border, painted once, on the outer box. */
+  min-height: var(--motif-cs-msa-frame-min-height, 172px);
+  /* flex-shrink stays at 1. Setting it to 0 does fix S2 outright — the residue
+     viewport holds 377px and 9/9 rows through a whole drag — but the frame then
+     demands its full content height everywhere, and 1024x768 goes to 39px of body
+     overflow: whole-UI scrolling, the same regression `min-height: min-content`
+     was reverted for (40px), reached by a different route. Measured, not assumed. */
+  /* The enclosure moved to the shell; drawing it twice would double the border. */
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
 .motif-cs-msa-matrix {
   position: relative;
-  --motif-cs-msa-selection-rule: color-mix(in srgb, var(--accent) 86%, var(--text-primary));
+  /* Undiluted accent, NOT `color-mix(... var(--accent) 86%, var(--text-primary))`.
+     `--text-primary` is by definition the maximum-contrast colour against the
+     background, so mixing any mark toward it buys contrast against the mark's own
+     backdrop — a quantity this design already holds in surplus — and spends it on
+     the scarce one: separation from the CURSOR, which IS ink
+     (`--motif-cs-msa-cursor-rule`, ~line 46), and which sits pixel-coincident with
+     the band's own corner after a drag-select. Self-defeating for the one pair that
+     has to stay apart.
+
+     Read out of Chrome (not recomputed from source), band-vs-cursor WCAG,
+     mixed -> undiluted:
+       light 2.94 -> 3.60 (crosses 3:1)   dark 2.41 -> 2.79
+       claude-light 2.20 -> 2.52          claude-dark 1.95 -> 2.19
+     Nothing is given up for it: band-vs-`--bg-primary` goes 5.98-6.66 -> 5.29-5.76,
+     still nearly double the 3:1 floor a region boundary owes.
+     `claude-science-msa-colour-guards.test.ts` pins both the shape and that floor. */
+  --motif-cs-msa-selection-rule: var(--accent);
   --motif-cs-msa-hover-rule: color-mix(in srgb, var(--text-primary) 42%, var(--border-strong));
   --motif-cs-msa-jump-rule: var(--purple);
 }
@@ -89,12 +190,28 @@
 }
 
 /* Roving keyboard focus stays independent of hover, selection, search, and
-   jump overlays so every combination remains visible. */
+   jump overlays so every combination remains visible. It cannot share the
+   selection's hue: the cursor's default position IS the selection's own corner,
+   and a single click makes the two pixel-coincident, where the cursor (z 5)
+   covers the band (z 3) entirely. Ink plus a surface keyline instead. The
+   channels are disjoint on purpose — outline + ::before here, box-shadow for
+   search, ::after for the jump tick — so one cell can carry all three at once. */
 .motif-cs-msa-symbol[data-active-cell='true'] {
   position: relative;
   z-index: 5;
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--motif-cs-msa-cursor-rule);
   outline-offset: -2px;
+}
+/* Keeps the ink ring off any saturated cell fill — blocks mode reaches accent
+   52%. Collapses to nothing below ~4px cells, which is correct: at that zoom
+   the cursor should read as a solid tile. */
+.motif-cs-msa-symbol[data-active-cell='true']::before {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  z-index: 1;
+  border: 1px solid var(--motif-cs-msa-cursor-keyline);
+  pointer-events: none;
 }
 .motif-cs-msa-symbol[data-active-cell='true']:focus-visible {
   outline-width: 3px;
@@ -145,6 +262,31 @@
   border: 1px solid color-mix(in srgb, var(--accent) 26%, transparent);
   color: var(--text-primary, inherit);
 }
+/* Mid-drag the readout floats over the shell's bottom chrome instead of claiming a row
+   of its own. Taking a row while the pointer is down shrinks the residue viewport by
+   46px and cuts 1-2 rows off the bottom — moving the rows being dragged toward.
+
+   The viewer only raises data-live when that chrome strip is measurably tall enough to
+   hold it (see readoutPlacement). The float is anchored to the shell's bottom and grows
+   upward, so where the strip is a lone status line — which is whenever the alignment
+   fits horizontally and no pan row mounts — it overhangs into the last residue row.
+   Measured at 7px of opaque panel across the rows the pointer is aiming at, which is
+   worse than the shrink the float exists to avoid, so that case stays in flow.
+
+   For the length of the drag it covers the status line and pan slider, neither of which
+   can be operated while a pointer is captured on the grid. That is NOT a claim they do
+   not matter: on a short panel the whole strip is below the fold, so the float is
+   off-screen there too and provides no feedback at all. Where mid-drag feedback should
+   actually live is a separate question, filed rather than answered here. */
+.motif-cs-msa-selection-readout[data-live] {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 3;
+  margin-top: 0;
+}
+
 .motif-cs-msa-selection-readout strong { color: var(--accent); }
 .motif-cs-msa-selection-readout span { color: var(--text-secondary, inherit); }
 .motif-cs-msa-selection-readout .motif-cs-mini-button { margin-left: auto; }
@@ -184,8 +326,11 @@
   outline: none;
 }
 
-/* Remove the legacy jump wash before later residue, shade, and blocks rules
-   restore their own backgrounds. The marker itself is drawn near search. */
+/* position:relative is load-bearing: it anchors the edge tick drawn further
+   down. The background/shadow resets are only a baseline saying "being the jump
+   target is not itself a fill" — later residue, shade, difference, and search
+   rules deliberately override them, so a marked cell still shows its own
+   colouring. Do not raise this rule's specificity to make them stick. */
 .motif-cs-msa-symbol[data-jump='true'] {
   position: relative;
   background: transparent;
@@ -770,21 +915,81 @@
   top: 25%;
   bottom: 25%;
   left: 1px;
-  width: 3px;
+  /* Zooming out shrinks cells to ~3px, where a fixed 3px tick is wider than the
+     column it marks and bleeds into its neighbour. Cap it against cell width. */
+  width: min(3px, max(1px, calc(var(--motif-cs-msa-cell-width, 10px) * 0.5)));
   border-radius: 999px;
   background: var(--motif-cs-msa-jump-rule);
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--bg-primary) 78%, transparent);
   pointer-events: none;
 }
 
+/* Where the tick sits on a saturated fill, the translucent halo above is not
+   enough separation — purple on the dark conservation bar measures 1.5:1, and
+   in blocks mode a "positive" cell is purple under a purple tick. An opaque
+   ring gives the marker its own edge to be read by, independent of the fill.
+   Must stay above the forced-colors block below: equal specificity, so a later
+   rule would silently reinstate a shadow there. */
+.motif-cs-msa-hist-cell[data-jump='true']::after,
+.motif-cs-msa-logo-col[data-jump='true']::after,
+.motif-cs-msa-matrix[data-blocks='true'] .motif-cs-msa-symbol[data-jump='true']::after {
+  box-shadow: 0 0 0 1px var(--bg-primary);
+}
+
+/* Forced-colors neutralises background and box-shadow, which would erase the
+   tick entirely. Re-express it as a system-coloured bar so the jump target
+   stays findable in high-contrast mode. */
+@media (forced-colors: active) {
+  .motif-cs-msa-hist-cell[data-jump='true']::after,
+  .motif-cs-msa-logo-col[data-jump='true']::after,
+  .motif-cs-msa-aa[data-jump='true']::after,
+  .motif-cs-msa-symbol[data-jump='true']::after {
+    /* Not Highlight: it resolves near-CanvasText, so the tick reads as one more
+       black bar among the letters, and it is semantically the selection colour. */
+    background: LinkText;
+    forced-color-adjust: none;
+    box-shadow: none;
+  }
+  /* Forced-colors collapses every border and outline onto one system ink, which
+     would re-merge the cursor and the selection rule that the cursor token above
+     exists to separate. Highlight is right here, unlike for the jump tick: this
+     one IS the selection. */
+  .motif-cs-msa-selection-band {
+    border-color: Highlight;
+    forced-color-adjust: none;
+  }
+}
+
 /* ===== Sequence search ===== */
+/* The elastic member of the control row. With one item that can give width back,
+   the row cannot be forced to wrap by the others — that is a property, not a
+   coincidence that happens to hold at one window size. */
 .motif-cs-msa-search {
   display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
   align-items: center;
   gap: 4px;
 }
 .motif-cs-msa-search-icon { color: var(--text-muted, inherit); flex: 0 0 auto; }
-.motif-cs-msa-search-input { width: 150px; min-width: 90px; }
+
+/* The shared .motif-cs-input is sized for stacked form panels: 36px tall with
+   12px/6px block margins. Inline in a control row that is ~28px of dead
+   height. This sheet loads before motif-artifact.css, so an equal-specificity
+   override would lose on order — hence the parent-scoped selector. */
+.motif-cs-msa-search .motif-cs-msa-search-input {
+  width: auto;
+  min-width: 90px;
+  max-width: 190px;
+  flex: 1 1 150px;
+  height: 26px;
+  margin: 0;
+}
+/* React renders an empty string as no child at all, so this matches whenever no
+   query is typed — the row gets 52px back for free while idle. */
+.motif-cs-msa-search-count:empty {
+  min-width: 0;
+}
 .motif-cs-msa-search-count {
   min-width: 52px;
   font-size: 11px;

--- a/src/artifacts/claude-science-msa.ts
+++ b/src/artifacts/claude-science-msa.ts
@@ -1254,8 +1254,8 @@ function compareMotifMatches(a: MsaMotifMatchOrder, b: MsaMotifMatchOrder): numb
  * Retains only the `capacity` globally-earliest matches (by compareMotifMatches)
  * using a binary max-heap, so a low-complexity query stays O(total × log capacity)
  * in time and O(capacity) in memory no matter how many raw hits it produces —
- * instead of collecting every hit and sorting (which the row-order cap got wrong,
- * and which could exhaust memory before the count cap ever tripped).
+ * instead of collecting every hit and sorting, which could exhaust memory before
+ * the count cap ever tripped.
  */
 class BoundedEarliestMatches {
   private heap: MsaMotifMatch[] = [];

--- a/src/artifacts/claude-science-primer-workspace.css
+++ b/src/artifacts/claude-science-primer-workspace.css
@@ -698,6 +698,7 @@
 .motif-cs-primer-workspace-footer {
   flex: 0 0 auto;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 14px;
@@ -707,13 +708,18 @@
   background: var(--panel-bg);
 }
 
+/* The status carries the QC verdict, so it wraps rather than ellipsising: the
+   ΔTm sits at the end of the sentence and was the first thing cut. It is the
+   only yielding item next to a rigid 858px button block, so it also needs a
+   flex-basis small enough to stay on the buttons' row at the default window
+   width, and wrap onto its own row rather than collapse to 0 below that. */
 .motif-cs-primer-live-status {
+  flex: 1 1 180px;
   min-width: 0;
-  overflow: hidden;
   color: var(--text-muted);
   font-size: 11px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .motif-cs-primer-footer-actions {
@@ -794,7 +800,11 @@
     flex-direction: column;
   }
 
+  /* The footer is a column here, so the base rule's flex-basis would be read as
+     a height and give the status 180px of empty box. It already spans the full
+     width in a column, so it needs no basis at all. */
   .motif-cs-primer-live-status {
+    flex: 0 0 auto;
     white-space: normal;
   }
 

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -381,14 +381,30 @@ summary,
   background-repeat: no-repeat;
   background-size: 34px 100%, 34px 100%, 16px 100%, 16px 100%, 100% 100%;
   scrollbar-width: thin;
-}
+  /* Thirteen records need 1137px, so this strip scrolls from 1024 down and is
+     the only place the tab for a hidden record can be reached. The edge fades
+     above do work — measured headed, the right fade reads 1.15:1 against the
+     field at scrollLeft 0 and swaps to the left edge at the end — but the bar
+     is the affordance that says how much is left, and it had no colour, so it
+     fell through to the platform default at 1.72:1 in BOTH light themes and
+     2.66:1 in both dark ones, under the 3.0 non-text floor. Identical rgb
+     across light/claude-light and dark/claude-dark is the tell that it was
+     never themed rather than themed badly — the same signature the inventory
+     list had before it was given these tokens.
 
-.motif-cs-record-tabs::-webkit-scrollbar {
-  height: 5px;
-}
+     The two ::-webkit-scrollbar rules that used to sit here were dead text and
+     are gone: `scrollbar-width` above is a standard property, and naming
+     either standard property makes Chromium ignore the pseudo-elements
+     entirely. They declared a 5px bar and a border-strong thumb; the bar
+     measured 11px with Chromium's own thumb, and forcing scrollbar-width back
+     to `auto` snapped it to the declared 5px, which is what proves they were
+     being suppressed rather than simply losing to something else.
 
-.motif-cs-record-tabs::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--border-strong) 45%, transparent);
+     Same two tokens as the alignment matrix, the inventory list and the tools
+     rail, so the app has one scrollbar and not four. */
+  scrollbar-color:
+    color-mix(in srgb, var(--text-muted) 68%, var(--border-strong))
+    color-mix(in srgb, var(--bg-secondary) 78%, var(--bg-primary));
 }
 
 .motif-cs-record-tab {
@@ -488,10 +504,6 @@ summary,
   white-space: nowrap;
 }
 
-.motif-cs-topbar > .motif-cs-chip {
-  margin-left: auto;
-}
-
 .motif-cs-panel-meta {
   flex: 0 0 auto;
   color: var(--text-muted);
@@ -508,10 +520,6 @@ summary,
   gap: 8px;
   margin-left: auto;
   min-width: 0;
-}
-
-.motif-cs-topbar-meta > .motif-cs-chip {
-  display: none;
 }
 
 .motif-cs-pane-switcher {
@@ -842,7 +850,13 @@ summary,
   .motif-cs-sequence-column {
     flex-grow: 0.55;
     flex-shrink: 1;
-    max-width: min(760px, 52vw);
+    /* Raised from min(760px, 52vw), which clipped a drag the script had already
+       allowed and so silently overrode PANE_WIDTH_LIMITS.sequence. Both terms are
+       now set to clear the physical ceiling (main - inventory - toolsRail - handles
+       - map.min) everywhere this rule applies: 80vw is 1025px at 1281 against a
+       ~709px ceiling, and 2048px at 2560 against a ~1988px one. This stays a
+       backstop against runaway flex-grow, not the thing that stops the pointer. */
+    max-width: min(2000px, 80vw);
   }
 }
 
@@ -1038,6 +1052,42 @@ body[data-motif-cs-rail-popover-resizing] {
   pointer-events: auto;
 }
 
+/* Below this height the rail's fifteen tools do not fit, and until now they
+   simply left the screen: Settings — theme, backup, Clear workspace — and
+   Alignment, the 14th icon, became unreachable with no way back. Measured at
+   1440x600: content 625 against 530 of room, and wheel, touch-drag and 120
+   presses of Tab all left it exactly where it was. Only page zoom under 100%
+   recovered them, which is a workaround a stuck user has to already know.
+
+   694px is not a chosen number. The rail holds 15 heads at 34px with 3px
+   between them plus its title and 8px padding, which is 625px of content under
+   a 70px top bar — so 695 is the last height where the last icon fits, and 694
+   is the first where something is hidden. It is exactly the boundary the
+   advisor observed independently. A 16th tool moves it; the guard test ties
+   this constant to the tool count so it cannot drift silently.
+
+   `pointer-events: auto` here does NOT weaken the rule above it. That rule
+   protects EMPTY rail space, and empty rail space is what has just run out:
+   measured 205px at 900, 65px at 760, 5px at 700 and 0px at 694 and below. The
+   passthrough is restored in full the moment there is anything to pass through.
+   Scoping it this way was not caution — with the rail left `pointer-events:
+   none`, `overflow-y: auto` alone is a mirage. The wheel then targets whatever
+   sits BENEATH the rail, so it scrolls only while the pointer is over an icon
+   and is dead in the 3px gaps between them (measured: 103 over an icon, 0 in a
+   gap, at the same height), and the thumb cannot be dragged at all. */
+@media (max-height: 694px) {
+  .motif-cs-inspector[data-tools-pinned="false"] {
+    overflow-y: auto;
+    overflow-x: hidden;
+    pointer-events: auto;
+    /* Same two tokens as the alignment matrix and the inventory list, so the
+       app has one scrollbar and not three. */
+    scrollbar-color:
+      color-mix(in srgb, var(--text-muted) 68%, var(--border-strong))
+      color-mix(in srgb, var(--bg-secondary) 78%, var(--bg-primary));
+  }
+}
+
 .motif-cs-inspector[data-tools-pinned="false"] .motif-cs-pane-title {
   justify-content: center;
   min-height: 32px;
@@ -1105,6 +1155,46 @@ body[data-motif-cs-rail-popover-resizing] {
   display: none;
 }
 
+/* The collapsed rail is the default state, and it hides the chip that sits
+   beside each tool's name. For fourteen of the fifteen tools that costs nothing
+   — their chips are fixed labels ("record", "PCR", "Light") or counts that are
+   already there at load. The Alignment chip is the only one that changes when
+   session content arrives, going from "MSA" to "3 MSA", so suppressing it left
+   the rail looking the same whether the session held no alignments or twenty.
+   This restores that one signal at rail scale. It re-uses the disclosure
+   marker's ::after, which the rule above switches off, rather than adding a
+   node, and it renders only when the attribute is present — a session with no
+   alignments is unmarked, exactly as before. */
+.motif-cs-inspector[data-tools-pinned="false"] summary.motif-cs-panel-head[data-rail-count]::after {
+  position: absolute;
+  top: 5px;
+  right: 6px;
+  display: block;
+  width: 7px;
+  height: 7px;
+  border: 1.5px solid var(--bg-secondary);
+  border-radius: 999px;
+  background: var(--accent);
+  /* A dot, not the number. The rail is deliberately icon-only — it sets every
+     panel label and chip to display:none — so a numeric badge reintroduces text
+     to the one surface that has none, and at two digits it grew wide enough to
+     cover the icon that identifies the tool. What this has to answer is whether
+     the feature has anything in it, not how much; the count itself stays one
+     hover away in the title and spelled out in the panel behind it.
+
+     The `/ ""` is load-bearing rather than decoration. Chrome folds ::after
+     generated content into the accessible name, and an earlier revision that
+     printed the count here REPLACED the head's name outright: measured over
+     CDP, it went from "Multiple sequence alignment" — sourced from the title,
+     since the rail hides the label and chip — to bare "1". */
+  content: "" / "";
+  pointer-events: none;
+}
+
+.motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel-head[data-rail-count] {
+  position: relative;
+}
+
 .motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel-head:hover,
 .motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel-head:focus-visible {
   border-color: color-mix(in srgb, var(--border-strong) 58%, var(--border-subtle));
@@ -1146,7 +1236,17 @@ body[data-motif-cs-rail-popover-resizing] {
   max-width: min(620px, calc(100vw - 104px));
   height: var(--rail-popover-height, auto);
   min-height: 96px;
-  max-height: min(calc(100vh - var(--rail-popover-fixed-top) - 22px), 600px);
+  /* The viewport bound is the only real constraint. A flat 600px used to sit
+     below it at every size we lay out for — including 2560x1400, where this
+     resolves to ~1300px — and because the drag reads its limit straight off the
+     computed max-height, that constant was literally what stopped the pointer.
+     Measured at 1440x980, across the panels that were all cut to 598px visible:
+     translation 811 and analysis 686 now fit whole, settings goes from 341px
+     hidden to 67px, and guide RNA — 1344px, more than any viewport here can
+     hold — shows 872px instead of 598px. Same shape as the sequence pane's old
+     760px cap: a constant below the physical ceiling stops being a backstop and
+     becomes the governor. */
+  max-height: calc(100vh - var(--rail-popover-fixed-top) - 22px);
   overflow: auto;
   overscroll-behavior: contain;
   scrollbar-gutter: stable;
@@ -1157,12 +1257,12 @@ body[data-motif-cs-rail-popover-resizing] {
 }
 
 @media (max-width: 1280px) {
+  /* Only the offset changes here. The base rule's max-height reads this custom
+     property through var(), so it re-resolves on its own — the copy of the
+     declaration that used to live here was byte-identical and did nothing. Two
+     copies of one cap is how the sequence pane ended up needing two fixes. */
   .motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel {
     --rail-popover-fixed-top: 132px;
-  }
-
-  .motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel[open] > .motif-cs-tool-panel-body {
-    max-height: min(calc(100vh - var(--rail-popover-fixed-top) - 22px), 600px);
   }
 }
 
@@ -1178,7 +1278,6 @@ body[data-motif-cs-rail-popover-resizing] {
   gap: 9px;
   padding: 12px;
   --rail-popover-title-offset-x: 12px;
-  --rail-popover-title-offset-y: 12px;
 }
 
 .motif-cs-inspector[data-tools-pinned="false"] .motif-cs-tool-panel-body > .motif-cs-muted:only-child {
@@ -1186,8 +1285,21 @@ body[data-motif-cs-rail-popover-resizing] {
   padding: 12px;
 }
 
+/* The heading spans the popover edge to edge, which means escaping the body's own
+   padding. A negative top margin does that in a block body but NOT in a grid one:
+   grid subtracts the margin from the row track rather than moving the item, so the
+   heading renders `padding - gap` past the bottom of its own track and its opaque
+   sticky background paints over the panel's first line. Measured before this
+   change: 8px of a 20px line in the Inspector — 39% of the glyph height — plus
+   1-4px in five other grid panels. Cancel the body's top padding instead; the
+   heading already carries its own. The horizontal bleed keeps its negative margin,
+   where widening the item past its track is exactly what grid does. */
+.motif-cs-inspector[data-tools-pinned="false"] .motif-cs-tool-panel-body:has(> .motif-cs-rail-popover-title:first-child) {
+  padding-top: 0;
+}
+
 .motif-cs-inspector[data-tools-pinned="false"] .motif-cs-tool-panel-body > .motif-cs-rail-popover-title:first-child {
-  margin: calc(var(--rail-popover-title-offset-y, 0px) * -1) calc(var(--rail-popover-title-offset-x, 0px) * -1) 0;
+  margin: 0 calc(var(--rail-popover-title-offset-x, 0px) * -1) 0;
 }
 
 .motif-cs-inspector[data-tools-pinned="false"] .motif-cs-rail-popover-title {
@@ -1385,10 +1497,6 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
   gap: 6px;
 }
 
-.motif-cs-sequence-title .motif-cs-title-actions .motif-cs-chip {
-  display: none;
-}
-
 .motif-cs-title-row h1 {
   margin: 0;
   font-size: 15px;
@@ -1476,6 +1584,15 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
 
 .motif-cs-map-frame {
   position: relative;
+  /* How much of a row the zoom toolbar occupies, declared on the frame because
+     the toolbar and the status readout are SIBLINGS and in linear mode they
+     share the bottom edge from opposite ends — the readout subtracts this to
+     stay clear. It used to be a bare 126px written into the readout's own
+     max-width, which meant every control added to the toolbar had to remember
+     to go and re-guess a number living somewhere else. Protein and RNA records
+     get no Labels chip, so their toolbar is the original three zoom buttons
+     wide: 28 + 34 + 28, two 2px gaps, and the 12px inset at each end. */
+  --map-toolbar-reserve: 126px;
   /* Map-first workspace: keep the restriction/source panels below the primary
      canvas rather than letting them crowd it. */
   height: clamp(560px, 70vh, 820px);
@@ -1486,6 +1603,14 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
   border-bottom: 1px solid color-mix(in srgb, var(--border-subtle) 72%, transparent);
   border-radius: 0;
   overflow: hidden;
+}
+
+/* DNA records add the Labels chip, so their toolbar runs 163px rather than 94px
+   and the readout has to start further in. Keyed off the chip being present so
+   the reserve follows what is actually rendered instead of restating the gate
+   that renders it. */
+.motif-cs-map-frame:has(.motif-cs-map-labels-toggle) {
+  --map-toolbar-reserve: 200px;
 }
 
 /* A linear map is short and wide — don't reserve a tall square frame for it,
@@ -1555,13 +1680,18 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
   stroke: none;
 }
 
+/* Crosshair unconditionally, because background drag is range selection and that
+   is true at every zoom. There used to be a second rule here keyed on
+   `data-pannable='true'` setting the identical cursor — it existed to beat the
+   `grab` that the map's own stylesheet applied once the viewport was
+   transformed. So the map advertised a drag-to-pan that no host ever wired, and
+   this override quietly hid the evidence: the cursor a user saw was always
+   crosshair. The attribute and the `grab` are both gone now, and a rule that
+   overrides something no longer declared is just a place for the next reader to
+   lose ten minutes. */
 .motif-cs-map-frame .motif-pm-bg {
   cursor: crosshair;
   touch-action: none;
-}
-
-.motif-cs-map-frame .motif-pm-bg[data-pannable='true'] {
-  cursor: crosshair;
 }
 
 /* The painted backbone is map geometry, not a control. Let pointer starts fall
@@ -1616,6 +1746,27 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
   font-weight: 700;
 }
 
+/* Puts restriction-label state on the map instead of only in a panel whose own
+   heading is below the fold at every laptop size. Sized for the wider of its
+   two captions so the zoom buttons beside it do not shift when it is pressed —
+   a control that moves when you use it reads as two controls. */
+.motif-cs-map-labels-toggle {
+  width: auto;
+  min-width: 62px;
+  padding-inline: 7px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+/* Labels default on, so this is the resting look: a filled chip is both the
+   state and what makes the caption legible over map ink. */
+.motif-cs-map-labels-toggle[data-active] {
+  border-color: color-mix(in srgb, var(--border-strong) 55%, transparent);
+  background: color-mix(in srgb, var(--bg-primary) 82%, transparent);
+  color: var(--text-primary);
+}
+
 .motif-cs-map-button:hover,
 .motif-cs-map-button:focus-visible {
   border-color: color-mix(in srgb, var(--border-strong) 55%, transparent);
@@ -1654,8 +1805,30 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
 .motif-cs-map-frame[data-map-mode="linear"] .motif-cs-map-hint {
   right: 12px;
   left: auto;
-  max-width: min(320px, calc(100% - 126px));
+  max-width: min(320px, calc(100% - var(--map-toolbar-reserve)));
   text-align: right;
+}
+
+/* Between 768px and 1535px a circular frame is floored taller than its column
+   can show — measured 504px of frame in a 442px column at 1440x900, with 141px
+   scrolled away — so the frame's BOTTOM edge is off-screen in every state. That
+   is not a zoom artefact: the readout's top sits at the same y at rest and at
+   244%, because the clip is static. The zoom controls survive only by being
+   anchored to `top`, so anchor the readout to the same edge it is safe on,
+   opposite the controls for the reason written above. Deliberately not applied
+   from 1536px up, where the column does fit its frame and the quiet lower-left
+   corner is both reachable and less noisy. The structural half — that a 410px
+   map floor plus a 26px title plus a 33px dock cannot fit a 442px column — is
+   filed separately; this rule stops the readout paying for it. */
+@media (min-width: 768px) and (max-width: 1535px) {
+  .motif-cs-map-frame[data-map-mode="circular"] .motif-cs-map-hint {
+    top: 12px;
+    right: 12px;
+    bottom: auto;
+    left: auto;
+    max-width: min(320px, calc(100% - 126px));
+    text-align: right;
+  }
 }
 
 .motif-cs-panel {
@@ -1742,6 +1915,38 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
 .motif-cs-map-dock-strip:has(> details[open]) {
   display: block;
   border-bottom: 0;
+}
+
+/* A column footer, because these two heads are the end of the map workflow and
+   they were reliably off-screen: measured below the column's visible edge by
+   138px at 900x700, 133px at 1024x768, 131px at 1280x900 and at 1440x900, and
+   85px at 1440x1200 — every desktop size below 1536 except 1920x1080, where the
+   column does not overflow at all.
+
+   This is the app's first sticky FOOTER; the ten that already exist are headers
+   at `top: 0`, so this mirrors their idiom rather than inventing one. It needs no
+   breakpoint: `bottom` only engages while an ancestor actually scrolls, so at
+   1920 — where the column hides 0px — the strip stays exactly where it is today,
+   in flow at the end of the content.
+
+   Only while both panels are COLLAPSED. Open one and this element becomes the
+   whole panel body, and pinning that to the bottom would cover the map rather
+   than finish it; open is also the state the column already scrolls into view.
+
+   `bottom: -10px` cancels the column's own 10px padding so the strip lands flush
+   on the scrollport edge rather than floating a gap above it. Opaque
+   `--bg-primary` matches the map frame it now overlaps, so the map cannot show
+   through it, and the top border supplies the separation the bottom border gave
+   while this sat at the end of the flow.
+
+   It cannot collide with the map's status readout: e69d11e anchors that to the
+   frame's TOP edge across 768–1535, which is this rule's entire working range. */
+.motif-cs-map-dock-strip:not(:has(> details[open])) {
+  position: sticky;
+  bottom: -10px;
+  z-index: 4;
+  border-top: 1px solid color-mix(in srgb, var(--border-subtle) 78%, transparent);
+  background: var(--bg-primary);
 }
 
 .motif-cs-map-dock-strip > .motif-cs-panel {
@@ -1942,7 +2147,6 @@ details:not([open]) > .motif-cs-panel-head {
   gap: 4px;
   padding: 12px;
   --rail-popover-title-offset-x: 12px;
-  --rail-popover-title-offset-y: 12px;
   /* Reserve the tallest state (title + meta + stats) so selecting a feature
      never grows the Inspector and shoves Motif / Features / editor down. */
   min-height: 98px;
@@ -2025,6 +2229,18 @@ details:not([open]) > .motif-cs-panel-head {
   overflow: auto;
   overscroll-behavior: contain;
   scrollbar-gutter: stable;
+  /* This list is the only place a laptop-sized session meets its whole vector
+     inventory, and it hides 237px of it at 1440x900 and 303px at 1024x768. The
+     gutter above reserves the lane, but with no colour the bar fell through to
+     the platform default and measured 1.72:1 against its own track in BOTH
+     light themes and 2.66:1 in both dark ones — under the 3.0 non-text floor.
+     Identical rgb in all four themes is how you can tell it was never themed
+     rather than themed badly. At that contrast the list appears to end, leaving
+     the rows below it undiscoverable. Same two tokens as the alignment matrix's
+     scroller, so the app has one scrollbar and not two. */
+  scrollbar-color:
+    color-mix(in srgb, var(--text-muted) 68%, var(--border-strong))
+    color-mix(in srgb, var(--bg-secondary) 78%, var(--bg-primary));
   border-top: 0;
 }
 
@@ -2220,14 +2436,65 @@ summary.motif-cs-panel-head {
   border-top: 1px solid color-mix(in srgb, var(--border-subtle) 72%, transparent);
 }
 
+/* No height cap, because nothing here needs one: every container this list can
+   appear in already scrolls. Measured in all three — the unpinned rail popover's
+   body is overflow-y: auto with a definite height, and in BOTH the pinned docked
+   column and the floated Tools pane the inspector itself is overflow-y: auto and
+   already scrolling, so the extra height is absorbed by a scroller that exists.
+
+   It used to read `max-height: min(24vh, 190px)`, which resolves to a flat 190px
+   at every viewport height above 792px. `c999493` fixed that — but only inside
+   `.motif-cs-inspector[data-tools-pinned="false"]`, so the two states that
+   selector does not match kept the whole defect, and nothing looked wrong because
+   a fix was on record. Measured in the pinned state: clientHeight 189 against
+   scrollHeight 288, 3 of 8 rows unreachable while the panel's own header said "8
+   features" — identically at 1440x900, 1440x980, 1920x1080 and 2560x1400, which
+   is the constant winning rather than any viewport effect. Those are the same
+   numbers that comment below records as already fixed.
+
+   Fixed at the BASE rule rather than with a third higher-specificity override:
+   an override leaves the original in force for every state it does not match,
+   which is exactly how this survived the first fix. `overflow: auto` stays — it
+   is live in the popover, where the list can be squeezed below its content. */
 .motif-cs-feature-annotation-list {
-  max-height: min(24vh, 190px);
   overflow: auto;
 }
 
 .motif-cs-translation-annotation-list {
   max-height: 96px;
   overflow: auto;
+}
+
+/* As a rail popover this panel has a definite height — dragged, or the viewport
+   bound — so the features list takes what is left instead of capping itself at a
+   constant. min(24vh, 190px) resolves to 190 at every viewport height above
+   792px, so the list sat at clientHeight 189 against scrollHeight 288 with 3 of
+   8 features unreachable, identically at 1440x980 and 2560x1400, while the
+   panel's own header said "8 features". Dragging the popover from 391px to
+   598px moved none of them: 207px of new height went to a list that had already
+   decided how tall it was.
+
+   Only the features list flexes. Giving both lists flex-shrink weights the
+   shrink by flex-basis, so a long features list would crush the translations
+   list from the 95px it needs to about 7px — the two lists are not peers, and
+   the small one has no reason to yield. The popover keeps overflow: auto, so if
+   a panel is dragged shorter than the floor below, it scrolls as one surface
+   rather than clipping. */
+.motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel[open] > .motif-cs-annotation-panel-body {
+  display: flex;
+  flex-direction: column;
+}
+
+.motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel[open] > .motif-cs-annotation-panel-body > .motif-cs-feature-annotation-list {
+  flex: 1 1 auto;
+  min-height: 72px; /* two rows; the popover scrolls rather than go below this */
+  max-height: none;
+}
+
+.motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel[open] > .motif-cs-annotation-panel-body > .motif-cs-rail-popover-title,
+.motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel[open] > .motif-cs-annotation-panel-body > .motif-cs-annotation-section-label,
+.motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel[open] > .motif-cs-annotation-panel-body > .motif-cs-translation-annotation-list {
+  flex: 0 0 auto;
 }
 
 .motif-cs-annotation-list .motif-cs-muted {
@@ -3548,7 +3815,6 @@ summary.motif-cs-panel-head {
 
 .motif-cs-entry-form {
   --rail-popover-title-offset-x: 12px;
-  --rail-popover-title-offset-y: 10px;
 }
 
 .motif-cs-form-body label,
@@ -4820,6 +5086,19 @@ body[data-motif-cs-export-resizing] {
   white-space: nowrap;
 }
 
+/* Marks where this bar stops editing the open record and starts adding new ones
+   to the inventory. Decoration only — the "New" in the two labels after it is
+   what actually carries the meaning, so this is aria-hidden and never the sole
+   signal. Kept to a hairline because the cluster already clips below ~720px. */
+.motif-cs-selection-actions .motif-cs-selection-action-rule {
+  flex: 0 0 auto;
+  align-self: center;
+  width: 1px;
+  height: 16px;
+  margin-inline: 1px;
+  background: color-mix(in srgb, var(--border-strong) 70%, transparent);
+}
+
 .motif-cs-selection-actions .motif-cs-label-short {
   display: none;
 }
@@ -5129,8 +5408,18 @@ body[data-motif-cs-export-resizing] {
   background: linear-gradient(to bottom, var(--bg-primary), color-mix(in srgb, var(--bg-primary) 96%, var(--workspace-bg)));
 }
 
+/* The corner grip is window chrome, so it has to paint above whatever the body
+   happens to contain. Without a z-index it only beat content that stacks at
+   auto: a sticky toolbar (z-index 10) that wraps taller than a short body ends
+   up drawn over the bottom-right corner, and then the grip is not the element
+   under the pointer — press, drag, release all go to the toolbar and the window
+   can no longer be resized by mouse at all. 20 clears every layer a body can
+   raise today (sticky toolbar 10, drag-drop overlay 12) and is scoped to this
+   window by the `isolation: isolate` above, so it cannot reorder anything else.
+   The floating-pane grip already does the same thing with its own z-index: 8. */
 .motif-cs-window-resize {
   position: absolute;
+  z-index: 20;
   right: 0;
   bottom: 0;
   width: 28px;
@@ -5236,7 +5525,6 @@ summary.motif-cs-panel-head:focus-visible {
   gap: 8px;
   padding: 12px;
   --rail-popover-title-offset-x: 12px;
-  --rail-popover-title-offset-y: 12px;
 }
 
 .motif-cs-cloning-launcher-copy {
@@ -6130,7 +6418,6 @@ summary.motif-cs-panel-head:focus-visible {
   gap: 10px;
   padding: 12px;
   --rail-popover-title-offset-x: 12px;
-  --rail-popover-title-offset-y: 12px;
 }
 
 .motif-cs-alignment-tool-intro {
@@ -6233,9 +6520,26 @@ summary.motif-cs-panel-head:focus-visible {
 .motif-cs-msa-workspace {
   position: relative;
   display: flex;
+  flex: 1 1 auto;
   min-width: 0;
+  min-height: 0;
   flex-direction: column;
   gap: 9px;
+}
+
+/* Let the workspace claim the panel's height so the matrix can flex into it.
+   Scoped with :has() so other windows keep their plain block body.
+
+   The matrix frame, not the workspace, is the condition. Only the Viewer has a
+   matrix, and only the Viewer wants this: it flexes into the panel and owns its
+   own scrolling, so the body must not scroll. Traces and Text have no matrix and
+   are naturally taller than the panel — they need the body to scroll as it
+   always did. Keying this on the workspace alone made the body a flex column in
+   every mode, which stopped the trace stack's window scrolling entirely. */
+.motif-cs-window-body:has(> .motif-cs-msa-workspace .motif-cs-msa-matrix-frame),
+.motif-cs-pane:has(> .motif-cs-msa-workspace .motif-cs-msa-matrix-frame) {
+  display: flex;
+  flex-direction: column;
 }
 
 .motif-cs-msa-drop-overlay {
@@ -6312,6 +6616,11 @@ summary.motif-cs-panel-head:focus-visible {
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--bg-secondary) 60%, var(--bg-primary));
+}
+
+/* Reclaim the banner's row once a result exists — "Edit inputs" reopens it. */
+.motif-cs-msa-source[data-redundant="true"] {
+  display: none;
 }
 
 .motif-cs-msa-source > summary {
@@ -6426,8 +6735,7 @@ summary.motif-cs-panel-head:focus-visible {
 
 .motif-cs-msa-source-fields label,
 .motif-cs-msa-export-row label,
-.motif-cs-msa-reference-picker,
-.motif-cs-msa-sort-picker {
+.motif-cs-msa-reference-picker {
   display: grid;
   min-width: 0;
   gap: 3px;
@@ -6719,12 +7027,22 @@ summary.motif-cs-panel-head:focus-visible {
   gap: 5px;
 }
 
-.motif-cs-msa-view-menu {
-  position: relative;
+/* The toolbar's disclosure menus share one trigger treatment. `:is()` keeps the
+   specificity at a single class, so these still lose to anything more specific
+   exactly as the single-selector rules did.
+
+   They are deliberately NOT positioned. The panels are right-anchored, so
+   anchoring to the trigger meant any panel wider than the gap between the
+   trigger and the left edge hung off-screen — at a 760px window the view menu's
+   panel began 106px past the left edge, unreachable. Left static, the panels
+   resolve against .motif-cs-msa-toolbar, which is already a containing block
+   (position: sticky); `right: 0` then means the toolbar's right edge, and a
+   panel narrower than the toolbar cannot overflow at any width. */
+:is(.motif-cs-msa-view-menu, .motif-cs-msa-export-menu, .motif-cs-msa-goto-menu) {
   flex: 0 0 auto;
 }
 
-.motif-cs-msa-view-menu > summary {
+:is(.motif-cs-msa-view-menu, .motif-cs-msa-export-menu, .motif-cs-msa-goto-menu) > summary {
   display: inline-flex;
   min-height: 28px;
   align-items: center;
@@ -6742,29 +7060,121 @@ summary.motif-cs-panel-head:focus-visible {
   white-space: nowrap;
 }
 
-.motif-cs-msa-view-menu > summary::-webkit-details-marker {
+:is(.motif-cs-msa-view-menu, .motif-cs-msa-export-menu, .motif-cs-msa-goto-menu) > summary::-webkit-details-marker {
   display: none;
 }
 
-.motif-cs-msa-view-menu > summary:hover,
-.motif-cs-msa-view-menu > summary:focus-visible,
-.motif-cs-msa-view-menu[open] > summary {
+:is(.motif-cs-msa-view-menu, .motif-cs-msa-export-menu, .motif-cs-msa-goto-menu) > summary:hover,
+:is(.motif-cs-msa-view-menu, .motif-cs-msa-export-menu, .motif-cs-msa-goto-menu) > summary:focus-visible,
+:is(.motif-cs-msa-view-menu, .motif-cs-msa-export-menu, .motif-cs-msa-goto-menu)[open] > summary {
   border-color: color-mix(in srgb, var(--accent) 45%, var(--border-subtle));
   background: var(--control-hover);
   color: var(--text-primary);
 }
 
-.motif-cs-msa-view-menu > summary:focus-visible {
+:is(.motif-cs-msa-view-menu, .motif-cs-msa-export-menu, .motif-cs-msa-goto-menu) > summary:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
 
-.motif-cs-msa-view-menu > summary > svg:last-child {
+:is(.motif-cs-msa-view-menu, .motif-cs-msa-export-menu, .motif-cs-msa-goto-menu) > summary > svg:last-child {
   transition: transform var(--duration-fast) ease;
 }
 
-.motif-cs-msa-view-menu[open] > summary > svg:last-child {
+:is(.motif-cs-msa-view-menu, .motif-cs-msa-export-menu, .motif-cs-msa-goto-menu)[open] > summary > svg:last-child {
   transform: rotate(180deg);
+}
+
+/* The export panel is a small stack of grouped controls rather than the view
+   menu's checkbox grid, so it gets its own box. Width is capped against the
+   panel it lives in, not the viewport, so a narrow host cannot push it off the
+   left edge. */
+.motif-cs-msa-export-menu > .motif-cs-msa-export-menu-panel {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 5px);
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  /* The panel keeps .motif-cs-msa-export-row, whose `flex-wrap: wrap` is right
+     for a horizontal strip and wrong here: in a column box, wrapping breaks
+     overflow into a SECOND COLUMN instead of a scroll, so `overflow: auto` below
+     could never fire vertically and a tall panel grew sideways into its own
+     max-width clip. */
+  flex-wrap: nowrap;
+  align-items: stretch;
+  gap: 7px;
+  width: max-content;
+  max-width: min(300px, calc(100cqw - 20px));
+  /* Bounded by the WINDOW, not the viewport. The panel is absolutely positioned
+     against the toolbar, which is sticky inside a scrolling body — so a panel
+     taller than the body is clipped and scrolling reveals nothing, because the
+     sticky toolbar carries its own child along. `100vh` measured the wrong box
+     entirely: on a large display it never binds, and a window dragged down to
+     its 180px floor put Save PNG and Save SVG out of reach. */
+  max-height: max(120px, min(430px, calc(var(--motif-cs-window-height, 100vh) - 110px)));
+  overflow: auto;
+  overscroll-behavior: contain;
+  padding: 9px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+}
+
+.motif-cs-msa-export-menu > .motif-cs-msa-export-menu-panel > .motif-cs-msa-export-image {
+  padding-top: 7px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.motif-cs-msa-export-menu > .motif-cs-msa-export-menu-panel > .motif-cs-muted {
+  /* The panel keeps the export-row class, so `flex: 1 1 220px` from the old
+     horizontal strip still matches — but this box is a column, where a
+     flex-basis is a HEIGHT. Unreset it added 220px of empty space under 150px
+     of controls. */
+  flex: 0 0 auto;
+  max-width: 260px;
+  white-space: normal;
+  font-size: 9.5px;
+  line-height: 1.35;
+}
+
+/* One small form rather than the export panel's stack, but the same box so the
+   three toolbar menus read as one family. Anchored to the toolbar, not the
+   trigger, for the same reason given above the shared trigger rules. */
+.motif-cs-msa-goto-menu > .motif-cs-msa-goto-menu-panel {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 5px);
+  right: 0;
+  width: max-content;
+  max-width: min(300px, calc(100cqw - 20px));
+  /* Same window-relative bound as the export panel. This one had no cap at all,
+     so a short window took the Go button and the coordinate error message with
+     it and offered nothing to scroll. */
+  max-height: max(120px, min(430px, calc(var(--motif-cs-window-height, 100vh) - 110px)));
+  overflow: auto;
+  overscroll-behavior: contain;
+  padding: 9px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+}
+
+.motif-cs-msa-goto-menu-panel > .motif-cs-msa-column-jump {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px;
+}
+
+.motif-cs-msa-goto-menu-panel .motif-cs-msa-coordinate-system {
+  grid-column: 1 / -1;
+}
+
+/* Ties on specificity with claude-science-msa.css's fixed-width input rule, and
+   this file loads second, so these win. That is why they live here. */
+.motif-cs-msa-goto-menu-panel .motif-cs-msa-coordinate-system select,
+.motif-cs-msa-goto-menu-panel .motif-cs-msa-column-jump input {
+  width: 100%;
 }
 
 .motif-cs-msa-view-menu-panel {
@@ -6773,10 +7183,49 @@ summary.motif-cs-panel-head:focus-visible {
   top: calc(100% + 5px);
   right: 0;
   display: grid;
-  width: min(244px, calc(100vw - 36px));
-  max-height: min(430px, calc(100vh - 110px));
+  /* An auto column takes the widest child's min-content width, which here is 5px
+     wider than the panel's content box — enough for a horizontal scrollbar under
+     a vertical one in a 244px menu. minmax(0, 1fr) lets the rows shrink to the
+     panel instead of the panel reporting overflow it cannot show. */
+  grid-template-columns: minmax(0, 1fr);
+  /* 242px of content plus the 15px the scroll gutter below takes out of the
+     content box, so the rows keep the width they had before the gutter was
+     reserved. On a system that already drew a classic scrollbar this panel was
+     227px of content and "Colour scheme" wrapped onto two lines with its select
+     truncated to "Auto (by mo…"; that is now 242 everywhere. */
+  width: min(259px, calc(100vw - 36px));
+  /* Window-relative, for the reason spelled out above the export panel — and now
+     window-relative all the way down. The `min(430px, …)` this used to carry was
+     a constant wearing responsive clothing: the window has to be shorter than
+     540px before the calc() term wins, so every ordinary window got a flat 430px
+     of an 807px list, 379px hidden. Dragging the window taller changed nothing —
+     at a 1384px window the menu still showed 428px and hid 379, leaving 852px of
+     window unused. The subtraction is measured rather than guessed: this panel
+     hangs off the toolbar, which sits 102px below the window top while the
+     toolbar is one row and 184px once it has wrapped to three, so 184 plus 8px
+     of clearance is what fits at every window width. Fitting is not optional:
+     .motif-cs-window is overflow: hidden, so a panel past its bottom edge is
+     gone rather than scrolled to. */
+  max-height: max(120px, calc(var(--motif-cs-window-height, 100vh) - 192px));
   overflow: auto;
   overscroll-behavior: contain;
+  /* The list still outgrows most windows, so the scrollbar is the only thing that
+     says so — and on a system using overlay scrollbars nothing was drawn at rest,
+     which left the menu ending flush against its own border looking complete.
+     Naming a `scrollbar-color` is what forces the classic painted bar there; the
+     gutter is then reserved even when nothing overflows, while the track paints
+     only when there is something to scroll, so it stays a truthful signal.
+     Deliberately NOT the ::-webkit-scrollbar route: setting either standard
+     property makes Chromium ignore those pseudo-elements entirely, so a
+     ::-webkit-scrollbar width beside a scrollbar-color is dead text that
+     silently reverts to the platform's 15px. The alignment matrix carried
+     exactly that pair until it was measured headed and the dead half deleted;
+     a guard now keeps the two from being recombined on any element. */
+  scrollbar-gutter: stable;
+  scrollbar-color:
+    color-mix(in srgb, var(--text-muted) 68%, var(--border-strong))
+    color-mix(in srgb, var(--bg-secondary) 78%, var(--bg-primary));
+  scrollbar-width: auto;
   padding: 8px;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
@@ -6853,9 +7302,13 @@ summary.motif-cs-panel-head:focus-visible {
   max-width: min(320px, 46%);
 }
 
+/* .motif-cs-msa-view-select is here because Sort moved into the View menu and
+   left this shared box behind, rendering as a bare browser control next to the
+   app's own. The other three selects in that menu had never picked it up
+   either, so all four were unstyled and two of them disagreed on height. */
 .motif-cs-msa-alignment-picker select,
 .motif-cs-msa-reference-picker select,
-.motif-cs-msa-sort-picker select,
+.motif-cs-msa-view-select select,
 .motif-cs-msa-export-row select {
   min-width: 0;
   height: 28px;
@@ -6870,6 +7323,17 @@ summary.motif-cs-panel-head:focus-visible {
 .motif-cs-msa-alignment-picker select {
   width: 100%;
 }
+
+/* Row names in one alignment often differ only in their tail ("PAL — Prunus
+   avium" vs "PAL — Pisum sativum"), so a clipped value hides the only part that
+   identifies it. Reserve room for the chevron and ellipsize rather than slicing
+   a glyph in half. */
+.motif-cs-msa-reference-picker select,
+.motif-cs-msa-view-select select {
+  padding-right: 26px;
+  text-overflow: ellipsis;
+}
+
 
 .motif-cs-msa-engine-chip[data-fallback="true"] {
   border-color: color-mix(in srgb, var(--amber) 58%, var(--border-strong));
@@ -7024,6 +7488,35 @@ summary.motif-cs-panel-head:focus-visible {
   background: color-mix(in srgb, var(--red) 9%, var(--control-bg));
 }
 
+/* Counts and provenance share one row: both are read-once metadata, and each
+   previously cost a full strip of the height the residues need. */
+.motif-cs-msa-meta-row {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 6px;
+}
+
+.motif-cs-msa-meta-row > .motif-cs-msa-stats {
+  flex: 1 1 320px;
+}
+
+/* The toolbar above is sticky and opaque. Should any state ever reintroduce
+   overflow in the window body, a transparent row here would read through it. */
+.motif-cs-msa-meta-row {
+  background: var(--bg-primary);
+}
+
+.motif-cs-msa-meta-row > .motif-cs-msa-provenance {
+  flex: 0 1 auto;
+}
+
+/* Expanded provenance needs the full width for its definition list. */
+.motif-cs-msa-meta-row > .motif-cs-msa-provenance[open] {
+  flex: 1 0 100%;
+}
+
 .motif-cs-msa-stats {
   display: flex;
   min-width: 0;
@@ -7047,16 +7540,65 @@ summary.motif-cs-panel-head:focus-visible {
 .motif-cs-msa-view-controls {
   color: var(--text-muted);
   font-size: 10px;
+  /* The container goes HERE, not on .motif-cs-msa-workspace: container-type
+     implies contain: layout, which would make the workspace a containing block
+     for its position: fixed descendants — the hover readout and the context
+     menu, both of which are clamped against the viewport in JS. This row has no
+     fixed descendants. */
+  container-name: motif-cs-msa-controls;
+  container-type: inline-size;
 }
+
+/* The row is left wrappable on purpose. Forcing nowrap here cannot be done with
+   a container query — an element cannot query its own container — and a
+   viewport media query is the wrong axis for a panel that floats inside one.
+   Instead the row is made to FIT: the coordinate form moved to a toolbar menu,
+   the comparison select is narrower, and search is elastic, so it compresses
+   before it ever reaches the point of wrapping. A wrapped row at genuinely
+   narrow widths is the honest outcome anyway — better than hiding controls in a
+   horizontal scroller nobody scrolls. */
 
 .motif-cs-msa-reference-picker {
-  grid-template-columns: auto minmax(90px, 170px);
+  /* The comparison row is pinned to the top of the matrix and tinted, so this
+     select is a secondary path to a value already on screen. It can afford to
+     truncate; every option carries the full name as its title. */
+  grid-template-columns: auto minmax(84px, 132px);
   align-items: center;
 }
 
-.motif-cs-msa-sort-picker {
-  grid-template-columns: auto minmax(84px, 130px);
-  align-items: center;
+/* Under real width pressure the label shortens rather than the row wrapping.
+   Clip-rect, NOT display: none — that would take the select's accessible name
+   with it, and no jsdom test would catch it, because jsdom has no container
+   queries. */
+@container motif-cs-msa-controls (max-width: 820px) {
+  /* Must stay `position: absolute`: out of flow is what keeps the label from
+     becoming a third item in a two-column grid and dropping the select onto a
+     second row. A clip-path variant without it would silently re-wrap the row. */
+  .motif-cs-msa-view-controls .motif-cs-msa-reference-picker > span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
+  .motif-cs-msa-view-controls .motif-cs-msa-reference-picker::before {
+    /* The `/ ''` is the alternative text, and it is load-bearing: generated
+       content counts toward a control's accessible name, and this pseudo-element
+       precedes the clipped label inside it. Without the empty alt the select is
+       announced as "vs Compare against" below 820px and as "Compare against"
+       above it — the same control renaming itself on resize. */
+    content: 'vs' / '';
+    color: var(--text-muted);
+    font-size: 10px;
+    font-weight: 700;
+  }
+
+  .motif-cs-msa-view-controls .motif-cs-msa-reference-picker {
+    grid-template-columns: auto minmax(72px, 118px);
+  }
 }
 
 .motif-cs-msa-difference-nav,
@@ -7120,6 +7662,7 @@ summary.motif-cs-panel-head:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
+
 .motif-cs-msa-difference-nav .motif-cs-mini-button,
 .motif-cs-msa-font-controls .motif-cs-mini-button {
   width: 25px;
@@ -7128,7 +7671,28 @@ summary.motif-cs-panel-head:focus-visible {
 }
 
 .motif-cs-msa-matrix-frame {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
   min-width: 0;
+  /* CLOSED: the non-scrolling children moved out. Only the overview row and the
+     residue viewport live in this clipped box now; the pan slider, status line,
+     order note and selection readout are siblings held by
+     .motif-cs-msa-matrix-shell, so shrinking this frame can no longer put them
+     somewhere no scrollbar reaches.
+
+     The declarations below are what the shell OVERRIDES, and they are kept as the
+     unwrapped fallback: `.motif-cs-msa-matrix-shell > .motif-cs-msa-matrix-frame`
+     in claude-science-msa.css out-specifies them (0,2,0 against 0,1,0, so source
+     order does not decide it) and supplies the real floor plus a transparent,
+     border-less frame — the enclosure paints once, on the shell. Measured on the
+     live app: frame border-top-width 0px and background rgba(0, 0, 0, 0); shell
+     1px / rgb(231, 231, 231) with the rounded corner.
+
+     `min-height: min-content` here is still NOT the fix (~469px, whole-UI scrolling
+     at 1024x768), and neither is `flex-shrink: 0` on the frame (39px of body
+     overflow at the same size). Both were measured and reverted. */
+  min-height: 0;
   overflow: hidden;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
@@ -7188,7 +7752,14 @@ summary.motif-cs-panel-head:focus-visible {
 .motif-cs-msa-overview-viewport {
   right: auto;
   min-width: 6px;
-  border: 1px solid color-mix(in srgb, var(--accent) 82%, var(--text-primary));
+  /* Ink, not accent: this rectangle and the selection band are the viewer's two
+     region outlines, one strip apart, and accent 82% put them within ΔE 2.6 of
+     each other in every theme — the same colour. The viewport marks where the
+     system is looking, which is the cursor's statement, so it takes the cursor's
+     channel (declared on .motif-cs-msa-matrix-frame). Accent then means the
+     selection and nothing else. The 9% accent wash below stays: it is a fill,
+     not a rule, so it never competes with either outline. */
+  border: 1px solid var(--motif-cs-msa-cursor-rule, var(--text-primary));
   border-radius: 2px;
   background: color-mix(in srgb, var(--accent) 9%, transparent);
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--bg-primary) 80%, transparent);
@@ -7197,42 +7768,45 @@ summary.motif-cs-panel-head:focus-visible {
 
 .motif-cs-msa-matrix-scroll {
   width: 100%;
+  /* Height follows the panel this viewer is mounted in, not the browser
+     viewport. A vh cap overflows any host pane shorter than the cap, which
+     forced the whole workspace to scroll and pushed the residues out of view. */
+  flex: 1 1 auto;
   min-height: 142px;
-  max-height: min(46vh, 460px);
+  /* Horizontal is hidden because this surface's horizontal scrollbar is drawn
+     by hand, one box below, as .motif-cs-msa-pan-row — not because the surface
+     does not pan. It does: scrollWidth 3694 against clientWidth 893 on a
+     330-column alignment, and the pan row's range spans exactly that 2801px.
+     The reasons for replacing the platform bar are recorded on that rule.
+     `auto` here would stack a second, redundant horizontal bar on the same
+     2801px, misaligned with the residue columns by the label gutter, and would
+     eat height out of the three floors derived above and in
+     claude-science-msa.css. This note exists because the missing rationale got
+     the pair re-litigated as a bug twice. */
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior-x: contain;
   overscroll-behavior-y: auto;
   scrollbar-gutter: stable;
+  /* Themed through the standard property alone. Five ::-webkit-scrollbar rules
+     used to sit below this one — an 11px inset pill with an accent hover tint —
+     and none of them ever painted: naming a `scrollbar-color` makes Chromium
+     ignore every ::-webkit-scrollbar rule on the same element, so the pair
+     cannot be combined. The reasoning is written out on
+     .motif-cs-msa-view-menu-panel, which points here. Measured headed, this
+     element rendered byte-identical with and without those five rules, so they
+     read as intent and were not it. Do not delete the colour to revive them:
+     that re-breaks what the colour was added for — on a system drawing overlay
+     scrollbars nothing is painted at rest, which made this scroller look like
+     it simply ended. The 11px would not come back anyway; Chromium takes
+     thickness from an unqualified ::-webkit-scrollbar, and measured headed a
+     `:vertical`-qualified width leaves the bar at the platform's 15px even
+     with no standard property present at all. */
   scrollbar-color:
     color-mix(in srgb, var(--text-muted) 68%, var(--border-strong))
     color-mix(in srgb, var(--bg-secondary) 78%, var(--bg-primary));
   scrollbar-width: auto;
   outline: none;
-}
-
-.motif-cs-msa-matrix-scroll::-webkit-scrollbar:vertical {
-  width: 11px;
-}
-
-.motif-cs-msa-matrix-scroll::-webkit-scrollbar-track:vertical {
-  background: color-mix(in srgb, var(--bg-secondary) 62%, var(--bg-primary));
-}
-
-.motif-cs-msa-matrix-scroll::-webkit-scrollbar-thumb {
-  border: 3px solid transparent;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--text-muted) 68%, var(--border-strong));
-  background-clip: padding-box;
-}
-
-.motif-cs-msa-matrix-scroll::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--accent) 48%, var(--text-muted));
-  background-clip: padding-box;
-}
-
-.motif-cs-msa-matrix-scroll::-webkit-scrollbar-corner {
-  background: var(--bg-secondary);
 }
 
 .motif-cs-msa-matrix-scroll:focus-visible {
@@ -7277,11 +7851,21 @@ summary.motif-cs-panel-head:focus-visible {
   cursor: grabbing;
 }
 
+/* The empty track is what says "there is more alignment beyond this edge, and
+   this much of it". Diluted to 72% the boundary measured 2.14:1 in light and
+   dark and 2.28:1 in the claude themes — under the 3.0 non-text floor — while
+   the fill sat at 1.03-1.05 against the row behind it, so the trough read as
+   nothing at all and the thumb as a pill floating on the chrome. Two reviewers
+   in a row concluded from the rendered pixels that the alignment had no
+   horizontal scroll affordance while this control was on screen under their
+   cursor. Undiluted border plus a fill pushed further toward the page colour
+   restores the trough; the thumb was already 4.56-5.94 and is untouched.
+   Duplicated verbatim in ::-moz-range-track below — change both. */
 .motif-cs-msa-pan-range::-webkit-slider-runnable-track {
   height: 10px;
-  border: 1px solid color-mix(in srgb, var(--border-strong) 72%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-strong) 76%, var(--text-muted));
   border-radius: 999px;
-  background: color-mix(in srgb, var(--bg-primary) 76%, var(--bg-secondary));
+  background: color-mix(in srgb, var(--bg-primary) 88%, var(--text-muted));
 }
 
 .motif-cs-msa-pan-range::-webkit-slider-thumb {
@@ -7299,11 +7883,13 @@ summary.motif-cs-panel-head:focus-visible {
   background: color-mix(in srgb, var(--accent) 38%, var(--text-muted));
 }
 
+/* Second copy of the trough above. Kept byte-identical in colour so the lane
+   does not read as a different control per engine. */
 .motif-cs-msa-pan-range::-moz-range-track {
   height: 8px;
-  border: 1px solid color-mix(in srgb, var(--border-strong) 72%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-strong) 76%, var(--text-muted));
   border-radius: 999px;
-  background: color-mix(in srgb, var(--bg-primary) 76%, var(--bg-secondary));
+  background: color-mix(in srgb, var(--bg-primary) 88%, var(--text-muted));
 }
 
 .motif-cs-msa-pan-range::-moz-range-thumb {
@@ -7566,11 +8152,6 @@ summary.motif-cs-panel-head:focus-visible {
   font-weight: 720;
 }
 
-.motif-cs-msa-symbol[data-jump="true"] {
-  box-shadow: inset 0 -2px 0 var(--accent), inset 0 2px 0 var(--accent);
-  background: color-mix(in srgb, var(--accent) 15%, var(--bg-primary));
-}
-
 .motif-cs-msa-symbol[data-tone="gap"] { color: var(--text-muted); }
 .motif-cs-msa-symbol[data-tone="a"],
 .motif-cs-msa-symbol[data-tone="polar"] { color: var(--green); }
@@ -7600,6 +8181,47 @@ summary.motif-cs-panel-head:focus-visible {
   font: 9.5px/1.2 var(--font-mono);
   text-align: right;
   font-variant-numeric: tabular-nums;
+}
+
+/* One status line under the alignment: zoom on the left, the visible-column
+   readout on the right. They used to be two full-width strips, spending 46px
+   to say what fits on one 26px line. It wraps rather than clips when the panel
+   is genuinely too narrow for both. The child overrides are descendant-scoped
+   because this file loads AFTER claude-science-msa.css, so a bare class here
+   would still be fighting that file's zoom rules on specificity alone. */
+.motif-cs-msa-statusbar {
+  /* A floor, and a deliberate one: MSA_STATUSBAR_HEIGHT in ClaudeScienceMsaViewer
+     mirrors this number as the fallback for the matrix shell's height floor, used
+     until the strip has been measured. If the two part company nothing fails — the
+     shell is simply short by the difference and its border cuts across the status
+     line. Do not delete this as a no-op on a content-sized row.
+
+     It floors the row; it does not stop it GROWING. The status line wraps at narrow
+     widths (an e2e expectation already has the zoom row past 40px at 440x760), which
+     is why the shell's floor measures the strip at runtime rather than trusting this
+     value. When a wrap does outrun the reserve the border cuts chrome rather than
+     residues, which is the right way round for it to fail. */
+  min-height: 33px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0 12px;
+  padding: 0 8px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.motif-cs-msa-statusbar > .motif-cs-msa-zoom-row {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-top: 0;
+  padding: 3px 0;
+}
+
+.motif-cs-msa-statusbar > .motif-cs-msa-window-note {
+  flex: 0 0 auto;
+  padding: 0;
+  border-top: 0;
 }
 
 .motif-cs-msa-text-view textarea {
@@ -7951,10 +8573,11 @@ summary.motif-cs-panel-head:focus-visible {
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   }
 
-  .motif-cs-msa-matrix-scroll {
-    max-height: min(42vh, 350px);
-  }
-
+  /* No max-height here. The matrix flexes to the panel it is mounted in; a vh
+     cap sizes it against the browser instead, which is what used to push the
+     residues out of view. It would bind the moment a narrow panel is tall
+     enough to give the matrix more than the cap, and then stop it growing and
+     leave dead space at the bottom. */
   .motif-cs-msa-stats {
     gap: 3px 9px;
   }
@@ -7996,12 +8619,7 @@ summary.motif-cs-panel-head:focus-visible {
     flex: 1 1 150px;
   }
 
-  .motif-cs-msa-sort-picker {
-    flex: 1 1 120px;
-  }
-
-  .motif-cs-msa-reference-picker select,
-  .motif-cs-msa-sort-picker select {
+  .motif-cs-msa-reference-picker select {
     width: 100%;
   }
 
@@ -8009,9 +8627,10 @@ summary.motif-cs-panel-head:focus-visible {
     display: none;
   }
 
+  /* Phone width only tightens the floor; the height still comes from the panel,
+     never from a vh cap. */
   .motif-cs-msa-matrix-scroll {
     min-height: 132px;
-    max-height: min(38vh, 300px);
   }
 
   .motif-cs-msa-export-row > .motif-cs-muted {
@@ -8383,7 +9002,9 @@ summary.motif-cs-panel-head:focus-visible {
 .motif-cs-guide-select {
   display: grid;
   grid-template-columns: 14px 40px minmax(0, 1fr) 54px;
-  align-items: center;
+  /* `start`, not `center`: the spacer wraps to two lines on the longer PAMs, and
+     centring would drag the checkbox and score off the first line with it. */
+  align-items: start;
   gap: 8px;
   flex: 1 1 auto;
   min-width: 0;
@@ -8406,12 +9027,19 @@ summary.motif-cs-panel-head:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 .motif-cs-guide-spacer {
-  overflow: hidden;
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.01em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  /* The PAM is the last 3-6 nt of this string and the panel's own subtitle
+     promises it, so the string may wrap but must never be cut. Ellipsising it
+     hid every PAM base on every row at every width: for a 3-letter NGG you
+     cannot confirm the site, and for a degenerate NNGRRT reading it is the only
+     way to know the site is real. A 5'-anchored PAM was unaffected, which is
+     what shows this was "the tail is cut" and not anything about PAMs. This is
+     the same treatment the pinned layout below already gives the same element. */
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 .motif-cs-guide-pam {
   color: var(--amber);
@@ -9185,8 +9813,19 @@ summary.motif-cs-panel-head:focus-visible {
     background: var(--accent);
   }
 
+  /* Focus has to run the whole separator, not just its centre grip. The grip is
+     34px wide on a handle that is the full width of the workspace — measured at
+     1440x900, focusing it repaints 580 of 35,200 pixels, 1.65%, and all of them
+     are in the middle. Its vertical sibling lights its entire length instead
+     and repaints 23.13%, so this is the same control answering the same key
+     two different ways. Matched to that sibling: a 2px accent line at the same
+     y the grip occupies, so the grip lands inside it rather than fighting it.
+     Hover keeps the grip-only treatment deliberately — a pointer already gets
+     an ns-resize cursor over this element, and focus must not be the quieter
+     of the two signals. */
   .motif-cs-stacked-resize-handle[data-pane="sequence"]:focus-visible {
     outline: none;
+    background: linear-gradient(to bottom, transparent 0 3px, var(--accent) 3px 5px, transparent 5px 100%);
   }
 
   .motif-cs-map-frame {
@@ -9295,13 +9934,28 @@ summary.motif-cs-panel-head:focus-visible {
   .motif-cs-map-frame {
     flex: 1 1 auto;
     height: auto;
-    min-height: 410px;
+    /* This floor is what the map actually gets: `height: auto` here drops the
+       clamp(560px, 70vh, 820px) declared on the base rule, and this block
+       applies at every width from 768px up. A flat 410px letterboxed a square
+       viewBox into a wide short box on every sub-1536px desktop — which shrank
+       declared 10px labels to 5.5px, left most of the pane empty, cut cluster
+       hit targets to a few pixels, and dropped the auto-label threshold from 96
+       sites to 24, so restriction labels defaulted to off. Scale the floor with
+       the viewport instead, never below the old value. */
+    min-height: clamp(410px, 56vh, 620px);
   }
 }
 
-/* Drop the informational topbar chips (record count, length) before the primary
-   controls (pane nav / Translations / Theme) run out of room — the annotate-corner
-   reserve eats width, and these facts are shown elsewhere (inventory + seq pane). */
+/* Shrink the brand and let the meta group sit flush before the primary controls
+   (pane nav / Translations / Theme) run out of room — the annotate-corner
+   reserve eats width from the right.
+
+   This block used to also drop two informational topbar chips here, which is
+   what made them look like a narrow-width concession. They were hidden in the
+   BASE block as well, from the same initial commit, so the chip rule here never
+   changed an outcome: measured at 225 widths from 320 to 2560, under every
+   record type, pane placement and media mode, they were `display: none` and 0x0
+   in all of them. Both rules and the markup are gone. */
 @media (max-width: 1180px) {
   .motif-cs-brand {
     flex: 0 0 auto;
@@ -9310,10 +9964,6 @@ summary.motif-cs-panel-head:focus-visible {
 
   .motif-cs-topbar-meta {
     margin-left: 0;
-  }
-
-  .motif-cs-topbar-meta > .motif-cs-chip {
-    display: none;
   }
 
   .motif-cs-brand small {
@@ -9462,8 +10112,11 @@ summary.motif-cs-panel-head:focus-visible {
     background: var(--accent);
   }
 
+  /* Same full-length focus line as the sequence handle above, for the phone
+     stack where both stacked handles exist. See that rule for the numbers. */
   .motif-cs-stacked-resize-handle:focus-visible {
     outline: none;
+    background: linear-gradient(to bottom, transparent 0 3px, var(--accent) 3px 5px, transparent 5px 100%);
   }
 
   body[data-motif-cs-stacked-resizing] {
@@ -9808,8 +10461,13 @@ summary.motif-cs-panel-head:focus-visible {
     background: var(--accent);
   }
 
+  /* Same full-length focus line again. This variant outranks the unpinned rule
+     on specificity, so leaving it grip-only would have quietly restored the old
+     behaviour for anyone with the Tools panel pinned — the guard test caught
+     exactly that. */
   .motif-cs-main[data-tools-pinned="true"] > .motif-cs-stacked-resize-handle[data-pane="sequence"]:focus-visible {
     outline: none;
+    background: linear-gradient(to bottom, transparent 0 3px, var(--accent) 3px 5px, transparent 5px 100%);
   }
 
   .motif-cs-main[data-tools-pinned="true"] .motif-cs-map-frame {

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -41,6 +41,14 @@ import { bpToAngle, pointOnCircle } from '../plasmid-map/geometry/coordinates';
 import { featureSegments as mapFeatureSegments, featureSpans, normalizeSpan } from '../plasmid-map/geometry/ranges';
 import { selectionOverlayPaths } from '../plasmid-map/selection-overlay';
 import { mapModeForBlock, type MapLayout, type MapSpan } from '../plasmid-map/types';
+import {
+  contentPointFromRoot,
+  mapContentPoint,
+  mapRootPoint,
+  rootPointFromContent,
+  type MapContentPoint,
+  type MapRootPoint,
+} from '../plasmid-map/point-spaces';
 import { SequenceMapView } from '../components/plasmid-map/SequenceMapView';
 import { LargeSequenceViewer } from './LargeSequenceViewer';
 import { ClaudeScienceMsaViewer } from './ClaudeScienceMsaViewer';
@@ -161,6 +169,7 @@ import {
   type ArtifactWorkflowResult,
 } from './claude-science-workspace-collections';
 import { normalizeArtifactWorkspaceEnvelope } from './claude-science-workspace-envelope';
+import { chooseRailPopoverPlacement, collectRailPopoverObstacles, RAIL_POPOVER_MIN_HEIGHT } from './rail-popover-placement';
 import {
   MOTIF_INVENTORY_SCHEMA,
   MOTIF_INVENTORY_SCHEMA_V1,
@@ -427,10 +436,11 @@ type Selection =
   | { kind: 'restriction'; clusterId: string; tickIds: readonly string[]; enzyme?: string }
   | null;
 
-type SvgPoint = {
-  x: number;
-  y: number;
-};
+// A bare {x, y} for a map point used to be enough. It is not: the click surface
+// and the geometry beneath it live in two different coordinate spaces that are
+// equal only at a pristine fit. See ../plasmid-map/point-spaces — use
+// MapRootPoint for pan/zoom anchoring and MapContentPoint for anything that
+// resolves to an angle or a base.
 
 type MapViewport = {
   k: number;
@@ -574,9 +584,26 @@ const DEFAULT_PANE_WIDTHS: PaneWidths = {
   tools: 260,
 };
 
+// Sequence's max is a backstop, not the working constraint. Two mechanisms already
+// bound this pane physically: resizePanePair refuses to take the neighbour below its
+// own min, and clampPaneWidthsForViewport shrinks everything proportionally once the
+// row stops fitting. The old 760 sat BELOW both of them, so it — not the workspace —
+// was what stopped the drag, at every desktop width including 2560 where the map was
+// sitting on 1528px of slack and dragging moved nothing at all.
+//
+// The pane earns the width: at 760 the sequence renders 85 bases per line over 79
+// lines; at 1500 it renders 185 over 41, with no horizontal overflow either way. The
+// cap was costing 2.2x the vertical scrolling for nothing.
+//
+// 2000 is chosen so the real constraints bind first across every width we lay out for:
+// the physical ceiling is main - inventory - toolsRail - handles - map.min, which is
+// ~1348px at 1920 and ~1988px at 2560 (the widest common desktop). Past that the cap
+// resumes as a backstop rather than a governor. It must stay a CONSTANT: the drag
+// handler clamps preferredPaneWidths to this max, so a viewport-derived value would
+// permanently shrink the user's remembered width every time they narrowed the window.
 const PANE_WIDTH_LIMITS: Record<ResizablePaneKey, { min: number; max: number }> = {
   inventory: { min: 160, max: 420 },
-  sequence: { min: 240, max: 760 },
+  sequence: { min: 240, max: 2000 },
   map: { min: 300, max: 900 },
   tools: { min: 220, max: 540 },
 };
@@ -634,6 +661,28 @@ const PANE_ICONS: Record<PaneKey, LucideIcon> = {
   sequence: List,
   tools: Wrench,
 };
+
+/**
+ * The pane widths React holds are flex-basis values; what the user sees is the basis
+ * plus whatever share of the row's leftover space flex-grow assigned. Any interaction
+ * that reasons about "how much room does the neighbour have left" has to use the
+ * rendered geometry, or it will refuse to move while slack is still visible on screen.
+ *
+ * Falls back to the stored width per pane, so a pane that is floating (and therefore
+ * not part of the row), hidden, or not yet mounted keeps its value rather than
+ * collapsing to zero.
+ */
+function measuredPaneWidths(stored: PaneWidths, placements: PanePlacements): PaneWidths {
+  const next = { ...stored };
+  if (typeof document === 'undefined') return next;
+  for (const pane of Object.keys(next) as ResizablePaneKey[]) {
+    if (placements[pane] !== 'docked') continue;
+    const element = document.querySelector<HTMLElement>(PANE_SELECTOR[pane]);
+    const width = element?.getBoundingClientRect().width ?? 0;
+    if (width > 0) next[pane] = width;
+  }
+  return next;
+}
 
 const DEFAULT_PANE_PLACEMENTS: PanePlacements = {
   inventory: 'docked',
@@ -898,7 +947,7 @@ type MapSelectionRange = {
 
 type MapDragState = {
   mode: 'range';
-  start: SvgPoint;
+  start: MapContentPoint;
   startBp: number;
   lastAngle: number;
   cumulativeAngle: number;
@@ -940,8 +989,15 @@ function defaultTranslationsWindowRect(): WindowRect {
 function defaultAlignmentWindowRect(): WindowRect {
   const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1280;
   const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 800;
+  // An alignment is the widest, tallest thing this workspace shows, and the
+  // caps are what it opens at before anyone drags a corner. The old 940x600
+  // ignored the screen entirely: on a 2560x1400 display it left 810px of unused
+  // width and 400px of unused height while the residues scrolled in a 194px
+  // slot. These caps still keep a visible margin, so it reads as a window
+  // rather than a takeover, and both are clamped by the viewport terms beside
+  // them on small screens.
   const width = Math.min(940, Math.max(320, viewportWidth - 40));
-  const height = Math.min(600, Math.max(300, viewportHeight - 112));
+  const height = Math.min(820, Math.max(300, viewportHeight - 150));
   return clampWindowRect({
     x: Math.max(16, Math.round((viewportWidth - width) / 2)),
     y: Math.max(54, Math.round((viewportHeight - height) / 2)),
@@ -1086,6 +1142,17 @@ type MotifHelp = {
 
 const DATA_PLACEHOLDERS = ['__SEQUENCE_INVENTORY__', '__MOTIF_ARTIFACT_DATA__'];
 const DEFAULT_SCHEMA = MOTIF_INVENTORY_SCHEMA;
+/* Two different ORF floors are in use and they are not interchangeable. The
+   Analysis panel scans exploratively at 10 aa; the record summary makes a
+   citable statement at the classic 30 aa floor. On pUC19 that is 221 against
+   96 — the same word, the same record, and a 2.3x disagreement that no reader
+   could resolve, because neither readout named its floor except the summary's
+   empty case ("none >=30 aa"). Both are correct populations, so the fix is that
+   both now say which one they are; unifying them would have moved a number
+   somebody may already be quoting. Named here so the label and the argument
+   passed to findORFs cannot drift apart. */
+const ANALYSIS_ORF_MIN_AA = 10;
+const SUMMARY_ORF_MIN_AA = 30;
 const MIN_ZOOM = 1;
 const MAX_ZOOM = 8;
 const ZOOM_STEP = 1.25;
@@ -1268,7 +1335,6 @@ const enzymeByLowerName = new Map(RESTRICTION_ENZYMES.map((enzyme) => [enzyme.na
 const fullEnzymeByLowerName = new Map(RESTRICTION_ENZYMES_FULL.map((enzyme) => [enzyme.name.toLowerCase(), enzyme]));
 const ALLOWED_SEQUENCE_TYPES = new Set<SequenceType>(['dna', 'rna', 'protein', 'misc', 'unknown', 'mixed']);
 const emptyFeatures: readonly Feature[] = [];
-const emptySites: readonly RestrictionSite[] = [];
 const emptyTracks: readonly InlineTranslationTrack[] = [];
 const emptyTickIds: readonly string[] = [];
 const EMPTY_ARTIFACT_VECTOR: ArtifactVector = {
@@ -1904,9 +1970,17 @@ function uniqueAlignmentId(base: string, alignments: readonly ArtifactAlignment[
 }
 
 function uniqueAlignmentName(base: string, alignments: readonly ArtifactAlignment[]): string {
-  const root = base.trim() || 'Alignment';
+  const requested = base.trim() || 'Alignment';
   const used = new Set(alignments.map((alignment) => alignment.name.trim().toLowerCase()));
-  if (!used.has(root.toLowerCase())) return root;
+  if (!used.has(requested.toLowerCase())) return requested;
+  // Saving a copy of a copy passes in a name this function already suffixed, and
+  // suffixing that again concatenated instead of counting: "REVIEW 2" became
+  // "REVIEW 2 2" and then "REVIEW 2 2 2", names that defeat telling the results
+  // apart. Count from the root instead — but only when the bare root is itself
+  // taken, so a name that merely ends in a number ("Run 2019") is never rewritten
+  // into one the user never chose.
+  const suffixed = /^(.*\S)\s+\d+$/.exec(requested);
+  const root = suffixed && used.has(suffixed[1].toLowerCase()) ? suffixed[1] : requested;
   for (let index = 2; index < 10000; index += 1) {
     const candidate = `${root} ${index}`;
     if (!used.has(candidate.toLowerCase())) return candidate;
@@ -2054,7 +2128,12 @@ function scanRestrictionSitesForRecord(
   record: ArtifactVector,
   scanEnzymes: readonly RestrictionEnzyme[],
 ): readonly RestrictionSite[] {
-  if (record.type !== 'dna' || scanEnzymes.length === 0) return emptySites;
+  // Nothing to scan is not the same as nothing to report: sites that arrived in
+  // the payload belong to the record and are not this scan's to discard. This
+  // returned `emptySites`, so a record carrying supplied sites summarised as
+  // zero the moment no enzyme source was selected, while the export of the same
+  // record still listed them. Same answer as recordSitesForExport now.
+  if (record.type !== 'dna' || scanEnzymes.length === 0) return record.sites;
   const scanned = findRestrictionSites(record.sequence, [...scanEnzymes], { topology: record.topology });
   if (record.sites.length === 0) return scanned;
   const seen = new Set(scanned.map(restrictionSiteTickId));
@@ -2123,7 +2202,7 @@ function buildRecordSummary(
   const enzymesThatCut = counts.size;
 
   const orfs = isDna && translationCode.supported
-    ? findORFs(record.sequence, 30, translationCode.table, { topology })
+    ? findORFs(record.sequence, SUMMARY_ORF_MIN_AA, translationCode.table, { topology })
     : [];
   const longestOrf = orfs[0] ?? null; // findORFs sorts by length desc
 
@@ -2167,6 +2246,9 @@ function buildRecordSummary(
     orfs: isDna
       ? {
           count: orfs.length,
+          // A machine consumer has even less chance than a reader of guessing
+          // which population `count` describes, and the app publishes two.
+          minAminoAcids: SUMMARY_ORF_MIN_AA,
           longest: longestOrf
             ? { start: longestOrf.start, end: longestOrf.end, aminoAcids: longestOrf.aminoAcids, strand: longestOrf.strand }
             : null,
@@ -2198,12 +2280,15 @@ function buildRecordSummary(
         `${enzymesThatCut} enzyme${enzymesThatCut === 1 ? '' : 's'} cut`,
     );
     if (longestOrf) {
+      // The empty case has always named its floor; the non-empty one did not,
+      // which is how this line came to report 96 while the Analysis chip
+      // reported 221 for the same record with nothing to tell them apart.
       lines.push(
-        `ORFs: ${orfs.length} (longest ${longestOrf.aminoAcids.toLocaleString()} aa at ` +
+        `ORFs: ${orfs.length} ≥${SUMMARY_ORF_MIN_AA} aa (longest ${longestOrf.aminoAcids.toLocaleString()} aa at ` +
           `${longestOrf.start + 1}–${longestOrf.end}, ${longestOrf.strand === -1 ? '−' : '+'} strand)`,
       );
     } else {
-      lines.push('ORFs: none ≥30 aa');
+      lines.push(`ORFs: none ≥${SUMMARY_ORF_MIN_AA} aa`);
     }
   }
   if (selectionData) {
@@ -2342,7 +2427,13 @@ export function toGenBankLite(record: ArtifactVector, topology: Topology): strin
   const date = genBankDate();
   const molecule = record.type === 'protein' ? 'aa' : record.type === 'rna' ? 'RNA' : 'DNA';
   const topologyLabel = topology === 'circular' ? 'circular' : 'linear';
-  const locus = `LOCUS       ${safeSlug(record.name).slice(0, 16).padEnd(16, ' ')} ${String(record.sequence.length).padStart(11, ' ')} ${molecule.padEnd(6, ' ')} ${topologyLabel.padEnd(8, ' ')} UNK ${date}`;
+  // The length needs its unit token. A reader only records a declared length when
+  // `bp` or `aa` follows the number, and that declared length is what arms the
+  // truncation checks when the file is read back in. Protein records already
+  // satisfy this because their molecule token is `aa`, so spelling out the unit
+  // is only needed for nucleotides.
+  const lengthUnit = record.type === 'protein' ? '' : 'bp ';
+  const locus = `LOCUS       ${safeSlug(record.name).slice(0, 16).padEnd(16, ' ')} ${String(record.sequence.length).padStart(11, ' ')} ${lengthUnit}${molecule.padEnd(6, ' ')} ${topologyLabel.padEnd(8, ' ')} UNK ${date}`;
   const features = record.features
     .flatMap((feature) => genBankFeatureLines(feature, record.translationTableId))
     .join('\n');
@@ -2962,13 +3053,13 @@ function codonRangeFromRangeOffset(spans: readonly MapSpan[], offset: number, se
   return { start: coords[0], end };
 }
 
-function pointToSequenceAngle(point: SvgPoint, layout: MapLayout): number {
+function pointToSequenceAngle(point: MapContentPoint, layout: MapLayout): number {
   const dx = point.x - layout.center.x;
   const dy = point.y - layout.center.y;
   return (Math.atan2(dy, dx) * 180 / Math.PI + 90 + 360) % 360;
 }
 
-function pointToSequenceOffset(point: SvgPoint, layout: MapLayout): number {
+function pointToSequenceOffset(point: MapContentPoint, layout: MapLayout): number {
   if (layout.length <= 0) return 0;
   if (layout.mode === 'linear' && layout.linearAxis) {
     const raw = ((point.x - layout.linearAxis.startX) / Math.max(1, layout.linearAxis.width)) * layout.length;
@@ -4775,7 +4866,8 @@ function App() {
   const sequenceScrollByRecordRef = useRef<Record<string, number>>({});
   const mapDragRef = useRef<MapDragState | null>(null);
   const mapPointerIdRef = useRef<number | null>(null);
-  const lastZoomAnchorRef = useRef<SvgPoint | null>(null);
+  // Root space: this is handed straight to zoomAtPoint, which pins a root point.
+  const lastZoomAnchorRef = useRef<MapRootPoint | null>(null);
   const suppressNextBackgroundClick = useRef(false);
   const selectedRecord = payload.records.find((record) => record.id === selectedRecordId) ?? payload.records[0];
   const vector = selectedRecord ?? EMPTY_ARTIFACT_VECTOR;
@@ -5131,10 +5223,19 @@ function App() {
   );
   const { ref: mapFrameRef, size: mapSize } = useElementSize();
   const mapColumnRef = useRef<HTMLElement | null>(null);
-  const mapHasRoomForRestrictionLabels = Math.min(mapSize.width, mapSize.height) >= 580;
-  const showRestrictionLabels = restrictionLabelsByRecord[recordId] ?? (
-    visibleRestrictionSites.length <= (mapHasRoomForRestrictionLabels ? 96 : 24)
-  );
+  // Labels default ON, with no site-count pre-gate. The layout engine already
+  // bounds the label ink two ways — display.maxRestrictionLabels caps how many
+  // clusters are even candidates, and the radial packer culls whatever will not
+  // fit the ring — and it reports the remainder through the "+N more sites" chip.
+  // Deciding up front from the raw SITE count skipped all of that: it is the
+  // wrong quantity (labels are per CLUSTER, and clusters stay in the 6-39 range
+  // while sites run 26-695) and it is all-or-nothing where the engine is graded.
+  // Past the threshold a map drew every tick and named none of them, and because
+  // labels-off also zeroes the unlabelled count, the chip that would have said so
+  // never appeared. Measured across the bundled vectors at 240px-1000px and with
+  // both the default and the full enzyme list, letting the packer run yields
+  // 4-24 names per map with no collisions, so there was nothing to protect.
+  const showRestrictionLabels = restrictionLabelsByRecord[recordId] ?? true;
   const canToggleTopology = hasActiveRecord && (sequenceType === 'dna' || sequenceType === 'rna');
   const mapViewport = mapViewportsByRecord[recordId] ?? DEFAULT_MAP_VIEWPORT;
   const selectedMapRange = mapRangesByRecord[recordId] ?? null;
@@ -6142,6 +6243,33 @@ function App() {
   const selectionBarLabel = selectionSummary?.label
     ?? (selectedRestriction ? `${selection?.kind === 'restriction' && selection.enzyme ? selection.enzyme : selectedRestriction.label?.text ?? 'Restriction'} site` : 'No range selected');
 
+  // The map's status corner reports two independent facts: how the view is
+  // transformed, and what is selected. They used to share one slot through a
+  // ternary, so any zoom or pan silently replaced the range readout — the
+  // selection stayed drawn on the map and stopped saying what it was. They are
+  // not alternatives, so join them instead of choosing.
+  const mapStatusHint = [
+    mapViewport.k > MIN_ZOOM + 0.0001 || Math.abs(mapViewport.tx) > 0.5 || Math.abs(mapViewport.ty) > 0.5
+      ? `${Math.round(mapViewport.k * 100)}%`
+      : null,
+    selectedMapRange ? `range ${mapRangeLabel(selectedMapRange, sequence.length)}` : null,
+  ].filter(Boolean).join(' · ');
+
+  // How many restriction sites the map is drawing without a label. The map says this
+  // in its "+N more sites" chip, but only through an SVG <title>, which no browser
+  // opens on keyboard focus — so a keyboard user is told nothing. This reads the SAME
+  // overflow entry the chip renders from, so the two cannot drift into disagreeing
+  // about one quantity.
+  //
+  // `unlabelled` specifically, never a total. An overflow chip reports two quantities
+  // — items with no body drawn, and items drawn without a name — and the sentence
+  // below is only true of the second. On the restriction chip the first is 0 (every
+  // site keeps its density tick), so a total would read the same today and start
+  // lying the moment it did not; on the FEATURE chip a total is already meaningless
+  // as a single number, which is why the field is not offered.
+  const mapUnlabelledSiteCount =
+    layout.overflows?.find((overflow) => overflow.kind === 'restriction-labels')?.unlabelled ?? 0;
+
   // The Translate window's target: the current selection (feature or range), or the
   // whole sequence when nothing is selected. Carries the target's natural strand so
   // a reverse feature defaults to antisense.
@@ -6296,7 +6424,8 @@ function App() {
     });
   }, [layout.bg, recordId]);
 
-  const zoomAtPoint = useCallback((point: SvgPoint, factor: number) => {
+  /** `point` is ROOT space — the new translate keeps that root point where it is. */
+  const zoomAtPoint = useCallback((point: MapRootPoint, factor: number) => {
     if (!Number.isFinite(factor) || factor <= 0) return;
     lastZoomAnchorRef.current = point;
     setCurrentMapViewport((currentViewport) => {
@@ -6312,19 +6441,27 @@ function App() {
   }, [setCurrentMapViewport]);
 
   const contentZoomAnchor = useMemo(
-    () => layout.mode === 'circular' && layout.radius > 0
-      ? { x: layout.center.x, y: layout.center.y - layout.radius }
-      : { x: layout.bg.x + layout.bg.width / 2, y: layout.bg.y + layout.bg.height / 2 },
+    (): MapContentPoint => (layout.mode === 'circular' && layout.radius > 0
+      ? mapContentPoint(layout.center.x, layout.center.y - layout.radius)
+      : mapContentPoint(layout.bg.x + layout.bg.width / 2, layout.bg.y + layout.bg.height / 2)),
     [layout.bg.height, layout.bg.width, layout.bg.x, layout.bg.y, layout.center.x, layout.center.y, layout.mode, layout.radius],
   );
 
-  const buttonZoomAnchor = useCallback(() => lastZoomAnchorRef.current ?? contentZoomAnchor, [contentZoomAnchor]);
+  // The remembered anchor is already root space; the layout-derived fallback is
+  // content space and has to be pushed through the current transform first. The
+  // fallback is reachable whenever the anchor ref is cleared but the zoom is
+  // kept — switching records, or changing map mode — so a zoomed map used to
+  // lurch away from the very point the + / - buttons are trying to hold still.
+  const buttonZoomAnchor = useCallback(
+    (): MapRootPoint => lastZoomAnchorRef.current ?? rootPointFromContent(contentZoomAnchor, mapViewport),
+    [contentZoomAnchor, mapViewport],
+  );
   const handleZoomIn = useCallback(() => zoomAtPoint(buttonZoomAnchor(), ZOOM_STEP), [buttonZoomAnchor, zoomAtPoint]);
   const handleZoomOut = useCallback(() => zoomAtPoint(buttonZoomAnchor(), 1 / ZOOM_STEP), [buttonZoomAnchor, zoomAtPoint]);
   const handleZoomReset = useCallback(() => setCurrentMapViewport(DEFAULT_MAP_VIEWPORT), [setCurrentMapViewport]);
 
   const handleMapWheel = useCallback((
-    point: SvgPoint,
+    point: MapRootPoint,
     deltaX: number,
     deltaY: number,
     deltaMode: number,
@@ -6352,8 +6489,9 @@ function App() {
     return true;
   }, [mapFrameRef, mapViewport.k, setCurrentMapViewport, zoomAtPoint]);
 
-  const handleMapPointerStart = useCallback((point: SvgPoint) => {
-    lastZoomAnchorRef.current = point;
+  // CONTENT space. The caller records the zoom anchor, because the caller is the
+  // one still holding the root-space point.
+  const handleMapPointerStart = useCallback((point: MapContentPoint) => {
     const startBp = pointToSequenceOffset(point, layout);
     const startAngle = pointToSequenceAngle(point, layout);
     mapDragRef.current = { mode: 'range', start: point, startBp, lastAngle: startAngle, cumulativeAngle: 0, moved: false };
@@ -6367,12 +6505,11 @@ function App() {
     return true;
   }, [layout, recordId, sequence.length, topology]);
 
-  const handleMapPointerMove = useCallback((point: SvgPoint) => {
+  const handleMapPointerMove = useCallback((point: MapContentPoint) => {
     const drag = mapDragRef.current;
     if (!drag) return;
     const dx = point.x - drag.start.x;
     const dy = point.y - drag.start.y;
-    lastZoomAnchorRef.current = point;
     if (!drag.moved && Math.hypot(dx, dy) > 2) drag.moved = true;
 
     const endBp = pointToSequenceOffset(point, layout);
@@ -6403,7 +6540,13 @@ function App() {
     mapDragRef.current = null;
   }, []);
 
-  const mapPointFromClient = useCallback((clientX: number, clientY: number): SvgPoint | null => {
+  /**
+   * Client -> SVG ROOT space. `getScreenCTM()` on the `<svg>` accounts for the
+   * viewBox and preserveAspectRatio but NOT for the viewport group's own
+   * translate/scale, so this is the space `{k, tx, ty}` is expressed in. Right
+   * for zoom anchoring; wrong for "which base is under the cursor".
+   */
+  const mapRootPointFromClient = useCallback((clientX: number, clientY: number): MapRootPoint | null => {
     const svg = mapFrameRef.current?.querySelector<SVGSVGElement>('svg.motif-plasmid-map');
     const matrix = svg?.getScreenCTM();
     if (!svg || !matrix) return null;
@@ -6411,7 +6554,7 @@ function App() {
     point.x = clientX;
     point.y = clientY;
     const transformed = point.matrixTransform(matrix.inverse());
-    return { x: transformed.x, y: transformed.y };
+    return mapRootPoint(transformed.x, transformed.y);
   }, [mapFrameRef]);
 
   useEffect(() => {
@@ -6420,7 +6563,7 @@ function App() {
 
     const handleCommandWheel = (event: globalThis.WheelEvent) => {
       if (!event.metaKey || event.ctrlKey) return;
-      const point = mapPointFromClient(event.clientX, event.clientY);
+      const point = mapRootPointFromClient(event.clientX, event.clientY);
       if (!point) return;
       const wheelUnit = event.deltaMode === 1 ? 18 : event.deltaMode === 2 ? mapFrame.clientHeight : 1;
       zoomAtPoint(point, Math.exp(-(event.deltaY * wheelUnit) * 0.0015));
@@ -6430,26 +6573,29 @@ function App() {
 
     mapFrame.addEventListener('wheel', handleCommandWheel, { passive: false, capture: true });
     return () => mapFrame.removeEventListener('wheel', handleCommandWheel, { capture: true });
-  }, [mapFrameRef, mapPointFromClient, zoomAtPoint]);
+  }, [mapFrameRef, mapRootPointFromClient, zoomAtPoint]);
 
   const handleMapSurfacePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (!event.isPrimary || event.button !== 0) return;
     const target = event.target as Element;
     if (target.closest('.motif-pm-feature, .motif-pm-restriction, .motif-pm-range-overlay[data-interactive="true"]')) return;
-    const point = mapPointFromClient(event.clientX, event.clientY);
-    if (!point || !handleMapPointerStart(point)) return;
+    const rootPoint = mapRootPointFromClient(event.clientX, event.clientY);
+    if (!rootPoint) return;
+    lastZoomAnchorRef.current = rootPoint;
+    if (!handleMapPointerStart(contentPointFromRoot(rootPoint, mapViewport))) return;
     mapPointerIdRef.current = event.pointerId;
     event.currentTarget.setPointerCapture?.(event.pointerId);
     event.preventDefault();
-  }, [handleMapPointerStart, mapPointFromClient]);
+  }, [handleMapPointerStart, mapRootPointFromClient, mapViewport]);
 
   const handleMapSurfacePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.pointerId !== mapPointerIdRef.current) return;
-    const point = mapPointFromClient(event.clientX, event.clientY);
-    if (!point) return;
+    const rootPoint = mapRootPointFromClient(event.clientX, event.clientY);
+    if (!rootPoint) return;
+    lastZoomAnchorRef.current = rootPoint;
     event.preventDefault();
-    handleMapPointerMove(point);
-  }, [handleMapPointerMove, mapPointFromClient]);
+    handleMapPointerMove(contentPointFromRoot(rootPoint, mapViewport));
+  }, [handleMapPointerMove, mapRootPointFromClient, mapViewport]);
 
   const handleMapSurfacePointerEnd = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.pointerId !== mapPointerIdRef.current) return;
@@ -7998,8 +8144,15 @@ function App() {
     if (activeEnzymeSourcesRef.current.length > 0) {
       lastVisibleEnzymeSourcesRef.current[recordId] = [...activeEnzymeSourcesRef.current];
     }
-    activeEnzymeSourcesRef.current = [];
-    setEnzymeSourcesByRecord((current) => ({ ...current, [recordId]: [] }));
+    // Hide the sites; do NOT clear the enzyme sources. `hiddenEnzymesByRecord`
+    // already drives every display surface — the map ticks, the sequence cuts and
+    // the inspector all filter through it — so emptying the source selection as
+    // well hid nothing extra, and instead reached the data: exports and
+    // `motifDescribe()` read the sources, so a control the user reads as "stop
+    // drawing these" silently changed what a downloaded GenBank/CSV/JSON said
+    // about the molecule. Measured on pUC19 before this change: the summary went
+    // from "11 single cutters; 22 enzymes cut" to "0 single cutters; 0 enzymes
+    // cut", and the exports quietly lost every non-Common source.
     setHiddenEnzymesByRecord((current) => ({
       ...current,
       [recordId]: enzymeNames,
@@ -9513,11 +9666,31 @@ function App() {
     setFloatingPaneZOrder([]);
   }, []);
 
+  // The seven floating tool windows keep their geometry in plain state, so a size
+  // dragged onto one survives closing and reopening it. That much is deliberate:
+  // a size chosen by dragging a corner is a choice, and closing a window is not a
+  // request to forget it. What was missing is the way back — "Reset display" put
+  // the panes right and left every window exactly as small as it found it, which
+  // is the one state a user actually needs the button for. The signal is what
+  // reaches windows that are already open; see FloatingWindow.
+  const [windowResetSignal, setWindowResetSignal] = useState(0);
+  const resetToolWindowRects = useCallback(() => {
+    setTranslationsWin(defaultTranslationsWindowRect());
+    setPrimerWin(defaultPrimerWindowRect());
+    setAlignmentWin(defaultAlignmentWindowRect());
+    setGelWin(defaultGelWindowRect());
+    setAssemblyWin(defaultAssemblyWindowRect());
+    setCloningDesignWin(defaultCloningDesignWindowRect());
+    setConstructVerificationWin(defaultConstructVerificationWindowRect());
+    setWindowResetSignal((value) => value + 1);
+  }, []);
+
   const resetDisplayPreferences = useCallback(() => {
     resetWorkspaceLayout();
+    resetToolWindowRects();
     clearMsaViewPreferences();
     setMsaViewPreferences({ ...DEFAULT_CLAUDE_SCIENCE_MSA_VIEW_PREFERENCES });
-  }, [resetWorkspaceLayout]);
+  }, [resetToolWindowRects, resetWorkspaceLayout]);
 
   const downloadWorkspaceBackup = useCallback(() => {
     const snapshot = createArtifactDatabaseSnapshot(payloadRef.current, artifactStateRef.current);
@@ -9902,7 +10075,14 @@ function App() {
     if (!event.isPrimary || event.button !== 0) return;
     event.preventDefault();
     const startX = event.clientX;
-    const startWidths = { ...paneWidths };
+    // paneWidths are flex BASIS values, and flex-grow then hands out whatever the row
+    // has left over on top of them. The two drift apart: at 1920 the map renders 976px
+    // against a basis of 560. Pricing the drag against the basis meant the pair stopped
+    // when the BASIS hit map.min, leaving ~400px of visibly unused map still on screen
+    // and the pane refusing to widen. Seed from the rendered geometry instead. Measured
+    // widths already sum to the row, so the free space flex-grow was distributing is
+    // zero for the duration of the drag and the pane tracks the pointer one-to-one.
+    const startWidths = measuredPaneWidths(paneWidths, panePlacements);
     const startPreferredWidths = { ...preferredPaneWidths };
     const neighbor = paneResizeNeighbor(pane, edge);
     const startWidth = startWidths[pane];
@@ -9996,7 +10176,7 @@ function App() {
     } catch {
       /* Window listeners keep resizing active when capture is unavailable. */
     }
-  }, [clampPaneWidthsForViewport, compactPinnedLayout, paneResizeNeighbor, paneWidthLimitsForCurrentLayout, paneWidths, preferredPaneWidths, resizeHandleCount, resizePanePair, showToolsResizeHandle, stopPaneResize, toolsRailWidth, visibleResizablePanes, workspaceMainSize.width]);
+  }, [clampPaneWidthsForViewport, compactPinnedLayout, paneResizeNeighbor, panePlacements, paneWidthLimitsForCurrentLayout, paneWidths, preferredPaneWidths, resizeHandleCount, resizePanePair, showToolsResizeHandle, stopPaneResize, toolsRailWidth, visibleResizablePanes, workspaceMainSize.width]);
   const resizePaneFromKeyboard = useCallback((pane: ResizablePaneKey, event: ReactKeyboardEvent<HTMLDivElement>, edge: ResizeEdge = 'after') => {
     if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
     event.preventDefault();
@@ -10171,6 +10351,18 @@ function App() {
       onDrop={handleDrop}
     >
       <a className="motif-cs-skip-link" href="#motif-cs-workspace">Skip to workspace</a>
+      {/* The Tools rail is authored last, so its first tool was Tab stop 124 of
+          139 at 1440x900 — measured with real keys, all fifteen tools behind
+          the whole workspace. A control that requires that many presses is
+          effectively unreachable for keyboard users.
+          A second skip link is the fix the first one already established: it
+          shares the first one's slot, since only the focused link is ever
+          untranslated, so no new CSS is needed. The rail is the last pane in
+          the DOM, so Tab from it continues straight into the tool summaries —
+          measured after: 2 Tab + Enter + 2 Tab, then all fifteen in order. */}
+      {paneVisibility.tools ? (
+        <a className="motif-cs-skip-link" href="#motif-cs-tools-pane">Skip to tools</a>
+      ) : null}
       {dropState.active ? (
         <div className="motif-cs-dropzone" aria-hidden="true">
           <div className="motif-cs-dropzone-card">{dropState.message}</div>
@@ -10204,9 +10396,15 @@ function App() {
           <span translate="no">Motif</span>
           <small translate="no">for Claude Science</small>
         </div>
+        {/* A record-count and a sequence-length chip used to render here on every
+            load and were hidden by `.motif-cs-topbar-meta > .motif-cs-chip` in the
+            BASE block — not a media query — so no viewport, record type, pane
+            placement or media mode could reveal them. Deleted rather than shown:
+            the topbar reserves 172px on the right for the host's Annotate pill
+            and leaves an 8px gap, so there is nowhere to put them, and both facts
+            are already on screen — the inventory badge carries the count and the
+            inventory row and map header both carry "circular · 2,578 bp". */}
         <div className="motif-cs-topbar-meta">
-          <span className="motif-cs-chip">{payload.records.length} record{payload.records.length === 1 ? '' : 's'}</span>
-          {hasActiveRecord ? <span className="motif-cs-chip">{sequenceLengthLabel(sequence.length, sequenceType)}</span> : null}
           <div
             className="motif-cs-pane-switcher"
             role="group"
@@ -10529,7 +10727,7 @@ function App() {
                   </div>
                 ) : null}
                 {hasActiveRecord ? (
-                <div className="motif-cs-map-toolbar" role="group" aria-label="Map zoom controls">
+                <div className="motif-cs-map-toolbar" role="group" aria-label="Map view controls">
                   <button className="motif-cs-map-button" type="button" onClick={handleZoomOut} disabled={!hasActiveRecord || mapViewport.k <= MIN_ZOOM + 0.0001} aria-label="Zoom out">-</button>
                   <button
                     className="motif-cs-map-button motif-cs-map-reset"
@@ -10542,12 +10740,34 @@ function App() {
                     Fit
                   </button>
                   <button className="motif-cs-map-button" type="button" onClick={handleZoomIn} disabled={!hasActiveRecord || mapViewport.k >= MAX_ZOOM - 0.0001} aria-label="Zoom in">+</button>
+                  {/* Whether the ring is named is a property of the map, but the
+                      only switch for it was in the Map Visibility panel, and at
+                      every laptop size measured — 1440x900, 1280x800, 1024x768,
+                      900x700 — that panel's own SUMMARY is already past the
+                      bottom of the map column, which hides 143-148px of itself.
+                      Reaching the toggle meant scrolling a pane nothing invites
+                      you to scroll and then opening a closed accordion, for a
+                      state you are looking straight at. Same handler and same
+                      wording as the panel button, so the two always agree; this
+                      is a second route to one control, not a second control.
+                      Gated on isDnaRecord exactly as the panel's is, since
+                      restriction labels are the only thing it governs. */}
+                  {isDnaRecord ? (
+                    <button
+                      className="motif-cs-map-button motif-cs-map-labels-toggle"
+                      type="button"
+                      data-active={showRestrictionLabels || undefined}
+                      aria-pressed={showRestrictionLabels}
+                      onClick={toggleRestrictionLabels}
+                      title={`Restriction labels ${showRestrictionLabels ? 'on' : 'off'}`}
+                    >
+                      Labels {showRestrictionLabels ? 'On' : 'Off'}
+                    </button>
+                  ) : null}
                 </div>
                 ) : null}
-                {mapViewport.k > MIN_ZOOM + 0.0001 || Math.abs(mapViewport.tx) > 0.5 || Math.abs(mapViewport.ty) > 0.5 ? (
-                  <div className="motif-cs-map-hint">{Math.round(mapViewport.k * 100)}%</div>
-                ) : selectedMapRange ? (
-                  <div className="motif-cs-map-hint">range {mapRangeLabel(selectedMapRange, sequence.length)}</div>
+                {mapStatusHint ? (
+                  <div className="motif-cs-map-hint">{mapStatusHint}</div>
                 ) : null}
               </div>
 
@@ -10613,6 +10833,19 @@ function App() {
                               Labels {showRestrictionLabels ? 'On' : 'Off'}
                             </button>
                             <span className="motif-cs-muted">{singleCutters.length} single-cutters</span>
+                            {/* The map's "+N more sites" chip carries this same number, but only
+                                to a pointer: it lives in an SVG <title>, which no browser opens
+                                on keyboard focus. Stated here it lands where a keyboard user is
+                                already going. Read off layout.overflows — the ARRAY THE CHIP
+                                RENDERS FROM — so the two cannot drift into disagreeing about the
+                                same quantity; a second derivation would be a second chance to be
+                                wrong. Worded as a caveat rather than a count, because sitting
+                                next to "39 single-cutters" a bare number reads as one more
+                                statistic instead of "the map is not showing you everything". */}
+                            {mapUnlabelledSiteCount > 0 ? (
+                              <span className="motif-cs-muted">{mapUnlabelledSiteCount.toLocaleString()} sites without labels on the map</span>
+                            ) : null}
+
                           </>
                         ) : (
                           <span className="motif-cs-muted">Restriction enzymes act on DNA; RNA is not converted implicitly.</span>
@@ -10713,13 +10946,13 @@ function App() {
                 {hasActiveRecord ? <EditableRecordTitle record={vector} onUpdate={updateRecordDetails} /> : <h1>No sequence loaded</h1>}
                 <p title={vector.description ?? payload.inventory.description}>{vector.description ?? payload.inventory.description}</p>
               </div>
+              {/* Same shape as the topbar pair above and found with them: a type
+                  chip and a length chip rendered here every time and hidden by
+                  `.motif-cs-sequence-title .motif-cs-title-actions .motif-cs-chip`
+                  in the base block. Four dead chips in total, not the two filed.
+                  Both facts survive in the inventory row's "dna · circular ·
+                  2,578 bp" and the map header's "circular · 2,578 bp". */}
               <div className="motif-cs-title-actions">
-                {hasActiveRecord ? (
-                  <>
-                    <span className="motif-cs-chip">{sequenceType}</span>
-                    <span className="motif-cs-chip">{sequenceLengthLabel(sequence.length, sequenceType)}</span>
-                  </>
-                ) : null}
                 <PanePlacementControl
                   pane="sequence"
                   title="Sequence"
@@ -10876,11 +11109,31 @@ function App() {
                   >
                     + Feature
                   </button>
-                  <button className="motif-cs-mini-button" type="button" disabled={!isNucleotideRecord || (!!selectionSummary && !hasMaterializableSequenceSelection)} onClick={addContextReverseComplementRecord} aria-label="Reverse complement" title={selectionSummary ? hasMaterializableSequenceSelection ? 'Create a reverse-complement record from this selection' : 'This ordered location cannot be materialized as one sequence' : 'Create a reverse-complement record from the whole sequence'}>
-                    <span className="motif-cs-label-full">Rev comp</span>
-                    <span className="motif-cs-label-short">RC</span>
+                  {/* Everything above acts on the record you are looking at;
+                      everything below adds a NEW one to the inventory. The two
+                      were spelled the same, so "Rev comp" read like the "Copy"
+                      beside it and quietly took the session from 13 records to
+                      14 with a new Derived group. Worse, with nothing selected
+                      it is the ONLY enabled control in this bar, so the one
+                      thing the resting state invites you to press was the
+                      heaviest thing in it. Both record-makers now carry the
+                      "New" the Export panel already uses to separate "Copy rev
+                      comp" from "New rev comp", and the rule marks where the
+                      weight changes. The behaviour is deliberately untouched:
+                      additive and non-destructive is the right semantics. */}
+                  <span className="motif-cs-selection-action-rule" aria-hidden="true" />
+                  <button className="motif-cs-mini-button" type="button" disabled={!isNucleotideRecord || (!!selectionSummary && !hasMaterializableSequenceSelection)} onClick={addContextReverseComplementRecord} aria-label="New rev comp record" title={selectionSummary ? hasMaterializableSequenceSelection ? 'Create a reverse-complement record from this selection' : 'This ordered location cannot be materialized as one sequence' : 'Create a reverse-complement record from the whole sequence'}>
+                    <span className="motif-cs-label-full">New rev comp</span>
+                    {/* Below a 360px pane the bar is already a scroller, and
+                        spelling "New" twice more pushed it 6px past its own
+                        clip. "+" is the same promise in one character and the
+                        "+ Feature" two buttons left already teaches it here. */}
+                    <span className="motif-cs-label-short">+ RC</span>
                   </button>
-                  <button className="motif-cs-mini-button" type="button" disabled={!selectionActionTranslation} onClick={addSelectionTranslationRecord} title="Create a new protein record from this selection's translation">Protein</button>
+                  <button className="motif-cs-mini-button" type="button" disabled={!selectionActionTranslation} onClick={addSelectionTranslationRecord} aria-label="New protein record" title="Create a new protein record from this selection's translation">
+                    <span className="motif-cs-label-full">New protein</span>
+                    <span className="motif-cs-label-short">+ Prot</span>
+                  </button>
                 </div>
               </div>
               </>
@@ -10983,8 +11236,13 @@ function App() {
               data-pane-placement={panePlacements.tools}
               data-tools-pinned={toolsDocked || toolsFloating ? 'true' : 'false'}
               role={toolsFloating ? 'dialog' : undefined}
-              aria-label={toolsFloating ? 'Tools pane' : undefined}
-              tabIndex={toolsFloating ? -1 : undefined}
+              aria-label={toolsFloating ? 'Tools pane' : 'Tools'}
+              // "Skip to tools" lands here, so the pane has to be a focus
+              // target in every placement, not only while floating: an href
+              // jump moves focus only if its target is focusable. -1 keeps it
+              // out of the sequential order it exists to let you skip.
+              id="motif-cs-tools-pane"
+              tabIndex={-1}
               onPointerDown={() => toolsFloating && bringFloatingPaneToFront('tools')}
               onFocusCapture={() => toolsFloating && bringFloatingPaneToFront('tools')}
               style={{
@@ -11441,7 +11699,21 @@ function App() {
           </details>
 
           <details className="motif-cs-panel" name="motif-cs-tools" data-rail-tool="alignment">
-            <summary ref={alignmentToggleRef} className="motif-cs-panel-head" data-rail-label="M" title="Multiple sequence alignment">
+            {/* data-rail-count is the collapsed rail's only view of the chip beside
+                it. The rail hides `.motif-cs-chip` outright, and of the fifteen tool
+                heads this is the one whose chip reports session content rather than a
+                static label, so hiding it made the rail identical whether the session
+                held no alignments or twenty. The attribute is absent at zero so a
+                session that never aligns anything gains no mark. */}
+            <summary
+              ref={alignmentToggleRef}
+              className="motif-cs-panel-head"
+              data-rail-label="M"
+              data-rail-count={payload.alignments.length || undefined}
+              title={payload.alignments.length
+                ? `Multiple sequence alignment — ${payload.alignments.length} in session`
+                : 'Multiple sequence alignment'}
+            >
               <AlignCenter className="motif-cs-panel-icon" size={14} strokeWidth={2.2} aria-hidden="true" />
               <span>Alignment</span>
               <span className="motif-cs-chip">{payload.alignments.length ? `${payload.alignments.length} MSA` : 'MSA'}</span>
@@ -11560,6 +11832,7 @@ function App() {
           title="Translations"
           subtitle={vector.name}
           initial={translationsWin}
+          resetSignal={windowResetSignal}
           rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={() => setShowTranslations(false)}
           onCommit={setTranslationsWin}
@@ -11600,6 +11873,7 @@ function App() {
           title="Gel Preview"
           subtitle="qualitative agarose"
           initial={gelWin}
+          resetSignal={windowResetSignal}
           rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={() => setShowGel(false)}
           onCommit={setGelWin}
@@ -11643,6 +11917,7 @@ function App() {
           title="Primer Design"
           subtitle={cloningPrimerRequest ? `${vector.name} · cloning preparation` : vector.name}
           initial={primerWin}
+          resetSignal={windowResetSignal}
           rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={closePrimerWorkspace}
           onCommit={setPrimerWin}
@@ -11703,6 +11978,7 @@ function App() {
           title="Cloning Workspace"
           subtitle="Golden Gate + ligation"
           initial={assemblyWin}
+          resetSignal={windowResetSignal}
           rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={() => setShowAssembly(false)}
           onCommit={setAssemblyWin}
@@ -11723,6 +11999,7 @@ function App() {
           title="Cloning Design"
           subtitle="Golden Gate profiles + Gibson"
           initial={cloningDesignWin}
+          resetSignal={windowResetSignal}
           rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={() => setShowCloningDesign(false)}
           onCommit={setCloningDesignWin}
@@ -11746,6 +12023,7 @@ function App() {
           title="Construct Verification"
           subtitle={`${constructVerificationReadCount} eligible Sanger read${constructVerificationReadCount === 1 ? '' : 's'}`}
           initial={constructVerificationWin}
+          resetSignal={windowResetSignal}
           rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={() => setShowConstructVerification(false)}
           onCommit={setConstructVerificationWin}
@@ -11767,6 +12045,7 @@ function App() {
           title="Multiple Sequence Alignment"
           subtitle={payload.alignments.length ? `${payload.alignments.length} in session` : 'local + imported'}
           initial={alignmentWin}
+          resetSignal={windowResetSignal}
           rightInset={toolsRail ? TOOLS_RAIL_WIDTH : 0}
           onClose={() => setShowAlignment(false)}
           onCommit={setAlignmentWin}
@@ -12144,7 +12423,7 @@ function InventoryList({
                 <span className="motif-cs-inventory-caret" aria-hidden="true">
                   <ChevronRight size={13} strokeWidth={2.2} />
                 </span>
-                <span>{group.label}</span>
+                <span title={group.label}>{group.label}</span>
                 <small>{group.records.length}</small>
               </button>
               {!collapsed ? group.records.map((record) => (
@@ -12157,7 +12436,12 @@ function InventoryList({
                   onClick={() => onSelect(record.id)}
                 >
                   <span className="motif-cs-row-main">
-                    <span translate="no">{record.name}</span>
+                    {/* Constructs are told apart by their suffix — _clone12_Rep2,
+                        -WPRE-hGHpA — and the suffix is the end the ellipsis eats
+                        at the pane's 210px default. Every other truncating
+                        control here carries the full string in a title; this row
+                        was the one that did not. */}
+                    <span translate="no" title={record.name}>{record.name}</span>
                     <small>{record.type} · {record.topology} · {sequenceLengthLabel(record.sequence.length, record.type)}</small>
                   </span>
                 </button>
@@ -12637,6 +12921,11 @@ function cssPixelValue(value: string, fallback: number): number {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+/* Only reached if the stylesheet stops positioning the popover at all; the real
+   values are read back off the element so the two cannot drift apart. */
+const RAIL_POPOVER_HOME_TOP_FALLBACK = 84;
+const RAIL_POPOVER_BOTTOM_GUTTER_FALLBACK = 22;
+
 function RailPopoverTitle({ title, meta }: { title: string; meta?: string }) {
   const [size, setSize] = useState<RailPopoverSize | null>(null);
   const [panelBody, setPanelBody] = useState<HTMLElement | null>(null);
@@ -12644,6 +12933,7 @@ function RailPopoverTitle({ title, meta }: { title: string; meta?: string }) {
   const titleRef = useRef<HTMLDivElement>(null);
   const resizeHandleRef = useRef<HTMLButtonElement>(null);
   const panelBodyRef = useRef<HTMLElement | null>(null);
+  const cssMetricsRef = useRef<{ key: string; homeTop: number; bottomGutter: number } | null>(null);
   const resizeRef = useRef<{
     pointerId: number;
     startX: number;
@@ -12678,6 +12968,141 @@ function RailPopoverTitle({ title, meta }: { title: string; meta?: string }) {
     panelBody.style.setProperty('--rail-popover-height', `${size.height}px`);
     panelBody.dataset.railPopoverResized = 'true';
   }, [size]);
+
+  /**
+   * Keep the popover off the floating window's controls. The stylesheet gives it
+   * a resting offset that knows nothing about what is underneath, which put all
+   * 15 panels on top of Maximize / Collapse / Close — the one overlap with no
+   * way out, because the control that would fix it is the control being hidden.
+   * The solver moves it the smallest distance that clears those zones and hands
+   * back the height cap that goes with wherever it landed.
+   */
+  useLayoutEffect(() => {
+    if (!panelBody) return undefined;
+    const panel = panelBody.closest<HTMLDetailsElement>('details.motif-cs-panel');
+    if (!panel) return undefined;
+
+    const clearPlacement = () => {
+      panelBody.style.removeProperty('--rail-popover-fixed-top');
+      panelBody.style.removeProperty('max-height');
+      delete panelBody.dataset.railPopoverPlacement;
+    };
+
+    /**
+     * The stylesheet owns both the resting offset and the bottom gutter baked
+     * into its max-height. Read them back off the element with our own values
+     * stripped rather than copying the numbers here, so a stylesheet edit cannot
+     * leave a stale duplicate governing the popover. Cached per viewport size,
+     * because a media query is allowed to change the offset.
+     */
+    const cssMetrics = () => {
+      const key = `${window.innerWidth}x${window.innerHeight}`;
+      const cached = cssMetricsRef.current;
+      if (cached?.key === key) return cached;
+      const ownTop = panelBody.style.getPropertyValue('--rail-popover-fixed-top');
+      const ownMaxHeight = panelBody.style.maxHeight;
+      panelBody.style.removeProperty('--rail-popover-fixed-top');
+      panelBody.style.removeProperty('max-height');
+      const computed = window.getComputedStyle(panelBody);
+      const homeTop = cssPixelValue(computed.top, RAIL_POPOVER_HOME_TOP_FALLBACK);
+      const cssMaxHeight = cssPixelValue(computed.maxHeight, window.innerHeight - homeTop - RAIL_POPOVER_BOTTOM_GUTTER_FALLBACK);
+      if (ownTop) panelBody.style.setProperty('--rail-popover-fixed-top', ownTop);
+      if (ownMaxHeight) panelBody.style.maxHeight = ownMaxHeight;
+      const metrics = {
+        key,
+        homeTop,
+        bottomGutter: Math.max(0, Math.round(window.innerHeight - homeTop - cssMaxHeight)),
+      };
+      cssMetricsRef.current = metrics;
+      return metrics;
+    };
+
+    const place = () => {
+      // Docked mode leaves the body in normal flow, where a fixed-position cap
+      // would clamp a panel nothing is covering.
+      if (!panel.open || window.getComputedStyle(panelBody).position !== 'fixed') {
+        clearPlacement();
+        return;
+      }
+      const { homeTop, bottomGutter } = cssMetrics();
+      const rect = panelBody.getBoundingClientRect();
+      const placement = chooseRailPopoverPlacement({
+        column: { left: rect.left, right: rect.right },
+        homeTop,
+        bottomGutter,
+        // Reported back as `hiddenHeight`; it does not move the panel. Content
+        // height rather than rendered height, because the rendered height is
+        // what the cap below produces and feeding that back in would let the
+        // popover chase its own tail.
+        desiredHeight: Math.max(
+          panelBody.scrollHeight,
+          cssPixelValue(panelBody.style.getPropertyValue('--rail-popover-height'), 0),
+          RAIL_POPOVER_MIN_HEIGHT,
+        ),
+        viewportHeight: window.innerHeight,
+        obstacles: collectRailPopoverObstacles(document),
+      });
+      const top = `${placement.top}px`;
+      const maxHeight = `${placement.maxHeight}px`;
+      if (panelBody.style.getPropertyValue('--rail-popover-fixed-top') !== top) {
+        panelBody.style.setProperty('--rail-popover-fixed-top', top);
+      }
+      if (panelBody.style.maxHeight !== maxHeight) panelBody.style.maxHeight = maxHeight;
+      if (panelBody.dataset.railPopoverPlacement !== placement.strategy) {
+        panelBody.dataset.railPopoverPlacement = placement.strategy;
+      }
+    };
+
+    let frame = 0;
+    const schedule = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        place();
+      });
+    };
+
+    // Windows move, resize, maximize and collapse under an open popover, and the
+    // rail can be pinned out of popover mode entirely. Watching for that is only
+    // worth the observer while this panel is the open one.
+    const observedRoot = panelBody.closest<HTMLElement>('.motif-cs-shell') ?? document.body;
+    let layoutObserver: MutationObserver | null = null;
+    const syncLayoutObserver = () => {
+      if (panel.open && !layoutObserver) {
+        layoutObserver = new MutationObserver(schedule);
+        layoutObserver.observe(observedRoot, {
+          attributes: true,
+          attributeFilter: ['style', 'class', 'data-maximized', 'data-collapsed', 'data-tools-pinned'],
+          childList: true,
+          subtree: true,
+        });
+      } else if (!panel.open && layoutObserver) {
+        layoutObserver.disconnect();
+        layoutObserver = null;
+      }
+    };
+
+    // `open` flips inside the click that toggles the panel, and a mutation
+    // callback runs at the microtask checkpoint straight after — before the
+    // browser paints — so the popover never appears at the resting offset and
+    // then jumps to the solved one.
+    const openObserver = new MutationObserver(() => {
+      syncLayoutObserver();
+      place();
+    });
+    openObserver.observe(panel, { attributes: true, attributeFilter: ['open'] });
+    window.addEventListener('resize', schedule);
+    syncLayoutObserver();
+    place();
+
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      window.removeEventListener('resize', schedule);
+      openObserver.disconnect();
+      layoutObserver?.disconnect();
+      clearPlacement();
+    };
+  }, [panelBody]);
 
   useLayoutEffect(() => {
     if (!panelBody) {
@@ -13787,11 +14212,30 @@ function AnalysisPanel({
   const composition = useMemo(() => isNucleotide ? nucleotideComposition(record.sequence) : null, [isNucleotide, record.sequence]);
   const allOrfs = useMemo(
     () => isNucleotide && translationCode.supported
-      ? findORFs(record.sequence, 10, translationCode.table, { topology })
+      ? findORFs(record.sequence, ANALYSIS_ORF_MIN_AA, translationCode.table, { topology })
       : [],
     [isNucleotide, record.sequence, topology, translationCode],
   );
   const visibleOrfs = useMemo(() => allOrfs.slice(0, 8), [allOrfs]);
+  // findORFs emits one entry per START codon, so every in-frame start upstream
+  // of the same stop is counted again. On pUC19 that is 221 entries over 159
+  // distinct (strand, stop) reading frames — and four of the eight rows this
+  // panel lists are the same reverse-strand frame entered at four different
+  // starts. Read off the SAME array the list renders from, so the note and the
+  // rows cannot drift into disagreeing about one quantity.
+  const orfReadingFrameCount = useMemo(
+    () => new Set(allOrfs.map((orf) => `${orf.strand}:${orf.end}`)).size,
+    [allOrfs],
+  );
+  // Read the start codons off the table the scan actually used. This panel has
+  // a "Record genetic code" select right below it, and the tables disagree —
+  // the standard one initiates at ATG/TTG/CTG, vertebrate mitochondrial at
+  // ATT/ATC/ATA/ATG/GTG — so naming a fixed set here would have been one more
+  // readout that is true of some other configuration than the one on screen.
+  const orfStartCodons = useMemo(
+    () => (translationCode.supported ? [...translationCode.table.starts].sort().join(', ') : ''),
+    [translationCode],
+  );
   const mw = useMemo(
     () => sequenceType === 'protein' ? proteinMolecularWeight(record.sequence) : molecularWeight(record.sequence),
     [record.sequence, sequenceType],
@@ -13826,10 +14270,10 @@ function AnalysisPanel({
       <summary className="motif-cs-panel-head" data-rail-label="A" title="Analysis">
         <Activity className="motif-cs-panel-icon" size={14} strokeWidth={2.2} aria-hidden="true" />
         <span>Analysis</span>
-        <span className="motif-cs-chip">{isNucleotide ? `${allOrfs.length} ORFs` : 'protein'}</span>
+        <span className="motif-cs-chip">{isNucleotide ? `${allOrfs.length} ORFs ≥${ANALYSIS_ORF_MIN_AA} aa` : 'protein'}</span>
       </summary>
       <div className="motif-cs-tool-panel-body">
-        <RailPopoverTitle title="Analysis" meta={isNucleotide ? `${allOrfs.length} ORFs` : 'protein'} />
+        <RailPopoverTitle title="Analysis" meta={isNucleotide ? `${allOrfs.length} ORFs ≥${ANALYSIS_ORF_MIN_AA} aa` : 'protein'} />
         <div className="motif-cs-stat-grid">
           <div className="motif-cs-stat"><span>Length</span><strong>{sequenceLengthLabel(record.sequence.length, sequenceType)}</strong></div>
           <div className="motif-cs-stat"><span>Mass</span><strong>{formatMass(mw)}</strong></div>
@@ -13863,7 +14307,21 @@ function AnalysisPanel({
           </label>
           <div className="motif-cs-list">
             {allOrfs.length > visibleOrfs.length ? (
-              <p className="motif-cs-form-note">Showing the 8 longest of {allOrfs.length} detected ORFs.</p>
+              /* The chip can only carry the floor; this is where the count's
+                 definition fits, and it is the number's whole meaning. "221
+                 ORFs" on a 2.6 kb vector reads as a result about the molecule
+                 when it is a result about the scan: a 10 aa floor, six frames,
+                 and the standard table's near-cognate starts, of which only 76
+                 of the 221 are ATG. The reading-frame figure is the honest
+                 denominator — entering one stop from several in-frame starts
+                 makes several entries, which is why the eight rows below
+                 include the same reverse-strand frame four times. */
+              <p className="motif-cs-form-note">
+                Showing the 8 longest of {allOrfs.length} start-to-stop intervals ≥{ANALYSIS_ORF_MIN_AA} aa
+                across {orfReadingFrameCount} distinct reading frames — six frames, both strands,
+                starting at {orfStartCodons}, so one frame entered at several starts appears more
+                than once.
+              </p>
             ) : null}
             {visibleOrfs.length > 0 ? visibleOrfs.map((orf, index) => {
               const wraps = orf.end > record.sequence.length;
@@ -14431,11 +14889,14 @@ function SequenceToolsPanel({
   );
   const exportRecordsWithSites = useMemo(
     () => needsInventoryExport ? exportRecords.map((item) => {
-      const byName = new Map<string, RestrictionEnzyme>();
       const itemSources = enzymeSourcesByRecord[item.id] ?? DEFAULT_ENZYME_SOURCES;
-      for (const enzyme of resolveEnzymeUnion(itemSources)) byName.set(enzyme.name.toLowerCase(), enzyme);
-      for (const enzyme of customEnzymes) byName.set(enzyme.name.toLowerCase(), enzyme);
-      return { ...item, sites: recordSitesForExport(item, Array.from(byName.values())) };
+      // Resolve through the shared helper rather than a second inline copy of it.
+      // The copy called resolveEnzymeUnion directly, which falls back to the
+      // Common working set for an empty list, so a record with no sources
+      // selected exported Common's sites while every on-screen surface showed
+      // none — the export disagreeing with the app about which enzymes were even
+      // in play. The helper's own empty check keeps the two answers the same.
+      return { ...item, sites: recordSitesForExport(item, restrictionEnzymesForSources(itemSources, customEnzymes)) };
     }) : [],
     [customEnzymes, enzymeSourcesByRecord, exportRecords, needsInventoryExport],
   );
@@ -14732,6 +15193,7 @@ function FloatingWindow({
   returnFocusRef,
   maximizable = false,
   inactive = false,
+  resetSignal,
   children,
 }: {
   title: string;
@@ -14741,6 +15203,12 @@ function FloatingWindow({
   rightInset?: number;
   onClose: () => void;
   onCommit?: (rect: WindowRect) => void;
+  /**
+   * Bumped by "Reset display" to make an ALREADY OPEN window adopt `initial`
+   * again. Without it that button cannot reach these windows at all: `initial`
+   * is read once, at mount.
+   */
+  resetSignal?: number;
   returnFocusRef?: RefObject<HTMLElement | null>;
   maximizable?: boolean;
   /** Keeps a draft mounted beneath a temporarily active child workflow. */
@@ -14810,6 +15278,28 @@ function FloatingWindow({
       // native checkbox click. An open child menu still owns the first Escape
       // even when the key target is no longer inside that menu.
       if (windowRef.current?.querySelector('[data-motif-cs-escape-scope="true"]')) return;
+      // That attribute is rendered from React state, and for a native <details>
+      // menu the state arrives late: the browser opens the menu during the click,
+      // but React only hears about it from the `toggle` event, measured here at
+      // ~52ms after the click. For that whole interval the menu is open on screen
+      // while the check above sees nothing, so an Escape aimed at the menu closed
+      // the window instead. A disclosure's own `open` property is true the instant
+      // it opens, so that is the signal to read. Opt-in through the attribute
+      // rather than matching every `details[open]`: an ordinary accordion left
+      // open inside a window would otherwise swallow Escape for good, because
+      // nothing would ever close it.
+      if (windowRef.current?.querySelector('details[data-motif-cs-escape-scope-when-open][open]')) return;
+      // A tools-rail popover renders outside this window's subtree, so the check
+      // above cannot see it. This listener is in capture on window and stops
+      // propagation, so without this the window closes out from under a panel
+      // that is sitting on top of it — and the panel survives. Same selector the
+      // popover's own handler uses, so the two cannot disagree about what is open.
+      // Keyed on data-tools-pinned="false" because that is the same condition the
+      // stylesheet uses to float the panel: the guard then fires exactly when an
+      // overlay actually exists. Docked mode has the same markup but sits beside
+      // the window rather than over it, and its handler is not registered — so
+      // matching there would leave Escape doing nothing at all.
+      if (document.querySelector('.motif-cs-inspector[data-tools-pinned="false"] details[name="motif-cs-tools"][open]')) return;
       event.preventDefault();
       event.stopPropagation();
       closeWindow();
@@ -14830,6 +15320,28 @@ function FloatingWindow({
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, [maximized, rightInset]);
+
+  // "Reset display" has to reach a window that is open right now. `initial` is
+  // read once, in the useState initialiser above, so a parent handing back a
+  // fresh default rect moves nothing on screen — the user keeps staring at the
+  // 280x180 window they are trying to escape and the button reads as broken.
+  // Driven by an explicit counter rather than by `initial` changing identity,
+  // because `onCommit` writes every finished drag back into that same prop:
+  // adopting on identity would re-apply mid-interaction, against the very
+  // gesture that produced it. Maximize and collapse are cleared too — a reset
+  // that restored the size but left the window maximized would not show it.
+  const lastResetSignalRef = useRef(resetSignal);
+  useEffect(() => {
+    if (resetSignal === lastResetSignalRef.current) return;
+    lastResetSignalRef.current = resetSignal;
+    stopActiveDrag(false);
+    const next = clampWindowRect(initial, window.innerWidth, window.innerHeight, rightInset);
+    restoreRectRef.current = next;
+    rectRef.current = next;
+    setCollapsed(false);
+    setMaximized(false);
+    setRect(next);
+  }, [initial, resetSignal, rightInset, stopActiveDrag]);
 
   const restoreWindow = useCallback(() => {
     const next = clampWindowRect(restoreRectRef.current, window.innerWidth, window.innerHeight, rightInset);
@@ -14997,6 +15509,12 @@ function FloatingWindow({
         width: rect.w,
         height: collapsed ? undefined : rect.h,
         '--motif-cs-floating-right-inset': `${rightInset}px`,
+        // Anything anchored inside this window has to bound itself against the
+        // window, not the browser viewport — a 240px window on a 1400px screen
+        // is the case where the two disagree, and where a viewport-sized popover
+        // is clipped by the body with nothing able to scroll it into reach.
+        // Left unset while maximized, where the viewport IS the right bound.
+        '--motif-cs-window-height': maximized || collapsed ? undefined : `${rect.h}px`,
       } as CSSProperties}
     >
       <div

--- a/src/artifacts/rail-popover-placement.ts
+++ b/src/artifacts/rail-popover-placement.ts
@@ -1,0 +1,307 @@
+/**
+ * Placement solver for the tools-rail popovers.
+ *
+ * The rail popovers used to open at a literal CSS position — `top: 84px;
+ * right: 58px` — with no idea what was underneath them. Measured with a
+ * floating window open, all 15 of them landed squarely on that window's
+ * Maximize / Collapse / Close cluster, 45 of 45 control instances covered, and
+ * there was no way out: the popover is right-anchored and not draggable, so the
+ * user could not move either thing out of the other's way.
+ *
+ * Obstacles are TIERED, which is what makes this more than a constant nudge:
+ *   'hard' — must never be covered. A window's title bar (which carries
+ *            Maximize / Collapse / Close) and the control row directly beneath
+ *            it, plus the topbar / record-tabs band. Covering these is what
+ *            makes the app feel broken, because the control that would undo the
+ *            overlap is the control being hidden.
+ *   'soft'  — prefer not to cover. Window bodies, floating panes. Overlapping
+ *            the content is bad but recoverable — you can scroll it, or close
+ *            the popover with the button that is still visible.
+ *
+ * POLICY: stability. The popover keeps the horizontal dock the stylesheet gives
+ * it and keeps its vertical home too, moving only far enough down (or up) to
+ * clear the hard zones. It may cover some of the window body; that is the
+ * accepted trade. The point of a rail is that the panel is in the same place
+ * every time, so the solver is a pure function of the layout — same layout in,
+ * same pixel out, with no hysteresis and no memory of previous solves.
+ *
+ * Horizontal placement is therefore not searched at all. The docked column is
+ * an input, which lets the vertical search reduce to intervals: hard zones cut
+ * the column into free bands, and the answer is the band that costs least.
+ */
+
+export type PlacementPriority = 'hard' | 'soft';
+
+export type PlacementRect = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+export type PlacementObstacle = PlacementRect & {
+  id: string;
+  priority: PlacementPriority;
+};
+
+export type RailPopoverPlacementInput = {
+  /** The docked x-span the stylesheet gives the popover. Owned by CSS, not searched. */
+  column: { left: number; right: number };
+  /** Where the popover sits when nothing is in the way — the stylesheet's own offset. */
+  homeTop: number;
+  /**
+   * Content height, or the height the user dragged the popover to. Deliberately
+   * NOT an input to the choice — only to `hiddenHeight`. Letting it choose was
+   * measured making a tall panel and a short panel land in different places at
+   * the same window position, which breaks the one thing a rail promises.
+   */
+  desiredHeight: number;
+  viewportHeight: number;
+  /** The stylesheet's bottom breathing room, read back from its own max-height. */
+  bottomGutter: number;
+  obstacles: PlacementObstacle[];
+  /** Mirrors the stylesheet's min-height: a band narrower than this cannot hold the popover. */
+  minHeight?: number;
+  /** A band narrower than this is a last resort, not a choice. See the constant. */
+  minUsableHeight?: number;
+  /** Breathing room left between the popover and a hard zone it is tucking beside. */
+  gap?: number;
+};
+
+export type RailPopoverPlacement = {
+  top: number;
+  /** Cap for the popover — and, because the drag-resize reads its limit off the
+   *  computed max-height, the limit the user's drag is allowed to reach. */
+  maxHeight: number;
+  clearsHard: boolean;
+  /** px² of hard zone the popover would still cover. 0 in every good outcome. */
+  hardOverlap: number;
+  softOverlap: number;
+  /** px of desired height that does not fit in the chosen band. */
+  hiddenHeight: number;
+  strategy: 'home' | 'shifted-down' | 'shifted-up' | 'no-clear-band';
+};
+
+/** Mirrors the stylesheet's `min-height` for the popover body. */
+export const RAIL_POPOVER_MIN_HEIGHT = 96;
+/**
+ * The smallest band worth putting a panel in.
+ *
+ * The stylesheet's 96px is the smallest popover that can legally exist, not the
+ * smallest one worth opening: measured against the live panels, a 96px band
+ * renders exactly ONE of the fourteen rail panels whole. Preferring a band that
+ * small over a roomier one further away recreates this codebase's signature
+ * defect — a box reserving less room than its content needs — except that here
+ * the solver would be choosing to do it, with space visibly free elsewhere.
+ *
+ * Derived from what the panels actually need, measured at 1440x980:
+ *   content heights 94, 111, 156, 171, 179, 193, 205, 220, 337, 367, 490, 686,
+ *   811, 939 — median 220.
+ *   96px band -> 1/14 panels whole      240px -> 8/14
+ *   200px     -> 6/14                   300px -> 8/14 (buys nothing over 240)
+ *                                       356px -> 9/14
+ * 240 is the cheapest floor that clears the median panel, and nothing improves
+ * again until 356 — so anything between them costs displacement for no gain.
+ *
+ * A band under this is still taken when it is the ONLY way to clear a hard zone;
+ * never covering Close is the one rule that does not bend.
+ */
+export const RAIL_POPOVER_MIN_USABLE_HEIGHT = 240;
+/** Breathing room so the popover reads as beside a hard zone rather than welded to it. */
+export const RAIL_POPOVER_GAP = 8;
+
+/** Clearing a hard zone is not negotiable, so it outweighs every other term. */
+const HARD_WEIGHT = 1e6;
+/** Travel away from home, in px. The panel showing up where you expect it is the policy. */
+const DRIFT_WEIGHT = 1;
+/** Covering the window body is the accepted cost of staying docked, so this only
+ *  breaks ties between bands that are otherwise equally good. Scored against the
+ *  band rather than the rendered panel, so a short panel and a tall one are
+ *  placed identically. */
+const SOFT_WEIGHT = 120;
+
+const clamp = (value: number, low: number, high: number): number => Math.max(low, Math.min(high, value));
+
+function overlapArea(a: PlacementRect, b: PlacementRect): number {
+  const x = Math.max(0, Math.min(a.left + a.width, b.left + b.width) - Math.max(a.left, b.left));
+  const y = Math.max(0, Math.min(a.top + a.height, b.top + b.height) - Math.max(a.top, b.top));
+  return x * y;
+}
+
+function overlapsColumn(obstacle: PlacementRect, column: { left: number; right: number }): boolean {
+  return obstacle.left < column.right && obstacle.left + obstacle.width > column.left;
+}
+
+/** Merge the hard zones that cross the docked column into disjoint, sorted y-bands. */
+function mergeBands(bands: Array<[number, number]>): Array<[number, number]> {
+  const sorted = bands.filter(([start, end]) => end > start).sort((a, b) => a[0] - b[0]);
+  const merged: Array<[number, number]> = [];
+  for (const [start, end] of sorted) {
+    const last = merged[merged.length - 1];
+    if (last && start <= last[1]) last[1] = Math.max(last[1], end);
+    else merged.push([start, end]);
+  }
+  return merged;
+}
+
+export function chooseRailPopoverPlacement(input: RailPopoverPlacementInput): RailPopoverPlacement {
+  const gap = input.gap ?? RAIL_POPOVER_GAP;
+  const minHeight = input.minHeight ?? RAIL_POPOVER_MIN_HEIGHT;
+  const minUsableHeight = Math.max(minHeight, input.minUsableHeight ?? RAIL_POPOVER_MIN_USABLE_HEIGHT);
+  const safeTop = 0;
+  const safeBottom = Math.max(safeTop + minHeight, input.viewportHeight - input.bottomGutter);
+  const columnWidth = Math.max(0, input.column.right - input.column.left);
+  const desired = Math.max(minHeight, Math.round(input.desiredHeight));
+  const homeTop = clamp(Math.round(input.homeTop), safeTop, safeBottom - minHeight);
+
+  const hard = input.obstacles.filter((o) => o.priority === 'hard');
+  const soft = input.obstacles.filter((o) => o.priority !== 'hard');
+
+  const blocked = mergeBands(hard
+    .filter((o) => overlapsColumn(o, input.column))
+    .map((o) => [Math.max(safeTop, o.top), Math.min(safeBottom, o.top + o.height)] as [number, number]));
+
+  // What the hard zones leave behind. A band's start abuts a hard zone unless it
+  // is the top of the safe area, and likewise for its end — so trimming by `gap`
+  // exactly where a hard zone is adjacent gives breathing room without eating
+  // into the screen edges, which have their own gutters already.
+  const free: Array<[number, number]> = [];
+  let cursor = safeTop;
+  for (const [start, end] of blocked) {
+    if (start > cursor) free.push([cursor, start]);
+    cursor = Math.max(cursor, end);
+  }
+  if (safeBottom > cursor) free.push([cursor, safeBottom]);
+
+  const bands = free.map(([start, end]): [number, number] => [
+    start > safeTop ? start + gap : start,
+    end < safeBottom ? end - gap : end,
+  ]);
+
+  // Two tiers, not one threshold. A band that can hold a usable panel is always
+  // preferred, however far away it is; a band that merely satisfies the
+  // stylesheet's minimum is taken only when it is the only thing on offer,
+  // because clearing the hard zones still beats being 96px tall AND on top of
+  // Close. Both floors are constants, so which tier applies — and therefore
+  // where the popover lands — stays a function of the layout alone.
+  const usable = bands.filter(([start, end]) => end - start >= minUsableHeight);
+  const tier = usable.length > 0 ? usable : bands.filter(([start, end]) => end - start >= minHeight);
+  const floor = usable.length > 0 ? minUsableHeight : minHeight;
+
+  const candidates = tier.map(([start, end]) => {
+    // Sit at home when home is inside the band; otherwise at the near edge. The
+    // clamp uses the tier's floor rather than the desired height, so a tall
+    // popover in a roomy band still opens at home and simply runs shorter — and
+    // so a band that qualified on size cannot then hand back a sliver because
+    // home happened to sit near its bottom edge.
+    const top = clamp(homeTop, start, Math.max(start, end - floor));
+    return { top, available: end - top };
+  });
+
+  // Nothing clears. Stay home rather than wedging into a band too small to hold
+  // the popover, which would cover a hard zone AND move — the worst of both.
+  if (candidates.length === 0) candidates.push({ top: homeTop, available: safeBottom - homeTop });
+
+  // Score the BAND, not the panel that is about to sit in it. Every term here is
+  // a function of the layout alone, which is what makes all 15 panels land on
+  // the same pixel for a given window arrangement.
+  let best = candidates[0];
+  let bestScore = Number.POSITIVE_INFINITY;
+  for (const candidate of candidates) {
+    const band: PlacementRect = { left: input.column.left, top: candidate.top, width: columnWidth, height: candidate.available };
+    const area = columnWidth * candidate.available;
+    const score = hard.reduce((sum, o) => sum + overlapArea(band, o), 0) * HARD_WEIGHT
+      + Math.abs(candidate.top - homeTop) * DRIFT_WEIGHT
+      + (area > 0 ? soft.reduce((sum, o) => sum + overlapArea(band, o), 0) / area : 0) * SOFT_WEIGHT;
+    if (score < bestScore) {
+      bestScore = score;
+      best = candidate;
+    }
+  }
+
+  const maxHeight = Math.max(minHeight, Math.round(best.available));
+  // Report against what the popover will actually occupy, which is the answer to
+  // "does this cover Close", rather than against the whole band it may not fill.
+  const rendered: PlacementRect = {
+    left: input.column.left,
+    top: best.top,
+    width: columnWidth,
+    height: Math.min(desired, best.available),
+  };
+  const bestHard = hard.reduce((sum, o) => sum + overlapArea(rendered, o), 0);
+  const bestSoft = soft.reduce((sum, o) => sum + overlapArea(rendered, o), 0);
+  const clearsHard = bestHard === 0;
+  return {
+    top: Math.round(best.top),
+    maxHeight,
+    clearsHard,
+    hardOverlap: bestHard,
+    softOverlap: bestSoft,
+    hiddenHeight: Math.max(0, desired - maxHeight),
+    strategy: !clearsHard
+      ? 'no-clear-band'
+      : best.top === homeTop
+        ? 'home'
+        : best.top > homeTop
+          ? 'shifted-down'
+          : 'shifted-up',
+  };
+}
+
+/** Topbar + record tabs: the app chrome the popover must never sit on. */
+const TOP_CHROME_SELECTOR = '.motif-cs-topbar, .motif-cs-record-tabs';
+const WINDOW_SELECTOR = '.motif-cs-window';
+const WINDOW_HEAD_SELECTOR = '.motif-cs-window-head';
+/** A window's own control row, whatever the window holds. Matching on the class
+ *  substring keeps this from becoming a list that has to be revisited every time
+ *  a new window type lands; the adjacency test below is what makes it safe. */
+const WINDOW_CONTROL_ROW_SELECTOR = '[class*="-toolbar"]';
+/** How far below the title bar a row can start and still count as its control row. */
+const CONTROL_ROW_ADJACENCY = 40;
+const FLOATING_PANE_SELECTOR = '[data-pane-placement="floating"]';
+
+function toRect(element: Element): PlacementRect {
+  const rect = element.getBoundingClientRect();
+  return { left: rect.left, top: rect.top, width: rect.width, height: rect.height };
+}
+
+const hasArea = (rect: PlacementRect): boolean => rect.width > 0 && rect.height > 0;
+
+/**
+ * Read the obstacle list out of live DOM. Kept out of the solver so the solver
+ * stays a pure function of geometry and can be tested without a document.
+ */
+export function collectRailPopoverObstacles(root: Document | HTMLElement): PlacementObstacle[] {
+  const obstacles: PlacementObstacle[] = [];
+  const push = (id: string, priority: PlacementPriority, rect: PlacementRect) => {
+    if (hasArea(rect)) obstacles.push({ id, priority, ...rect });
+  };
+
+  for (const element of root.querySelectorAll(TOP_CHROME_SELECTOR)) {
+    push('top-chrome', 'hard', toRect(element));
+  }
+
+  let index = 0;
+  for (const element of root.querySelectorAll(WINDOW_SELECTOR)) {
+    const suffix = index > 0 ? `-${index}` : '';
+    index += 1;
+    push('window', 'soft', toRect(element));
+    const head = element.querySelector(WINDOW_HEAD_SELECTOR);
+    if (!head) continue;
+    const headRect = toRect(head);
+    push(`window-head${suffix}`, 'hard', headRect);
+    const headBottom = headRect.top + headRect.height;
+    for (const row of element.querySelectorAll(WINDOW_CONTROL_ROW_SELECTOR)) {
+      const rowRect = toRect(row);
+      const offset = rowRect.top - headBottom;
+      if (offset < 0 || offset > CONTROL_ROW_ADJACENCY) continue;
+      push(`window-controls${suffix}`, 'hard', rowRect);
+    }
+  }
+
+  for (const element of root.querySelectorAll(FLOATING_PANE_SELECTOR)) {
+    push('floating-pane', 'soft', toRect(element));
+  }
+
+  return obstacles;
+}

--- a/src/components/plasmid-map/SequenceMapView.tsx
+++ b/src/components/plasmid-map/SequenceMapView.tsx
@@ -18,7 +18,6 @@ import {
   Fragment,
   type CSSProperties,
   type KeyboardEvent,
-  type PointerEvent,
 } from 'react';
 import type {
   MapLayout,
@@ -63,15 +62,18 @@ export interface SequenceMapViewProps {
   /** SVG paths for the current sequence selection projected onto the map. */
   selectionPaths?: readonly string[];
   viewport?: MapViewport;
-  isPanning?: boolean;
   onFeatureClick?: (featureId: string) => void;
   onRestrictionClick?: (clusterId: string, tickIds: readonly string[]) => void;
   onRangeOverlayClick?: (overlayId: string) => void;
   onBackgroundClick?: () => void;
+  /**
+   * Wheel is the map's ONLY viewport gesture: plain wheel translates, ctrl/pinch
+   * scales. There is deliberately no drag-to-pan — background drag belongs to the
+   * host's range selection, and this component used to advertise a pan (data-pannable,
+   * cursor:grab, onPanStart/Move/End) that nothing ever wired, so a grab cursor invited
+   * a drag that moved nothing. An affordance nobody implements is worse than none.
+   */
   onWheelZoom?: (point: SvgPoint, deltaX: number, deltaY: number, deltaMode: number, ctrlKey: boolean, shiftKey: boolean) => boolean;
-  onPanStart?: (point: SvgPoint) => boolean;
-  onPanMove?: (point: SvgPoint) => void;
-  onPanEnd?: () => void;
   /** Dock-fill linear maps are height-stretched by CSS; center their content in that viewport. */
   centerLinearContent?: boolean;
 }
@@ -110,10 +112,13 @@ function restrictionAccessibleName(restriction: MapRestrictionRender): string {
   const titleName = restriction.title?.split(' · ', 1)[0]?.trim();
   const name = titleName || restriction.label?.text || 'Restriction site';
   const coordinate = Math.max(0, Math.trunc(restriction.anchorBp)) + 1;
-  const tickCount = restriction.tickIds.length;
-  const kind = tickCount === 1 ? 'site' : 'cluster';
-  const tickWord = tickCount === 1 ? 'map tick' : 'map ticks';
-  return `${name}, restriction ${kind} at ${MAP_NUMBER_FORMAT.format(coordinate)} bp, ${MAP_NUMBER_FORMAT.format(tickCount)} ${tickWord}`;
+  const siteCount = restriction.tickIds.length;
+  const kind = siteCount === 1 ? 'site' : 'cluster';
+  // "cut sites", not "map ticks": the cluster's own tooltip counts the same quantity
+  // as "N sites" and the overflow chip as "+N more sites". A third word for it left a
+  // screen-reader user reconciling ticks against sites against the label's "+N" names.
+  const siteWord = siteCount === 1 ? 'cut site' : 'cut sites';
+  return `${name}, restriction ${kind} at ${MAP_NUMBER_FORMAT.format(coordinate)} bp, ${MAP_NUMBER_FORMAT.format(siteCount)} ${siteWord}`;
 }
 
 function restrictionAnnotationSemanticScale(zoom: number): number {
@@ -266,10 +271,10 @@ function MapText({
           ? segments.map((seg, i) => (
               <Fragment key={i}>
                 {/* Separators are bare text nodes (normal ink): enzyme tokens join
-                    with "," and the "+N" overflow tail (always "+"-prefixed, never
+                    with ", " and the "+N" overflow tail (always "+"-prefixed, never
                     first) with " " — matching clusterLabelText exactly. Only the
                     enzyme <tspan> carries the Type IIS class, so commas/tail stay ink. */}
-                {i > 0 ? (seg.text.startsWith('+') ? ' ' : ',') : null}
+                {i > 0 ? (seg.text.startsWith('+') ? ' ' : ', ') : null}
                 <tspan className={seg.typeIIS ? 'motif-pm-restriction-enz--typeiis' : undefined}>
                   {seg.text}
                 </tspan>
@@ -366,8 +371,10 @@ const RestrictionMark = memo(function RestrictionMark({
   const activate = () => onClick?.(restriction.clusterId, restriction.tickIds);
   // Segmented labels color per-enzyme via <tspan>; data-segmented tells the CSS to
   // drop the aggregate whole-label tint (unsegmented linear labels keep it).
+  // Must reproduce clusterLabelText's join rule exactly: mismatch silently falls back
+  // to the flat label and drops per-enzyme Type IIS coloring, with no error anywhere.
   const segmentedText = restriction.labelSegments
-    ?.map((seg, i) => `${i > 0 ? (seg.text.startsWith('+') ? ' ' : ',') : ''}${seg.text}`)
+    ?.map((seg, i) => `${i > 0 ? (seg.text.startsWith('+') ? ' ' : ', ') : ''}${seg.text}`)
     .join('');
   const segmented =
     !!restriction.label && !!restriction.labelSegments && restriction.labelSegments.length > 0 && segmentedText === restriction.label.text;
@@ -481,21 +488,16 @@ export const SequenceMapView = memo(function SequenceMapView({
   selectedRangeOverlayId,
   selectionPaths,
   viewport = DEFAULT_VIEWPORT,
-  isPanning = false,
   onFeatureClick,
   onRestrictionClick,
   onRangeOverlayClick,
   onBackgroundClick,
   onWheelZoom,
-  onPanStart,
-  onPanMove,
-  onPanEnd,
   centerLinearContent = false,
 }: SequenceMapViewProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const onWheelZoomRef = useRef(onWheelZoom);
   onWheelZoomRef.current = onWheelZoom;
-  const panPointerRef = useRef<number | null>(null);
   const isCircular = layout.mode === 'circular';
   const preserveAspectRatio = isCircular || centerLinearContent ? 'xMidYMid meet' : 'xMidYMin meet';
   // Protein maps count residues, not base pairs.
@@ -608,38 +610,6 @@ export const SequenceMapView = memo(function SequenceMapView({
     return () => el.removeEventListener('wheel', onWheelNative);
   }, [interactive]);
 
-  const handleBackgroundPointerDown = (e: PointerEvent<SVGRectElement>) => {
-    if (!interactive) return;
-    if (e.button !== 0 || !onPanStart) return;
-    const svg = svgRef.current;
-    if (!svg) return;
-    const point = svgPointFromClient(svg, e.clientX, e.clientY);
-    if (!point || !onPanStart(point)) return;
-    panPointerRef.current = e.pointerId;
-    e.currentTarget.setPointerCapture(e.pointerId);
-    e.preventDefault();
-  };
-
-  const handleBackgroundPointerMove = (e: PointerEvent<SVGRectElement>) => {
-    if (!interactive) return;
-    if (panPointerRef.current !== e.pointerId || !onPanMove) return;
-    const svg = svgRef.current;
-    if (!svg) return;
-    const point = svgPointFromClient(svg, e.clientX, e.clientY);
-    if (!point) return;
-    e.preventDefault();
-    onPanMove(point);
-  };
-
-  const endBackgroundPan = (e: PointerEvent<SVGRectElement>) => {
-    if (!interactive) return;
-    if (panPointerRef.current !== e.pointerId) return;
-    if (e.currentTarget.hasPointerCapture(e.pointerId)) e.currentTarget.releasePointerCapture(e.pointerId);
-    panPointerRef.current = null;
-    e.preventDefault();
-    onPanEnd?.();
-  };
-
   return (
     <svg
       ref={svgRef}
@@ -651,26 +621,24 @@ export const SequenceMapView = memo(function SequenceMapView({
       }`}
       preserveAspectRatio={preserveAspectRatio}
       data-interactive={interactive ? 'true' : undefined}
-      data-zoomed={hasViewportTransform || undefined}
-      data-panning={isPanning || undefined}
       onClick={interactive ? () => onBackgroundClick?.() : undefined}
     >
       {/* Background-clear lives on the SVG root above, so clicking ANY
           non-interactive area (inner ring, center label, coord numbers, gaps)
           deselects — features/restrictions stopPropagation so their clicks never
           reach it. The rect stays outside the zoom transform as the full-view
-          transparent hit/pan surface. */}
+          transparent hit surface.
+
+          It carries NO pointer handlers on purpose. Whatever drag the host wants over
+          the map (range selection, in this app) it listens for on its own wrapper and
+          receives by bubbling; a handler here would only be able to compete with that.
+          Viewport translation is the wheel's job — see onWheelZoom. */}
       <rect
         className="motif-pm-bg"
         x={layout.bg.x}
         y={layout.bg.y}
         width={layout.bg.width}
         height={layout.bg.height}
-        data-pannable={hasViewportTransform || undefined}
-        onPointerDown={handleBackgroundPointerDown}
-        onPointerMove={handleBackgroundPointerMove}
-        onPointerUp={endBackgroundPan}
-        onPointerCancel={endBackgroundPan}
       />
       {isCircular && selectionPaths && selectionPaths.length > 0 ? (
         <defs>
@@ -828,14 +796,13 @@ export const SequenceMapView = memo(function SequenceMapView({
         {layout.overflows?.length ? (
           <g className="motif-pm-overflows">
             {layout.overflows.map((overflow) => (
-              <text
-                key={overflow.id}
-                className="motif-pm-overflow"
-                x={overflow.x}
-                y={overflow.y}
-                textAnchor={overflow.anchor}
-                data-kind={overflow.kind}
-              >
+              // The <title> is the ONLY place the map says what the chip's count
+              // means and that nothing was actually dropped from the drawing. It
+              // hangs off the GROUP, not the text, so the layout's hit rect resolves
+              // to it too — a <title> is inherited by whichever child the pointer
+              // lands on. The chip still declares NO pointer handlers of its own, so
+              // a press bubbles on to whatever surface owns the map's drag.
+              <g key={overflow.id} className="motif-pm-overflow-chip" data-kind={overflow.kind}>
                 <title>
                   {restrictionDensityRender.binned && overflow.kind === 'restriction-labels'
                     ? overflow.title.replace(
@@ -844,8 +811,23 @@ export const SequenceMapView = memo(function SequenceMapView({
                       )
                     : overflow.title}
                 </title>
-                {overflow.text}
-              </text>
+                <rect
+                  className="motif-pm-overflow-hit"
+                  x={overflow.hit.x}
+                  y={overflow.hit.y}
+                  width={overflow.hit.width}
+                  height={overflow.hit.height}
+                />
+                <text
+                  className="motif-pm-overflow"
+                  x={overflow.x}
+                  y={overflow.y}
+                  textAnchor={overflow.anchor}
+                  data-kind={overflow.kind}
+                >
+                  {overflow.text}
+                </text>
+              </g>
             ))}
           </g>
         ) : null}

--- a/src/components/plasmid-map/__tests__/background-affordance.test.tsx
+++ b/src/components/plasmid-map/__tests__/background-affordance.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+
+/**
+ * The map background used to promise a drag it could not perform. Once the viewport
+ * was transformed the rect flipped `data-pannable="true"` and the stylesheet answered
+ * with `cursor: grab` / `grabbing`, but no host ever passed onPanStart/onPanMove/
+ * onPanEnd, so the press was dropped on the first line of the handler and the map moved
+ * by zero pixels. Grabbing something that does not move is a worse first impression
+ * than a background that never invited the gesture.
+ *
+ * The affordance was deleted rather than wired: the background drag is already claimed
+ * by the host's range selection, and plain wheel already translates the viewport while
+ * ctrl/pinch scales it — so there is no free gesture, and inventing one (space-drag,
+ * middle-drag) would hide the answer behind something undiscoverable.
+ *
+ * These tests hold the map to claiming only what it does.
+ */
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SequenceMapView } from '../SequenceMapView';
+import { computeMapLayout } from '../../../plasmid-map/layout';
+
+const here = dirname(fileURLToPath(import.meta.url));
+/**
+ * Match against CODE, not prose: the comments in both files name the deleted
+ * affordance on purpose, so that the next reader learns why it is gone rather than
+ * re-adding it. (Crude but sufficient here — neither file contains a `//` inside a
+ * string literal.)
+ */
+const stripComments = (src: string) => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+const viewSource = readFileSync(resolve(here, '..', 'SequenceMapView.tsx'), 'utf8');
+const viewCode = stripComments(viewSource);
+
+/**
+ * BOTH stylesheets, because the affordance was declared in both: the component's own
+ * `cursor: grab`, and a host override in motif-artifact.css that quietly restored
+ * `crosshair` on top of it. Pinning the guard to only the copy that was fixed is the
+ * exact failure this branch has hit before — one value declared twice, one copy
+ * corrected, the test watching the corrected one.
+ */
+const stylesheets = [
+  ['plasmid-map.css', resolve(here, '..', 'plasmid-map.css')],
+  ['motif-artifact.css', resolve(here, '..', '..', '..', 'artifacts', 'motif-artifact.css')],
+].map(([name, path]) => {
+  const text = readFileSync(path, 'utf8');
+  return { name, text, code: stripComments(text) };
+});
+const mapCss = stylesheets[0].text;
+
+/**
+ * Rule blocks whose SELECTOR targets the map background. `grab` has to be judged per
+ * selector, not per file: motif-artifact.css uses grab/grabbing legitimately for window
+ * drag handles and row grips, and claude-science-msa.css for the reorder grip. Those are
+ * real affordances with real handlers. A blanket "no grab anywhere" rule would reject
+ * those valid controls instead of guarding the map background.
+ */
+const backgroundRules = (css: string) =>
+  css.split('}').map((chunk) => {
+    const brace = chunk.lastIndexOf('{');
+    return brace < 0
+      ? null
+      : { selector: chunk.slice(0, brace).split(/[;{}]/).pop()!.trim(), body: chunk.slice(brace + 1) };
+  }).filter((rule): rule is { selector: string; body: string } => !!rule && rule.selector.includes('motif-pm-bg'));
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+function renderMap(viewport: { k: number; tx: number; ty: number }): SVGRectElement {
+  const layout = computeMapLayout({
+    mode: 'circular',
+    name: 'pan affordance fixture',
+    length: 2686,
+    topology: 'circular',
+    sequenceType: 'dna',
+    features: [],
+    restrictionSites: [],
+    width: 600,
+    height: 600,
+  });
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  act(() => {
+    root!.render(<SequenceMapView layout={layout} theme="light" interactive viewport={viewport} />);
+  });
+  const bg = host.querySelector<SVGRectElement>('rect.motif-pm-bg');
+  expect(bg).not.toBeNull();
+  return bg!;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+});
+
+describe('the map background claims only the gestures it can perform', () => {
+  it('flags nothing as pannable, zoomed in or not', () => {
+    expect(renderMap({ k: 1, tx: 0, ty: 0 }).getAttribute('data-pannable')).toBeNull();
+    act(() => root?.unmount());
+    host?.remove();
+    // 195% with an offset: precisely the state that used to turn on the grab cursor.
+    expect(renderMap({ k: 1.953125, tx: -343.6, ty: -82.2 }).getAttribute('data-pannable')).toBeNull();
+  });
+
+  it('never advertises a grab cursor, in either stylesheet that styles it', () => {
+    const offenders = stylesheets.flatMap(({ name, code }) =>
+      backgroundRules(code)
+        .filter((rule) => /grab/.test(rule.body))
+        .map((rule) => `${name}: ${rule.selector}`),
+    );
+
+    expect(offenders).toEqual([]);
+    // Both files must actually contribute a rule, or "no offenders" is vacuous — a
+    // renamed class or a changed path would silently reduce this to scanning nothing.
+    for (const { name, code } of stylesheets) {
+      expect(backgroundRules(code).length, `${name} contributed no .motif-pm-bg rule`).toBeGreaterThan(0);
+    }
+  });
+
+  it('would catch the grab rule coming back in either file', () => {
+    // Proof the detector fires without editing another stylesheet. The fixture
+    // is the rule this component used to ship, and the second
+    // block is a real grab affordance from the same stylesheet that must NOT trip it.
+    const reintroduced = `
+      .motif-pm-bg[data-pannable='true'] { cursor: grab; touch-action: none; }
+      .motif-cs-window-titlebar { cursor: grab; }
+    `;
+    const caught = backgroundRules(reintroduced).filter((rule) => /grab/.test(rule.body));
+
+    expect(caught.map((rule) => rule.selector)).toEqual([".motif-pm-bg[data-pannable='true']"]);
+  });
+
+  it('leaves the pan attributes declared in neither stylesheet', () => {
+    // These two names only ever existed to drive the dead affordance, so outside a
+    // comment they cannot mean anything else in either file.
+    for (const { name, code } of stylesheets) {
+      expect(code, `${name} still selects on data-pannable`).not.toContain('data-pannable');
+      expect(code, `${name} still selects on data-panning`).not.toContain('data-panning');
+    }
+  });
+
+  it('keeps the background a bare hit surface with no pointer handlers', () => {
+    const bgStart = viewCode.indexOf('className="motif-pm-bg"');
+    const bgEnd = viewCode.indexOf('/>', bgStart);
+    const bgJsx = viewCode.slice(bgStart, bgEnd);
+
+    expect(bgStart).toBeGreaterThan(-1);
+    expect(bgJsx).not.toMatch(/onPointer|data-pannable/);
+  });
+
+  it('carries no pan plumbing left over to be re-enabled by accident', () => {
+    // Dead props are an invitation to re-wire the wrong gesture; the viewport API is
+    // deliberately wheel-only now.
+    expect(viewCode).not.toMatch(/onPanStart|onPanMove|onPanEnd|isPanning|panPointerRef/);
+    expect(viewCode).toContain('onWheelZoom?:');
+  });
+
+  it('still keeps touch drags from being stolen by page scroll', () => {
+    // The one genuinely functional property in the old data-pannable block; it now
+    // applies always, not just once the viewport happens to be transformed.
+    const bgRule = mapCss.slice(
+      mapCss.indexOf('.motif-pm-bg {'),
+      mapCss.indexOf('}', mapCss.indexOf('.motif-pm-bg {')),
+    );
+    expect(bgRule).toContain('touch-action: none;');
+    expect(bgRule).toContain('pointer-events: all;');
+  });
+});

--- a/src/components/plasmid-map/__tests__/overflow-chip-reachability.test.tsx
+++ b/src/components/plasmid-map/__tests__/overflow-chip-reachability.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+
+/**
+ * The "+N more sites" chip carries the only sentence on the map that says what its
+ * count means and that no site was actually dropped from the drawing. That sentence
+ * lives in a native <title>, which a mouse can only reach if the chip is a hit target
+ * — and .motif-pm-overflows sets pointer-events:none, so it was not one: the browser
+ * resolved the chip's own centre to .motif-pm-bg.
+ *
+ * Making it hit-testable is only half the fix. The background owns click (to clear the
+ * selection) and pointerdown (to start a range drag), so these tests pin BOTH: the chip
+ * is reachable, and it hands those interactions on rather than eating them.
+ */
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SequenceMapView } from '../SequenceMapView';
+import { computeMapLayout } from '../../../plasmid-map/layout';
+import type { MapLayout } from '../../../plasmid-map/types';
+import type { RestrictionSite } from '../../../bio/types';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const viewSource = readFileSync(resolve(here, '..', 'SequenceMapView.tsx'), 'utf8');
+const mapCss = readFileSync(resolve(here, '..', 'plasmid-map.css'), 'utf8');
+
+/** Dense enough that the label band overflows and the chip is emitted. */
+function overflowingLayout(): MapLayout {
+  const length = 4000;
+  const sites: RestrictionSite[] = Array.from({ length: 40 }, (_, i) => ({
+    enzyme: `Enzyme${i}`,
+    position: 50 + i * 100,
+    cutPosition: 51 + i * 100,
+    recognitionSequence: 'GAATTC',
+    overhang: 'blunt',
+  }));
+  return computeMapLayout({
+    mode: 'linear',
+    name: 'overflow chip fixture',
+    length,
+    topology: 'linear',
+    sequenceType: 'dna',
+    features: [],
+    restrictionSites: sites,
+    width: 1000,
+    height: 420,
+    display: { maxRestrictionLabels: 8 },
+  });
+}
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+function render(props: Partial<Parameters<typeof SequenceMapView>[0]> = {}) {
+  const layout = overflowingLayout();
+  expect(layout.overflows?.some((o) => o.kind === 'restriction-labels')).toBe(true);
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  act(() => {
+    root!.render(<SequenceMapView layout={layout} theme="light" interactive {...props} />);
+  });
+  const group = host.querySelector<SVGGElement>('g.motif-pm-overflow-chip');
+  const chip = host.querySelector<SVGTextElement>('text.motif-pm-overflow');
+  expect(group).not.toBeNull();
+  expect(chip).not.toBeNull();
+  return { group: group!, chip: chip!, layout };
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+  vi.restoreAllMocks();
+});
+
+describe('the "+N more sites" chip can be reached without stealing the background', () => {
+  it('puts the explanation in a <title> the browser can serve to a pointer', () => {
+    const { group, chip } = render();
+
+    // <title> must be the FIRST child: that is what makes it the tooltip for the
+    // element rather than stray text painted into the chip. It hangs off the GROUP so
+    // the hit rect inherits it too — a rect that enlarges the target but resolves to
+    // no tooltip would be a bigger nothing.
+    expect(group.firstElementChild?.tagName.toLowerCase()).toBe('title');
+    expect(group.firstElementChild?.textContent).toContain('hidden labels');
+    expect(group.firstElementChild?.textContent).toContain('All density ticks remain visible.');
+    expect(chip.textContent).toContain('more sites');
+    expect(chip.querySelector('title')).toBeNull();
+  });
+
+  it('draws the hit rect at the geometry the layout computed, not one of its own', () => {
+    const { group, layout } = render();
+    const expected = layout.overflows!.find((o) => o.kind === 'restriction-labels')!.hit;
+    const rect = group.querySelector<SVGRectElement>('rect.motif-pm-overflow-hit');
+
+    expect(rect).not.toBeNull();
+    expect(Number(rect!.getAttribute('x'))).toBe(expected.x);
+    expect(Number(rect!.getAttribute('y'))).toBe(expected.y);
+    expect(Number(rect!.getAttribute('width'))).toBe(expected.width);
+    expect(Number(rect!.getAttribute('height'))).toBe(expected.height);
+    // Fixture geometry, absolute — a rect that quietly collapsed to zero would still
+    // satisfy the equality above.
+    expect(expected).toEqual({ x: 885.091, y: 60.8, width: 94.909, height: 14 });
+  });
+
+  it('paints the rect under the glyphs so it never hides the count it explains', () => {
+    const { group } = render();
+    const kids = [...group.children].map((c) => c.tagName.toLowerCase());
+    expect(kids).toEqual(['title', 'rect', 'text']);
+  });
+
+  it('hands press and click on to the surfaces that own the map drag and clear', () => {
+    // The map's drag (range selection) is listened for on the host's wrapper and its
+    // background-clear on the <svg> root, so BOTH reach the chip only by bubbling.
+    // This is the whole reason a hit-testable chip costs the map nothing.
+    const { chip } = render();
+    const surface = document.createElement('div');
+    const seen: string[] = [];
+    surface.addEventListener('pointerdown', () => seen.push('pointerdown'));
+    surface.addEventListener('click', () => seen.push('click'));
+    // Stand in for the host's [data-map-interaction-surface] wrapper.
+    host!.parentNode!.insertBefore(surface, host);
+    surface.appendChild(host!);
+
+    act(() => {
+      chip.dispatchEvent(new window.MouseEvent('pointerdown', { bubbles: true, cancelable: true }));
+      chip.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+
+    expect(seen).toEqual(['pointerdown', 'click']);
+  });
+
+  it('declares no pointer handler of its own that could swallow either', () => {
+    // Cheapest way to keep the bubbling above true: the chip carries no pointer props
+    // at all — on the group, the rect or the text. A handler added to any of them
+    // would not fail to render, it would just quietly start competing with the host
+    // for the gesture.
+    const chipStart = viewSource.indexOf('className="motif-pm-overflow-chip"');
+    const chipEnd = viewSource.indexOf('</g>', chipStart);
+    const chipJsx = viewSource.slice(chipStart, chipEnd);
+
+    expect(chipStart).toBeGreaterThan(-1);
+    expect(chipJsx).toContain('motif-pm-overflow-hit');
+    expect(chipJsx).not.toMatch(/onPointer|onMouseDown|stopPropagation/);
+  });
+});
+
+describe('plasmid-map.css keeps the chip hit-testable and visibly hoverable', () => {
+  const chipRule = mapCss.slice(
+    mapCss.indexOf('.motif-pm-overflow {'),
+    mapCss.indexOf('}', mapCss.indexOf('.motif-pm-overflow {')),
+  );
+  // The rule's own comment explains at length what was tried and dropped, so the
+  // negative assertions below have to look at declarations, not prose.
+  const chipDecls = chipRule.replace(/\/\*[\s\S]*?\*\//g, '');
+
+  it('re-enables pointer events the .motif-pm-overflows group switched off', () => {
+    expect(mapCss).toContain('.motif-pm-overflows {\n  pointer-events: none;');
+    expect(chipDecls).toContain('pointer-events: all;');
+    expect(chipDecls).toContain('cursor: help;');
+  });
+
+  it('keeps the target independent of whether the chip is painted', () => {
+    // `all`, not `visiblePainted`: the chip is the faintest ink on the map, and a theme
+    // or forced-colors pass that drove its fill to zero would otherwise take the only
+    // explanation of the count with it.
+    expect(chipDecls).toMatch(/pointer-events:\s*all;/);
+    expect(chipDecls).not.toMatch(/pointer-events:\s*visiblePainted/);
+  });
+
+  it('carries no stroke hit-area, which measurement showed does nothing for text', () => {
+    // Chromium resolves a hit anywhere inside a text run's box, so the fattened
+    // transparent stroke used by .motif-pm-tick-hit leaves this element's hit region
+    // byte-identical at stroke-width 0, 12 and 40. Shipping it would be a decoration
+    // that reads like the mechanism. A genuinely bigger target needs real geometry.
+    expect(chipDecls).not.toMatch(/stroke/);
+    expect(chipDecls).not.toMatch(/paint-order/);
+  });
+
+  it('lands the hover rule after the theme rules that also set fill-opacity', () => {
+    const hoverAt = mapCss.indexOf('.motif-pm-overflow-chip:hover');
+    const lastThemeAt = mapCss.lastIndexOf("] .motif-pm-container[data-map-mode='circular'] .motif-pm-overflow {");
+
+    expect(hoverAt).toBeGreaterThan(-1);
+    expect(hoverAt).toBeGreaterThan(lastThemeAt);
+    // ...and out-specifies them, or the chip would never visibly react to a pointer.
+    expect(mapCss).toContain(".motif-pm-container[data-map-mode='circular'] .motif-pm-overflow-chip:hover .motif-pm-overflow");
+  });
+
+  it('keys hover on the group, so the enlarged target reacts as well as answering', () => {
+    // The rect is the text's SIBLING. A rule written `.motif-pm-overflow:hover` only
+    // fires over the glyphs, so every point the new rect added would serve a tooltip
+    // from a chip that visibly did nothing.
+    const hoverRules = mapCss.match(/^[^\n{]*:hover[^\n{]*\{/gm) ?? [];
+    const chipHover = hoverRules.filter((r) => r.includes('motif-pm-overflow'));
+
+    expect(chipHover.length).toBeGreaterThan(0);
+    for (const rule of chipHover) {
+      expect(rule).toContain('.motif-pm-overflow-chip:hover');
+      expect(rule).not.toMatch(/\.motif-pm-overflow:hover/);
+    }
+  });
+
+  it('makes the hit rect present but invisible, and hit-testable', () => {
+    const start = mapCss.indexOf('.motif-pm-overflow-hit {');
+    const rule = mapCss.slice(start, mapCss.indexOf('}', start));
+
+    expect(start).toBeGreaterThan(-1);
+    // `fill: none` is not hit-testable in every engine even under pointer-events: all;
+    // transparent is. This is the difference between a target and a decoration.
+    expect(rule).toMatch(/fill:\s*transparent;/);
+    expect(rule).not.toMatch(/fill:\s*none;/);
+    expect(rule).toMatch(/pointer-events:\s*all;/);
+  });
+});

--- a/src/components/plasmid-map/plasmid-map.css
+++ b/src/components/plasmid-map/plasmid-map.css
@@ -314,13 +314,18 @@
 .motif-pm-bg {
   fill: transparent;
   pointer-events: all;
-}
-.motif-pm-bg[data-pannable='true'] {
-  cursor: grab;
+  /* A drag here belongs to whatever the host listens for on its own wrapper (range
+     selection, in this app), so the browser must not claim the gesture as a page
+     scroll first. This used to be conditional on data-pannable — i.e. only once the
+     viewport was transformed — but the touch gesture is no less real at 100%.
+
+     No cursor is set, because there is no drag-to-pan. The rect used to advertise
+     `grab` / `grabbing` whenever the viewport was transformed, yet nothing ever wired
+     the pan it promised: pressing and dragging moved the map by exactly zero pixels.
+     A cursor is a promise about what a drag will do, and the map should only make the
+     ones its host can keep. Viewport translation is the wheel's job (plain wheel
+     translates, ctrl/pinch scales). */
   touch-action: none;
-}
-.motif-plasmid-map[data-panning='true'] .motif-pm-bg[data-pannable='true'] {
-  cursor: grabbing;
 }
 
 .motif-pm-range-overlays {
@@ -621,9 +626,17 @@
 .motif-pm-feature:focus {
   outline: none;
 }
+/* An indicator did exist here, so "no visible change on focus" was wrong — but
+   it was a 0.7px stroke diluted 30% into the feature's own colour, and a real
+   Tab onto the arc repainted 124 of 11,500 pixels, 1.08%. Every other focusable
+   thing in this app answers with a 2px undiluted accent, so this now matches
+   that: same colour, same thickness, following the arc's own geometry instead
+   of boxing it. Hover stays diluted at 0.55, so focus is unambiguously the
+   louder of the two rather than 0.15px louder. `vector-effect:
+   non-scaling-stroke` on the body means these widths are screen pixels. */
 .motif-pm-feature:focus-visible .motif-pm-feature-body {
-  stroke: color-mix(in srgb, var(--accent, #0169cc) 70%, var(--pm-base, #8a8a8a));
-  stroke-width: 0.7;
+  stroke: var(--accent, #0169cc);
+  stroke-width: 2;
 }
 .motif-pm-feature-label {
   fill: var(--text-primary, #131313);
@@ -678,7 +691,47 @@
   font-size: 10px;
   font-weight: 500;
   font-variant-numeric: tabular-nums;
-  cursor: default;
+  /* The chip's <title> is the only text that says what its count means and that no
+     site was actually dropped from the drawing. .motif-pm-overflows sets
+     pointer-events:none, so that sentence used to be unreachable by a mouse: the
+     browser resolved the chip's own centre to .motif-pm-bg. This one declaration —
+     the child overriding the group — is the entire fix.
+
+     `all` rather than `visiblePainted` so the target does not depend on the chip being
+     painted; it is the faintest ink on the map (fill-opacity 0.56 in circular) and a
+     theme or forced-colors pass that drove it to zero would otherwise take the
+     explanation with it.
+
+     No stroke hit-area here, deliberately. .motif-pm-tick-hit / .motif-pm-feature-hit
+     fatten a transparent stroke to enlarge a hit target, and the same trick was tried
+     on this text — but measured against Chromium it changes nothing: the resolved hit
+     region is identical at stroke-width 0, 12 and 40 (38x6 CSS px circular, 81x13
+     linear), because text is hit-tested as its whole run box, not per glyph outline.
+     That also means there are no inter-word gaps to bridge — sweeping the chip's centre
+     row misses 0 of 37 (circular) and 0 of 80 (linear) points. Dead declarations that
+     look load-bearing are worse than none.
+
+     Enlarging the target therefore takes a real rect, sized in the layout from the
+     chip's own text extent — see .motif-pm-overflow-hit below. This declaration stays
+     so the glyphs themselves keep working wherever the rect cannot reach. */
+  pointer-events: all;
+  cursor: help;
+}
+
+/* The chip's real pointer target. Sized in layout.ts from the estimated glyph run,
+   so it tracks the text instead of a guessed constant, and kept to ONE label line
+   tall for two reasons that are easy to undo by accident:
+     - stacked chips are placed one line apart, so a taller rect would cover the
+       chip below it and answer with the wrong tooltip;
+     - .motif-pm-overflows paints AFTER .motif-pm-features, so a rect that reached
+       into the feature lane under the linear chip would silently eat feature clicks.
+   `fill: none` would make it unhittable under pointer-events: all in some engines;
+   a transparent fill is the portable way to be present but invisible. */
+.motif-pm-overflow-hit {
+  fill: transparent;
+  stroke: none;
+  pointer-events: all;
+  cursor: help;
 }
 
 .motif-pm-container[data-map-mode='circular'] .motif-pm-overflow {
@@ -700,6 +753,22 @@
 
 [data-theme='dark'] .motif-pm-container[data-map-mode='circular'] .motif-pm-overflow {
   fill-opacity: 0.62;
+}
+
+/* Dead-looking text invites no hover, and the chip is deliberately the faintest ink on
+   the map. Lifting it to full strength under the pointer is the cue that there is
+   something here to read. Must out-specify (and follow) the four theme rules above,
+   which set fill-opacity at up to (0,4,0) — a bare .motif-pm-overflow:hover loses to
+   them and the chip would never visibly react.
+
+   Keyed on the GROUP, not the text. The hit rect is the text's SIBLING, so hovering
+   the rect never puts :hover on the text — the enlarged target would answer with a
+   tooltip while the chip sat there looking inert, which is worse than a small target
+   that reacts. The group is the one element both children have in common. */
+.motif-pm-container .motif-pm-overflow-chip:hover .motif-pm-overflow,
+.motif-pm-container[data-map-mode='circular'] .motif-pm-overflow-chip:hover .motif-pm-overflow {
+  fill: var(--text-primary, #131313);
+  fill-opacity: 1;
 }
 
 /* Type IIS enzymes get a distinct tan visual language.

--- a/src/plasmid-map/__tests__/label-collision.probe.test.ts
+++ b/src/plasmid-map/__tests__/label-collision.probe.test.ts
@@ -306,6 +306,13 @@ describe('label collision regression coverage', () => {
     { name: 'circular 40feat/20site @320(dock)', input: base({ mode: 'circular', topology: 'circular', width: 320, height: 320, features: denseFeatures(40, 6000), restrictionSites: denseSites(20, 6000) }) },
     { name: 'linear 24feat/28site @1000', input: base({ mode: 'linear', topology: 'linear', length: 9276, width: 1000, height: 420, features: denseFeatures(24, 9276), restrictionSites: denseSites(28, 9276) }) },
     { name: 'linear 40feat/20site @1000', input: base({ mode: 'linear', topology: 'linear', width: 1000, height: 420, features: denseFeatures(40, 6000), restrictionSites: denseSites(20, 6000) }) },
+    // The circular ruler WRAPS, so a length barely over a nice-step multiple leaves the
+    // last tick a few bp short of the origin and prints its number on top of "0". 4008
+    // on a 1000 step leaves 8 bp — about 3px of arc — and "4000" is four times wider
+    // than "0", so "0" vanishes and the map reads as starting at 4000. Every other
+    // fixture here has a comfortable remainder (6000→1000, 9276→1276, 4000→500), which
+    // is exactly why this shipped unnoticed.
+    { name: 'circular 4008bp origin seam @720', input: base({ mode: 'circular', topology: 'circular', length: 4008, features: denseFeatures(6, 4008), restrictionSites: denseSites(8, 4008) }) },
   ];
 
   for (const s of scenarios) {

--- a/src/plasmid-map/__tests__/lanes-restrictions.test.ts
+++ b/src/plasmid-map/__tests__/lanes-restrictions.test.ts
@@ -138,13 +138,20 @@ describe('restrictions: clustering', () => {
     // The two BsmBI cuts collapse to ONE display name (was the "BsmBI,BsmBI" bug);
     // ticks[] still holds all four real cut sites so density + "+N more sites" stay put.
     expect(cluster.ticks).toHaveLength(4);
-    expect(cluster.enzymes).toEqual(['BsmBI', 'BbsI', 'AfeI']); // 3 distinct, position order
+    expect(cluster.enzymes).toEqual(['BsmBI', 'BbsI', 'AfeI']); // 3 distinct, display order
     expect(cluster.shownEnzymes).toEqual(['BsmBI', 'BbsI']); // Type IIS first, distinct, capped at 2
     expect(cluster.overflow).toBe(1); // one DISTINCT enzyme (AfeI) unshown, NOT the extra BsmBI tick
     expect(cluster.hasTypeIIS).toBe(true); // BsmBI/BbsI cut downstream
   });
 
-  it('shows a Type IIS enzyme name first without reordering the full enzyme list', () => {
+  it('orders the WHOLE enzyme list the way the label reads it, Type IIS first', () => {
+    // The full list used to stay in position order while only the shown slice was
+    // promoted, so a label reading "BbsI +3" sat over a tooltip opening "PstI, AluI".
+    // On live pUC19 with every source on that hit 9 of 20 circular clusters and 6 of
+    // 17 linear ones, with the clicked name as deep as 14th of 39. The list is ordered
+    // once now and `shownEnzymes` is a slice of it, so "the label's names are the
+    // tooltip's first names" holds by construction instead of by two functions
+    // happening to agree.
     const ticks = [
       toRestrictionTick(site('PstI', 50, 51, 'CTGCAG')),
       toRestrictionTick(site('AluI', 51, 52, 'AGCT')),
@@ -157,10 +164,12 @@ describe('restrictions: clustering', () => {
       circular: false,
     });
 
-    expect(cluster.enzymes).toEqual(['PstI', 'AluI', 'BbsI', 'HaeIII']);
+    expect(cluster.enzymes).toEqual(['BbsI', 'PstI', 'AluI', 'HaeIII']);
     expect(cluster.hasTypeIIS).toBe(true);
     expect(cluster.shownEnzymes).toEqual(['BbsI', 'PstI']);
     expect(cluster.overflow).toBe(2);
+    // The property the label depends on, stated rather than implied.
+    expect(cluster.enzymes.slice(0, cluster.shownEnzymes.length)).toEqual(cluster.shownEnzymes);
   });
 
   it('merges the circular origin seam', () => {

--- a/src/plasmid-map/__tests__/layout.test.ts
+++ b/src/plasmid-map/__tests__/layout.test.ts
@@ -884,7 +884,7 @@ describe('computeMapLayout: circular pUC19', () => {
     expect(cluster).toBeDefined();
     expect(cluster!.hasTypeIIS).toBe(true);
     // label.text (aria / hit-test / collision probe) stays the flat joined string.
-    expect(cluster!.label?.text).toBe('BsaI,HpaII,MspI +2');
+    expect(cluster!.label?.text).toBe('BsaI, HpaII, MspI +2');
     // Per-enzyme breakdown: BsaI is the ONLY Type IIS; the "+N" tail is ink.
     expect(cluster!.labelSegments).toEqual([
       { text: 'BsaI', typeIIS: true },
@@ -892,9 +892,9 @@ describe('computeMapLayout: circular pUC19', () => {
       { text: 'MspI', typeIIS: false },
       { text: '+2', typeIIS: false },
     ]);
-    // The renderer's join rule (enzymes by "," + tail by " ") reconstructs label.text.
+    // The renderer's join rule (enzymes by ", " + tail by " ") reconstructs label.text.
     const rebuilt = cluster!
-      .labelSegments!.map((s, i) => (i === 0 ? '' : s.text.startsWith('+') ? ' ' : ',') + s.text)
+      .labelSegments!.map((s, i) => (i === 0 ? '' : s.text.startsWith('+') ? ' ' : ', ') + s.text)
       .join('');
     expect(rebuilt).toBe(cluster!.label?.text);
   });
@@ -914,13 +914,28 @@ describe('computeMapLayout: circular pUC19', () => {
     const visibleRestrictionLabels = layout.restrictions
       .map((restriction) => restriction.label?.text)
       .filter((text): text is string => Boolean(text));
-    const capPx = 112; // Mirrors CIRCULAR_REC_LABEL_MAX_WIDTH_PX.
+    const capPx = 126; // Mirrors CIRCULAR_REC_LABEL_MAX_WIDTH_PX.
 
     expect(visibleRestrictionLabels.length).toBeGreaterThan(0);
     expect(visibleRestrictionLabels.some((text) => text.includes(' +'))).toBe(true);
-    expect(visibleRestrictionLabels.some((text) => text.includes(', '))).toBe(false);
     for (const label of visibleRestrictionLabels) {
       expect(approxTextWidth(label)).toBeLessThanOrEqual(capPx);
+    }
+
+    // This used to assert no label contained ", ", using the separator as a proxy for
+    // "the sprawling re-grouped label path fired" — that path (radial-labels' groupText)
+    // is the only thing that used to emit a spaced comma. Per-cluster labels now join
+    // names with ", " themselves, so the proxy would silently pass forever. Assert the
+    // SHAPE the proxy stood for instead: a per-cluster label is a short list of plain
+    // enzyme names plus an optional "+N" count, never a concatenated cluster dump.
+    for (const label of visibleRestrictionLabels) {
+      const names = label.replace(/ \+\d+$/, '').split(', ');
+      expect(names.length).toBeLessThanOrEqual(3);
+      // Nicking enzymes carry a dot (Nt.BstNBI, Nb.BbvCI, Nt.BbvCI all ship in
+      // src/bio/enzyme-data.ts) and circularClusterLabel may ellipsise a name that
+      // will not fit, so the character class has to admit both. An alphanumeric-only
+      // class passes here purely because this fixture's enzymes happen to be clean.
+      for (const name of names) expect(name).toMatch(/^[A-Za-z0-9.]+…?$/);
     }
   });
 
@@ -1031,9 +1046,111 @@ describe('computeMapLayout: circular pUC19', () => {
     // Direct leaders remain the default when their chord is unobstructed; the
     // radial-first elbow is reserved for a real collision escape. Label positions
     // and the represented label set remain fixed.
+    // Rebaselined after a crowded label began preferring an outward tier over a
+    // tangential slide (TIER_ESCALATION_ANGLE_EQUIV_DEG 4 -> 1.5). Verified to be
+    // the minimal consequence of that change: the label SET, every label's text
+    // and the viewBox are byte-identical to the previous pin, and exactly one
+    // label moved — "EcoRI,SacI,KpnI +2" from 524,123 to 544,117, i.e. one tier
+    // out rather than sideways. Leader straightness itself is pinned by
+    // 'keeps circular restriction leaders pointing at their own tick' below.
+    // Rebaselined again for the ", " name separator (and the width cap raised to keep
+    // the same enzyme content fitting). Verified minimal: exactly one label changed —
+    // "EcoRI,SacI,KpnI +2" -> "EcoRI, SacI, KpnI +2", which recentres it from 544,117
+    // to 548,114. No label gained, lost, or shed a name; feature labels and the viewBox
+    // are byte-identical.
+    // Rebaselined for the cluster tooltip naming its enzyme count alongside its site
+    // count, so the drawn label's "+N" (enzyme NAMES) stops reading as a contradiction
+    // of the tooltip's "N sites". NOTHING DRAWN MOVED: hashing this layout with
+    // restrictions[].title stripped gives d304bb878f6a569d82df3f30aa4fc0ea457543c5f96
+    // ef7ed9286292111e2777f both before and after, so geometry, the label set and every
+    // label's text are byte-identical. The only delta is one tooltip string,
+    // "EcoRI, SacI, KpnI, BamHI, HindIII · 5 sites" -> "... · 5 enzymes · 5 sites".
+    // Rebaselined for the additive overflow-chip hit rect. NOTHING DRAWN MOVED:
+    // hashing this layout with overflows[].hit stripped gives
+    // 35262ad877aa6404ff777c734b5b9bb42d1416c886b3d63e36265a09290078a6, i.e. the
+    // previous pin exactly, so geometry, the label set, every label's text and the
+    // viewBox are byte-identical. The only delta is the new pointer target, which the
+    // renderer draws and the SVG export ignores.
+    // Rebaselined again for the additive overflow `count`, which lets the map dock
+    // state the chip's number to a keyboard user without re-deriving it from the
+    // chip's display text. NOTHING DRAWN MOVED: hashing this layout with
+    // overflows[].count stripped gives
+    // 59f8c609fd6b0f01efd27b54882b97c15d04bac12efc7b72f8a8d6f4e3a77ec3, the previous
+    // pin exactly.
+    // Rebaselined once more for splitting that `count` into overflows[].hiddenBodies
+    // + overflows[].unlabelled, because one integer holding "bodies not drawn plus
+    // labels not drawn" is a quantity no reader can state truthfully. NOTHING DRAWN
+    // MOVED: hashing this layout with all three of count/hiddenBodies/unlabelled
+    // stripped gives 59f8c609fd6b0f01efd27b54882b97c15d04bac12efc7b72f8a8d6f4e3a77ec3
+    // both before and after — the same digest recorded above — and a line diff of the
+    // two full layouts is exactly `"count": 1` -> `"hiddenBodies": 0, "unlabelled": 1`
+    // on the single overflow entry, with every path, label, tick and the viewBox
+    // byte-identical.
     expect(layoutHash(layout)).toBe(
-      'f7b5ec70523e97d40f49ee8afff81178c539114faa3153b8ec0a39c9a30934d1',
+      '36be85f8350cb3a6108bd002c490af9ad1b04a34bb93ec15a8bbbbb27661d09c',
     );
+  });
+
+  it('keeps circular restriction leaders pointing at their own tick', () => {
+    // A leader is only useful if you can follow it back to the cut site it names.
+    // What breaks that is not length and not angle on their own, but the two
+    // together: a label that slid a long way AROUND the ring ends up joined to
+    // its tick by a line running almost tangentially, indistinguishable from the
+    // neighbouring ticks it sweeps past. The honest measure is therefore how far
+    // the label sits SIDEWAYS of its own tick's radial spoke — len * sin(angle
+    // between the leader and that spoke. A long leader pointing straight out
+    // scores 0 and reads fine; a short stub at any angle scores small; only the
+    // long-and-tangential case scores high.
+    //
+    // Crowded map, so the packer is actually under pressure: 36 sites, several in
+    // tight clusters that cannot all fit on one tier near their own angle.
+    const dense: RestrictionSite[] = Array.from({ length: 36 }, (_, i) => {
+      const cluster = Math.floor(i / 3);
+      const pos = (cluster * 220 + (i % 3) * 9) % PUC19_LEN;
+      return site(`Enz${String.fromCharCode(65 + (i % 26))}${i}`, pos, pos + 1, 'GAATTC');
+    });
+    const crowded = computeMapLayout(
+      circularInput({ restrictionSites: dense, width: 900, height: 900 }),
+    );
+
+    // Guard the guard, and count LABELS not leaders. Filtering on leader.length > 1
+    // would let the guard be satisfied by the very thing it is meant to catch:
+    // circularLeaderToLabelEdge returns [] when the leader start lands inside the
+    // label's guard box, so pulling a label onto its tick removes it from the sample
+    // and can only flatter the measurement below. Straightening leaders by dropping
+    // labels is a regression wearing a fix's clothes.
+    const withLabels = crowded.restrictions.filter((r) => r.label);
+    expect(withLabels.length).toBeGreaterThanOrEqual(11);
+    const labelled = withLabels.filter((r) => r.label!.leader.length > 1);
+    expect(labelled.length).toBeGreaterThanOrEqual(8);
+
+    const sideways = labelled.map((r) => {
+      const leader = r.label!.leader;
+      const anchor = leader[0];
+      const end = leader[leader.length - 1];
+      const spokeX = anchor.x - crowded.center.x;
+      const spokeY = anchor.y - crowded.center.y;
+      const spokeLen = Math.hypot(spokeX, spokeY) || 1;
+      // component of the anchor->label vector perpendicular to the tick's spoke
+      return Math.abs(
+        ((end.x - anchor.x) * -spokeY + (end.y - anchor.y) * spokeX) / spokeLen,
+      );
+    });
+
+    // 8% keeps a leader visually attached to its tick while leaving the packer room
+    // to nudge labels apart. For scale, measured on the real bundled plasmids at
+    // 1920x1080 (worst leader, as a % of ring radius), before -> after the packer
+    // started preferring an outward tier over a tangential slide:
+    //   pUC19 26.1 -> 5.0   pBR322 25.8 -> 5.3   pBluescript 27.7 -> 5.3
+    //   pcDNA3.1 13.9 -> 5.0   pACYC184 25.6 -> 9.1  (the real-world worst case,
+    //   and the reason this bound is not tighter than 8% on a synthetic fixture)
+    // Restriction label counts held or improved on all five. Total label counts do
+    // NOT: on a crowded ring the feature pass, which shares this constant and runs
+    // first, can lose one (32 -> 31, "M13-rev primer") on some inputs and gain one
+    // on others. That is bounded by the feature-count assertion in
+    // label-collision.probe.test.ts, not by this test.
+    const worst = Math.max(...sideways);
+    expect(worst).toBeLessThanOrEqual(crowded.radius * 0.08);
   });
 
   it('culls dense tiny inside labels without dropping visible feature geometry', () => {
@@ -1583,7 +1700,13 @@ describe('computeMapLayout: linear + protein', () => {
     expect(layout.budgets.overflowFeatureCount).toBeGreaterThan(0);
   });
 
-  it('emits a linear feature overflow marker for hidden feature bodies and labels', () => {
+  it('emits a linear feature overflow marker that reports only what is missing', () => {
+    // 40 identical full-width features: 17 are pushed past the last row the stack can
+    // fit, and every feature that IS drawn keeps its label. So the chip has exactly one
+    // thing to say, and the version of this test that demanded it also mention dropped
+    // LABELS was passing on a bug — an overflow row used to be counted twice, once as
+    // an undrawn body and again as a dropped label, and the chip printed the sum. The
+    // clause was there because the number was wrong.
     const layout = computeMapLayout({
       mode: 'linear',
       name: 'dense stack overflow marker',
@@ -1596,16 +1719,59 @@ describe('computeMapLayout: linear + protein', () => {
       height: 420,
     });
     const marker = featureOverflow(layout);
+    const drawnUnlabelled = layout.features.filter((f) => f.segmentPaths.length > 0 && !f.label);
 
-    expect(layout.budgets.overflowFeatureCount).toBeGreaterThan(0);
+    expect(layout.budgets.overflowFeatureCount).toBe(17);
+    expect(drawnUnlabelled).toHaveLength(0);
     expect(marker).not.toBeNull();
     expect(marker!.kind).toBe('feature-labels');
-    expect(overflowCount(marker!.text)).toBe(
-      layout.budgets.overflowFeatureCount + layout.budgets.hiddenLabelCount,
-    );
-    expect(marker!.title).toMatch(/feature bod(?:y|ies)/);
-    expect(marker!.title).toContain('feature label');
+    expect(marker!.hiddenBodies).toBe(17);
+    expect(marker!.unlabelled).toBe(0);
+    expect(overflowCount(marker!.text)).toBe(17);
+    expect(marker!.title).toContain('17 feature bodies hidden');
+    expect(marker!.title).not.toContain('feature label');
     expect(marker!.title).toContain('Features tab');
+  });
+
+  it('counts a linear overflow feature once, not once per thing it is missing', () => {
+    // Both halves non-zero, which is the shape that tells a split apart from a sum: 26
+    // full-width features stack past the last row, 40 short ones are drawn and lose
+    // labels to the row de-collider. An undrawn feature has no label left to drop, so
+    // it must appear in ONE of the two numbers. It appeared in both until this test,
+    // and the chip read "+57" over 32 affected features out of 66.
+    const stacked = stackedLinearFeatures(26);
+    const shorts = Array.from({ length: 40 }, (_, i) =>
+      feat({ id: `short-${i}`, name: `short-${i}`, type: 'cds', start: i * 140, end: i * 140 + 30, strand: 1 }),
+    );
+    const layout = computeMapLayout({
+      mode: 'linear',
+      name: 'stacked plus shorts',
+      length: 6000,
+      topology: 'linear',
+      sequenceType: 'dna',
+      features: [...stacked, ...shorts],
+      restrictionSites: [],
+      width: 1000,
+      height: 420,
+    });
+    const marker = featureOverflow(layout)!;
+    const arcless = layout.features.filter((f) => f.segmentPaths.length === 0);
+    const drawnUnlabelled = layout.features.filter((f) => f.segmentPaths.length > 0 && !f.label);
+
+    // Recounted off the drawn output, which is the only reading that is not the chip's
+    // own arithmetic handed back to it.
+    expect(marker.hiddenBodies).toBe(arcless.length);
+    expect(marker.unlabelled).toBe(drawnUnlabelled.length);
+    expect(arcless).toHaveLength(25);
+    expect(drawnUnlabelled).toHaveLength(7);
+    expect(overflowCount(marker.text)).toBe(32);
+
+    // No feature is in both halves, so the printed total is a count of distinct
+    // features and can never exceed the number of features on the map.
+    const affected = new Set([...arcless, ...drawnUnlabelled].map((f) => f.id));
+    expect(affected.size).toBe(marker.hiddenBodies + marker.unlabelled);
+    expect(overflowCount(marker.text)).toBeLessThanOrEqual(layout.features.length);
+    expect(marker.title).toContain('25 feature bodies hidden and 7 feature labels dropped');
   });
 
   it('does not overlap visible linear feature labels in dense scenarios', () => {

--- a/src/plasmid-map/__tests__/linear-cluster-count.test.ts
+++ b/src/plasmid-map/__tests__/linear-cluster-count.test.ts
@@ -1,0 +1,162 @@
+/**
+ * A linear cluster label is a summary: one enzyme name plus "+N" more. The count is the
+ * only mark that says so, and it used to be the first thing sacrificed — when the pair
+ * overran the width cap, the name was ellipsised and then returned ALONE, so a cluster
+ * of fourteen enzymes rendered as a bare "Nt.BstNBI", indistinguishable from a lone cut
+ * site. Truncation that hides itself states something false rather than something
+ * incomplete.
+ *
+ * These tests pin both halves of the fix: the count always survives, and paying for it
+ * never widens the label — because linear labels are placed by their ACTUAL width, so a
+ * label that grows takes room from a neighbour and can push it off the map entirely.
+ */
+import { describe, it, expect } from 'vitest';
+import { computeMapLayout } from '../layout';
+import { approxTextWidth } from '../geometry/labels';
+import type { MapInput, MapRestrictionRender } from '../types';
+import type { RestrictionSite } from '../../bio/types';
+
+function site(
+  enzyme: string,
+  position: number,
+  cutPosition: number,
+  recognitionSequence: string,
+): RestrictionSite {
+  return { enzyme, position, cutPosition, recognitionSequence, overhang: 'blunt' };
+}
+
+/**
+ * Nt.BstNBI is the ONLY bundled enzyme whose name exceeds 8 characters, which is what
+ * routes a label past the early return and into the width path where the count was
+ * being dropped. Its cut sits outside the recognition window, so it is also Type IIS
+ * and gets promoted to lead the label — the exact combination that shipped the defect.
+ */
+const LEAD = 'Nt.BstNBI';
+
+function clusterOf(extraEnzymes: number, over = {}): MapInput {
+  const sites: RestrictionSite[] = [site(LEAD, 1000, 1012, 'GAGTC')];
+  for (let i = 0; i < extraEnzymes; i += 1) {
+    sites.push(site(`Enz${i}`, 1004 + i * 3, 1006 + i * 3, 'GAATTC'));
+  }
+  return {
+    mode: 'linear',
+    name: 'linear count fixture',
+    length: 6000,
+    topology: 'linear',
+    sequenceType: 'dna',
+    features: [],
+    restrictionSites: sites,
+    width: 1000,
+    height: 420,
+    ...over,
+  };
+}
+
+function leadCluster(renders: readonly MapRestrictionRender[], siteCount: number): MapRestrictionRender {
+  const found = renders.find((r) => r.tickIds.length === siteCount);
+  expect(found, 'fixture must collapse into a single cluster').toBeDefined();
+  return found!;
+}
+
+describe('a linear cluster label never drops the count that says it is a summary', () => {
+  it('keeps "+N" on a long lead name instead of returning the name alone', () => {
+    const cluster = leadCluster(computeMapLayout(clusterOf(13)).restrictions, 14);
+    const text = cluster.label?.text ?? '';
+
+    expect(text).toMatch(/ \+13$/);
+    // ...and the count still reconciles against the tooltip, as on the circular ring.
+    expect(cluster.title).toContain(' · 14 enzymes · 14 sites');
+    // The name may be shortened; it may not be the whole label.
+    expect(text.startsWith('Nt.B')).toBe(true);
+    expect(text).not.toBe(LEAD);
+  });
+
+  it('pays for the count out of the name, not out of a neighbouring label', () => {
+    // The width of the summary must not exceed the width of the bare name it replaces:
+    // anything wider is taken from the row, and a crowded row drops its lowest-priority
+    // label to make space. A 6.2px growth here cost a real "AclI" label at 1920x1080.
+    for (const extra of [1, 4, 9, 13, 38]) {
+      const cluster = leadCluster(computeMapLayout(clusterOf(extra)).restrictions, extra + 1);
+      const text = cluster.label?.text ?? '';
+      expect(text, `+${extra} lost its count`).toMatch(new RegExp(` \\+${extra}$`));
+      expect(
+        approxTextWidth(text),
+        `+${extra} label is wider than the bare name it replaces`,
+      ).toBeLessThanOrEqual(approxTextWidth(LEAD));
+    }
+  });
+
+  it('leaves a short lead name exactly as it was', () => {
+    // 153 of the 154 bundled enzymes take the early return; it already kept the count,
+    // so this fix must not have touched it.
+    const layout = computeMapLayout(
+      clusterOf(4, {
+        restrictionSites: [
+          site('EcoRI', 1000, 1001, 'GAATTC'),
+          site('SacI', 1004, 1009, 'GAGCTC'),
+          site('KpnI', 1008, 1013, 'GGTACC'),
+          site('BamHI', 1012, 1013, 'GGATCC'),
+          site('HindIII', 1016, 1017, 'AAGCTT'),
+        ],
+      }),
+    );
+    const cluster = leadCluster(layout.restrictions, 5);
+
+    expect(cluster.label?.text).toBe('EcoRI +4');
+  });
+
+  it('keeps the lone-site label unadorned — there is nothing to disclose', () => {
+    const layout = computeMapLayout(
+      clusterOf(0, { restrictionSites: [site(LEAD, 1000, 1012, 'GAGTC')] }),
+    );
+    const cluster = leadCluster(layout.restrictions, 1);
+
+    expect(cluster.label?.text).toBe(LEAD);
+  });
+
+  it('shortens a long custom enzyme name rather than dropping its count', () => {
+    // Custom enzymes are user-named, so a name far longer than any bundled one is the
+    // reachable way deep into this path — not a four-digit cluster.
+    const long = 'MyVeryLongEnzymeNameX';
+    const sites: RestrictionSite[] = [site(long, 1000, 1012, 'GAGTC')];
+    for (let i = 0; i < 40; i += 1) sites.push(site(`Enz${i}`, 1004 + i, 1006 + i, 'GAATTC'));
+    const cluster = leadCluster(
+      computeMapLayout(clusterOf(0, { restrictionSites: sites })).restrictions,
+      41,
+    );
+    const text = cluster.label?.text ?? '';
+
+    expect(text).toBe('MyVer… +40');
+    expect(approxTextWidth(text)).toBeLessThanOrEqual(64); // LINEAR_REC_LABEL_MAX_WIDTH_PX
+  });
+
+  it('documents what the stem floor does when it finally binds', () => {
+    // Not a wish — a record. The floor is reachable only at ~1000 distinct enzymes in a
+    // single cluster (the bundled set has 154 in total), and past it the label trades
+    // away the no-wider invariant, then the cap itself, to keep a legible stem. Pinned
+    // so a future change to either constant shows its consequences here, not on a map.
+    const build = (n: number) => {
+      const sites: RestrictionSite[] = [site(LEAD, 1000, 1012, 'GAGTC')];
+      for (let i = 0; i < n; i += 1) {
+        sites.push(site(`E${i}`, 1000 + (i % 100), 1002 + (i % 100), 'GAATTC'));
+      }
+      return (
+        leadCluster(computeMapLayout(clusterOf(0, { restrictionSites: sites })).restrictions, n + 1)
+          .label?.text ?? ''
+      );
+    };
+    const nameWidth = approxTextWidth(LEAD);
+
+    // 3 digits: floor exactly met, and still no wider than the name it replaces.
+    expect(build(999)).toBe('Nt.… +999');
+    expect(approxTextWidth('Nt.… +999')).toBeLessThanOrEqual(nameWidth);
+
+    // 4 digits: the floor wins over the width budget — wider than the name, inside the cap.
+    expect(build(1200)).toBe('Nt.… +1200');
+    expect(approxTextWidth('Nt.… +1200')).toBeGreaterThan(nameWidth);
+    expect(approxTextWidth('Nt.… +1200')).toBeLessThanOrEqual(64);
+
+    // 5 digits: overruns the cap by 4.2px. Nothing clips — placement uses actual widths.
+    expect(approxTextWidth(build(12000))).toBeCloseTo(68.2, 1);
+  });
+});

--- a/src/plasmid-map/__tests__/overflow-chip-hit.test.ts
+++ b/src/plasmid-map/__tests__/overflow-chip-hit.test.ts
@@ -1,0 +1,389 @@
+/**
+ * The overflow chip's pointer target.
+ *
+ * The chip carries the only sentence on the map that says what its count means, and
+ * SVG text is hit-tested as its whole run box — so before this the target WAS the
+ * glyph run: 39x6 CSS px circular, 81x11 linear, measured on live pUC19 at 1180x900.
+ * `MapOverflowRender.hit` is a real rect sized from the chip's own estimated text
+ * extent.
+ *
+ * Two properties here are load-bearing rather than cosmetic, and both are cheap to
+ * break by "just making the target bigger":
+ *
+ *   - stacked chips are placed ONE label line apart, so a rect taller than a line
+ *     covers the chip below and answers with the wrong tooltip;
+ *   - the overflow layer paints after the features, so a rect that reached down into
+ *     the feature lane under the linear chip would silently eat feature clicks.
+ *
+ * Numbers below are absolute on purpose. Writing them as `PAD * 2 + run` would let
+ * them travel with whatever constant a future edit changes, and pass either way.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { computeMapLayout } from '../layout';
+import type { MapLayout, MapOverflowRender } from '../types';
+import type { Feature, RestrictionSite } from '../../bio/types';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const mapCss = readFileSync(resolve(here, '..', '..', 'components', 'plasmid-map', 'plasmid-map.css'), 'utf8');
+const artifactSource = readFileSync(resolve(here, '..', '..', 'artifacts', 'motif-artifact.tsx'), 'utf8');
+
+/**
+ * The chips' ink boxes as MEASURED in Chromium, in em of the chip's own font size:
+ * how far the run box reaches above and below the baseline. This is the ruler
+ * `OVERFLOW_HIT_CENTER_EM` in layout.ts was read off, and the one input to the rect's
+ * vertical placement that no code there can see — SVG text is boxed by its font's
+ * ascent and descent, and that module may not touch the DOM.
+ */
+const MEASURED_INK_ABOVE_BASELINE_EM = 0.9;
+const MEASURED_INK_BELOW_BASELINE_EM = 0.25;
+
+const sites: RestrictionSite[] = Array.from({ length: 40 }, (_, i) => ({
+  enzyme: `Enzyme${i}`,
+  position: 50 + i * 100,
+  cutPosition: 51 + i * 100,
+  recognitionSequence: 'GAATTC',
+  overhang: 'blunt',
+}));
+
+// `color` and `metadata` are required on Feature, and they are supplied rather than
+// cast away: this fixture's whole job is to make the layout emit real feature
+// geometry for the hit rect to keep clear of, so a feature that is not a real
+// Feature would be testing the wrong thing.
+const features: Feature[] = Array.from({ length: 30 }, (_, i) => ({
+  id: `f${i}`,
+  name: `Feature ${i}`,
+  type: 'cds',
+  start: i * 120,
+  end: i * 120 + 90,
+  strand: 1 as const,
+  color: '#8a8a8a',
+  metadata: {},
+}));
+
+/** Dense enough that BOTH circular chips are emitted and therefore stack. */
+function circularLayout() {
+  return computeMapLayout({
+    mode: 'circular',
+    name: 'chip fixture',
+    length: 4000,
+    topology: 'circular',
+    sequenceType: 'dna',
+    features,
+    restrictionSites: sites,
+    width: 720,
+    height: 720,
+    display: { maxRestrictionLabels: 6, maxFeatureLabels: 5 },
+  });
+}
+
+function linearLayout() {
+  return computeMapLayout({
+    mode: 'linear',
+    name: 'chip fixture',
+    length: 4000,
+    topology: 'linear',
+    sequenceType: 'dna',
+    features: [],
+    restrictionSites: sites,
+    width: 1000,
+    height: 420,
+    display: { maxRestrictionLabels: 8 },
+  });
+}
+
+/**
+ * The only fixture on this file where the feature chip's TWO quantities are BOTH
+ * non-zero, which is the only shape that can tell a split apart from a sum. 26
+ * full-width features stack past the last row the compressed stack can fit (bodies
+ * undrawn); 40 short ones are drawn and lose their labels to the row de-collider.
+ */
+function denseFeatureLinearLayout() {
+  const stacked: Feature[] = Array.from({ length: 26 }, (_, i) => ({
+    id: `stack-${i}`,
+    name: `stack-${i}`,
+    type: 'cds',
+    start: 100,
+    end: 5600,
+    strand: (i % 2 === 0 ? 1 : -1) as 1 | -1,
+    color: '#8a8a8a',
+    metadata: {},
+  }));
+  const shorts: Feature[] = Array.from({ length: 40 }, (_, i) => ({
+    id: `short-${i}`,
+    name: `short-${i}`,
+    type: 'cds',
+    start: i * 140,
+    end: i * 140 + 30,
+    strand: 1 as const,
+    color: '#8a8a8a',
+    metadata: {},
+  }));
+  return computeMapLayout({
+    mode: 'linear',
+    name: 'dense feature fixture',
+    length: 6000,
+    topology: 'linear',
+    sequenceType: 'dna',
+    features: [...stacked, ...shorts],
+    restrictionSites: [],
+    width: 1000,
+    height: 420,
+  });
+}
+
+/**
+ * Recount a chip's two quantities from the layout's OWN drawn output.
+ *
+ * This is the point of the function. Reading them back off `text` or `title` only
+ * proves the chip's arithmetic equals itself — the numbers it prints and the numbers
+ * it carries come from one expression, so an assertion between them cannot fail on a
+ * wrong number, only on a divergent one. Counting what the map actually drew is an
+ * independent derivation, and is what a reader of these fields is entitled to.
+ */
+function recount(layout: MapLayout, kind: string): { hiddenBodies: number; unlabelled: number } {
+  if (kind === 'restriction-labels') {
+    return {
+      // Every site keeps a density tick, so nothing restriction-side is undrawn.
+      hiddenBodies: 0,
+      unlabelled: layout.restrictions.reduce((n, r) => n + (r.label ? 0 : r.tickIds.length), 0),
+    };
+  }
+  const arcless = layout.features.filter((f) => f.segmentPaths.length === 0);
+  // An arc-less render with no hover title is the degenerate "feature has no drawable
+  // span" case, which the chip deliberately does not report; the overflow rows are the
+  // ones that carry a title. Asserted rather than assumed so this recount cannot
+  // quietly start counting a different set than the chip does.
+  expect(arcless.every((f) => Boolean(f.title))).toBe(true);
+  return {
+    hiddenBodies: arcless.length,
+    unlabelled: layout.features.filter((f) => f.segmentPaths.length > 0 && !f.label).length,
+  };
+}
+
+function printedNumber(chip: MapOverflowRender): number {
+  const printed = Number((chip.text.match(/[\d,]+/) ?? ['NaN'])[0].replace(/,/g, ''));
+  expect(printed, `chip "${chip.text}" prints a number`).not.toBeNaN();
+  return printed;
+}
+
+describe('overflow chip hit rect', () => {
+  it('gives the circular chips a target sized from their own text', () => {
+    const chips = circularLayout().overflows ?? [];
+    const feature = chips.find((c) => c.kind === 'feature-labels');
+    const restriction = chips.find((c) => c.kind === 'restriction-labels');
+
+    expect(feature?.text).toBe('+25 more');
+    expect(feature?.hit).toEqual({ x: 393.709, y: 415.12, width: 56.582, height: 14 });
+    expect(restriction?.text).toBe('+34 more sites');
+    expect(restriction?.hit).toEqual({ x: 378.491, y: 429.12, width: 87.018, height: 14 });
+
+    // The longer string gets the wider rect — i.e. the size tracks the text and is
+    // not one constant handed to both.
+    expect(restriction!.hit.width).toBeGreaterThan(feature!.hit.width);
+  });
+
+  it('stacks the two circular targets edge to edge instead of overlapping', () => {
+    // This is the whole reason the rect is one label line tall. Overlapping targets
+    // would hand the upper chip's tooltip to a pointer aimed at the lower one, which
+    // looks like it works and is wrong.
+    const chips = circularLayout().overflows ?? [];
+    expect(chips).toHaveLength(2);
+    const [upper, lower] = [...chips].sort((a, b) => a.hit.y - b.hit.y);
+
+    expect(upper.hit.y + upper.hit.height).toBe(429.12);
+    expect(lower.hit.y).toBe(429.12);
+    expect(lower.hit.y).toBeGreaterThanOrEqual(upper.hit.y + upper.hit.height);
+  });
+
+  it('keeps the linear target clear of the feature lane below it', () => {
+    // The overflow layer paints after .motif-pm-features, so anything this rect
+    // covers stops being clickable as a feature. The first feature row starts at
+    // LINEAR_ROW_TOP = 82; the rect must end above it.
+    const chip = (linearLayout().overflows ?? []).find((c) => c.kind === 'restriction-labels');
+
+    expect(chip?.hit).toEqual({ x: 885.091, y: 60.8, width: 94.909, height: 14 });
+    expect(chip!.hit.y + chip!.hit.height).toBe(74.8);
+    expect(chip!.hit.y + chip!.hit.height).toBeLessThan(82);
+  });
+
+  it('anchors the rect on the side the text runs from', () => {
+    // anchor 'end' draws the glyphs leftward from x, so a rect centred on x would sit
+    // half off the map's right edge, where it can never be pointed at.
+    const chip = (linearLayout().overflows ?? []).find((c) => c.kind === 'restriction-labels')!;
+    expect(chip.anchor).toBe('end');
+    expect(chip.x).toBe(972);
+    // Right edge overhangs the text end by the horizontal pad only.
+    expect(chip.hit.x + chip.hit.width).toBe(980);
+    expect(chip.hit.x).toBeLessThan(chip.x);
+
+    const circular = (circularLayout().overflows ?? []).find((c) => c.kind === 'feature-labels')!;
+    expect(circular.anchor).toBe('middle');
+    expect(circular.x).toBe(422);
+    // Centred: the anchor sits at the rect's midpoint.
+    expect(circular.hit.x + circular.hit.width / 2).toBe(422);
+  });
+
+  it('covers the text baseline it was derived from', () => {
+    for (const chip of [...(circularLayout().overflows ?? []), ...(linearLayout().overflows ?? [])]) {
+      expect(chip.hit.y).toBeLessThan(chip.y);
+      expect(chip.hit.y + chip.hit.height).toBeGreaterThan(chip.y);
+    }
+  });
+
+  it('carries numbers the drawn map can be counted back to', () => {
+    // The map dock states one of these to keyboard users, who cannot open the chip's
+    // <title> — no browser shows an SVG title on focus. So the fields are read by
+    // something other than the chip, and the question they have to survive is not
+    // "do you agree with the chip" (the chip is the same expression) but "are you
+    // right". Both are recounted here from the layout's own drawn output.
+    const layouts = [circularLayout(), linearLayout(), denseFeatureLinearLayout()];
+    const seen = new Set<string>();
+
+    for (const layout of layouts) {
+      for (const chip of layout.overflows ?? []) {
+        const expected = recount(layout, chip.kind);
+        expect(chip.hiddenBodies, `${chip.id} hiddenBodies`).toBe(expected.hiddenBodies);
+        expect(chip.unlabelled, `${chip.id} unlabelled`).toBe(expected.unlabelled);
+        expect(chip.hiddenBodies + chip.unlabelled).toBeGreaterThan(0);
+        seen.add(chip.kind);
+      }
+    }
+
+    // Guard the guard: a recount that ran over no chips, or only over the easy chip
+    // whose hiddenBodies is structurally 0, would pass while proving nothing.
+    expect([...seen].sort()).toEqual(['feature-labels', 'restriction-labels']);
+  });
+
+  it('splits the feature chip into two quantities neither of which is its printed total', () => {
+    // The trap this replaced: `count` held bodies + labels, one integer standing for
+    // two unlike things, and the guard on it compared that sum to the chip's text —
+    // which is the same sum. It agreed by construction and would have gone on
+    // agreeing while a dock printed "32 features have no label" about a number that
+    // was never that. The fixture below is chosen so BOTH parts are non-zero, i.e. so
+    // no single field equals the total and a surfacing site is forced to say which
+    // one it means.
+    const layout = denseFeatureLinearLayout();
+    const chip = (layout.overflows ?? []).find((c) => c.kind === 'feature-labels')!;
+
+    expect(chip.hiddenBodies).toBe(25);
+    expect(chip.unlabelled).toBe(7);
+    expect(printedNumber(chip)).toBe(32);
+    expect(chip.hiddenBodies).not.toBe(printedNumber(chip));
+    expect(chip.unlabelled).not.toBe(printedNumber(chip));
+
+    // The total is a count of DISTINCT features, not of events: a feature with no body
+    // drawn has no label left to drop, so it must not also appear in `unlabelled`. It
+    // did, once, and the chip printed "+57" for 32 affected features out of 66.
+    expect(chip.hiddenBodies + chip.unlabelled).toBe(printedNumber(chip));
+    expect(chip.hiddenBodies + chip.unlabelled).toBeLessThanOrEqual(layout.features.length);
+
+    // Only the title can hold both, and it states them apart rather than added up.
+    expect(chip.title).toContain('25 feature bodies hidden');
+    expect(chip.title).toContain('7 feature labels dropped');
+    expect(chip.title).not.toContain('32');
+  });
+
+  it('prints the sum in `text` and nowhere else offers it as one number', () => {
+    const chips = [
+      ...(circularLayout().overflows ?? []),
+      ...(linearLayout().overflows ?? []),
+      ...(denseFeatureLinearLayout().overflows ?? []),
+    ];
+    expect(chips.length).toBeGreaterThan(3);
+
+    for (const chip of chips) {
+      expect(printedNumber(chip), `chip "${chip.text}" text is its two parts`)
+        .toBe(chip.hiddenBodies + chip.unlabelled);
+      // A restriction chip draws every site's density tick, so its total is its
+      // `unlabelled` and the dock can read that field without qualification.
+      if (chip.kind === 'restriction-labels') {
+        expect(chip.hiddenBodies).toBe(0);
+        expect(chip.title).toContain(`${chip.unlabelled} restriction sites`);
+      }
+      // No third field quietly re-offering the total: the type is the guard, and this
+      // fails loudly if one is added back.
+      expect(Object.keys(chip).sort()).toEqual(
+        ['anchor', 'hiddenBodies', 'hit', 'id', 'kind', 'text', 'title', 'unlabelled', 'x', 'y'],
+      );
+    }
+  });
+
+  it('is read by the Map Visibility dock as one named quantity, not a total', () => {
+    // The dock is the reason these fields exist and the only place outside the map
+    // that prints one. Everything above is about the layout; this is the half that
+    // could still be wrong while the layout is right — the sentence it writes is true
+    // of `unlabelled` alone, and of a sum only by the accident that the restriction
+    // chip's other part is 0 today.
+    const start = artifactSource.indexOf('const mapUnlabelledSiteCount');
+    expect(start, 'dock readout not found in motif-artifact.tsx').toBeGreaterThan(-1);
+    const read = artifactSource.slice(start, artifactSource.indexOf(';', start) + 1);
+
+    expect(read).toContain("overflow.kind === 'restriction-labels'");
+    expect(read).toContain('.unlabelled');
+    expect(read).not.toMatch(/hiddenBodies|\+/);
+    expect(artifactSource).toContain('{mapUnlabelledSiteCount.toLocaleString()} sites without labels on the map');
+  });
+
+  it('sizes itself at the type size the stylesheet actually draws the chip at', () => {
+    // layout.ts cannot measure the DOM, so it hard-codes the chip's font size. If the
+    // stylesheet moves and this does not, every rect silently mis-sizes.
+    const base = mapCss.slice(mapCss.indexOf('.motif-pm-overflow {'));
+    expect(base.slice(0, base.indexOf('}'))).toMatch(/font-size:\s*10px;/);
+
+    const circular = mapCss.slice(mapCss.indexOf(".motif-pm-container[data-map-mode='circular'] .motif-pm-overflow {"));
+    expect(circular.slice(0, circular.indexOf('}'))).toMatch(/font-size:\s*9px;/);
+  });
+
+  it('stays centred on the ink box its vertical offset was measured from', () => {
+    // OVERFLOW_HIT_CENTER_EM is the one number in the rect that is a reading off a
+    // screen rather than a consequence of anything: SVG text is boxed by its font's
+    // ascent and descent, and layout.ts places the rect's middle 0.32em above the
+    // baseline because that is where the middle was measured. Nothing in the module
+    // would notice if it stopped being true.
+    //
+    // So it is pinned against the measurement instead of being restated: rebuild the
+    // measured ink box around each chip's own baseline and require the rect to sit
+    // centred on it. Any drift in the offset lands entirely in the difference between
+    // the two slacks, at twice the offset's own size, which holds it to ~±0.008em
+    // without this test ever naming 0.32.
+    const cases: { chip: MapOverflowRender; fontPx: number }[] = [
+      { chip: (circularLayout().overflows ?? []).find((c) => c.kind === 'feature-labels')!, fontPx: 9 },
+      { chip: (linearLayout().overflows ?? []).find((c) => c.kind === 'restriction-labels')!, fontPx: 10 },
+    ];
+
+    for (const { chip, fontPx } of cases) {
+      const inkTop = chip.y - MEASURED_INK_ABOVE_BASELINE_EM * fontPx;
+      const inkBottom = chip.y + MEASURED_INK_BELOW_BASELINE_EM * fontPx;
+      const slackAbove = inkTop - chip.hit.y;
+      const slackBelow = chip.hit.y + chip.hit.height - inkBottom;
+
+      expect(Math.abs(slackAbove - slackBelow), `${chip.id} rect is off-centre on its glyphs`)
+        .toBeLessThanOrEqual(0.25);
+      // ...and it clears the measured glyphs by a whole CSS pixel top and bottom, which
+      // is the margin that makes a font swap's tenths of an em a non-event rather than
+      // an uncovered chip. Report it as a number so shrinking it is a visible choice.
+      expect(Math.min(slackAbove, slackBelow), `${chip.id} rect barely clears its glyphs`)
+        .toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('was measured on the font stack the stylesheet still asks for', () => {
+    // The measurement above is only a measurement OF something: swap the family and
+    // the ascent/descent move, the middle moves with them, and no assertion here or
+    // in layout.ts would fail — the rect would just sit slightly high or low forever.
+    // Pinning the declared stack makes that swap fail loudly instead, next to the
+    // font-size guard that exists for the same reason.
+    //
+    // What this cannot see: the host's own `--font-ui`, which resolves at runtime and
+    // wins over the fallbacks below. That is out of reach of a test that may not touch
+    // the DOM, and the consequence there is sub-pixel — the rect is a full label line
+    // tall, so tenths of an em never uncover the glyphs.
+    const base = mapCss.slice(mapCss.indexOf('.motif-pm-overflow {'));
+    expect(base.slice(0, base.indexOf('}'))).toContain(
+      "font-family: var(--font-ui, var(--font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif));",
+    );
+  });
+});

--- a/src/plasmid-map/__tests__/point-spaces.test.ts
+++ b/src/plasmid-map/__tests__/point-spaces.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+  contentPointFromRoot,
+  mapContentPoint,
+  mapRootPoint,
+  rootPointFromContent,
+  type MapPointTransform,
+} from '../point-spaces';
+
+// Real viewport states, taken from the measured investigation rather than
+// invented: a pristine fit, a pan with the zoom badge still reading 100%, a zoom
+// anchored on the ring centre, the reported off-centre zoom, and max zoom.
+const VIEWPORTS: Array<{ name: string; transform: MapPointTransform }> = [
+  { name: 'pristine fit', transform: { k: 1, tx: 0, ty: 0 } },
+  { name: 'pan at fit', transform: { k: 1, tx: 0, ty: 57.2 } },
+  { name: 'zoomed on the ring centre', transform: { k: 1.499, tx: -179.9, ty: -211.7 } },
+  { name: 'zoomed off centre', transform: { k: 1.949, tx: -183.1, ty: -243.6 } },
+  { name: 'max zoom', transform: { k: 8, tx: -1349.9, ty: -1796.3 } },
+];
+
+describe('map point spaces', () => {
+  it('is the identity only at a pristine fit', () => {
+    const point = mapRootPoint(600, 400);
+    expect(contentPointFromRoot(point, { k: 1, tx: 0, ty: 0 })).toMatchObject({ x: 600, y: 400 });
+
+    // A pan alone moves the point even though k is still 1 and the zoom badge
+    // still reads 100%. This is the case that makes the bug look intermittent.
+    expect(contentPointFromRoot(point, { k: 1, tx: 0, ty: 57.2 })).toMatchObject({ x: 600, y: 342.8 });
+  });
+
+  it.each(VIEWPORTS)('round-trips a point under $name', ({ transform }) => {
+    const point = mapRootPoint(613.7, 402.1);
+    const back = rootPointFromContent(contentPointFromRoot(point, transform), transform);
+    expect(back.x).toBeCloseTo(point.x, 9);
+    expect(back.y).toBeCloseTo(point.y, 9);
+  });
+
+  it.each(VIEWPORTS)('round-trips the other direction under $name', ({ transform }) => {
+    const point = mapContentPoint(360.5, 86.2);
+    const back = contentPointFromRoot(rootPointFromContent(point, transform), transform);
+    expect(back.x).toBeCloseTo(point.x, 9);
+    expect(back.y).toBeCloseTo(point.y, 9);
+  });
+
+  it('places a content point where the rendered transform would draw it', () => {
+    // root = k * content + t, the same arithmetic the SVG group applies.
+    const transform = { k: 1.949, tx: -183.1, ty: -243.6 };
+    expect(rootPointFromContent(mapContentPoint(360.5, 86.2), transform)).toMatchObject({
+      x: (360.5 * 1.949) - 183.1,
+      y: (86.2 * 1.949) - 243.6,
+    });
+  });
+
+  it('falls back to the identity rather than producing Infinity or NaN', () => {
+    for (const bad of [
+      { k: 0, tx: 100, ty: 50 },
+      { k: -2, tx: 0, ty: 0 },
+      { k: Number.NaN, tx: Number.NaN, ty: Number.NaN },
+      { k: Number.POSITIVE_INFINITY, tx: 0, ty: 0 },
+    ]) {
+      expect(contentPointFromRoot(mapRootPoint(10, 10), bad)).toMatchObject({ x: 10, y: 10 });
+      expect(rootPointFromContent(mapContentPoint(10, 10), bad)).toMatchObject({ x: 10, y: 10 });
+    }
+  });
+
+  it('grows the error with the displacement of the origin, not with zoom alone', () => {
+    // Zooming anchored exactly on a point leaves that point where it was, so an
+    // unconverted click there stays correct however far you zoom in. That is why
+    // "it only breaks when zoomed" was the wrong description of this defect.
+    const anchor = mapContentPoint(360, 424);
+    const k = 4;
+    const anchored: MapPointTransform = { k, tx: anchor.x - (anchor.x * k), ty: anchor.y - (anchor.y * k) };
+    const unconverted = rootPointFromContent(anchor, anchored);
+    expect(unconverted.x).toBeCloseTo(anchor.x, 9);
+    expect(unconverted.y).toBeCloseTo(anchor.y, 9);
+
+    // Pan the same zoom and the identical click is now wrong by the pan.
+    const panned: MapPointTransform = { ...anchored, ty: anchored.ty + 120 };
+    expect(rootPointFromContent(anchor, panned).y).toBeCloseTo(anchor.y + 120, 9);
+  });
+});

--- a/src/plasmid-map/__tests__/restriction-label-units.test.ts
+++ b/src/plasmid-map/__tests__/restriction-label-units.test.ts
@@ -1,0 +1,209 @@
+/**
+ * A crowded restriction cluster shows the reader TWO numbers about itself: the "+N"
+ * tail on the drawn label, and a count in the hover tooltip. They are in different
+ * units — "+N" counts enzyme NAMES that did not fit, the tooltip counts SITES — and
+ * the map used to print them side by side with nothing to say so ("Nt.BstNBI +38"
+ * against "50 sites"). These tests pin the reconciliation: the tooltip must name the
+ * enzyme count with its unit, that count must equal shown-names + N, and it must equal
+ * the length of the very name list the same tooltip prints.
+ */
+import { describe, it, expect } from 'vitest';
+import { computeMapLayout } from '../layout';
+import type { MapInput, MapRestrictionRender } from '../types';
+import type { RestrictionSite } from '../../bio/types';
+
+function site(
+  enzyme: string,
+  position: number,
+  cutPosition: number,
+  recognitionSequence: string,
+): RestrictionSite {
+  return { enzyme, position, cutPosition, recognitionSequence, overhang: 'blunt' };
+}
+
+/**
+ * One tight cluster, 6 distinct enzymes across 8 cut sites — two enzymes cut twice, so
+ * the enzyme count and the site count are DIFFERENT NUMBERS. That gap is the whole
+ * point: with 6 enzymes at 6 sites either count would satisfy the assertions below and
+ * the test would pass for the wrong reason. Every cut falls inside its own recognition
+ * window so no enzyme is promoted to the label lead as Type IIS, and the lead name is
+ * short enough that the linear axis keeps its "+N" tail instead of ellipsising it away.
+ */
+const CLUSTER_SITES: RestrictionSite[] = [
+  site('AatII', 1000, 1004, 'GACGTC'),
+  site('BspQI', 1004, 1010, 'GCTCTTC'),
+  site('HincII', 1008, 1011, 'GTYRAC'),
+  site('Eco53kI', 1012, 1015, 'GAGCTC'),
+  site('BsiHKAI', 1016, 1021, 'GWGCWC'),
+  site('AflIII', 1020, 1021, 'ACRYGT'),
+  site('AatII', 1024, 1028, 'GACGTC'),
+  site('HincII', 1028, 1031, 'GTYRAC'),
+];
+const DISTINCT_ENZYMES = 6;
+const CLUSTER_CUT_SITES = 8;
+
+function input(over: Partial<MapInput> = {}): MapInput {
+  return {
+    mode: 'circular',
+    name: 'unit-mismatch fixture',
+    length: 6000,
+    topology: 'circular',
+    sequenceType: 'dna',
+    features: [],
+    restrictionSites: CLUSTER_SITES,
+    width: 700,
+    height: 700,
+    ...over,
+  };
+}
+
+/** The one cluster that swallowed every fixture site. */
+function crowdedCluster(renders: readonly MapRestrictionRender[]): MapRestrictionRender {
+  const found = renders.find((r) => r.tickIds.length === CLUSTER_CUT_SITES);
+  expect(found, 'fixture must collapse into a single cluster').toBeDefined();
+  return found!;
+}
+
+describe('restriction cluster label and tooltip agree on what they are counting', () => {
+  it('names the enzyme count so the label "+N" reconciles against it', () => {
+    const cluster = crowdedCluster(computeMapLayout(input()).restrictions);
+
+    expect(cluster.label?.text).toBeTruthy();
+    const [, shown, tail] = /^(.+?) \+(\d+)$/.exec(cluster.label!.text) ?? [];
+    expect(shown, `label should have been truncated: ${cluster.label!.text}`).toBeTruthy();
+
+    const shownNames = shown.split(', ');
+    const hidden = Number(tail);
+    // The reader's arithmetic: names on screen + the "+N" tail.
+    expect(shownNames.length + hidden).toBe(DISTINCT_ENZYMES);
+
+    // ...and that is the number the tooltip must state, in enzymes, next to the sites.
+    expect(cluster.title).toContain(` · ${DISTINCT_ENZYMES} enzymes · ${CLUSTER_CUT_SITES} sites`);
+
+    // The fixture is only meaningful because the two counts differ.
+    expect(DISTINCT_ENZYMES).not.toBe(CLUSTER_CUT_SITES);
+  });
+
+  it('makes the stated enzyme count equal the name list the same tooltip prints', () => {
+    const cluster = crowdedCluster(computeMapLayout(input()).restrictions);
+    const [names, stated] = (cluster.title ?? '').split(' · ');
+
+    expect(names.split(', ')).toHaveLength(DISTINCT_ENZYMES);
+    expect(stated).toBe(`${DISTINCT_ENZYMES} enzymes`);
+  });
+
+  it('keeps the same reconciliation on the linear axis, where only one name is shown', () => {
+    const cluster = crowdedCluster(
+      computeMapLayout(input({ mode: 'linear', topology: 'linear', width: 900, height: 420 })).restrictions,
+    );
+
+    const [, shown, tail] = /^(.+?) \+(\d+)$/.exec(cluster.label?.text ?? '') ?? [];
+    expect(shown, `linear label should have been truncated: ${cluster.label?.text}`).toBeTruthy();
+    expect(shown.split(', ').length + Number(tail)).toBe(DISTINCT_ENZYMES);
+    expect(cluster.title).toContain(` · ${DISTINCT_ENZYMES} enzymes · ${CLUSTER_CUT_SITES} sites`);
+  });
+
+  it('leaves a cluster that enumerates its cuts alone — there is no bare count to confuse', () => {
+    const layout = computeMapLayout(
+      input({
+        restrictionSites: [
+          site('EcoRI', 400, 401, 'GAATTC'),
+          site('SacI', 406, 411, 'GAGCTC'),
+        ],
+      }),
+    );
+    const pair = layout.restrictions.find((r) => r.tickIds.length === 2);
+
+    expect(pair?.title).toBe('EcoRI, SacI · cut 402, 412');
+    expect(pair?.title).not.toContain('enzymes');
+  });
+
+  it('says "1 enzyme" when one enzyme cuts a cluster repeatedly', () => {
+    const layout = computeMapLayout(
+      input({
+        restrictionSites: [
+          site('AluI', 400, 402, 'AGCT'),
+          site('AluI', 408, 410, 'AGCT'),
+          site('AluI', 416, 418, 'AGCT'),
+          site('AluI', 424, 426, 'AGCT'),
+        ],
+      }),
+    );
+    const cluster = layout.restrictions.find((r) => r.tickIds.length === 4);
+
+    expect(cluster?.title).toBe('AluI · 1 enzyme · 4 sites');
+  });
+});
+
+/**
+ * The other way a cluster can mislead: the drawn label leads with a Type IIS enzyme,
+ * but the tooltip used to enumerate names in POSITION order. So "Nt.BstNBI +38" opened
+ * a tooltip reading "HindIII, AluI, ..." and the name you clicked sat 14th of 39. On
+ * live pUC19 with every source on that was 9 of 20 circular clusters, 6 of 17 linear.
+ */
+describe('a cluster tooltip opens on the name its own label leads with', () => {
+  // BsmBI cuts downstream of its recognition window -> Type IIS -> promoted to the
+  // label lead, and it is deliberately NOT first by position, so the two orders differ.
+  const MIXED: RestrictionSite[] = [
+    site('AluI', 1000, 1002, 'AGCT'),
+    site('BsmBI', 1004, 1015, 'CGTCTC'),
+    site('MseI', 1008, 1009, 'TTAA'),
+  ];
+
+  it('leads the tooltip with the same enzyme the label leads with', () => {
+    const cluster = computeMapLayout(input({ restrictionSites: MIXED }))
+      .restrictions.find((r) => r.tickIds.length === 3);
+
+    expect(cluster?.label?.text).toMatch(/^BsmBI/);
+    expect(cluster?.title).toMatch(/^BsmBI/);
+    // Position order — what the tooltip printed before.
+    expect(cluster?.title).not.toMatch(/^AluI/);
+  });
+
+  it('keeps every shown name a prefix of the tooltip list', () => {
+    // What "reading the tooltip top to bottom finds the name you clicked" reduces to.
+    const cluster = computeMapLayout(input({ restrictionSites: CLUSTER_SITES }))
+      .restrictions.find((r) => r.tickIds.length === CLUSTER_CUT_SITES);
+    const shown = (cluster?.label?.text ?? '').split(' +')[0].split(', ');
+    const listed = (cluster?.title ?? '').split(' · ', 1)[0].split(', ');
+
+    expect(shown.length).toBeGreaterThan(0);
+    expect(listed.slice(0, shown.length)).toEqual(shown);
+  });
+
+  it('moves the cut list with the names, so the pairing still tells the truth', () => {
+    // The short form prints two same-length lists and a reader pairs them off. Ordering
+    // the names for display while leaving the cuts in position order would keep every
+    // number correct on its own and make the tooltip as a whole state something false.
+    // AluI cuts at bond 1002 (printed 1003), BsmBI at 1015 (printed 1016).
+    const cluster = computeMapLayout(input({
+      restrictionSites: [site('AluI', 1000, 1002, 'AGCT'), site('BsmBI', 1004, 1015, 'CGTCTC')],
+    })).restrictions.find((r) => r.tickIds.length === 2);
+
+    expect(cluster?.title).toBe('BsmBI, AluI · cut 1016, 1003');
+  });
+
+  it("groups a twice-cutting enzyme's cuts under its own name", () => {
+    // Strictly better than the position-ordered list, which interleaved them.
+    // AluI cuts at 1002 and 1020 (printed 1003, 1021); BsmBI at 1015 (printed 1016).
+    const cluster = computeMapLayout(input({
+      restrictionSites: [
+        site('AluI', 1000, 1002, 'AGCT'),
+        site('BsmBI', 1004, 1015, 'CGTCTC'),
+        site('AluI', 1018, 1020, 'AGCT'),
+      ],
+    })).restrictions.find((r) => r.tickIds.length === 3);
+
+    expect(cluster?.title).toBe('BsmBI, AluI · cut 1016, 1003, 1021');
+  });
+
+  it('leaves the name segment free of the separator the renderer splits on', () => {
+    // SequenceMapView builds the accessible name with title.split(' · ', 1)[0]. A
+    // reorder that put a ' · ' inside the list would truncate every accessible name.
+    for (const restriction of computeMapLayout(input()).restrictions) {
+      const [names, ...rest] = (restriction.title ?? '').split(' · ');
+      expect(names).not.toContain(' · ');
+      expect(rest.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/plasmid-map/geometry/radial-labels.ts
+++ b/src/plasmid-map/geometry/radial-labels.ts
@@ -133,10 +133,38 @@ const DEFAULT_ANGLE_STEP_DEG = 1.5;
  *
  * It never changes WHICH spots exist — every tier/shift combination is still attempted —
  * only the ORDER they are tried in. A single label therefore still places iff some spot
- * fits, exactly as before, so this can never drop a label; it only steers each label
- * toward a spot nearer its own tick.
+ * fits, exactly as before. That does NOT make the label COUNT invariant — see point 2
+ * below, which is precisely the mistake this sentence used to invite.
+ *
+ * Set to one DEFAULT_ANGLE_STEP_DEG: stepping out one tier costs exactly what the
+ * smallest sideways step costs. That is the right exchange rate because a tier bump
+ * adds NO tangential displacement while even the smallest slide adds several units
+ * of it, and tangential displacement is what actually breaks a leader (see the
+ * 'pointing at their own tick' test in plasmid-map/__tests__/layout.test.ts).
+ *
+ * Chosen by measurement, not taste. Worst-case sideways offset of a label from its own
+ * tick's spoke, in ring-radius %, on the bundled plasmids at 1920x1080:
+ *   value 4 (previous): 26%   <- one leader ran 86 degrees off radial, unreadable
+ *   value 1.5:           5%
+ *   value <= 1:          0%   but stacks far enough out to shrink the drawn ring.
+ *
+ * Two measured constraints matter when changing this value:
+ *
+ * 1. "Ring size is unchanged at 1.5" holds only on the SPARSE bundled fixtures. On a
+ *    crowded ring WITH features the drawn ring (radius / bg.width) goes 77.0% -> 71.4%
+ *    at 1920x1080 and 67.8% -> 66.2% at 1440x900. The ring does shrink here, so the
+ *    value may still be affordable. Re-measure both on a crowded-with-features map
+ *    before changing it.
+ *
+ * 2. The label COUNT is not invariant. The pack is sequential, and this same constant
+ *    also governs the FEATURE label pass, which runs first and whose output becomes the
+ *    obstacle set for the restriction pass. Measured on a crowded ring, totals move both
+ *    ways: 32 -> 31 on one seed (the casualty was a feature label, "M13-rev primer") and
+ *    24 -> 25 on another. A sweep with `features: []` cannot see this at all — with no
+ *    features the outer tiers are empty, the packer stacks freely, and the effect very
+ *    nearly vanishes. Any future sweep here MUST vary features.
  */
-const TIER_ESCALATION_ANGLE_EQUIV_DEG = 4;
+const TIER_ESCALATION_ANGLE_EQUIV_DEG = 1.5;
 const CENTERED_LABEL_RING_CLEARANCE_PX = 1;
 const CENTERED_LABEL_COLLISION_PAD_PX = 0;
 /**

--- a/src/plasmid-map/geometry/restrictions.ts
+++ b/src/plasmid-map/geometry/restrictions.ts
@@ -32,9 +32,14 @@ export interface MapRestrictionCluster {
   /** Representative bp for the label anchor + leader (a real tick position). */
   anchorBp: number;
   ticks: readonly MapRestrictionTick[];
-  /** Distinct enzyme names, first-occurrence (position) order (deduped). */
+  /**
+   * Distinct enzyme names in DISPLAY order: Type IIS first, then first-occurrence
+   * (position) order. This is the order the drawn label reads in, and the order the
+   * cluster's tooltip must list, or the name the user clicked is not the name the
+   * tooltip opens with — "Nt.BstNBI +38" against a tooltip starting "HindIII, AluI".
+   */
   enzymes: readonly string[];
-  /** Names actually shown before overflow. */
+  /** Names actually shown before overflow — always a PREFIX of `enzymes`. */
   shownEnzymes: readonly string[];
   /** Count folded into the "+N" suffix. */
   overflow: number;
@@ -150,16 +155,22 @@ function buildCluster(
 ): MapRestrictionCluster {
   // Display/name lists are DISTINCT enzyme names — an enzyme that cuts several
   // times inside one cluster becomes a single name, never "BsmFI,BsmFI". Set
-  // preserves first-occurrence (position) order; ticks[] below keeps every real
-  // cut site, so tick counts / overflow-site banners are unaffected.
-  const enzymes = [...new Set(group.map((t) => t.enzyme))];
-  // Show Type IIS names first, still DISTINCT, before capping to maxNames.
-  const shownEnzymes = [
+  // preserves first-occurrence order; ticks[] below keeps every real cut site, so
+  // tick counts / overflow-site banners are unaffected.
+  //
+  // Type IIS names sort first because the label leads with them. The FULL list is
+  // ordered here, not just the capped one, so that `shownEnzymes` is a prefix of
+  // `enzymes` by construction rather than by coincidence — that is what lets the
+  // cluster's tooltip enumerate `enzymes` and still open on the name the label drew.
+  // Ordering only the shown slice is what produced a label reading "Nt.BstNBI +38"
+  // over a tooltip reading "HindIII, AluI, ...", with the clicked name 14th of 39.
+  const enzymes = [
     ...new Set([
       ...group.filter((t) => t.isTypeIIS).map((t) => t.enzyme),
       ...group.filter((t) => !t.isTypeIIS).map((t) => t.enzyme),
     ]),
-  ].slice(0, Math.max(1, maxNames));
+  ];
+  const shownEnzymes = enzymes.slice(0, Math.max(1, maxNames));
   // "+N" counts DISTINCT enzymes not shown (not raw ticks).
   const overflow = enzymes.length - shownEnzymes.length;
   // Anchor on a real middle tick so wrap-merged clusters still get a sane bp.

--- a/src/plasmid-map/layout.ts
+++ b/src/plasmid-map/layout.ts
@@ -73,12 +73,26 @@ const REC_TICK_LEN = 7; // restriction tick length (radial, outside R)
 const REC_DENSITY_TICK_INNER_OFFSET = 1; // per-site density substrate starts just outside R
 const REC_DENSITY_TICK_LEN = 5; // shorter than clustered interactive ticks
 const COORD_TICK_LEN = 6; // coordinate tick length (radial, inside R)
+const COORD_LABEL_SEAM_PAD = 2; // air demanded between the wrapped ruler number and "0"
 const FEATURE_INSIDE_LABEL_GAP = 6;
 const FEATURE_INSIDE_LABEL_EDGE_PAD = 6;
 const FEATURE_INSIDE_LABEL_CAP_PAD = LABEL_LINE_HEIGHT_PX;
 const CENTER_LABEL_PAD = 8;
 const REC_LABEL_RADIAL_SLOT_PX = 62; // approximate radial outside-label slot used for label caps
-const CIRCULAR_REC_LABEL_MAX_WIDTH_PX = 112;
+/**
+ * Width budget for a circular restriction cluster label. Over it, circularClusterLabel
+ * drops a name and grows the "+N" tail instead.
+ *
+ * Was 112, with the widest labels sitting at 111.2 — hard against it. Adding the space
+ * after each name separator costs 6.2px per separator (measured), so a three-name label
+ * needed +12.4 and six labels across the bundled plasmids silently fell back to two
+ * names. 126 = 112 + two separators' worth + headroom, which restores byte-identical
+ * enzyme content everywhere: a readable separator must not be paid for with a hidden
+ * enzyme name. Verified on pUC19 / pBR322 / pACYC184 / pBluescript / pcDNA3.1 at
+ * 1920x1080 — label counts unchanged, zero label-box overlaps, and the worst leader's
+ * sideways offset from its own tick unchanged (2.9-9.2% of ring radius).
+ */
+const CIRCULAR_REC_LABEL_MAX_WIDTH_PX = 126;
 const LABEL_BAND_MARGIN = 10; // fitted viewBox padding around outside labels
 const FEATURE_OUTSIDE_LABEL_PRIORITY_BASE = 1_000_000; // feature/gene names win over crowded enzyme text
 const RADIAL_LABEL_MIN_LEADER_GAP = 8;
@@ -154,6 +168,26 @@ const LINEAR_ROW_MIN_GAP = 4;
 const LINEAR_BOTTOM_PAD = 10;
 const LINEAR_FEATURE_RADIUS = 0; // Square-ended feature bars
 const LINEAR_REC_LABEL_MAX_WIDTH_PX = 64;
+/**
+ * Floor on the visible stem when a cluster label shortens its enzyme name to keep its
+ * "+N" count, so a pathological count cannot grind the name down to a single letter.
+ *
+ * Where it bites, measured rather than assumed (proportional mode, 6.2px/char, 9-char
+ * lead name):
+ *   - Counts up to 3 digits — floor not binding, or exactly met. "Nt.… +999" is 55.8px,
+ *     equal to the bare name it replaces, so the no-wider invariant still holds.
+ *   - 4-digit counts — the floor wins over the width budget. "Nt.… +1200" is 62.0px
+ *     against a 55.8px name: ~6px wider than what it replaces, still inside the 64px
+ *     cap, so the only cost is that much row width.
+ *   - 5-digit counts — "Nt.… +12000" is 68.2px and OVERRUNS the cap by 4.2px. Nothing
+ *     clips or overprints, because placement uses actual widths; the row's slot estimate
+ *     is simply short by that much, so a very crowded row could drop one more label.
+ *
+ * Reaching even the 4-digit case needs ~1000 DISTINCT enzymes cutting inside a single
+ * cluster window. The bundled set has 154 in total and the densest real cluster on
+ * pUC19 is 39. Left unguarded deliberately — the guard would be dead code.
+ */
+const LINEAR_REC_LABEL_MIN_STEM_CHARS = 3;
 const LINEAR_REC_LABEL_GAP_X = 8;
 const LINEAR_REC_SLOT_PX = LINEAR_REC_LABEL_MAX_WIDTH_PX + LINEAR_REC_LABEL_GAP_X;
 // Min px gap between two ADJACENT restriction labels in a row. Real enzyme names
@@ -965,6 +999,10 @@ function computeCircularLayout(input: MapInput): MapLayout {
     writeCircularOutsideLabel,
   );
   featureHiddenLabels += featureOutsideHidden.feature;
+  // Order matters: if the leader pass ran first and had already nulled "0", the seam
+  // guard would find nothing to compare against and leave the wrapped number alone at
+  // 12 o'clock, reading as the origin — strictly worse than the bug it fixes.
+  dropOriginSeamCoordinateLabel(coordinates, labelFontMode);
   dropCoordinateLabelsConflictingWithFeatureLeaders(featureRenders, coordinates, labelFontMode);
 
   const restrictionOutsideObstacles = circularRadialLabelObstacles({
@@ -1004,6 +1042,18 @@ function computeCircularLayout(input: MapInput): MapLayout {
     return Boolean(render && render.tickIds.length > 1 && !render.label);
   });
   if (missingGroupedRestrictionCandidates.length > 0) {
+    // This pass is an ESCALATION: it re-places grouped clusters the ordinary pass
+    // could not fit, ignoring feature labels as obstacles, then deletes whatever
+    // feature labels they landed on. It buys enzyme names with feature names, so
+    // it runs as a transaction and is kept only if the trade is worth making.
+    // Measured before this guard: pET-28a(+) spent FIVE feature labels — its
+    // promoter, operator, RBS, tag and terminator, the entire cloning site — to
+    // gain TWO enzyme names, and pETDuet-1 spent four to gain one.
+    const rescueTargetIds = new Set(
+      missingGroupedRestrictionCandidates
+        .map((candidate) => restrictionOutsideMeta.get(candidate.id)?.targetId)
+        .filter((id): id is string => Boolean(id)),
+    );
     const groupedRestrictionFallbackObstacles = circularRadialLabelObstacles({
       centerGuard,
       featureGlyphBoxes,
@@ -1035,9 +1085,10 @@ function computeCircularLayout(input: MapInput): MapLayout {
       groupedRestrictionFallbackObstacles.leaderTextObstacles,
       writeCircularOutsideLabel,
     );
-    featureHiddenLabels += dropFeatureLabelsConflictingWithGroupedRestrictionLabels(
+    featureHiddenLabels += keepRescuedGroupedRestrictionLabelsWorthTheirCost(
       featureRenders,
       restrictionRenders,
+      rescueTargetIds,
       labelFontMode,
     );
   }
@@ -1063,28 +1114,38 @@ function computeCircularLayout(input: MapInput): MapLayout {
   const overflowChipBaseY = round(overflowChipY);
   const featureOverflowTotal = featureHiddenLabels + overflowFeatureCount;
   if (featureOverflowTotal > 0) {
+    const text = `+${featureOverflowTotal} more`;
     overflows.push({
       id: 'circular-feature-overflow',
       kind: 'feature-labels',
-      text: `+${featureOverflowTotal} more`,
+      text,
       title: featureOverflowTitle(overflowFeatureCount, featureHiddenLabels, 'hidden'),
+      hiddenBodies: overflowFeatureCount,
+      unlabelled: featureHiddenLabels,
       x: overflowChipX,
       y: overflowChipBaseY,
       anchor: 'middle',
+      hit: overflowHitRect(text, overflowChipX, overflowChipBaseY, 'middle', OVERFLOW_FONT_PX_CIRCULAR),
     });
   }
   const recHiddenSites = showRestrictionLabels
     ? restrictionRenders.reduce((n, r) => n + (r.label ? 0 : r.tickIds.length), 0)
     : 0;
   if (recHiddenSites > 0) {
+    const text = `+${recHiddenSites} more sites`;
+    const y = round(overflowChipBaseY + (featureOverflowTotal > 0 ? LABEL_LINE_HEIGHT_PX : 0));
     overflows.push({
       id: 'circular-restriction-overflow',
       kind: 'restriction-labels',
-      text: `+${recHiddenSites} more sites`,
+      text,
       title: `${recHiddenSites} restriction sites have hidden labels. All density ticks remain visible.`,
+      // Every site keeps its density tick, so nothing here is undrawn — only unnamed.
+      hiddenBodies: 0,
+      unlabelled: recHiddenSites,
       x: overflowChipX,
-      y: round(overflowChipBaseY + (featureOverflowTotal > 0 ? LABEL_LINE_HEIGHT_PX : 0)),
+      y,
       anchor: 'middle',
+      hit: overflowHitRect(text, overflowChipX, y, 'middle', OVERFLOW_FONT_PX_CIRCULAR),
     });
   }
 
@@ -1298,8 +1359,14 @@ function computeLinearLayout(input: MapInput): MapLayout {
     const title = featureTitle(name, f.type, segs, f.strand);
     const band = rowBand(lane);
     if (!band) {
+      // Overflow row — counted ONCE, as a body the map does not draw. It used to be
+      // counted here a second time as a dropped label, and since the chip prints
+      // bodies + labels the same feature arrived twice in one number: a stack of 26
+      // features with 25 pushed off the rows and 7 more drawn-but-unnamed printed
+      // "+57" for 32 affected features. The label is not separately missing — there
+      // is nothing drawn for it to name, and hiddenFeatureLabelCount is what the
+      // circular pass already means by it (features drawn without a name).
       overflowFeatureCount += 1;
-      if (showFeatureLabels && name) hiddenFeatureLabelCount += 1;
       featureRenders.push({
         id: f.id,
         name,
@@ -1929,27 +1996,40 @@ function computeLinearLayout(input: MapInput): MapLayout {
   hiddenFeatureLabelCount += placeLinearOutsideFeatureLabels();
 
   if (recHidden.hiddenSites > 0) {
+    const text = `+${recHidden.hiddenSites} more sites`;
+    const chipX = round(width - padX);
+    const chipY = round(recLabelRowYs[1] + LINEAR_REC_LABEL_CENTER_OFFSET);
     overflows.push({
       id: 'linear-restriction-overflow',
       kind: 'restriction-labels',
-      text: `+${recHidden.hiddenSites} more sites`,
+      text,
       title: `${recHidden.hiddenSites} restriction sites have hidden labels. All density ticks remain visible.`,
-      x: round(width - padX),
-      y: round(recLabelRowYs[1] + LINEAR_REC_LABEL_CENTER_OFFSET),
+      // Every site keeps its density tick, so nothing here is undrawn — only unnamed.
+      hiddenBodies: 0,
+      unlabelled: recHidden.hiddenSites,
+      x: chipX,
+      y: chipY,
       anchor: 'end',
+      hit: overflowHitRect(text, chipX, chipY, 'end', OVERFLOW_FONT_PX),
     });
   }
 
   const featureOverflowTotal = overflowFeatureCount + hiddenFeatureLabelCount;
   if (featureOverflowTotal > 0) {
+    const text = `+${featureOverflowTotal}`;
+    const chipX = round(width - 2);
+    const chipY = round(rowTopY + LABEL_LINE_HEIGHT_PX);
     overflows.push({
       id: 'linear-feature-overflow',
       kind: 'feature-labels',
-      text: `+${featureOverflowTotal}`,
+      text,
       title: featureOverflowTitle(overflowFeatureCount, hiddenFeatureLabelCount, 'dropped'),
-      x: round(width - 2),
-      y: round(rowTopY + LABEL_LINE_HEIGHT_PX),
+      hiddenBodies: overflowFeatureCount,
+      unlabelled: hiddenFeatureLabelCount,
+      x: chipX,
+      y: chipY,
       anchor: 'end',
+      hit: overflowHitRect(text, chipX, chipY, 'end', OVERFLOW_FONT_PX),
     });
   }
 
@@ -2506,6 +2586,62 @@ function plural(count: number, one: string, many: string): string {
   return count === 1 ? one : many;
 }
 
+/**
+ * Chip type sizes, mirroring `.motif-pm-overflow` in plasmid-map.css (10px, with a
+ * 9px circular override). Duplicated here because the hit rect must be sized from
+ * the same metric the glyphs are drawn at, and this module may not touch the DOM.
+ * `overflow-chip-hit.test.ts` reads the stylesheet and fails if the two drift.
+ */
+const OVERFLOW_FONT_PX = 10;
+const OVERFLOW_FONT_PX_CIRCULAR = 9;
+/** Horizontal breathing room each side of the glyph run. */
+const OVERFLOW_HIT_PAD_X = 8;
+/**
+ * Baseline-to-visual-middle offset, in em. Taken off the rendered chips: a 9px
+ * circular chip's box is 10.25 units tall and a 10px linear chip's is 12, each
+ * sitting ~0.9em above and ~0.25em below its baseline.
+ *
+ * It is a MEASUREMENT, not a derivation — SVG text is boxed by its font's own
+ * ascent/descent and this module may not touch the DOM, so a font swap moves the
+ * middle and nothing here would notice. So it is guarded rather than trusted:
+ * `overflow-chip-hit.test.ts` holds the measured ink box, asserts the rect stays
+ * centred on it (which pins this number to ~±0.01em without restating it), and pins
+ * the family `.motif-pm-overflow` declares — change the font stack and the guard
+ * fails until someone re-measures. Same arrangement as the font sizes above, whose
+ * external truth is the stylesheet rather than a ruler.
+ */
+const OVERFLOW_HIT_CENTER_EM = 0.32;
+
+/**
+ * The chip's pointer target: its own estimated glyph run, padded sideways into the
+ * empty space the chip sits in, and exactly one label line tall.
+ *
+ * One line is not a round number picked for looks. It is the pitch `overflows` are
+ * stacked at, so a second chip's target abuts this one instead of covering it, and
+ * it is what keeps the rect clear of the feature lane below the linear chip — the
+ * chip layer paints above the features and a taller rect would eat their clicks.
+ */
+function overflowHitRect(
+  text: string,
+  x: number,
+  y: number,
+  anchor: 'start' | 'middle' | 'end',
+  fontPx: number,
+): { x: number; y: number; width: number; height: number } {
+  const width = approxTextWidth(text, fontPx) + OVERFLOW_HIT_PAD_X * 2;
+  const height = LABEL_LINE_HEIGHT_PX;
+  const left =
+    anchor === 'middle' ? x - width / 2
+      : anchor === 'end' ? x + OVERFLOW_HIT_PAD_X - width
+        : x - OVERFLOW_HIT_PAD_X;
+  return {
+    x: round(left),
+    y: round(y - OVERFLOW_HIT_CENTER_EM * fontPx - height / 2),
+    width: round(width),
+    height: round(height),
+  };
+}
+
 function featureOverflowTitle(
   hiddenBodies: number,
   hiddenLabels: number,
@@ -2670,7 +2806,14 @@ function circularClusterLabel(
   const candidateNames = c.shownEnzymes.length > 0 ? c.shownEnzymes : c.enzymes.slice(0, 1);
   const build = (shown: readonly string[], displayNames: readonly string[] = shown) => {
     const overflow = Math.max(0, c.enzymes.length - shown.length);
-    const text = `${displayNames.join(',')}${overflow > 0 ? ` +${overflow}` : ''}`;
+    // Enzyme names join with ", " and the "+N" overflow tail with " ". The tail is a
+    // COUNT, not another list member, so it is deliberately not comma-separated.
+    // The space after the comma is load-bearing: without it the only thing separating
+    // "BsmBI" from "Esp3I" is the Type IIS colour change, and colour does not survive
+    // a monochrome export or forced-colors mode. Any change here must be mirrored in
+    // SequenceMapView's tspan renderer AND its `segmented` guard, which silently drops
+    // per-enzyme coloring when its reconstruction stops matching this string.
+    const text = `${displayNames.join(', ')}${overflow > 0 ? ` +${overflow}` : ''}`;
     const segments = shown.map((name, index) => ({
       text: displayNames[index] ?? name,
       typeIIS: typeIISByEnzyme.get(name) ?? false,
@@ -2707,6 +2850,23 @@ function circularClusterLabel(
   return build([lead], [displayLead.slice(0, 1)]);
 }
 
+/**
+ * Compact label for a linear restriction cluster: the lead enzyme name plus the "+N"
+ * count of names that did not fit.
+ *
+ * The count is not optional. This used to ellipsise the name and then return the stem
+ * ALONE when the pair overran the width cap, so a 14-enzyme cluster led by a long name
+ * rendered as a bare "Nt.BstNBI" — visually identical to a lone cut site. That is worse
+ * than a crowded label: a truncation that hides that it truncated states something
+ * false, where a crowded one merely states something incomplete. So characters of the
+ * NAME are what gets spent; the "+N" is the only mark saying "there is more here".
+ *
+ * Names of 8 characters or fewer (153 of the 154 bundled enzymes) take the early return
+ * and are not width-checked at all — "HindIII +13" ships at 68px against a 64px cap.
+ * That inconsistency predates this and is deliberately left alone: it already keeps the
+ * count, which is the property that matters, and re-imposing the cap there would
+ * re-truncate a lot of labels that are placed by their ACTUAL width anyway.
+ */
 function compactLinearClusterText(c: MapRestrictionCluster): string {
   const first = c.shownEnzymes[0] ?? c.enzymes[0] ?? '';
   const extra = c.enzymes.length - 1;
@@ -2716,14 +2876,25 @@ function compactLinearClusterText(c: MapRestrictionCluster): string {
   const full = `${first}${suffix}`;
   if (approxTextWidth(full) <= LINEAR_REC_LABEL_MAX_WIDTH_PX) return full;
 
+  // Budget the name against what is left after the count, never the other way round —
+  // and never let the summary take MORE room than the bare name it replaces. Labels are
+  // placed by actual width, so width taken here is width taken from a neighbour: the
+  // first cut of this fix grew these two labels by 6.2px each and cost an unrelated
+  // "AclI" label its place in a crowded row at 1920x1080 with all sources on. Trading
+  // name characters for count characters one-for-one keeps the width identical, so the
+  // packing cannot move and the only thing that changes is what the label says.
+  const budget =
+    Math.min(LINEAR_REC_LABEL_MAX_WIDTH_PX, approxTextWidth(first)) - approxTextWidth(suffix);
   let stem = first;
   while (
-    stem.length > 8 &&
-    approxTextWidth(`${stem}…`) > LINEAR_REC_LABEL_MAX_WIDTH_PX
+    stem.length > LINEAR_REC_LABEL_MIN_STEM_CHARS &&
+    approxTextWidth(`${stem}…`) > budget
   ) {
     stem = stem.slice(0, -1);
   }
-  return stem === first ? first : `${stem}…`;
+  // Unreachable with a non-empty suffix (a stem that fits the budget would have fit the
+  // cap alongside it), but if the name alone was the thing that overran, it keeps both.
+  return stem === first ? full : `${stem}…${suffix}`;
 }
 
 function ellipsizeToWidth(
@@ -3042,12 +3213,43 @@ function clusterPositions(c: MapRestrictionCluster): number[] {
   return c.ticks.map((t) => t.position).sort((a, b) => a - b);
 }
 
-/** Native-tooltip text for a restriction cluster: "EcoRI, SacI · cut 398, 408"
- * (cut bonds shown 1-indexed to match the detail restriction UI). */
+/**
+ * Native-tooltip text for a restriction cluster: "EcoRI, SacI · cut 398, 408"
+ * (cut bonds shown 1-indexed to match the detail restriction UI).
+ *
+ * A crowded cluster names BOTH counts — "· 39 enzymes · 50 sites" — because the two
+ * numbers a reader meets are in DIFFERENT UNITS. The label's "+N" tail counts enzyme
+ * NAMES that did not fit (circularClusterLabel / compactLinearClusterText), while the
+ * cut tally counts SITES. Printing only the site count put "Nt.BstNBI +38" on the ring
+ * beside a tooltip reading "50 sites" with nothing anywhere to say they measure
+ * different things. Naming the enzyme count lets 1 shown + 38 hidden reconcile against
+ * "39 enzymes" — and it is the same 39 names this very string already enumerates — so
+ * "50 sites" keeps its own unit instead of looking like a contradiction.
+ */
 function restrictionTitle(c: MapRestrictionCluster): string {
-  const enz = [...new Set(c.enzymes)].join(', '); // dedupe isoschizomers/repeats
-  const cuts = c.ticks.map((t) => t.cutPosition + 1);
-  return cuts.length <= 3 ? `${enz} · cut ${cuts.join(', ')}` : `${enz} · ${cuts.length} sites`;
+  // `c.enzymes` is in DISPLAY order (Type IIS first), which is the order the drawn
+  // label reads in — so the name the user clicked is the name this opens with, and
+  // the label's shown names are this list's first few.
+  const names = [...new Set(c.enzymes)]; // dedupe isoschizomers/repeats
+  const enz = names.join(', ');
+  // The short form prints two same-length lists side by side and a reader pairs them
+  // off: "AluI, BsmFI, MseI · cut 1898, 1919, 1945" is only true if the Nth cut
+  // belongs to the Nth name. Measured on pUC19 with every source on, 14 of 14
+  // multi-name short-form tooltips were pairable that way — so the pairing is real,
+  // and ordering the NAMES for display without reordering the cuts would have quietly
+  // made it lie. Sorting the ticks the same way keeps it, and beats the old code when
+  // one enzyme cuts twice in a cluster: its two cuts now sit together under its own
+  // name instead of straddling a neighbour's.
+  const rank = new Map(names.map((name, index) => [name, index]));
+  const cuts = [...c.ticks]
+    .sort((a, b) =>
+      (rank.get(a.enzyme) ?? names.length) - (rank.get(b.enzyme) ?? names.length)
+      || a.cutPosition - b.cutPosition)
+    .map((t) => t.cutPosition + 1);
+  // <=3 cuts enumerates the cut bonds, so there is no bare count to be mistaken for
+  // the name count; the reader can see every name and every cut.
+  if (cuts.length <= 3) return `${enz} · cut ${cuts.join(', ')}`;
+  return `${enz} · ${names.length} ${names.length === 1 ? 'enzyme' : 'enzymes'} · ${cuts.length} sites`;
 }
 
 interface CircularRadialLabelMeta {
@@ -3209,41 +3411,104 @@ function circularRadialLabelObstacles({
   };
 }
 
-function dropFeatureLabelsConflictingWithGroupedRestrictionLabels(
+/**
+ * Settle the grouped-cluster rescue: keep the rescued restriction labels that are
+ * worth what they cost, and undo the rest. Returns how many feature labels were
+ * actually evicted.
+ *
+ * The rescue pass places grouped clusters while ignoring feature labels, so each
+ * label it wins may be sitting on one. Deciding that per rescued label rather than
+ * for the pass as a whole matters: a rescue that overlaps nothing is free and is
+ * always kept, and only the ones that would cost a feature name have to justify
+ * themselves.
+ *
+ * Cheapest first, then two conditions checked against the running totals — no
+ * tuned constant, just counts:
+ *  - the rescue must never delete more names than it adds, since that leaves the
+ *    map strictly poorer, with fewer labels AND one class quieter; and
+ *  - it must not erase most of the feature class. Destroying more feature labels
+ *    than survive is no longer resolving a local collision, it is deciding the map
+ *    answers only one of its two questions.
+ *
+ * A rescue that fails either test gives its label back; that cluster keeps its
+ * ticks and is counted by the "+N more sites" chip like any other unnamed one.
+ */
+function keepRescuedGroupedRestrictionLabelsWorthTheirCost(
   featureRenders: MapFeatureRender[],
   restrictionRenders: readonly MapRestrictionRender[],
+  rescuedClusterIds: ReadonlySet<string>,
   labelFontMode: LabelFontMode,
 ): number {
-  const groupedRestrictions = restrictionRenders
+  const grouped = restrictionRenders
     .filter((restriction) => restriction.tickIds.length > 1 && restriction.label)
     .map((restriction) => ({
+      render: restriction,
       label: restriction.label!,
       box: labelBBoxForRender(restriction.label!, labelFontMode),
+      rescued: rescuedClusterIds.has(restriction.clusterId),
     }));
-  if (groupedRestrictions.length === 0) return 0;
+  if (grouped.length === 0) return 0;
 
-  let dropped = 0;
-  for (const feature of featureRenders) {
-    const label = feature.label;
-    if (!label || label.inside) continue;
-    const featureBox = labelBBoxForRender(label, labelFontMode);
-    const featureLeader = label.leader;
-    const conflicts = groupedRestrictions.some((restriction) => {
-      const restrictionLeader = restriction.label.leader;
-      return (
-        bboxIntersects(featureBox, restriction.box) ||
-        (featureLeader.length > 1 && polylineIntersectsBBox(featureLeader, restriction.box)) ||
-        (restrictionLeader.length > 1 && polylineIntersectsBBox(restrictionLeader, featureBox)) ||
-        (featureLeader.length > 1 &&
-          restrictionLeader.length > 1 &&
-          polylinesIntersect(featureLeader, restrictionLeader))
-      );
-    });
-    if (!conflicts) continue;
-    feature.label = null;
-    dropped += 1;
+  const outsideFeatures = featureRenders
+    .filter((feature) => feature.label && !feature.label.inside)
+    .map((feature) => ({
+      feature,
+      box: labelBBoxForRender(feature.label!, labelFontMode),
+      leader: feature.label!.leader,
+    }));
+
+  const collides = (
+    featureEntry: (typeof outsideFeatures)[number],
+    restriction: (typeof grouped)[number],
+  ): boolean => {
+    const restrictionLeader = restriction.label.leader;
+    return (
+      bboxIntersects(featureEntry.box, restriction.box) ||
+      (featureEntry.leader.length > 1 && polylineIntersectsBBox(featureEntry.leader, restriction.box)) ||
+      (restrictionLeader.length > 1 && polylineIntersectsBBox(restrictionLeader, featureEntry.box)) ||
+      (featureEntry.leader.length > 1 &&
+        restrictionLeader.length > 1 &&
+        polylinesIntersect(featureEntry.leader, restrictionLeader))
+    );
+  };
+
+  // Labels that were already placed the ordinary way have precedence: the feature
+  // labels they overlap are not the rescue's doing and are dropped unconditionally,
+  // exactly as before.
+  const evicted = new Set<(typeof outsideFeatures)[number]>();
+  for (const restriction of grouped) {
+    if (restriction.rescued) continue;
+    for (const featureEntry of outsideFeatures) {
+      if (collides(featureEntry, restriction)) evicted.add(featureEntry);
+    }
   }
-  return dropped;
+
+  const rescues = grouped
+    .filter((restriction) => restriction.rescued)
+    .map((restriction) => ({
+      restriction,
+      cost: outsideFeatures.filter(
+        (featureEntry) => !evicted.has(featureEntry) && collides(featureEntry, restriction),
+      ),
+    }))
+    .sort((a, b) => a.cost.length - b.cost.length || cmpKey(a.restriction.render.clusterId, b.restriction.render.clusterId));
+
+  let kept = 0;
+  for (const rescue of rescues) {
+    const wouldEvict = new Set(evicted);
+    for (const featureEntry of rescue.cost) wouldEvict.add(featureEntry);
+    const survivingFeatures = outsideFeatures.length - wouldEvict.size;
+    if (kept + 1 >= wouldEvict.size && survivingFeatures >= wouldEvict.size) {
+      for (const featureEntry of rescue.cost) evicted.add(featureEntry);
+      kept += 1;
+      continue;
+    }
+    rescue.restriction.render.label = null;
+    rescue.restriction.render.labelSegments = undefined;
+  }
+
+  for (const featureEntry of evicted) featureEntry.feature.label = null;
+  return evicted.size;
 }
 
 function dropRestrictionLabelsConflictingWithFeatureLeaders(
@@ -3292,6 +3557,33 @@ function dropCoordinateLabelsConflictingWithFeatureLeaders(
       coordinate.label = null;
     }
   }
+}
+
+/**
+ * The circular ruler wraps, so the last nice-step tick can land a few bp short of the
+ * origin and print its number on top of "0" at 12 o'clock. pACYCDuet-1 is 4,008 bp on a
+ * 1,000 bp step: the 4000 tick sits 8 bp — about 3px of arc — before the seam, and
+ * "4000" is four times wider than "0", so "0" is 100% covered and the map reads as
+ * though it starts at 4000.
+ *
+ * The wrapped neighbour yields its NUMBER and keeps its TICK. "0" is what orients the
+ * whole map, so it is never the one dropped, and keeping the tick leaves the ruler's
+ * cadence unbroken.
+ *
+ * Circular only: the linear generator puts its last tick at the right-hand end of the
+ * axis with nothing after it, so it has no seam to guard.
+ */
+function dropOriginSeamCoordinateLabel(
+  coordinates: MapCoordinateTick[],
+  labelFontMode: LabelFontMode,
+): void {
+  if (coordinates.length < 2) return;
+  const origin = coordinates[0];
+  const last = coordinates[coordinates.length - 1];
+  if (origin.bp !== 0 || !origin.label || !last.label) return;
+  const originBox = expandBBox(labelBBoxForRender(origin.label, labelFontMode), COORD_LABEL_SEAM_PAD);
+  if (!bboxIntersects(originBox, labelBBoxForRender(last.label, labelFontMode))) return;
+  last.label = null;
 }
 
 function chooseRadialPlacementOwner(

--- a/src/plasmid-map/point-spaces.ts
+++ b/src/plasmid-map/point-spaces.ts
@@ -1,0 +1,76 @@
+/**
+ * The plasmid map draws its geometry inside a pan/zoom group:
+ *
+ *   <svg class="motif-plasmid-map" viewBox="...">        <- ROOT space
+ *     <rect class="motif-pm-bg" />                       <- the click surface, ROOT space
+ *     <g class="motif-pm-viewport" transform="translate(tx ty) scale(k)">
+ *       ...backbone, features, restriction ticks...      <- CONTENT space
+ *     </g>
+ *   </svg>
+ *
+ * The transparent surface the user actually clicks is rendered OUTSIDE the group
+ * on purpose, so it always covers the whole view. That puts the pointer position
+ * in root space while every value a map layout emits — `center`, `radius`,
+ * `linearAxis`, and all the drawn paths — is in content space.
+ *
+ * The two are related by the group transform, and are equal ONLY at a pristine
+ * fit (k === 1, tx === 0, ty === 0):
+ *
+ *   root = k * content + t          content = (root - t) / k
+ *
+ * That "only at fit" is what makes confusing them so easy to ship: the default
+ * state is the identity, so an unconverted point is exactly right until the user
+ * touches the map, and then it is quietly wrong by a growing amount. A pan alone
+ * is enough — the zoom badge can still read 100%.
+ *
+ * Which space a value is in is therefore part of its type, not a comment.
+ */
+
+/** The SVG pan/zoom transform applied to `<g class="motif-pm-viewport">`. */
+export interface MapPointTransform {
+  k: number;
+  tx: number;
+  ty: number;
+}
+
+/**
+ * A point in the map's SVG ROOT space, i.e. before the viewport group's
+ * translate/scale. This is the space `{k, tx, ty}` itself is expressed in, so it
+ * is the space zoom anchoring must work in.
+ */
+export type MapRootPoint = { x: number; y: number; readonly space?: 'root' };
+
+/**
+ * A point in the map's CONTENT space — inside the viewport group, where the
+ * layout's geometry lives. This is the space that converts to an angle or a base.
+ */
+export type MapContentPoint = { x: number; y: number; readonly space?: 'content' };
+
+export const mapRootPoint = (x: number, y: number): MapRootPoint => ({ x, y, space: 'root' });
+export const mapContentPoint = (x: number, y: number): MapContentPoint => ({ x, y, space: 'content' });
+
+/**
+ * A transform is only usable if it can be inverted. A zero, negative or
+ * non-finite scale would divide a coordinate to Infinity or NaN and place a
+ * selection at a nonsense base, so fall back to the identity: the point passes
+ * through unchanged, which is the pristine-fit behaviour and visibly harmless.
+ */
+function usableTransform(transform: MapPointTransform): MapPointTransform {
+  if (!Number.isFinite(transform.k) || transform.k <= 0) return { k: 1, tx: 0, ty: 0 };
+  const k = transform.k;
+  const tx = Number.isFinite(transform.tx) ? transform.tx : 0;
+  const ty = Number.isFinite(transform.ty) ? transform.ty : 0;
+  return { k, tx, ty };
+}
+
+/** Undo the viewport transform. Required before deriving any angle or base. */
+export function contentPointFromRoot(point: MapRootPoint, transform: MapPointTransform): MapContentPoint {
+  const { k, tx, ty } = usableTransform(transform);
+  return mapContentPoint((point.x - tx) / k, (point.y - ty) / k);
+}
+
+/** Apply the viewport transform. Required before anchoring a zoom on layout geometry. */
+export function rootPointFromContent(point: MapContentPoint, transform: MapPointTransform): MapRootPoint {
+  const { k, tx, ty } = usableTransform(transform);
+  return mapRootPoint((point.x * k) + tx, (point.y * k) + ty);
+}

--- a/src/plasmid-map/types.ts
+++ b/src/plasmid-map/types.ts
@@ -169,9 +169,67 @@ export interface MapOverflowRender {
   kind: string;
   text: string;
   title: string;
+  /*
+   * What the chip is reporting, as numbers rather than as digits embedded in `text`
+   * ("+30 more sites") or `title`.
+   *
+   * The chip is not the only place these belong: it explains itself through an SVG
+   * `<title>`, which no browser opens on keyboard focus, so anywhere that has to
+   * state the same quantity to a keyboard user needs the same number. Recovering it
+   * with a regex over the display string would make every such reader a
+   * reconstruction that has to keep matching the chip's wording — the map has been
+   * bitten by exactly that before (see the labelSegments note on MapRestrictionRender).
+   *
+   * TWO fields rather than one total, and that is the point. The feature chip reports
+   * two different things at once — items the map draws no body for, and items it draws
+   * but cannot name — and a single integer holding their sum is a number no sentence
+   * can truthfully use: of a summed "32", both "32 features have no label" and "32
+   * features are missing from the map" are false. `text` still prints the sum, because
+   * a chip has room for one number and its own `title` breaks that sum apart right
+   * beside it. Every OTHER reader has to state which quantity it means, so the type
+   * makes it pick one. A single `count` holding the sum was here before, and the
+   * agreement test guarding it could only ever confirm the sum matched itself.
+   *
+   * The two are disjoint by construction — an item is either drawn or it is not, and
+   * an undrawn one has no label left to drop — so `hiddenBodies + unlabelled` counts
+   * distinct affected items, which is exactly what `text` prints.
+   */
+  /**
+   * Items the map draws no geometry for at all: features pushed past the last lane the
+   * compressed stack could fit, kept discoverable by hover title + the Features tab.
+   * Always 0 on a restriction chip — every site keeps its density tick, which is what
+   * that chip's own title promises.
+   */
+  hiddenBodies: number;
+  /**
+   * Items the map DOES draw but does not name: features whose label was culled, or
+   * restriction SITES under a cluster whose label was culled.
+   *
+   * Counts unnamed ITEMS, not label glyphs. One dropped cluster label can leave a
+   * dozen sites unlabelled, and "N sites" is the wording the chip, the cluster tooltip
+   * and the Map Visibility dock already share for it — naming this `hiddenLabels`
+   * would invite the next reader to print "12 labels hidden" over a map that dropped
+   * one.
+   */
+  unlabelled: number;
   x: number;
   y: number;
   anchor: 'start' | 'middle' | 'end';
+  /**
+   * Pointer target for the chip, in the same space as `x`/`y`.
+   *
+   * The chip's ONLY explanation of its own count is a `<title>`, and SVG text is
+   * hit-tested as its whole run box — so without this the target is exactly the
+   * glyph run, a few CSS px tall once the map's meet-scaling is applied. This rect
+   * is sized from the chip's own estimated text extent, never from taste.
+   *
+   * Height is deliberately ONE label line: that is the pitch stacked chips are
+   * placed at, so two chips' targets tile instead of overlapping, and it keeps the
+   * rect clear of the feature lane that sits just below the linear chip. The chip
+   * layer paints above the features, so a taller rect would silently eat their
+   * clicks. Growing this is not free.
+   */
+  hit: { x: number; y: number; width: number; height: number };
 }
 
 export interface MapCenterTitle {


### PR DESCRIPTION
# Workspace, plasmid map and alignment viewer: measured fixes

A measured set of fixes to the Claude Science artifact, cut from `c9764b1`. Regression tests cover
the reproducible software contracts; browser measurements cover the visual behaviours that cannot
be established by a source or DOM assertion alone.

## Why the branch is shaped this way

Most of these are instances of one defect pattern: **a box reserving less space than its content
renders, then hiding the difference with no scrollbar and no signal.** Once that pattern was named
it turned up in the alignment matrix, the plasmid map column, six rail popovers, the annotations
panel, the toolbar menus, the primer footer, the guide panel and the Tools rail. Where it appears,
the fix is the same shape: derive the floor from what the children already declare rather than
picking a constant, and let the container scroll instead of clipping.

A second cluster is **readouts that publish a number without the population it counted** — two
panels printed different totals for the same record under the same word, a "+N more" chip summed
two unlike quantities into one integer, and a stats bar named a population it was not counting.

## Alignment viewer

- Matrix is sized from its panel rather than a constant, and the panel's floor is derived from its
  own children, so a short panel no longer hides its pan slider and status line (137px were
  unreachable with no scrollbar leading to them).
- The horizontal pan lane is drawn as the scrollbar it already was; its trough measured 2.14:1
  against a 3.0 non-text contrast floor.
- The last ~1.4 columns of every alignment were unreachable behind the reserved scrollbar gutter —
  a constant 15px from 120 to 50,000 columns.
- Selection band no longer mixes itself toward the ink it must be distinguished from; the cursor
  gets its own channel rather than sharing the selection's hue.
- Reference numbering is a round trip: one result per numbering state, instead of forking a new
  near-identical result on each toggle and accumulating names. Saved variants are reused only when
  all scientific and provenance fields match.
- The View menu sizes to the window instead of stopping at a 430px constant.
- Escape aimed at a just-opened menu no longer closes the whole window.
- The toolbar no longer paints over the window's own corner grip, which had been taking the press
  and leaving the window unresizable by mouse.
- Keyboard selection continues from the residue you clicked.
- Difference and search readouts report the position you are actually at.

## Plasmid map

- Map clicks resolve in the coordinate space the map is drawn in. Two spaces had been conflated,
  selecting the wrong base by up to 803bp when zoomed.
- Invalid viewport transforms fall back to the complete identity transform rather than retaining a
  translation with an unusable scale.
- Labels step outward instead of sliding around the ring, so a leader stays close to radial rather
  than running up to 86° off its own tick.
- A site-count pre-gate switched labelling off wholesale before the packer ran; at laptop window
  sizes that affected every bundled plasmid, not a subset.
- Label rescue is per-label and must pay for itself.
- Restriction counts state what they are counting; the "+N more" chip no longer adds two unlike
  quantities together.
- The circular map readout is anchored to the edge its column actually shows, and the map dock
  heads are pinned as a sticky column footer — they had been sitting up to 138px below the
  column's visible edge at every desktop size under 1536.
- The map no longer letterboxes itself on desktop.

## Export correctness

- The exported GenBank LOCUS line declares its length unit, so a truncated export no longer
  re-imports silently as a fragment.
- "Hide sites" is a display control again; it had been reaching the data and rewriting what CSV,
  GenBank, JSON and ZIP exports said about the molecule.
- The exported image obeys the residue-colour toggle it had been ignoring.
- "Reset alignment view" no longer changes the export format or the pane you are in.

## Layout and space

- The sequence pane widens while the map still has width to give. Pane widths are flex *basis*, so
  the drag had been priced against the basis and stopping with visible slack unspent.
- The annotations panel shows all the features it counts.
- Rail popovers no longer bury the controls that would close the window, and their headings no
  longer paint over their own first line.
- The Tools rail scrolls once its fifteen tools stop fitting.
- The primer footer no longer cuts off the number that decides the pair, and guides keep their PAM.

## Accessibility

- A skip link to the Tools rail, and two focus indicators that existed but rendered too faintly to
  serve (1.65% and 1.08% of the control's pixels repainting on focus, raised to 9.36% and 27.46%).
- Four chips that the stylesheet hid on every load are removed along with the rules that hid them.

## Tooling

- `npm run gate` is the single check list, and `scripts/__tests__/gate-parity.test.mjs` fails if it
  and CI disagree **in either direction** — a gate checking more than CI also makes green CI
  an incomplete signal.
- `tsc --noEmit` had been passing for a project it never read.
- The alignment-tail geometry check waits for the virtualized column window's animation-frame
  boundary before measuring, while retaining the exact final-column visibility assertions.

## Verification

Full gate green at the tip:

| check | result |
|---|---|
| typecheck, lint | 0 |
| unit | 1162 passed, 99 files |
| connector | 23 passed, 3 files |
| artifact e2e | 138 passed, 61 skipped (59 run by the alignment suite; 2 require external fixtures) |
| alignment e2e | 59 passed |
| strict plugin validation | passed |
| exit code | 0 |

Visual fixes that cannot be proven by an automated assertion were measured in a live browser across
six viewport sizes and four themes. The measurement probes were checked against both unchanged and
unfixed states.
