### PR TITLE
Draw plasmids as lines without changing topology

### DIFF
--- a/src/artifacts/__tests__/claude-science-record-lifecycle-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-record-lifecycle-guards.test.ts
@@ -45,16 +45,80 @@ describe('Claude Science record lifecycle guards', () => {
   });
 
   it('stores topology on the record so the UI, API, and exports agree', () => {
-    const toggleTopology = sliceBetween(
+    // Renamed from toggleTopology when #34 moved conversion out of the map
+    // panel: it now takes a target rather than flipping, because the two
+    // Entry Details buttons name the state they set. The invariant this guard
+    // exists for is unchanged — topology lives on the record, one copy.
+    const convertTopology = sliceBetween(
       artifactSource,
-      'const toggleTopology = useCallback',
+      'const convertRecordTopology = useCallback',
       'const addCustomEnzyme = useCallback',
     );
 
     expect(artifactSource).toContain('const topology = vector.topology;');
     expect(artifactSource).not.toContain('topologyOverrides');
-    expect(toggleTopology).toMatch(/const nextTopology(?:: Topology)? = topology === 'circular' \? 'linear' : 'circular';/);
-    expect(toggleTopology).toContain('record.id === recordId ? { ...record, topology: nextTopology } : record');
-    expect(toggleTopology).toContain('payloadRef.current = nextPayload;');
+    expect(convertTopology).toContain('(nextTopology: Topology)');
+    expect(convertTopology).toContain('record.id === recordId ? { ...record, topology: nextTopology } : record');
+    expect(convertTopology).toContain('payloadRef.current = nextPayload;');
+  });
+
+  it('lets the map be drawn as a line without converting the molecule', () => {
+    // #34. The map's shape control used to call the conversion above, so asking
+    // for a different picture rewrote the record. The drawing is now its own
+    // state.
+    //
+    // The size of the science it moved, measured against findRestrictionSites
+    // rather than counted off the SVG: pUC19 yields 325 sites circular and 324
+    // linear, the lost one being BtgZI at 2576, which straddles the origin. The
+    // drawn tick count changes by far more than that between the two modes (76
+    // against 49), but almost all of it is the two layouts drawing the same
+    // sites differently — circular clusters them, linear draws all of them with
+    // a density track and a "+N more sites" chip — so the tick count is the
+    // wrong instrument for a claim about the data.
+    //
+    // This is NOT the banned per-view topology override. That was shadow state
+    // that could make the map and an export disagree about the molecule; this
+    // decides a DRAWING and never reaches the record, which is why the ban
+    // above still stands and must keep standing.
+    expect(artifactSource).toContain('const [mapRenderModeByRecord, setMapRenderModeByRecord] = useState<Record<string, MapMode>>({});');
+
+    // The seam: computeMapLayout takes the render mode, not a mode derived from
+    // topology on the spot. `topology` still travels into the layout so feature
+    // segmentation stays true to the molecule.
+    const layoutCall = sliceBetween(artifactSource, '() => computeMapLayout({', 'useEffect(');
+    expect(layoutCall).toContain('mode: mapRenderMode,');
+    expect(layoutCall).toContain('topology,');
+    expect(layoutCall).not.toContain('mode: mapModeForBlock(topology, sequenceType)');
+
+    // The drawing control must never write to the record. Anything that calls
+    // setPayload from the map's shape toggle is the defect coming back.
+    const setRenderMode = sliceBetween(
+      artifactSource,
+      'const setMapRenderMode = useCallback',
+      'const mapViewport =',
+    );
+    expect(setRenderMode).not.toContain('setPayload');
+    expect(setRenderMode).not.toContain('topology');
+
+    // Converting DOES clear an explicit drawing choice, so a record converted to
+    // linear is not still drawn as a ring.
+    const convertTopology = sliceBetween(
+      artifactSource,
+      'const convertRecordTopology = useCallback',
+      'const addCustomEnzyme = useCallback',
+    );
+    expect(convertTopology).toContain('setMapRenderModeByRecord');
+
+    // Conversion is reachable from Entry Details — the panel that already edits
+    // record fields — and NOT from the map panel.
+    expect(artifactSource).toContain('onConvertTopology={convertRecordTopology}');
+    expect(artifactSource).toContain('aria-label="Convert molecule topology"');
+    const mapShapeToggle = sliceBetween(
+      artifactSource,
+      'className="motif-cs-segmented motif-cs-shape-toggle"',
+      '</div>',
+    );
+    expect(mapShapeToggle).toContain('setMapRenderMode(');
+    expect(mapShapeToggle).not.toContain('convertRecordTopology');
   });
 });

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -40,7 +40,7 @@ import { computeMapLayout } from '../plasmid-map/layout';
 import { bpToAngle, pointOnCircle } from '../plasmid-map/geometry/coordinates';
 import { featureSegments as mapFeatureSegments, featureSpans, normalizeSpan } from '../plasmid-map/geometry/ranges';
 import { selectionOverlayPaths } from '../plasmid-map/selection-overlay';
-import { mapModeForBlock, type MapLayout, type MapSpan } from '../plasmid-map/types';
+import { mapModeForBlock, type MapLayout, type MapMode, type MapSpan } from '../plasmid-map/types';
 import {
   contentPointFromRoot,
   mapContentPoint,
@@ -4688,6 +4688,18 @@ function App() {
     initialWorkspace.artifactState.motifsByRecord,
   );
   const [mapViewportsByRecord, setMapViewportsByRecord] = useState<Record<string, MapViewport>>({});
+  /* How the map is DRAWN, per record. Deliberately NOT a topology override:
+     `record.topology` stays the single source of truth for what the molecule
+     is, and nothing here reaches restriction finding, ORF finding, span
+     normalisation or the GenBank LOCUS line. A per-view topology override was
+     considered and banned before — see the "stores topology on the record so
+     the UI, API, and exports agree" guard — and the distinction is the point.
+     Banned: shadow state that lets the map and an export disagree about the
+     molecule. This: a choice of drawing, sitting beside the zoom viewport,
+     which is the other thing that changes the picture and not the science.
+     Absent entry = follow the molecule, so a record whose topology is later
+     converted goes back to being drawn the way it is. */
+  const [mapRenderModeByRecord, setMapRenderModeByRecord] = useState<Record<string, MapMode>>({});
   const [mapRangesByRecord, setMapRangesByRecord] = useState<Record<string, MapSelectionRange | null>>({});
   const [selection, setSelection] = useState<Selection>(null);
   const [featureEditorRequest, requestFeatureEditor] = useReducer((count: number) => count + 1, 0);
@@ -5237,6 +5249,18 @@ function App() {
   // 4-24 names per map with no collisions, so there was nothing to protect.
   const showRestrictionLabels = restrictionLabelsByRecord[recordId] ?? true;
   const canToggleTopology = hasActiveRecord && (sequenceType === 'dna' || sequenceType === 'rna');
+  /* Follows the molecule until someone asks for a different drawing. Protein is
+     forced linear here for the same reason computeMapLayout forces it: there is
+     no ring to draw. `canDrawAsRing` is what gates the control, so a genuinely
+     linear record is not offered a circular drawing of a molecule that has two
+     ends. */
+  const canDrawAsRing = hasActiveRecord && sequenceType !== 'protein' && topology === 'circular';
+  const mapRenderMode: MapMode = sequenceType === 'protein'
+    ? 'linear'
+    : mapRenderModeByRecord[recordId] ?? mapModeForBlock(topology, sequenceType);
+  const setMapRenderMode = useCallback((mode: MapMode) => {
+    setMapRenderModeByRecord((current) => (current[recordId] === mode ? current : { ...current, [recordId]: mode }));
+  }, [recordId]);
   const mapViewport = mapViewportsByRecord[recordId] ?? DEFAULT_MAP_VIEWPORT;
   const selectedMapRange = mapRangesByRecord[recordId] ?? null;
   const motif = motifsByRecord[recordId] ?? defaultMotifForRecord(sequenceType, payload.defaultMotif);
@@ -6145,7 +6169,14 @@ function App() {
 
   const layout = useMemo(
     () => computeMapLayout({
-      mode: mapModeForBlock(topology, sequenceType),
+      // THE SEAM. This one line used to collapse "what the molecule is" into
+      // "how to draw it" — computeMapLayout has always taken `mode` as a
+      // first-class input and consulted `topology` only as a fallback, so the
+      // capability to draw a plasmid as a line was built and unreachable.
+      // `topology` below still travels into the layout unchanged, which is what
+      // lets feature segmentation stay true to the molecule while the geometry
+      // follows the drawing.
+      mode: mapRenderMode,
       name: vector.name,
       length: sequence.length,
       topology,
@@ -6168,7 +6199,10 @@ function App() {
         showRestrictionLabels,
       },
     }),
-    [mapFeatures, visibleRestrictionSites, mapSize.height, mapSize.width, sequence.length, sequenceType, showRestrictionLabels, topology, vector.name],
+    // `mapRenderMode` belongs here now that it is no longer a pure function of
+    // `topology`: without it the map keeps its old drawing until some other
+    // dependency happens to change.
+    [mapFeatures, mapRenderMode, visibleRestrictionSites, mapSize.height, mapSize.width, sequence.length, sequenceType, showRestrictionLabels, topology, vector.name],
   );
 
   useEffect(() => {
@@ -6500,10 +6534,14 @@ function App() {
     setSelection(null);
     setMapRangesByRecord((current) => ({
       ...current,
-      [recordId]: rangeFromMapDrag(startBp, startBp + 1, sequence.length, topology),
+      // A drag is a gesture on a PICTURE, so it follows how the map is drawn.
+      // `layout.mode` and `topology` were always equal while the only way to
+      // get a linear drawing was to convert the record; they can differ now,
+      // and a wrapping range is not expressible by one drag along an axis.
+      [recordId]: rangeFromMapDrag(startBp, startBp + 1, sequence.length, layout.mode),
     }));
     return true;
-  }, [layout, recordId, sequence.length, topology]);
+  }, [layout, recordId, sequence.length]);
 
   const handleMapPointerMove = useCallback((point: MapContentPoint) => {
     const drag = mapDragRef.current;
@@ -6514,20 +6552,25 @@ function App() {
 
     const endBp = pointToSequenceOffset(point, layout);
     let nextRange: MapSelectionRange;
-    if (topology === 'circular') {
+    // Keyed on how the map is DRAWN. The angle model needs a ring: on a linear
+    // layout `layout.center` is the axis's left end, so dragging along the axis
+    // barely moves the angle and the sweep never grows. `pointToSequenceOffset`
+    // and the content-point projection above already key on layout.mode — this
+    // was the one place in the gesture still asking the molecule instead.
+    if (layout.mode === 'circular') {
       const nextAngle = pointToSequenceAngle(point, layout);
       drag.cumulativeAngle += signedCircularAngleDelta(drag.lastAngle, nextAngle);
       drag.lastAngle = nextAngle;
       nextRange = rangeFromCircularAngleDrag(drag.startBp, drag.cumulativeAngle, sequence.length);
     } else {
-      nextRange = rangeFromMapDrag(drag.startBp, endBp, sequence.length, topology);
+      nextRange = rangeFromMapDrag(drag.startBp, endBp, sequence.length, layout.mode);
     }
     setMapRangesByRecord((current) => {
       const previous = current[recordId];
       if (previous && previous.start === nextRange.start && previous.end === nextRange.end) return current;
       return { ...current, [recordId]: nextRange };
     });
-  }, [layout, recordId, sequence.length, topology]);
+  }, [layout, recordId, sequence.length]);
 
   const handleMapPointerEnd = useCallback(() => {
     const drag = mapDragRef.current;
@@ -8046,9 +8089,22 @@ function App() {
     setSequenceViewMode('detail');
   }, [addTranslationLayer]);
 
-  const toggleTopology = useCallback(() => {
+  /* Converts the MOLECULE. Reached from Entry Details only — the map's "Draw as"
+     control no longer comes here, which is the whole point of #34. Still clears
+     the selection, caret and map range, because after a conversion those really
+     can mean something different. */
+  const convertRecordTopology = useCallback((nextTopology: Topology) => {
     if (!canToggleTopology) return;
-    const nextTopology: Topology = topology === 'circular' ? 'linear' : 'circular';
+    if (nextTopology === topology) return;
+    // Drop any explicit drawing choice for this record so the map goes back to
+    // showing the molecule as it now is. Leaving it would mean converting to
+    // linear and still seeing a ring, which is the same class of lie in reverse.
+    setMapRenderModeByRecord((current) => {
+      if (!(recordId in current)) return current;
+      const next = { ...current };
+      delete next[recordId];
+      return next;
+    });
     setPayload((current) => {
       const nextPayload: LoadedPayload = {
         ...current,
@@ -10786,26 +10842,47 @@ function App() {
                   {isNucleotideRecord ? (
                     <>
                       <div className="motif-cs-layer-actions">
-                        <div className="motif-cs-segmented motif-cs-shape-toggle" role="group" aria-label="Map shape">
+                        {/* This used to read "◯ Circular | — Linear" and CONVERT the
+                            molecule: it wrote topology into the record, cleared the
+                            selection, caret and map range, and changed which
+                            restriction sites are FOUND — on pUC19, 325 against 324,
+                            the one lost being BtgZI at 2576, which straddles the
+                            origin — all from a panel called Map Visibility among
+                            controls that change only the picture. It now picks a
+                            DRAWING. The record is untouched, so nothing is cleared,
+                            and the signals that say what the molecule is stay put as
+                            the confirmation: the pane subtitle still reads "circular
+                            · 2,578 bp" and the inventory line still says circular.
+                            Converting lives in Entry Details with the other fields
+                            that describe the molecule. */}
+                        <span className="motif-cs-muted">Draw as</span>
+                        <div className="motif-cs-segmented motif-cs-shape-toggle" role="group" aria-label="Map drawing">
                           <button
                             type="button"
-                            data-active={topology === 'circular' || undefined}
-                            aria-pressed={topology === 'circular'}
-                            disabled={!canToggleTopology}
-                            onClick={() => { if (topology !== 'circular') toggleTopology(); }}
+                            data-active={mapRenderMode === 'circular' || undefined}
+                            aria-pressed={mapRenderMode === 'circular'}
+                            disabled={!canDrawAsRing}
+                            title={canDrawAsRing
+                              ? 'Draw this map as a ring'
+                              : 'A linear molecule has two ends; convert it in Entry Details to draw it as a ring'}
+                            onClick={() => setMapRenderMode('circular')}
                           >
                             ◯ Circular
                           </button>
                           <button
                             type="button"
-                            data-active={topology === 'linear' || undefined}
-                            aria-pressed={topology === 'linear'}
-                            disabled={!canToggleTopology}
-                            onClick={() => { if (topology !== 'linear') toggleTopology(); }}
+                            data-active={mapRenderMode === 'linear' || undefined}
+                            aria-pressed={mapRenderMode === 'linear'}
+                            disabled={!hasActiveRecord}
+                            title="Draw this map as a line. The record stays as it is."
+                            onClick={() => setMapRenderMode('linear')}
                           >
                             — Linear
                           </button>
                         </div>
+                        {mapRenderMode !== mapModeForBlock(topology, sequenceType) ? (
+                          <span className="motif-cs-muted">Drawing only — still a {topology} {sequenceType.toUpperCase()}</span>
+                        ) : null}
                         {isDnaRecord ? (
                           <>
                             <button
@@ -11289,7 +11366,13 @@ function App() {
               </div>
           {hasActiveRecord ? (
           <>
-          <EntryDetailsPanel record={vector} onUpdate={updateRecordDetails} onDelete={deleteActiveRecord} />
+          <EntryDetailsPanel
+            record={vector}
+            onUpdate={updateRecordDetails}
+            onConvertTopology={convertRecordTopology}
+            canConvertTopology={canToggleTopology}
+            onDelete={deleteActiveRecord}
+          />
           <FeatureList
             recordId={recordId}
             sequenceLength={sequence.length}
@@ -13304,10 +13387,14 @@ function defaultFeatureColor(type: FeatureType): string {
 function EntryDetailsPanel({
   record,
   onUpdate,
+  onConvertTopology,
+  canConvertTopology,
   onDelete,
 }: {
   record: ArtifactVector;
   onUpdate: (details: { name: string; description?: string; group?: string }) => void;
+  onConvertTopology: (next: Topology) => void;
+  canConvertTopology: boolean;
   onDelete: () => void;
 }) {
   const [name, setName] = useState(record.name);
@@ -13394,6 +13481,38 @@ function EntryDetailsPanel({
             placeholder="Optional folder…"
           />
         </label>
+        {/* Converting the molecule belongs with the fields that describe it, not
+            in a panel called Map Visibility among controls that change only the
+            picture. This edits the record, so it sits beside the ends — the
+            other statement about the molecule's physical shape — and says what
+            it costs, in the same voice as "Exports use this name." above. */}
+        {canConvertTopology ? (
+          <label>
+            <span>Topology</span>
+            <div className="motif-cs-segmented" role="group" aria-label="Convert molecule topology">
+              <button
+                type="button"
+                data-active={record.topology === 'circular' || undefined}
+                aria-pressed={record.topology === 'circular'}
+                onClick={() => { if (record.topology !== 'circular') onConvertTopology('circular'); }}
+              >
+                ◯ Circular
+              </button>
+              <button
+                type="button"
+                data-active={record.topology === 'linear' || undefined}
+                aria-pressed={record.topology === 'linear'}
+                onClick={() => { if (record.topology !== 'linear') onConvertTopology('linear'); }}
+              >
+                — Linear
+              </button>
+            </div>
+            <p className="motif-cs-form-note">
+              Converting changes which restriction sites are found and what exported files record.
+              To read this entry as a line without converting it, use Draw as in Map Visibility.
+            </p>
+          </label>
+        ) : null}
         {record.type === 'dna' && (record.overhang5 !== undefined || record.overhang3 !== undefined) ? (
           <dl className="motif-cs-record-ends" aria-label="Physical DNA ends">
             <div>

--- a/src/plasmid-map/__tests__/render-mode-independence.test.ts
+++ b/src/plasmid-map/__tests__/render-mode-independence.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { computeMapLayout } from '../layout';
+import type { MapInput } from '../types';
+import type { Feature } from '../../bio/types';
+import { normalizeSpan } from '../geometry/ranges';
+
+/**
+ * #34. The map can draw a circular molecule as a line WITHOUT converting it.
+ *
+ * `computeMapLayout` has always taken `mode` as a first-class input and
+ * consulted `topology` only as a fallback, so the capability was built and
+ * unreachable: the app's single call site derived `mode` from `topology` on the
+ * spot. These tests pin the two apart, because the whole value of the change is
+ * that they can now disagree — `mode` decides the drawing, `topology` still
+ * says what the molecule is.
+ */
+
+function feat(p: Partial<Feature> & { id: string }): Feature {
+  return {
+    id: p.id,
+    name: p.name ?? '',
+    type: p.type ?? 'misc_feature',
+    start: p.start ?? 0,
+    end: p.end ?? 0,
+    strand: p.strand ?? 1,
+    subRanges: p.subRanges,
+    color: p.color ?? '#8a8a8a',
+    metadata: {},
+  };
+}
+
+const LENGTH = 2686;
+const WRAPPING_ID = 'origin-spanner';
+
+function input(over: Partial<MapInput>): MapInput {
+  return {
+    name: 'pUC19',
+    length: LENGTH,
+    topology: 'circular',
+    sequenceType: 'dna',
+    features: [
+      feat({ id: 'lacZ', name: 'lacZ-alpha', type: 'cds', start: 150, end: 506, strand: 1 }),
+      // start > end: this feature crosses the origin, which only a circular
+      // molecule can do.
+      feat({ id: WRAPPING_ID, name: 'origin spanner', type: 'cds', start: 2600, end: 120, strand: 1 }),
+    ],
+    restrictionSites: [],
+    width: 900,
+    height: 600,
+    ...over,
+  } as MapInput;
+}
+
+function nonFinite(value: unknown, path = '$', bad: string[] = []): string[] {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) bad.push(path);
+    return bad;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((v, i) => nonFinite(v, `${path}[${i}]`, bad));
+    return bad;
+  }
+  if (value && typeof value === 'object') {
+    for (const [k, v] of Object.entries(value)) nonFinite(v, `${path}.${k}`, bad);
+    return bad;
+  }
+  return bad;
+}
+
+describe('map render mode is independent of molecule topology', () => {
+  it('draws a complete linear layout for a circular molecule', () => {
+    const cross = computeMapLayout(input({ mode: 'linear', topology: 'circular' }));
+    expect(cross.mode).toBe('linear');
+    expect(cross.linearAxis).toBeTruthy();
+    expect(nonFinite(cross), 'a cross-mode layout must not leak NaN/Infinity').toEqual([]);
+    // Same content as the ring, just drawn differently.
+    const ring = computeMapLayout(input({ mode: 'circular', topology: 'circular' }));
+    expect(cross.features.length).toBe(ring.features.length);
+  });
+
+  it('keeps an origin-spanning feature VISIBLE when a circular molecule is drawn as a line', () => {
+    // The regression this guards: the linear path used to segment every feature
+    // against a hardcoded 'linear', which is right only while a linear drawing
+    // implies a linear molecule. normalizeSpan drops a wrapping span under
+    // 'linear' and splits it under 'circular':
+    expect(normalizeSpan(2600, 120, LENGTH, 'linear')).toEqual([]);
+    expect(normalizeSpan(2600, 120, LENGTH, 'circular')).toEqual([
+      { start: 2600, end: LENGTH },
+      { start: 0, end: 120 },
+    ]);
+
+    const cross = computeMapLayout(input({ mode: 'linear', topology: 'circular' }));
+    const wrapping = cross.features.find((f) => f.id === WRAPPING_ID);
+
+    // Membership in `features` is NOT ink — the bug left the entry in place with
+    // an empty geometry, so assert the drawable paths, which is what a reader
+    // actually sees.
+    expect(wrapping, 'wrapping feature missing from the layout entirely').toBeTruthy();
+    expect(wrapping!.segmentPaths.length, 'wrapping feature present but drawn as nothing').toBeGreaterThan(0);
+  });
+
+  it('still drops a wrapping span when the molecule really is linear', () => {
+    // The fix must not invent geometry for a molecule with two ends: a feature
+    // whose start is past its end is meaningless there, and stays dropped.
+    const trulyLinear = computeMapLayout(input({ mode: 'linear', topology: 'linear' }));
+    const wrapping = trulyLinear.features.find((f) => f.id === WRAPPING_ID);
+    expect(wrapping!.segmentPaths).toEqual([]);
+  });
+
+  it('is unchanged for the two configurations that could already be reached', () => {
+    // mode always equalled topology before this change, so those layouts must be
+    // byte-identical or the fix has moved something a user could already see.
+    const circular = computeMapLayout(input({ mode: 'circular', topology: 'circular' }));
+    const linear = computeMapLayout(input({ mode: 'linear', topology: 'linear' }));
+    expect(circular.mode).toBe('circular');
+    expect(linear.mode).toBe('linear');
+    expect(nonFinite(circular)).toEqual([]);
+    expect(nonFinite(linear)).toEqual([]);
+  });
+
+  it('forces protein linear no matter what mode is asked for', () => {
+    const protein = computeMapLayout(input({ mode: 'circular', topology: 'circular', sequenceType: 'protein' }));
+    expect(protein.mode).toBe('linear');
+  });
+});

--- a/src/plasmid-map/layout.ts
+++ b/src/plasmid-map/layout.ts
@@ -1231,7 +1231,15 @@ function computeLinearLayout(input: MapInput): MapLayout {
   const segByFeature = new Map<string, MapFeatureSegment[]>();
   const laneItems: LaneItem[] = [];
   for (const f of features) {
-    const segs = featureSegments(f, length, 'linear');
+    // Segment against what the MOLECULE is, not how it is being drawn. The two
+    // were the same value for as long as the only way to get a linear drawing
+    // was to convert the record, so this hardcoded 'linear' never cost
+    // anything. Drawing a circular molecule as a line makes them differ, and an
+    // origin-spanning feature normalises to [] under 'linear' against
+    // [{2600,2686},{0,120}] under 'circular'. Measured: the feature stayed in
+    // the features array with segmentPaths [] and label null — present and
+    // invisible, which a list-membership check reports as fine.
+    const segs = featureSegments(f, length, input.topology);
     segByFeature.set(f.id, segs);
     if (segs.length > 0) {
       const name = f.name || f.type;


### PR DESCRIPTION
# Draw a plasmid as a line without converting it to one

## The problem

The map panel's "Circular | Linear" control read as a view toggle and was not one. Pressing
*Linear* wrote `topology` into the record itself. `topology` is not a display property — it feeds
restriction-site finding, ORF finding, span normalisation and the GenBank LOCUS line, so the
control silently changed what the molecule *was*. Measured on a circular record: pressing Linear
flipped `record.topology`, made the workspace export declare "linear", and cleared the selection,
caret and map range. The change reverts on reload, so it is session-scoped — but anything exported
in the meantime carries it.

There was no correct action available to someone who simply wanted to see a circular plasmid drawn
as a line.

## What changed

**The map keeps one control, now named "Draw as", and it changes only the picture.** When the
drawing disagrees with the molecule it shows a live caveat — *Drawing only — still a circular DNA*
— and the pane subtitle and inventory line continue to say circular, so the record's real state is
confirmed in the places that describe the record.

**Conversion moved to Entry Details**, beside the physical-ends block, with a note about what it
affects. Converting also drops any explicit drawing choice, so a record converted to linear is not
left being drawn as a ring.

`record.topology` remains the single source of truth. The render mode is a per-record view
preference that reaches exactly one seam — the layout call — and nothing else.

## Two bugs found on the way

- `featureSegments` was hardcoded to `'linear'`, so a feature spanning the origin was computed as
  non-wrapping. It appeared in the layout's feature collection with empty geometry and no label:
  present in the data structure, invisible on the map.
- The map's drag gesture was keyed on `topology` while the projection immediately beside it already
  used the layout's mode, so the two disagreed once the drawing and the molecule differed. Dragging
  across the axis now reports 611 / 1255 / 1900 / 2544 bp.

## Evidence that the render mode does not reach the data

The same circular record was captured drawn as a ring and drawn as a line, and every consumer of
`topology` was diffed:

| consumer | result |
|---|---|
| GenBank export (4,232 chars) | byte-identical |
| LOCUS line | identical — still declares `circular` |
| restriction scan | identical |
| ORF scan | identical |
| workspace payload | identical apart from the export timestamp |

The timestamp difference was checked against a control capture taken with no interaction at all,
which differs in the same field — it is the clock, not the change.

The distinction also holds at the data layer: a circular molecule genuinely has one more
restriction site than the same sequence treated as linear (325 vs 324 on the bundled 2,578 bp
plasmid across 154 enzymes — a single site straddling the origin), and that arithmetic is
unchanged by how the map chooses to draw it.

## Tests

Six added: five covering render-mode independence — a complete linear layout for a circular
molecule, an origin-spanning feature staying visible, a wrapping span still dropped when the
molecule really is linear, the two previously-reachable configurations unchanged, and protein
forced linear regardless — plus one asserting the drawing control cannot write to the record and
the conversion control is the only path that can.

Both new guards were verified to fail against the unfixed code. Full gate green: unit 1168 across
100 files; artifact e2e 138 passed and 61 skipped (59 run by the alignment suite and 2 requiring
external fixtures); alignment e2e 59 passed; strict plugin validation passed; exit 0.
