### PR TITLE
Refine Claude themes and pane resizing

### DIFF
--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -2179,7 +2179,7 @@ test.describe('Claude Science artifact campaign', () => {
 
     await page.locator('select[name="artifact-theme"]').selectOption('claude-dark');
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'claude-dark');
-    await expect(page.locator('meta[name="theme-color"]')).toHaveAttribute('content', '#2d2d2b');
+    await expect(page.locator('meta[name="theme-color"]')).toHaveAttribute('content', '#1f1f1f');
     await page.reload();
     await expect(page.locator('.motif-cs-shell')).toBeVisible();
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'claude-dark');
@@ -2489,7 +2489,8 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(page.locator('.motif-cs-main')).toHaveAttribute('data-sequence-hidden', 'true');
     await expect(page.locator('.motif-cs-sequence-column')).toHaveCount(0);
     expect(Math.round((await page.locator('.motif-cs-inspector').boundingBox())!.width)).toBe(48);
-    await expect(toolsToggle.locator('.motif-cs-pane-state')).toHaveText('Rail');
+    await expect(toolsToggle).toHaveAttribute('aria-label', /^Tools rail/);
+    await expect(toolsToggle.locator('.motif-cs-pane-state')).toHaveCount(0);
     const mainWidth = await page.locator('.motif-cs-main').evaluate((element) => ({
       clientWidth: element.clientWidth,
       scrollWidth: element.scrollWidth,
@@ -2715,7 +2716,8 @@ test.describe('Claude Science artifact campaign', () => {
       expect(Math.abs(rail.map.y - pinned.map.y)).toBeLessThanOrEqual(2);
       expect(rail.map.width).toBeGreaterThan(pinned.map.width + 150);
       expect(Math.round(rail.tools.width)).toBe(48);
-      await expect(toolsToggle.locator('.motif-cs-pane-state')).toHaveText('Rail');
+      await expect(toolsToggle).toHaveAttribute('aria-label', /^Tools rail/);
+      await expect(toolsToggle.locator('.motif-cs-pane-state')).toHaveCount(0);
       await expect(page.getByRole('separator', { name: 'Resize stacked sequence pane' })).toBeVisible();
 
       if (width === 1180) {

--- a/src/artifacts/__tests__/claude-science-inventory-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-inventory-guards.test.ts
@@ -192,6 +192,7 @@ describe('Claude Science Inventory regression guards', () => {
     expect(artifactCss).not.toContain('motif-cs-toggle-state');
     expect(artifactSource).not.toContain('data-state={showTranslations');
     expect(artifactCss).toMatch(/\.motif-cs-pane-toggle\[data-active="true"\][\s\S]*?background:\s*transparent/);
-    expect(artifactSource).toContain('<small className="motif-cs-pane-state">Rail</small>');
+    expect(artifactSource).not.toContain('<small className="motif-cs-pane-state">Rail</small>');
+    expect(artifactSource).toContain("toolsDocked ? 'expanded' : 'rail'");
   });
 });

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -37,7 +37,7 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toContain("description: 'Warm charcoal · coral'");
     expect(artifactCss).toContain('.motif-cs-theme-choice[data-theme-choice="claude-light"]');
     expect(artifactCss).toContain('--theme-preview-claude-light-surface: #f9f9f7;');
-    expect(artifactCss).toContain('--theme-preview-claude-dark-surface: #2d2d2b;');
+    expect(artifactCss).toContain('--theme-preview-claude-dark-surface: #1f1f1f;');
     expect(artifactCss).toContain('--choice-accent: var(--theme-preview-claude-accent);');
   });
 

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -59,23 +59,24 @@ html[data-theme="light"] {
 
 html[data-theme="claude-light"] {
   color-scheme: light;
-  --app-bg: #f4f4f2;
-  --workspace-bg: #f9f9f7;
-  --topbar-bg: #f9f9f7;
-  --panel-bg: #f4f4f2;
-  --bg-primary: #fbfbf9;
-  --bg-secondary: #f4f4f2;
-  --bg-tertiary: #e8e8e4;
-  --bg-hover: #efefec;
-  --bg-active: #ede4db;
-  --border: #d9d9d4;
-  --border-subtle: #e6e6e2;
-  --border-strong: #85847f;
-  --text-primary: #2d2d2b;
-  --text-secondary: #4f4f4c;
-  --text-muted: #686762;
-  --accent-base: #cc7d5e;
-  --accent: #a84f31;
+  --app-bg: #f6f2ed;
+  --workspace-bg: #fcfaf7;
+  --topbar-bg: #fcfaf7;
+  --panel-bg: #f8f4ef;
+  --bg-primary: #fffdf9;
+  --bg-secondary: #f7f2ec;
+  --bg-tertiary: #eee7df;
+  --bg-hover: #f4ebe3;
+  --bg-active: #c55f3d;
+  --border: #e2dad2;
+  --border-subtle: #eee7e0;
+  --border-strong: #95877d;
+  --text-primary: #2b2724;
+  --text-secondary: #504842;
+  --text-muted: #70665f;
+  --accent-base: #b95435;
+  --accent: #b04d2f;
+  --accent-contrast: #fffaf6;
   --green: #2c6e49;
   --purple: #6f4c9b;
   --amber: #805a10;
@@ -83,31 +84,150 @@ html[data-theme="claude-light"] {
   --feature-neutral: #5f5e5a;
 }
 
+html[data-theme="claude-light"] .motif-cs-record-tab {
+  margin: 4px 3px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+}
+
+html[data-theme="claude-light"] .motif-cs-record-tab[data-active="true"] {
+  border-color: var(--accent-base);
+  background: var(--accent-base);
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-light"] .motif-cs-record-tab[data-active="true"] .motif-cs-record-tab-name {
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-light"] .motif-cs-pane-toggle[data-active="true"],
+html[data-theme="claude-light"] .motif-cs-window-toggle[data-active="true"] {
+  border-color: var(--accent-base);
+  border-radius: var(--radius-md);
+  background: var(--accent-base);
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-light"] .motif-cs-pane-toggle[data-active="true"] .motif-cs-nav-icon,
+html[data-theme="claude-light"] .motif-cs-window-toggle[data-active="true"] .motif-cs-nav-icon {
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-light"] .motif-cs-row[data-active="true"] {
+  background: color-mix(in srgb, var(--accent-base) 9%, var(--bg-primary));
+  box-shadow: inset 3px 0 0 var(--accent-base);
+}
+
+html[data-theme="claude-light"] .motif-cs-row.motif-cs-inventory-record-row[data-active="true"],
+html[data-theme="claude-light"] .motif-cs-row.motif-cs-inventory-record-row[data-active="true"]:hover,
+html[data-theme="claude-light"] .motif-cs-row.motif-cs-inventory-record-row[data-active="true"]:focus-visible {
+  border-top-color: var(--accent-base);
+  background: var(--accent-base);
+  box-shadow: none;
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-light"] .motif-cs-inventory-record-row[data-active="true"] .motif-cs-row-main > span:first-child,
+html[data-theme="claude-light"] .motif-cs-inventory-record-row[data-active="true"] .motif-cs-row-main small {
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-light"] .motif-cs-mini-button[data-active="true"],
+html[data-theme="claude-light"] .motif-cs-view-toggle button[data-active],
+html[data-theme="claude-light"] .motif-cs-edit-mode-toggle button[data-active],
+html[data-theme="claude-light"] .motif-cs-segmented button[data-active] {
+  border-color: var(--accent-base);
+  background: var(--accent-base);
+  color: var(--accent-contrast);
+  box-shadow: none;
+}
+
 html[data-theme="claude-dark"] {
   color-scheme: dark;
-  --app-bg: #2d2d2b;
-  --workspace-bg: #2d2d2b;
-  --topbar-bg: #2d2d2b;
-  --panel-bg: #333331;
-  --bg-primary: #353533;
-  --bg-secondary: #3a3a37;
-  --bg-tertiary: #444440;
-  --bg-hover: #41413e;
-  --bg-active: #503b30;
-  --border: #4a4a46;
-  --border-subtle: #3b3b38;
-  --border-strong: #88857f;
-  --text-primary: #f9f9f7;
-  --text-secondary: #d9d9d4;
-  --text-muted: #b1aea8;
-  --accent-base: #cc7d5e;
-  --accent: #e09a7d;
+  --app-bg: #191919;
+  --workspace-bg: #1f1f1f;
+  --topbar-bg: #242424;
+  --panel-bg: #262626;
+  --bg-primary: #232323;
+  --bg-secondary: #2b2b2b;
+  --bg-tertiary: #363636;
+  --bg-hover: #323232;
+  --bg-active: #b95435;
+  --border: #414141;
+  --border-subtle: #333333;
+  --border-strong: #858585;
+  --text-primary: #f5f5f4;
+  --text-secondary: #d6d3d1;
+  --text-muted: #a7a3a0;
+  --accent-base: #b95435;
+  --accent: #e19475;
+  --accent-contrast: #fffaf6;
   --green: #66c58c;
   --purple: #b69adf;
   --amber: #e2b45d;
   --red: #f38b7d;
   --feature-neutral: #d9d7d1;
-  --focus-ring: #e09a7d;
+  --focus-ring: #e19475;
+}
+
+html[data-theme="claude-dark"] .motif-cs-record-tab {
+  margin: 4px 3px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+}
+
+html[data-theme="claude-dark"] .motif-cs-record-tab[data-active="true"] {
+  border-color: var(--accent-base);
+  background: var(--accent-base);
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-dark"] .motif-cs-record-tab[data-active="true"] .motif-cs-record-tab-name {
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-dark"] .motif-cs-pane-toggle[data-active="true"],
+html[data-theme="claude-dark"] .motif-cs-window-toggle[data-active="true"] {
+  border-color: var(--accent-base);
+  border-radius: var(--radius-md);
+  background: var(--accent-base);
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-dark"] .motif-cs-pane-toggle[data-active="true"] .motif-cs-nav-icon,
+html[data-theme="claude-dark"] .motif-cs-window-toggle[data-active="true"] .motif-cs-nav-icon {
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-dark"] .motif-cs-row[data-active="true"] {
+  background: color-mix(in srgb, var(--accent) 11%, var(--bg-primary));
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+html[data-theme="claude-dark"] .motif-cs-row.motif-cs-inventory-record-row[data-active="true"],
+html[data-theme="claude-dark"] .motif-cs-row.motif-cs-inventory-record-row[data-active="true"]:hover,
+html[data-theme="claude-dark"] .motif-cs-row.motif-cs-inventory-record-row[data-active="true"]:focus-visible {
+  border-top-color: var(--accent-base);
+  background: var(--accent-base);
+  box-shadow: none;
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-dark"] .motif-cs-inventory-record-row[data-active="true"] .motif-cs-row-main > span:first-child,
+html[data-theme="claude-dark"] .motif-cs-inventory-record-row[data-active="true"] .motif-cs-row-main small {
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-dark"] .motif-cs-mini-button[data-active="true"],
+html[data-theme="claude-dark"] .motif-cs-view-toggle button[data-active],
+html[data-theme="claude-dark"] .motif-cs-edit-mode-toggle button[data-active],
+html[data-theme="claude-dark"] .motif-cs-segmented button[data-active] {
+  border-color: var(--accent-base);
+  background: var(--accent-base);
+  color: var(--accent-contrast);
+  box-shadow: none;
 }
 
 :root {
@@ -134,7 +254,7 @@ html[data-theme="claude-dark"] {
   --theme-preview-dark-accent: #339cff;
   --theme-preview-claude-light-surface: #f9f9f7;
   --theme-preview-claude-light-ink: #2d2d2b;
-  --theme-preview-claude-dark-surface: #2d2d2b;
+  --theme-preview-claude-dark-surface: #1f1f1f;
   --theme-preview-claude-dark-ink: #f9f9f7;
   --theme-preview-claude-accent: #cc7d5e;
   --motif-cs-trace-a: var(--green);
@@ -1458,7 +1578,11 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
   font-size: 11px;
 }
 
-.motif-cs-main[data-sequence-hidden="true"] > .motif-cs-sidebar,
+.motif-cs-main[data-sequence-hidden="true"] > .motif-cs-sidebar {
+  flex-grow: 0;
+  flex-shrink: 1;
+}
+
 .motif-cs-main[data-sequence-hidden="true"] > .motif-cs-map-column,
 .motif-cs-main[data-sequence-hidden="true"] > .motif-cs-inspector[data-tools-pinned="true"] {
   flex-grow: 1;

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -10111,13 +10111,29 @@ function App() {
   ) => {
     const paneLimits = paneWidthLimitsForCurrentLayout(pane);
     const neighborLimits = paneWidthLimitsForCurrentLayout(neighbor);
+    // Flex-grow can make a rendered pane wider than its stored-width maximum.
+    // Keep zero in the legal delta range when either rendered width already
+    // sits outside its preferred limits, so the user can drag it back toward
+    // the configured range instead of being clamped in the wrong direction.
+    const paneMinDelta = startWidths[pane] < paneLimits.min
+      ? 0
+      : paneLimits.min - startWidths[pane];
+    const paneMaxDelta = startWidths[pane] > paneLimits.max
+      ? 0
+      : paneLimits.max - startWidths[pane];
+    const neighborMinDelta = startWidths[neighbor] > neighborLimits.max
+      ? Number.NEGATIVE_INFINITY
+      : startWidths[neighbor] - neighborLimits.max;
+    const neighborMaxDelta = startWidths[neighbor] < neighborLimits.min
+      ? 0
+      : startWidths[neighbor] - neighborLimits.min;
     const minDelta = Math.max(
-      paneLimits.min - startWidths[pane],
-      startWidths[neighbor] - neighborLimits.max,
+      paneMinDelta,
+      neighborMinDelta,
     );
     const maxDelta = Math.min(
-      paneLimits.max - startWidths[pane],
-      startWidths[neighbor] - neighborLimits.min,
+      paneMaxDelta,
+      neighborMaxDelta,
     );
     const appliedDelta = clamp(requestedPaneDelta, minDelta, maxDelta);
     return {
@@ -10505,7 +10521,6 @@ function App() {
                   <PaneIcon className="motif-cs-nav-icon" aria-hidden="true" />
                   <span>{PANE_LABELS[pane]}</span>
                   {paneFloating ? <small className="motif-cs-pane-state">Float</small> : null}
-                  {pane === 'tools' && toolsRail ? <small className="motif-cs-pane-state">Rail</small> : null}
                 </button>
               );
             })}


### PR DESCRIPTION
## Summary

- refine Claude Light with warm off-white surfaces and orange active controls
- refine Claude Dark with neutral graphite surfaces and matching active controls
- remove the visible Tools rail badge while preserving accessible state labels
- allow pane dividers to recover when flex layout renders a pane beyond its preferred width

## User impact

Claude Light and Claude Dark now use clearer selected states across records, panes, and compact controls. Pane resizing remains reversible when the sequence pane is hidden.

## Validation

- npm run typecheck
- npm run lint
- npm run check:css-tokens
- focused workspace layout guards: 49 passed
- browser checks in Claude Light and Claude Dark
- pane resize interaction checked in both directions
- public-path, process-language, and secret-pattern scan
