### PR TITLE
Improve Claude Science workbench usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ motif_create_workbench_artifact exactly once with filename "motif-demo.gb",
 the complete content, title "Motif demo — MOTIFDEMO", and outputFilename
 "motif-demo-workbench.html". Preserve the exact returned HTML as a Claude
 Science artifact and open it in the right pane. Report the record name,
-topology, and residue count.
+topology, residue count, and runtime build ID.
 ```
 
 Click the generated HTML to open the interactive workbench. The file contains
 a snapshot of the input and Motif build used to create it; later source or
-build changes do not update it. Export a new checkpoint to preserve edits made
-in the workbench. See the
+build changes do not update it. Settings shows the Motif version and runtime
+build ID. Export a new checkpoint to preserve edits made in the workbench. See the
 [Claude Science quickstart](docs/CLAUDE_SCIENCE_QUICKSTART.md) for permission,
 verification, and optional live-App steps.
 

--- a/docs/CLAUDE_SCIENCE_INTEGRATION.md
+++ b/docs/CLAUDE_SCIENCE_INTEGRATION.md
@@ -106,7 +106,8 @@ Use the portable artifact path as the primary visual test:
 2. Call `motif_create_workbench_artifact` with that complete text as `content`,
    the exact basename as `filename`, and a safe `.html` `outputFilename`.
 3. Verify the returned schema, source name, record count, residue count,
-   bounded record names/IDs, byte count, and checksum against the input.
+   bounded record names/IDs, runtime build ID, byte count, and checksum against
+   the input.
 4. Save the exact returned HTML and click or open it in Claude Science's right
    pane. Confirm the frame visibly says **Motif** and contains the intended
    records.
@@ -122,8 +123,9 @@ generic artifact fallback, not evidence of a Motif parse failure.
 
 After the portable artifact passes, optionally call `motif_open_workbench`
 with the same complete `content` and exact `filename`. Verify the returned
-source and counts, then separately confirm whether a live frame mounted. A tool
-summary or `ui://` link proves execution only.
+source, counts, runtime build ID, `delivery: live-app-request`, and
+`visibleMountConfirmed: false`, then separately confirm whether a live frame
+mounted. A tool summary or `ui://` link proves execution only.
 
 For visual acceptance, verify record name, molecule, topology, residue count,
 sequence content, annotations, selection drag, map selection, theme, and pane

--- a/docs/CLAUDE_SCIENCE_QUICKSTART.md
+++ b/docs/CLAUDE_SCIENCE_QUICKSTART.md
@@ -105,14 +105,15 @@ motif_create_workbench_artifact exactly once with filename "motif-demo.gb",
 content set to the complete GenBank text, title "Motif demo — MOTIFDEMO", and
 outputFilename "motif-demo-workbench.html". Preserve the exact returned HTML
 as a Claude Science artifact. Report its record count, residue count, and
-record names/IDs, then open it in the right pane.
+record names/IDs, and runtime build ID, then open it in the right pane.
 ```
 
 The expected record is `MOTIFDEMO`, linear DNA, 180 bp, with `source` and
 `demo_cds` features spanning 1–180. Clicking the generated HTML once is normal.
 Confirm a visible **Motif** identity and these values before testing Inventory,
 Sequence, Map, and Tools with mouse and keyboard. This HTML is interactive but
-immutable; regenerate it after changing the input or Motif build.
+immutable; regenerate it after changing the input or Motif build. Settings
+shows the version and runtime build ID embedded in the open file.
 
 ## Optional live-App check
 
@@ -123,7 +124,7 @@ mounts local MCP Apps automatically:
 Call motif-local's motif_open_workbench exactly once with filename set to
 motif-demo.gb and content set to the same complete GenBank text. Verify the
 returned source name, record count, residue count, and record names/IDs, then
-tell me whether a visible Motif frame mounted.
+report the runtime build ID and tell me whether a visible Motif frame mounted.
 ```
 
 A successful result proves execution and parsing; a text summary or `ui://`

--- a/docs/CLAUDE_SCIENCE_TROUBLESHOOTING.md
+++ b/docs/CLAUDE_SCIENCE_TROUBLESHOOTING.md
@@ -104,7 +104,7 @@ mounted a visible App frame.
 For a dependable visual result, call `motif_create_workbench_artifact` with the
 complete FASTA or GenBank text in `content`, the exact basename in `filename`,
 and a safe `.html` `outputFilename`. Verify the returned source, counts,
-bounded record names/IDs, bytes, and checksum. Save the exact embedded HTML and
+bounded record names/IDs, runtime build ID, bytes, and checksum. Save the exact embedded HTML and
 click or open it in Claude Science's right pane. The workbench is interactive,
 but it is an immutable snapshot rather than a live MCP App.
 
@@ -136,6 +136,7 @@ Use this matrix:
 Saved HTML workbenches are immutable snapshots. Rebuilding Motif does not
 modify a previously saved or already open artifact. Use a new filename during
 acceptance testing so the host cannot show stale bytes under an old artifact.
+Settings displays the version and runtime build ID embedded in the open file.
 
 ## Input and identity checks
 

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -225,6 +225,148 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(annotationsPanel.getByRole('button', { name: /Show 10 more translations/ })).toBeVisible();
   });
 
+  test('map feature clicks move the Sequence viewport to circular and linear selections', async ({ page }) => {
+    const features = [
+      { id: 'early-feature', name: 'Early feature', type: 'misc_feature', start: 100, end: 700, strand: 1 },
+      { id: 'middle-feature', name: 'Middle reverse feature', type: 'misc_feature', start: 5_600, end: 6_500, strand: -1 },
+      { id: 'late-feature', name: 'Late feature', type: 'misc_feature', start: 10_800, end: 11_600, strand: 1 },
+    ] as const;
+    const sequence = page.locator('.motif-cs-sequence');
+
+    const focusState = async () => sequence.evaluate((container) => {
+      const focus = container.querySelector<HTMLElement>('[data-seq-focus="true"]');
+      const bases = focus?.querySelector<HTMLElement>('[data-line-start]');
+      const pane = container.closest<HTMLElement>('.motif-cs-sequence-column');
+      const scroller = container.scrollHeight > container.clientHeight + 1
+        ? container
+        : pane && pane.scrollHeight > pane.clientHeight + 1
+          ? pane
+          : container;
+      const containerRect = scroller.getBoundingClientRect();
+      const focusRect = focus?.getBoundingClientRect();
+      return {
+        scrollTop: scroller.scrollTop,
+        scrollOwner: scroller === container ? 'sequence' : 'pane',
+        lineStart: Number(bases?.dataset.lineStart),
+        lineLength: Number(bases?.dataset.lineLen),
+        selectionHighlightCount: focus?.querySelectorAll(
+          '.motif-cs-seq-hl:not(.motif-cs-seq-hl-motif):not(.motif-cs-seq-hl-restriction)',
+        ).length ?? 0,
+        fullyVisible: Boolean(
+          focusRect
+          && focusRect.top >= containerRect.top + 24
+          && focusRect.bottom <= containerRect.bottom - 24
+        ),
+      };
+    });
+
+    for (const viewport of [
+      { label: 'wide', width: 1600, height: 700 },
+      { label: 'stacked', width: 900, height: 720 },
+    ] as const) {
+      await openArtifact(page, viewport.width, viewport.height);
+      if (viewport.label === 'stacked') {
+        const sequenceBox = (await page.locator('.motif-cs-sequence-column').boundingBox())!;
+        const mapBox = (await page.locator('.motif-cs-map-column').boundingBox())!;
+        expect(mapBox.y).toBeGreaterThan(sequenceBox.y);
+      }
+
+      for (const topology of ['circular', 'linear'] as const) {
+        await page.evaluate(({ recordTopology, recordFeatures, viewportLabel }) => {
+          window.motifRenderInventory([{
+            id: `map-sequence-scroll-${viewportLabel}-${recordTopology}`,
+            name: `Map sequence scroll ${viewportLabel} ${recordTopology}`,
+            molecule: 'dna',
+            topology: recordTopology,
+            seq: 'ATGC'.repeat(3_000),
+            annotations: recordFeatures,
+          }]);
+        }, { recordTopology: topology, recordFeatures: features, viewportLabel: viewport.label });
+        await expect(page.locator('.motif-pm-feature')).toHaveCount(features.length);
+        await sequence.evaluate((element) => {
+          element.scrollTop = 0;
+          const pane = element.closest<HTMLElement>('.motif-cs-sequence-column');
+          if (pane) pane.scrollTop = 0;
+        });
+
+        const scrollPositions: number[] = [];
+        const scrollOwners: string[] = [];
+        for (const feature of [...features].reverse()) {
+          const mapFeature = page.locator(`.motif-pm-feature[data-feature-id="${feature.id}"]`);
+          await mapFeature.locator('.motif-pm-feature-hit').click();
+          await expect(mapFeature).toHaveAttribute('aria-pressed', 'true');
+          await expect.poll(async () => {
+            const state = await focusState();
+            return state.fullyVisible
+              && state.selectionHighlightCount > 0
+              && state.lineStart <= feature.start
+              && state.lineStart + state.lineLength > feature.start;
+          }).toBe(true);
+          const state = await focusState();
+          scrollPositions.push(state.scrollTop);
+          scrollOwners.push(state.scrollOwner);
+        }
+
+        expect(scrollPositions[0]).toBeGreaterThan(1_000);
+        expect(scrollPositions[1]).toBeLessThan(scrollPositions[0]);
+        expect(scrollPositions[2]).toBeLessThan(scrollPositions[1]);
+        expect(new Set(scrollOwners)).toEqual(new Set([viewport.label === 'stacked' ? 'pane' : 'sequence']));
+      }
+    }
+  });
+
+  test('selected directional features outline the complete arrow shape', async ({ page }) => {
+    await openArtifact(page, 1180, 900);
+    for (const topology of ['circular', 'linear'] as const) {
+      await page.evaluate((recordTopology) => window.motifRenderInventory?.([{
+        id: `selected-arrow-${recordTopology}`,
+        name: `Selected arrow ${recordTopology}`,
+        molecule: 'dna',
+        topology: recordTopology,
+        sequence: 'A'.repeat(4_000),
+        annotations: [{
+          id: 'directional-feature',
+          name: 'Directional feature',
+          type: 'cds',
+          start: 500,
+          end: 2_800,
+          strand: 1,
+        }],
+      }]), topology);
+
+      const feature = page.locator('.motif-pm-feature[data-feature-id="directional-feature"]');
+      const body = feature.locator('.motif-pm-feature-body');
+      const hit = feature.locator('.motif-pm-feature-hit');
+      const clickPoint = await hit.evaluate((path) => {
+        const svgPath = path as SVGPathElement;
+        const point = svgPath.getPointAtLength(svgPath.getTotalLength() * 0.05);
+        const screen = point.matrixTransform(svgPath.getScreenCTM()!);
+        return { x: screen.x, y: screen.y };
+      });
+      await page.mouse.click(clickPoint.x, clickPoint.y);
+      await expect(feature).toHaveAttribute('data-selected', 'true');
+      const style = await body.evaluate((path) => {
+        const computed = getComputedStyle(path);
+        const swatch = document.createElement('span');
+        swatch.style.color = 'var(--accent)';
+        path.closest('.motif-cs-shell')!.appendChild(swatch);
+        const accent = getComputedStyle(swatch).color;
+        swatch.remove();
+        return {
+          path: path.getAttribute('d'),
+          stroke: computed.stroke,
+          accent,
+          strokeWidth: parseFloat(computed.strokeWidth),
+          strokeLinejoin: computed.strokeLinejoin,
+        };
+      });
+      expect(style.path).toMatch(/[AL].*Z$/);
+      expect(style.stroke).toBe(style.accent);
+      expect(style.strokeWidth).toBeGreaterThanOrEqual(1.5);
+      expect(style.strokeLinejoin).toBe('round');
+    }
+  });
+
   test('long import errors wrap inside the Add Entry popover', async ({ page }) => {
     await openArtifact(page, 640, 700);
     await page.getByRole('button', { name: 'Add entry' }).click();
@@ -3217,11 +3359,31 @@ test.describe('Claude Science artifact campaign', () => {
     expect(mapBox.y + mapBox.height).toBeLessThanOrEqual(mainBox.y + mainBox.height + 2);
   });
 
-  test('map supports wheel pan, modifier-wheel zoom, and bidirectional drag selection', async ({ page }) => {
+  test('map supports wheel and blank-canvas pan, modifier-wheel zoom, and sequence drag selection', async ({ page }) => {
     await openArtifact(page, 1180, 900);
     const mapFrame = page.locator('.motif-cs-map-frame');
     const viewport = page.locator('.motif-cs-map-frame .motif-pm-viewport');
     const svg = page.locator('.motif-cs-map-frame svg.motif-plasmid-map');
+    const sequenceFocus = () => page.locator('.motif-cs-sequence').evaluate((container) => {
+      const pane = container.closest<HTMLElement>('.motif-cs-sequence-column');
+      const scroller = container.scrollHeight > container.clientHeight + 1
+        ? container
+        : pane && pane.scrollHeight > pane.clientHeight + 1
+          ? pane
+          : container;
+      const focus = container.querySelector<HTMLElement>('[data-seq-focus="true"]');
+      const bases = focus?.querySelector<HTMLElement>('[data-line-start]');
+      const viewportRect = scroller.getBoundingClientRect();
+      const focusRect = focus?.getBoundingClientRect();
+      return {
+        lineStart: Number(bases?.dataset.lineStart),
+        visible: Boolean(
+          focusRect
+          && focusRect.top >= viewportRect.top + 24
+          && focusRect.bottom <= viewportRect.bottom - 24
+        ),
+      };
+    });
     const svgBox = await svg.boundingBox();
     expect(svgBox).toBeTruthy();
     const center = { x: svgBox!.x + svgBox!.width / 2, y: svgBox!.y + svgBox!.height / 2 };
@@ -3236,21 +3398,81 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(viewport).toHaveAttribute('transform', /translate/);
 
     await page.getByRole('button', { name: 'Reset map view' }).click();
-    const radius = Math.min(svgBox!.width, svgBox!.height) * 0.28;
-    await page.mouse.move(center.x, center.y - radius);
+    const circularBackbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
+    const circularCenter = {
+      x: circularBackbone.x + circularBackbone.width / 2,
+      y: circularBackbone.y + circularBackbone.height / 2,
+    };
+    const outsideRing = {
+      x: svgBox!.x + Math.max(12, (circularBackbone.x - svgBox!.x) * 0.45),
+      y: circularBackbone.y + circularBackbone.height / 2,
+    };
+    await page.mouse.move(outsideRing.x, outsideRing.y);
+    await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
     await page.mouse.down();
-    await page.mouse.move(center.x + radius, center.y, { steps: 8 });
+    await page.mouse.move(outsideRing.x + 48, outsideRing.y + 22, { steps: 8 });
+    await page.mouse.up();
+    await expect(viewport).toHaveAttribute('transform', /translate/);
+    await expect(mapFrame.locator('.motif-cs-map-hint')).not.toContainText('range');
+
+    await page.getByRole('button', { name: 'Reset map view' }).click();
+    const radius = circularBackbone.width / 2;
+    await page.mouse.move(circularCenter.x, circularCenter.y - radius);
+    await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'range');
+    await page.mouse.down();
+    await page.mouse.move(circularCenter.x + radius, circularCenter.y, { steps: 8 });
     await page.mouse.up();
     const clockwise = await mapFrame.locator('.motif-cs-map-hint').textContent();
     expect(clockwise).toContain('range');
 
-    await page.mouse.move(center.x, center.y - radius);
+    await page.mouse.move(circularCenter.x, circularCenter.y - radius);
     await page.mouse.down();
-    await page.mouse.move(center.x - radius, center.y, { steps: 8 });
+    await page.mouse.move(circularCenter.x - radius, circularCenter.y, { steps: 8 });
     await page.mouse.up();
     const counterclockwise = await mapFrame.locator('.motif-cs-map-hint').textContent();
     expect(counterclockwise).toContain('range');
     expect(counterclockwise).not.toBe(clockwise);
+    await expect.poll(async () => {
+      const focus = await sequenceFocus();
+      return focus.visible && focus.lineStart >= 1_700;
+    }).toBe(true);
+
+    await page.evaluate(() => window.motifRenderInventory?.([{
+      id: 'linear-drag-zones',
+      name: 'Linear drag zones',
+      molecule: 'dna',
+      topology: 'linear',
+      sequence: 'A'.repeat(4_000),
+    }]));
+    await expect(mapFrame).toHaveAttribute('data-map-mode', 'linear');
+    const linearSvgBox = (await svg.boundingBox())!;
+    const linearBackbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
+    const belowAxis = {
+      x: linearSvgBox.x + linearSvgBox.width / 2,
+      y: Math.min(linearSvgBox.y + linearSvgBox.height - 10, linearBackbone.y + 52),
+    };
+    await page.mouse.move(belowAxis.x, belowAxis.y);
+    await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
+    await page.mouse.down();
+    await page.mouse.move(belowAxis.x + 46, belowAxis.y + 18, { steps: 8 });
+    await page.mouse.up();
+    await expect(viewport).toHaveAttribute('transform', /translate/);
+    await expect(mapFrame.locator('.motif-cs-map-hint')).not.toContainText('range');
+
+    await page.getByRole('button', { name: 'Reset map view' }).click();
+    const axisY = linearBackbone.y + linearBackbone.height / 2;
+    const axisStart = linearBackbone.x + linearBackbone.width * 0.25;
+    const axisEnd = linearBackbone.x + linearBackbone.width * 0.7;
+    await page.mouse.move(axisStart, axisY);
+    await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'range');
+    await page.mouse.down();
+    await page.mouse.move(axisEnd, axisY, { steps: 8 });
+    await page.mouse.up();
+    await expect(mapFrame.locator('.motif-cs-map-hint')).toContainText('range');
+    await expect.poll(async () => {
+      const focus = await sequenceFocus();
+      return focus.visible && focus.lineStart >= 800 && focus.lineStart <= 1_200;
+    }).toBe(true);
   });
 
   test('the map keeps saying what is selected while the view is zoomed', async ({ page }) => {
@@ -3294,8 +3516,18 @@ test.describe('Claude Science artifact campaign', () => {
     expect(await mapFrame.locator('.motif-pm-selection').count()).toBe(selectionPaths);
   });
 
-  test('map clicks resolve the same base whether the view is fitted, panned, or zoomed', async ({ page }) => {
+  test('backbone clicks resolve the visible base after fit, pan, and zoom', async ({ page }) => {
     await openArtifact(page, 1180, 900);
+    await page.evaluate(() => window.motifRenderInventory?.([{
+      id: 'map-coordinate-fixture',
+      name: 'Map coordinate fixture',
+      molecule: 'dna',
+      topology: 'circular',
+      sequence: 'A'.repeat(12_000),
+      features: [],
+      sites: [],
+    }]));
+    await expect(page.locator('.motif-cs-map-frame')).toContainText('12,000 bp');
     const svg = page.locator('.motif-cs-map-frame svg.motif-plasmid-map');
     const svgBox = (await svg.boundingBox())!;
     const centre = { x: svgBox.x + svgBox.width / 2, y: svgBox.y + svgBox.height / 2 };
@@ -3338,14 +3570,40 @@ test.describe('Claude Science artifact campaign', () => {
       return match ? Number(match[1].replace(/,/g, '')) : null;
     };
 
-    const probe = { x: centre.x + (Math.min(svgBox.width, svgBox.height) * 0.3), y: centre.y };
+    // Blank canvas is now a pan surface. Sample a visible point on the transformed
+    // backbone for each state so the click remains a range-selection gesture while
+    // the coordinate conversion is exercised after both translation and scaling.
+    const backboneProbe = (offset: number) => page.evaluate((startOffset) => {
+      const root = document.querySelector<SVGSVGElement>('.motif-cs-map-frame svg.motif-plasmid-map');
+      const backbone = root?.querySelector<SVGGeometryElement>('.motif-pm-backbone');
+      if (!root || !backbone) return null;
+      const total = backbone.getTotalLength();
+      const rootRect = root.getBoundingClientRect();
+      for (let index = 0; index < 48; index += 1) {
+        const fraction = ((startOffset + (index * 7)) % 48) / 48;
+        const local = backbone.getPointAtLength(total * fraction);
+        const screen = local.matrixTransform(backbone.getScreenCTM()!);
+        if (
+          screen.x < rootRect.left + 12
+          || screen.x > rootRect.right - 12
+          || screen.y < rootRect.top + 12
+          || screen.y > rootRect.bottom - 12
+        ) continue;
+        const hit = document.elementFromPoint(screen.x, screen.y);
+        if (!hit?.closest('[data-map-interaction-surface]')) continue;
+        if (hit.closest('.motif-pm-feature, .motif-pm-restriction, .motif-pm-range-overlay')) continue;
+        return { x: screen.x, y: screen.y };
+      }
+      return null;
+    }, offset);
+
     const offCentre = { x: centre.x - 120, y: centre.y - 120 };
 
     // Three viewports: a pristine fit; a pan with the zoom badge still reading
     // 100%; and an off-centre zoom. The middle one matters most — a click can be
     // hundreds of bases wrong while nothing on screen says the view has moved.
     const seen: Array<{ label: string; expected: number; actual: number | null }> = [];
-    for (const step of [
+    const steps = [
       { label: 'fit', prepare: async () => {} },
       {
         label: 'panned at fit',
@@ -3361,12 +3619,15 @@ test.describe('Claude Science artifact campaign', () => {
           });
         },
       },
-    ]) {
+    ];
+    for (const [stepIndex, step] of steps.entries()) {
       await step.prepare();
       await page.waitForTimeout(220);
-      const expected = await baseUnderPoint(probe);
+      const probe = await backboneProbe(stepIndex * 13);
+      expect(probe, `could not find a visible backbone point at ${step.label}`).not.toBeNull();
+      const expected = await baseUnderPoint(probe!);
       expect(expected, `oracle failed to resolve a base at ${step.label}`).not.toBeNull();
-      await page.mouse.click(probe.x, probe.y);
+      await page.mouse.click(probe!.x, probe!.y);
       await page.waitForTimeout(160);
       seen.push({ label: step.label, expected: expected!, actual: await clickedBase() });
     }
@@ -3403,24 +3664,12 @@ test.describe('Claude Science artifact campaign', () => {
     const svgBox = await svg.boundingBox();
     expect(svgBox).toBeTruthy();
 
-    // Drag along a row that is actually the range-drag surface. A fixed fraction of
-    // the SVG height is not: enzyme labels are drawn across the middle of a short
-    // linear map, and a press that lands on one selects that cluster instead of
-    // starting a range — which leaves no range and no readout to place, so this
-    // test would fail describing the readout rather than the missed drag.
+    // Drag on the rendered sequence axis. Blank canvas above and below it pans,
+    // while the backbone remains the range-selection target.
     const startX = svgBox!.x + svgBox!.width * 0.28;
     const endX = svgBox!.x + svgBox!.width * 0.55;
-    const y = await page.evaluate(([x0, x1, top, height]) => {
-      for (let step = 0; step <= 20; step += 1) {
-        const candidate = top + (height * (2 + step * 3)) / 100;
-        const onBackground = [x0, x1].every((x) => document
-          .elementFromPoint(x, candidate)
-          ?.classList.contains('motif-pm-bg'));
-        if (onBackground) return candidate;
-      }
-      return -1;
-    }, [startX, endX, svgBox!.y, svgBox!.height]);
-    expect(y, 'no row of the linear map accepts a range drag').toBeGreaterThan(0);
+    const backboneBox = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
+    const y = backboneBox.y + backboneBox.height / 2;
 
     await page.mouse.move(startX, y);
     await page.mouse.down();

--- a/mcp/motif/artifact-export.ts
+++ b/mcp/motif/artifact-export.ts
@@ -8,6 +8,7 @@ import {
 } from './contracts.js';
 
 const DATA_TAG_PATTERN = /(<script type="application\/json" id="motif-artifact-data">)([\s\S]*?)(<\/script>)/u;
+const BUILD_ID_META_PATTERN = /<meta name="motif-build-id" content="([a-f0-9]{64})"\s*\/?>/u;
 
 function jsonForScriptTag(value: unknown): string {
   return JSON.stringify(value)
@@ -29,6 +30,7 @@ function safeArtifactBase(value: string): string {
 export type RenderMotifArtifactRequest = {
   template: string;
   workbench: MotifWorkbenchResult;
+  runtimeBuildId: string;
   title?: string;
   filename?: string;
 };
@@ -45,6 +47,10 @@ export function renderMotifArtifact(request: RenderMotifArtifactRequest): Render
   if (!request.workbench.payload) {
     throw new Error('A payload or sequence artifact is required to create a shareable Motif workbench.');
   }
+  const templateBuildId = request.template.match(BUILD_ID_META_PATTERN)?.[1];
+  if (!templateBuildId || templateBuildId !== request.runtimeBuildId) {
+    throw new Error('Motif artifact template build identity is missing or inconsistent. Rebuild the connector.');
+  }
   const title = request.title?.trim() || request.workbench.sourceName?.replace(/\.[^.]+$/u, '') || 'Motif workbench';
   const requestedFilename = request.filename?.trim().replace(/\.html?$/iu, '');
   const filename = `${safeArtifactBase(requestedFilename || title)}.html`;
@@ -56,6 +62,9 @@ export function renderMotifArtifact(request: RenderMotifArtifactRequest): Render
   const bytes = Buffer.byteLength(html, 'utf8');
   const summary = motifArtifactExportSummarySchema.parse({
     schema: MOTIF_ARTIFACT_EXPORT_SCHEMA,
+    delivery: 'embedded-html-resource',
+    visibleMountConfirmed: false,
+    runtimeBuildId: request.runtimeBuildId,
     filename,
     ...(request.workbench.sourceName ? { sourceName: request.workbench.sourceName } : {}),
     recordCount: request.workbench.recordCount,

--- a/mcp/motif/contracts.ts
+++ b/mcp/motif/contracts.ts
@@ -9,6 +9,10 @@ export const motifWorkbenchPayloadSchema = z.record(z.string(), z.unknown());
 export const motifWorkbenchResultSchema = z.object({
   schema: z.literal(MOTIF_WORKBENCH_RESULT_SCHEMA),
   mode: z.enum(['sample', 'payload', 'artifact']),
+  delivery: z.literal('live-app-request').optional(),
+  visibleMountConfirmed: z.literal(false).optional(),
+  fallbackTool: z.literal('motif_create_workbench_artifact').optional(),
+  runtimeBuildId: z.string().regex(/^[a-f0-9]{64}$/u).optional(),
   sourceName: z.string().min(1).max(512).optional(),
   payload: motifWorkbenchPayloadSchema.optional(),
   recordCount: z.number().int().nonnegative().max(100),
@@ -17,6 +21,9 @@ export const motifWorkbenchResultSchema = z.object({
 
 export const motifArtifactExportSummarySchema = z.object({
   schema: z.literal(MOTIF_ARTIFACT_EXPORT_SCHEMA),
+  delivery: z.literal('embedded-html-resource'),
+  visibleMountConfirmed: z.literal(false),
+  runtimeBuildId: z.string().regex(/^[a-f0-9]{64}$/u),
   filename: z.string().min(1).max(160),
   sourceName: z.string().min(1).max(512).optional(),
   recordCount: z.number().int().nonnegative().max(100),

--- a/mcp/motif/server.ts
+++ b/mcp/motif/server.ts
@@ -21,6 +21,7 @@ import {
 
 export type MotifClaudeScienceServerOptions = {
   version: string;
+  runtimeBuildId: string;
   readWorkbenchHtml: () => Promise<string>;
   readArtifactTemplate: () => Promise<string>;
   trace?: (event: MotifMcpTraceEvent) => void;
@@ -168,12 +169,13 @@ function emitTrace(options: MotifClaudeScienceServerOptions, event: MotifMcpTrac
 }
 
 function workbenchSummaryText(result: ReturnType<typeof prepareMotifWorkbench>): string {
+  const build = result.runtimeBuildId ? ` Runtime build ${result.runtimeBuildId.slice(0, 12)}.` : '';
   if (result.mode === 'sample') {
-    return 'Motif for Claude Science workbench requested with its bundled sample inventory. Host rendering is a separate client action.';
+    return `Motif for Claude Science workbench requested with its bundled sample inventory.${build} Host rendering is a separate client action.`;
   }
   const source = result.sourceName ? ` from ${result.sourceName}` : '';
   const records = workbenchRecordSummary(result);
-  return `Motif for Claude Science workbench requested${source} with ${result.recordCount} record${result.recordCount === 1 ? '' : 's'} and ${result.residueCount.toLocaleString()} residues.${records} Host rendering is a separate client action.`;
+  return `Motif for Claude Science workbench requested${source} with ${result.recordCount} record${result.recordCount === 1 ? '' : 's'} and ${result.residueCount.toLocaleString()} residues.${records}${build} Host rendering is a separate client action.`;
 }
 
 function workbenchRecordSummary(result: ReturnType<typeof prepareMotifWorkbench>): string {
@@ -243,9 +245,9 @@ export function createMotifClaudeScienceServer(options: MotifClaudeScienceServer
     server,
     'motif_open_workbench',
     {
-      title: 'Open Motif for Claude Science',
+      title: 'Request the live Motif workbench',
       description:
-        'Open the interactive Motif molecular-biology workbench. Accepts a bounded Motif inventory payload or exact FASTA, GenBank, raw sequence, or Motif JSON content. With no data, opens the bundled sample inventory. This read-only tool does not write a database or run external executables.',
+        'Request the live interactive Motif molecular-biology workbench. A successful result confirms parsing and requests the MCP App; it does not confirm that the host displayed a frame. Accepts a bounded Motif inventory payload or exact FASTA, GenBank, raw sequence, or Motif JSON content. With no data, requests the bundled sample inventory. This read-only tool does not write a database or run external executables.',
       inputSchema: workbenchInputSchema,
       outputSchema: motifWorkbenchResultSchema,
       annotations: readOnlyAnnotations('Open Motif for Claude Science'),
@@ -258,7 +260,13 @@ export function createMotifClaudeScienceServer(options: MotifClaudeScienceServer
       const trace = startTrace('motif_open_workbench');
       try {
         const input = workbenchInputSchema.parse(args) as MotifWorkbenchInput;
-        const result = prepareMotifWorkbench(input);
+        const result = motifWorkbenchResultSchema.parse({
+          ...prepareMotifWorkbench(input),
+          delivery: 'live-app-request',
+          visibleMountConfirmed: false,
+          fallbackTool: 'motif_create_workbench_artifact',
+          runtimeBuildId: options.runtimeBuildId,
+        });
         finishTrace(trace, 'ok', {
           mode: result.mode,
           recordCount: result.recordCount,
@@ -293,6 +301,7 @@ export function createMotifClaudeScienceServer(options: MotifClaudeScienceServer
         const artifact = renderMotifArtifact({
           template: await options.readArtifactTemplate(),
           workbench,
+          runtimeBuildId: options.runtimeBuildId,
           ...(input.title ? { title: input.title } : {}),
           ...(input.outputFilename ? { filename: input.outputFilename } : {}),
         });
@@ -306,7 +315,7 @@ export function createMotifClaudeScienceServer(options: MotifClaudeScienceServer
           content: [
             {
               type: 'text',
-              text: `Prepared self-contained Motif for Claude Science workbench ${artifact.summary.filename} with ${artifact.summary.recordCount} record${artifact.summary.recordCount === 1 ? '' : 's'}.${workbenchRecordSummary(workbench)} No file was written. Save or open the attached HTML resource in Claude Science.`,
+              text: `Prepared self-contained Motif for Claude Science workbench ${artifact.summary.filename} with ${artifact.summary.recordCount} record${artifact.summary.recordCount === 1 ? '' : 's'}.${workbenchRecordSummary(workbench)} Runtime build ${artifact.summary.runtimeBuildId.slice(0, 12)}. No file was written. Save or open the attached HTML resource in Claude Science.`,
             },
             {
               type: 'resource',

--- a/mcp/motif/stdio-server.ts
+++ b/mcp/motif/stdio-server.ts
@@ -45,6 +45,15 @@ async function readVersion(): Promise<string> {
   return '0.2.1';
 }
 
+async function readRuntimeBuildId(workbenchPath: string): Promise<string> {
+  const html = await readFile(workbenchPath, 'utf8');
+  const runtimeBuildId = html.match(/<meta name="motif-build-id" content="([a-f0-9]{64})"\s*\/?>/u)?.[1];
+  if (!runtimeBuildId) {
+    throw new Error('Motif MCP App build identity is missing. Rebuild or reinstall the connector.');
+  }
+  return runtimeBuildId;
+}
+
 async function main(): Promise<void> {
   const traceEnabled = process.env.MOTIF_MCP_TRACE === '1'
     || process.env.MOTIF_MCP_TRACE === 'true';
@@ -59,8 +68,10 @@ async function main(): Promise<void> {
     resolve(moduleDirectory, 'motif-template.html'),
     resolve(inferredRoot, 'dist-motif/motif-template.html'),
   ], 'Motif artifact template');
+  const runtimeBuildId = await readRuntimeBuildId(workbenchPath);
   const server = createMotifClaudeScienceServer({
     version,
+    runtimeBuildId,
     readWorkbenchHtml: () => readFile(workbenchPath, 'utf8'),
     readArtifactTemplate: () => readFile(artifactTemplatePath, 'utf8'),
     ...(traceEnabled ? {

--- a/motif.html
+++ b/motif.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="application-name" content="Motif for Claude Science" />
+    <meta name="motif-build-id" content="__MOTIF_BUILD_ID__" />
     <meta name="description" content="Motif is an interactive molecular-biology workbench for Claude Science." />
     <link rel="icon" href="data:," />
     <title>Motif for Claude Science</title>

--- a/scripts/__tests__/motif-build-identity.test.mjs
+++ b/scripts/__tests__/motif-build-identity.test.mjs
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { stampMotifBuildIdentity } from '../motif-build-identity.mjs';
+
+describe('Motif build identity', () => {
+  it('stamps a deterministic hash of the unstamped runtime template', () => {
+    const template = '<!doctype html><meta name="motif-build-id" content="__MOTIF_BUILD_ID__"><main>Motif</main>';
+    const first = stampMotifBuildIdentity(template);
+    const second = stampMotifBuildIdentity(template);
+
+    expect(first.runtimeBuildId).toMatch(/^[a-f0-9]{64}$/u);
+    expect(first).toEqual(second);
+    expect(first.html).toContain(`content="${first.runtimeBuildId}"`);
+    expect(first.html).not.toContain('__MOTIF_BUILD_ID__');
+  });
+
+  it('rejects HTML without the build identity marker', () => {
+    expect(() => stampMotifBuildIdentity('<!doctype html><main>Motif</main>'))
+      .toThrow('missing its build identity marker');
+  });
+});

--- a/scripts/build-claude-science-artifact.mjs
+++ b/scripts/build-claude-science-artifact.mjs
@@ -15,6 +15,7 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildSync } from 'esbuild';
 import { validatePayload as validateArtifactPayload } from '../src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/create-artifact.mjs';
+import { stampMotifBuildIdentity } from './motif-build-identity.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const outDir = join(root, 'dist-motif');
@@ -445,7 +446,9 @@ export function runBuild(args = process.argv.slice(2)) {
     return;
   }
 
-  const template = inlineAssetTags(readFileSync(distHtml, 'utf8'));
+  const { html: template, runtimeBuildId } = stampMotifBuildIdentity(
+    inlineAssetTags(readFileSync(distHtml, 'utf8')),
+  );
   writeFileSync(templateHtml, template);
   runConnectorBuild();
 
@@ -482,6 +485,7 @@ export function runBuild(args = process.argv.slice(2)) {
   console.log(`Wrote Claude Science connector ${connectorDistPath}`);
   console.log(`Wrote plugin archive ${pluginZipPath}`);
   console.log(`Wrote checksums ${pluginChecksumPath}`);
+  console.log(`Runtime build ${runtimeBuildId}`);
   if (handoffPath) console.log(`Wrote explicit handoff ${handoffPath}`);
 }
 

--- a/scripts/build-preview.mjs
+++ b/scripts/build-preview.mjs
@@ -13,6 +13,7 @@ import { spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
+import { stampMotifBuildIdentity } from './motif-build-identity.mjs';
 
 const root = resolve(new URL('..', import.meta.url).pathname);
 const previewDir = join(root, 'preview');
@@ -70,7 +71,8 @@ try {
   if (build.status !== 0) process.exitCode = build.status ?? 1;
   else {
     const distHtml = join(buildDir, 'motif.html');
-    let html = inlineAssetTags(readFileSync(distHtml, 'utf8'));
+    const stamped = stampMotifBuildIdentity(inlineAssetTags(readFileSync(distHtml, 'utf8')));
+    let html = stamped.html;
     if (payloadPath) {
       const payload = JSON.parse(readFileSync(resolve(payloadPath), 'utf8'));
       html = injectPayload(html, jsonForScriptTag(payload));
@@ -81,6 +83,7 @@ try {
     writeFileSync(finalPath, html);
 
     console.log(`\n✓ preview written: ${finalPath}`);
+    console.log(`  runtime build: ${stamped.runtimeBuildId}`);
     console.log(`  open: file://${finalPath}`);
   }
 } finally {

--- a/scripts/doctor-motif-claude-science-local.mjs
+++ b/scripts/doctor-motif-claude-science-local.mjs
@@ -246,6 +246,9 @@ async function inspectProtocol(paths, timeoutMs) {
     assert(!opened?.isError, 'open-workbench smoke test returned an error');
     assert(opened?.structuredContent?.schema === 'motif.mcp.workbench.v1', 'open result schema is not Motif-owned');
     assert(opened?.structuredContent?.mode === 'artifact', 'opened FASTA was not identified as an artifact');
+    assert(opened?.structuredContent?.delivery === 'live-app-request', 'open result does not identify its delivery boundary');
+    assert(opened?.structuredContent?.visibleMountConfirmed === false, 'open result overstates visible mounting');
+    assert(/^[a-f0-9]{64}$/u.test(opened?.structuredContent?.runtimeBuildId), 'open result is missing the runtime build identity');
     assert(opened?.structuredContent?.recordCount === 1, 'opened FASTA did not produce one record');
     assert(opened?.structuredContent?.residueCount === PRIVACY_SENTINEL.length, 'opened FASTA residue count is incorrect');
     const openedSummary = opened?.content?.find(item => item?.type === 'text')?.text;
@@ -272,6 +275,14 @@ async function inspectProtocol(paths, timeoutMs) {
       'standalone artifact result schema is not Motif-owned',
     );
     assert(artifactResult?.structuredContent?.recordCount === 1, 'standalone artifact did not retain its record');
+    assert(
+      artifactResult?.structuredContent?.delivery === 'embedded-html-resource',
+      'standalone artifact result does not identify its delivery boundary',
+    );
+    assert(
+      artifactResult?.structuredContent?.runtimeBuildId === opened?.structuredContent?.runtimeBuildId,
+      'standalone artifact and live App results disagree on the runtime build identity',
+    );
     const artifactSummary = artifactResult?.content?.find(item => item?.type === 'text')?.text;
     assert(
       typeof artifactSummary === 'string' && artifactSummary.includes('Records: motif-doctor [motif-doctor].'),

--- a/scripts/motif-build-identity.mjs
+++ b/scripts/motif-build-identity.mjs
@@ -1,0 +1,21 @@
+import { createHash } from 'node:crypto';
+
+const BUILD_ID_PLACEHOLDER = '__MOTIF_BUILD_ID__';
+const BUILD_ID_META_PATTERN = new RegExp(
+  `(<meta name="motif-build-id" content=")${BUILD_ID_PLACEHOLDER}("\\s*/?>)`,
+  'u',
+);
+
+export function stampMotifBuildIdentity(html) {
+  if (!BUILD_ID_META_PATTERN.test(html)) {
+    throw new Error('Motif HTML is missing its build identity marker.');
+  }
+  const runtimeBuildId = createHash('sha256').update(html, 'utf8').digest('hex');
+  return {
+    html: html.replace(
+      BUILD_ID_META_PATTERN,
+      (_match, prefix, suffix) => `${prefix}${runtimeBuildId}${suffix}`,
+    ),
+    runtimeBuildId,
+  };
+}

--- a/scripts/test-claude-science-plugin-packaging.mjs
+++ b/scripts/test-claude-science-plugin-packaging.mjs
@@ -158,6 +158,10 @@ check('plugin source has a matching, bounded manifest and skill', () => {
   assert.ok(manifest.name.length <= 64);
   assert.ok(manifest.description.length < 256);
   assert.ok(skillDescription.length > 0 && skillDescription.length <= 200);
+  assert.match(skill, /For a dependable visual result, call `motif_create_workbench_artifact`/u);
+  assert.match(skill, /Use `motif_open_workbench` first only when the current host is already known to\s+mount the live MCP App/u);
+  assert.match(skill, /A request to open, show, reload, or retry an existing construct is a display\s+request/u);
+  assert.match(skill, /Reuse the exact latest sequence, annotations, colors, and provenance/u);
   assert.match(manifest.version, /^\d+\.\d+\.\d+$/);
   assert.equal(manifest.version, '0.2.1');
   assert.equal(manifest.version, artifactVersion);

--- a/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
@@ -270,7 +270,7 @@ describe('Claude Science rail popover regression guards', () => {
     expect(artifactSource).toContain('<Settings className="motif-cs-panel-icon"');
     expect(artifactSource).toContain('<strong>Motif for Claude Science</strong>');
     expect(artifactSource).toContain("const MOTIF_ARTIFACT_VERSION = '0.2.1';");
-    expect(artifactSource).toContain('<span>Version {MOTIF_ARTIFACT_VERSION}</span>');
+    expect(artifactSource).toContain('Version {MOTIF_ARTIFACT_VERSION} · Build {MOTIF_ARTIFACT_BUILD_LABEL}');
     expect(artifactSource).not.toContain('__APP_VERSION__');
     expect(artifactSource).toContain('Motif is an open-source, AI-native molecular biology suite for researchers.');
     expect(artifactSource).toContain('<span>By Jacob Vogan</span>');

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -297,8 +297,9 @@ describe('Claude Science workspace layout guards', () => {
   it('keeps sequence scrolling local to each open record', () => {
     expect(artifactSource).toContain('const sequenceScrollByRecordRef = useRef<Record<string, number>>({});');
     expect(artifactSource).toContain('const rememberActiveSequenceScroll = useCallback(() => {');
-    expect(artifactSource).toContain('sequenceScrollByRecordRef.current[activeRecordId] = sequenceScroller.scrollTop;');
-    expect(artifactSource).toContain('sequenceScroller.scrollTop = sequenceScrollByRecordRef.current[recordId] ?? 0;');
+    expect(artifactSource).toContain('sequenceScrollByRecordRef.current[activeRecordId] = effectiveSequenceScroller(sequenceElement).scrollTop;');
+    expect(artifactSource).toContain('effectiveSequenceScroller(sequenceElement).scrollTop = sequenceScrollByRecordRef.current[recordId] ?? 0;');
+    expect(artifactSource).toContain("sequenceElement.closest<HTMLElement>('.motif-cs-sequence-column')");
     expect(artifactSource).toContain('window.motifAddRecords = (recordOrRecords) => {');
     expect(artifactSource).toContain('const addRecord = useCallback((recordInput: ArtifactRecordInput): boolean => (');
     expect(artifactSource).toContain('onClick={() => selectRecord(record.id)}');
@@ -599,19 +600,22 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).not.toContain('// eslint-disable-next-line react-hooks/exhaustive-deps -- reset only on target change');
   });
 
-  it('keeps plain map dragging available for range selection after zooming', () => {
+  it('keeps sequence dragging for range selection and blank-canvas dragging for pan', () => {
     const pointerStart = sliceBetween(
       artifactSource,
       'const handleMapPointerStart = useCallback',
       'const handleMapPointerMove = useCallback',
     );
+    expect(pointerStart).toContain('mapPointerActionAtPoint(contentPoint, layout)');
     expect(pointerStart).toContain("mode: 'range'");
-    expect(pointerStart).not.toContain("mode: 'pan'");
+    expect(pointerStart).toContain("mode: 'pan'");
     expect(pointerStart).not.toContain('mapViewport.k >');
     expect(artifactSource).toContain('data-map-interaction-surface');
+    expect(artifactSource).toContain('data-map-pointer-action={mapPointerAction}');
     expect(artifactSource).toContain("target.closest('.motif-pm-feature, .motif-pm-restriction, .motif-pm-range-overlay[data-interactive=\"true\"]')");
     expect(artifactSource).toContain('onPointerDown={handleMapSurfacePointerDown}');
     expect(artifactCss).toMatch(/\.motif-cs-map-frame \.motif-pm-backbone\s*\{[\s\S]*?pointer-events:\s*none/);
+    expect(artifactCss).toMatch(/\[data-map-pointer-action="pan"\] \.motif-pm-bg\s*\{[\s\S]*?cursor:\s*grab/);
   });
 
   it('accepts extended protein symbols and classifies Type IIS from enzyme geometry', () => {

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -1804,18 +1804,17 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
   stroke: none;
 }
 
-/* Crosshair unconditionally, because background drag is range selection and that
-   is true at every zoom. There used to be a second rule here keyed on
-   `data-pannable='true'` setting the identical cursor — it existed to beat the
-   `grab` that the map's own stylesheet applied once the viewport was
-   transformed. So the map advertised a drag-to-pan that no host ever wired, and
-   this override quietly hid the evidence: the cursor a user saw was always
-   crosshair. The attribute and the `grab` are both gone now, and a rule that
-   overrides something no longer declared is just a place for the next reader to
-   lose ten minutes. */
 .motif-cs-map-frame .motif-pm-bg {
   cursor: crosshair;
   touch-action: none;
+}
+
+.motif-cs-map-frame[data-map-pointer-action="pan"] .motif-pm-bg {
+  cursor: grab;
+}
+
+.motif-cs-map-frame[data-map-pointer-action="pan"] .motif-pm-container:active .motif-pm-bg {
+  cursor: grabbing;
 }
 
 /* The painted backbone is map geometry, not a control. Let pointer starts fall

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -211,6 +211,14 @@ import {
 import './motif-artifact.css';
 
 const MOTIF_ARTIFACT_VERSION = '0.2.1';
+const MOTIF_ARTIFACT_BUILD_ID = (() => {
+  if (typeof document === 'undefined') return 'development';
+  const value = document.querySelector<HTMLMetaElement>('meta[name="motif-build-id"]')?.content.trim() ?? '';
+  return /^[a-f0-9]{64}$/u.test(value) ? value : 'development';
+})();
+const MOTIF_ARTIFACT_BUILD_LABEL = MOTIF_ARTIFACT_BUILD_ID === 'development'
+  ? MOTIF_ARTIFACT_BUILD_ID
+  : MOTIF_ARTIFACT_BUILD_ID.slice(0, 12);
 const MAX_INTERACTIVE_TRANSLATION_RESIDUES = 5_000;
 const ANNOTATION_LIST_PAGE_SIZE = 120;
 export const MOTIF_MAX_RECORD_LENGTH = 250_000;
@@ -945,14 +953,23 @@ type MapSelectionRange = {
   end: number;
 };
 
-type MapDragState = {
-  mode: 'range';
-  start: MapContentPoint;
-  startBp: number;
-  lastAngle: number;
-  cumulativeAngle: number;
-  moved: boolean;
-};
+type MapPointerAction = 'range' | 'pan';
+
+type MapDragState =
+  | {
+      mode: 'range';
+      start: MapContentPoint;
+      startBp: number;
+      lastAngle: number;
+      cumulativeAngle: number;
+      moved: boolean;
+    }
+  | {
+      mode: 'pan';
+      start: MapRootPoint;
+      viewport: MapViewport;
+      moved: boolean;
+    };
 
 type WindowRect = { x: number; y: number; w: number; h: number };
 
@@ -1123,6 +1140,7 @@ declare global {
 // embedded seed JSON to add sequences — it can call motifAddRecords(...) at runtime.
 type MotifHelp = {
   summary: string;
+  build: { version: string; runtimeBuildId: string };
   howToAddSequences: string;
   capabilities: Record<string, string>;
   agentRules: string[];
@@ -1159,6 +1177,10 @@ const ZOOM_STEP = 1.25;
 const MAP_FIT_PAN_MARGIN_SCALE = 0.08;
 const MAP_FIT_WHEEL_PAN_SCALE = 0.22;
 const MAP_ZOOMED_WHEEL_PAN_SCALE = 0.78;
+const MAP_CIRCULAR_RANGE_HIT_MIN = 18;
+const MAP_CIRCULAR_RANGE_HIT_MAX = 34;
+const MAP_LINEAR_RANGE_HIT_Y = 18;
+const MAP_LINEAR_RANGE_HIT_X = 8;
 const DEFAULT_MAP_VIEWPORT: MapViewport = { k: 1, tx: 0, ty: 0 };
 const builtInRecords = JSON.parse(vectorsRaw) as ArtifactRecordInput[];
 
@@ -1197,6 +1219,10 @@ const MOTIF_HELP: MotifHelp = {
   summary:
     'Motif sequence workbench. Records (DNA/RNA/protein) are held in an in-memory inventory. ' +
     'You can add, group, inspect, annotate, translate, search, and export sequences at RUNTIME.',
+  build: {
+    version: MOTIF_ARTIFACT_VERSION,
+    runtimeBuildId: MOTIF_ARTIFACT_BUILD_ID,
+  },
   howToAddSequences:
     'Call window.motifAddRecords(recordOrRecords) to APPEND without disturbing existing records ' +
     '(returns the count added and focuses the first). Use window.motifRenderInventory(records) only ' +
@@ -1641,6 +1667,12 @@ function clampMapViewport(
     tx: clamp(Number.isFinite(viewport.tx) ? viewport.tx : 0, Math.min(minTx, maxTx), Math.max(minTx, maxTx)),
     ty: clamp(Number.isFinite(viewport.ty) ? viewport.ty : 0, Math.min(minTy, maxTy), Math.max(minTy, maxTy)),
   };
+}
+
+function effectiveSequenceScroller(sequenceElement: HTMLElement): HTMLElement {
+  if (sequenceElement.scrollHeight > sequenceElement.clientHeight + 1) return sequenceElement;
+  const pane = sequenceElement.closest<HTMLElement>('.motif-cs-sequence-column');
+  return pane && pane.scrollHeight > pane.clientHeight + 1 ? pane : sequenceElement;
 }
 
 function looksLikeImplicitProteinSequence(rawSequence: string): boolean {
@@ -3068,6 +3100,20 @@ function pointToSequenceOffset(point: MapContentPoint, layout: MapLayout): numbe
 
   const angle = pointToSequenceAngle(point, layout);
   return clamp(Math.round((angle / 360) * layout.length), 0, Math.max(0, layout.length - 1));
+}
+
+function mapPointerActionAtPoint(point: MapContentPoint, layout: MapLayout): MapPointerAction {
+  if (layout.mode === 'circular') {
+    const distance = Math.hypot(point.x - layout.center.x, point.y - layout.center.y);
+    const tolerance = clamp(layout.radius * 0.14, MAP_CIRCULAR_RANGE_HIT_MIN, MAP_CIRCULAR_RANGE_HIT_MAX);
+    return Math.abs(distance - layout.radius) <= tolerance ? 'range' : 'pan';
+  }
+
+  const axis = layout.linearAxis;
+  if (!axis) return 'pan';
+  const alongAxis = point.x >= axis.startX - MAP_LINEAR_RANGE_HIT_X
+    && point.x <= axis.endX + MAP_LINEAR_RANGE_HIT_X;
+  return alongAxis && Math.abs(point.y - axis.y) <= MAP_LINEAR_RANGE_HIT_Y ? 'range' : 'pan';
 }
 
 function signedCircularAngleDelta(fromAngle: number, toAngle: number): number {
@@ -4878,6 +4924,7 @@ function App() {
   const sequenceScrollByRecordRef = useRef<Record<string, number>>({});
   const mapDragRef = useRef<MapDragState | null>(null);
   const mapPointerIdRef = useRef<number | null>(null);
+  const [mapPointerAction, setMapPointerAction] = useState<MapPointerAction>('range');
   // Root space: this is handed straight to zoomAtPoint, which pins a root point.
   const lastZoomAnchorRef = useRef<MapRootPoint | null>(null);
   const suppressNextBackgroundClick = useRef(false);
@@ -5134,9 +5181,9 @@ function App() {
 
   const rememberActiveSequenceScroll = useCallback(() => {
     const activeRecordId = selectedRecordIdRef.current;
-    const sequenceScroller = document.querySelector<HTMLElement>('.motif-cs-sequence');
-    if (activeRecordId && sequenceScroller) {
-      sequenceScrollByRecordRef.current[activeRecordId] = sequenceScroller.scrollTop;
+    const sequenceElement = document.querySelector<HTMLElement>('.motif-cs-sequence');
+    if (activeRecordId && sequenceElement) {
+      sequenceScrollByRecordRef.current[activeRecordId] = effectiveSequenceScroller(sequenceElement).scrollTop;
     }
   }, []);
 
@@ -5176,9 +5223,9 @@ function App() {
   }, [payload.records, selectRecord]);
 
   useLayoutEffect(() => {
-    const sequenceScroller = document.querySelector<HTMLElement>('.motif-cs-sequence');
-    if (!sequenceScroller) return;
-    sequenceScroller.scrollTop = sequenceScrollByRecordRef.current[recordId] ?? 0;
+    const sequenceElement = document.querySelector<HTMLElement>('.motif-cs-sequence');
+    if (!sequenceElement) return;
+    effectiveSequenceScroller(sequenceElement).scrollTop = sequenceScrollByRecordRef.current[recordId] ?? 0;
   }, [recordId]);
 
   useEffect(() => {
@@ -6523,12 +6570,17 @@ function App() {
     return true;
   }, [mapFrameRef, mapViewport.k, setCurrentMapViewport, zoomAtPoint]);
 
-  // CONTENT space. The caller records the zoom anchor, because the caller is the
-  // one still holding the root-space point.
-  const handleMapPointerStart = useCallback((point: MapContentPoint) => {
-    const startBp = pointToSequenceOffset(point, layout);
-    const startAngle = pointToSequenceAngle(point, layout);
-    mapDragRef.current = { mode: 'range', start: point, startBp, lastAngle: startAngle, cumulativeAngle: 0, moved: false };
+  const handleMapPointerStart = useCallback((rootPoint: MapRootPoint, contentPoint: MapContentPoint) => {
+    const action = mapPointerActionAtPoint(contentPoint, layout);
+    setMapPointerAction(action);
+    if (action === 'pan') {
+      mapDragRef.current = { mode: 'pan', start: rootPoint, viewport: mapViewport, moved: false };
+      return true;
+    }
+
+    const startBp = pointToSequenceOffset(contentPoint, layout);
+    const startAngle = pointToSequenceAngle(contentPoint, layout);
+    mapDragRef.current = { mode: 'range', start: contentPoint, startBp, lastAngle: startAngle, cumulativeAngle: 0, moved: false };
     setLockedTranslateTarget(null);
     setSelectedTranslationLayerByRecord((current) => (current[recordId] ? { ...current, [recordId]: null } : current));
     setSelection(null);
@@ -6541,16 +6593,26 @@ function App() {
       [recordId]: rangeFromMapDrag(startBp, startBp + 1, sequence.length, layout.mode),
     }));
     return true;
-  }, [layout, recordId, sequence.length]);
+  }, [layout, mapViewport, recordId, sequence.length]);
 
-  const handleMapPointerMove = useCallback((point: MapContentPoint) => {
+  const handleMapPointerMove = useCallback((rootPoint: MapRootPoint, contentPoint: MapContentPoint) => {
     const drag = mapDragRef.current;
     if (!drag) return;
+    const point = drag.mode === 'pan' ? rootPoint : contentPoint;
     const dx = point.x - drag.start.x;
     const dy = point.y - drag.start.y;
     if (!drag.moved && Math.hypot(dx, dy) > 2) drag.moved = true;
 
-    const endBp = pointToSequenceOffset(point, layout);
+    if (drag.mode === 'pan') {
+      setCurrentMapViewport({
+        ...drag.viewport,
+        tx: drag.viewport.tx + dx,
+        ty: drag.viewport.ty + dy,
+      });
+      return;
+    }
+
+    const endBp = pointToSequenceOffset(contentPoint, layout);
     let nextRange: MapSelectionRange;
     // Keyed on how the map is DRAWN. The angle model needs a ring: on a linear
     // layout `layout.center` is the axis's left end, so dragging along the axis
@@ -6558,7 +6620,7 @@ function App() {
     // and the content-point projection above already key on layout.mode — this
     // was the one place in the gesture still asking the molecule instead.
     if (layout.mode === 'circular') {
-      const nextAngle = pointToSequenceAngle(point, layout);
+      const nextAngle = pointToSequenceAngle(contentPoint, layout);
       drag.cumulativeAngle += signedCircularAngleDelta(drag.lastAngle, nextAngle);
       drag.lastAngle = nextAngle;
       nextRange = rangeFromCircularAngleDrag(drag.startBp, drag.cumulativeAngle, sequence.length);
@@ -6570,7 +6632,7 @@ function App() {
       if (previous && previous.start === nextRange.start && previous.end === nextRange.end) return current;
       return { ...current, [recordId]: nextRange };
     });
-  }, [layout, recordId, sequence.length]);
+  }, [layout, recordId, sequence.length, setCurrentMapViewport]);
 
   const handleMapPointerEnd = useCallback(() => {
     const drag = mapDragRef.current;
@@ -6625,20 +6687,25 @@ function App() {
     const rootPoint = mapRootPointFromClient(event.clientX, event.clientY);
     if (!rootPoint) return;
     lastZoomAnchorRef.current = rootPoint;
-    if (!handleMapPointerStart(contentPointFromRoot(rootPoint, mapViewport))) return;
+    if (!handleMapPointerStart(rootPoint, contentPointFromRoot(rootPoint, mapViewport))) return;
     mapPointerIdRef.current = event.pointerId;
     event.currentTarget.setPointerCapture?.(event.pointerId);
     event.preventDefault();
   }, [handleMapPointerStart, mapRootPointFromClient, mapViewport]);
 
   const handleMapSurfacePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    if (event.pointerId !== mapPointerIdRef.current) return;
     const rootPoint = mapRootPointFromClient(event.clientX, event.clientY);
     if (!rootPoint) return;
+    const contentPoint = contentPointFromRoot(rootPoint, mapViewport);
+    if (mapPointerIdRef.current === null) {
+      setMapPointerAction(mapPointerActionAtPoint(contentPoint, layout));
+      return;
+    }
+    if (event.pointerId !== mapPointerIdRef.current) return;
     lastZoomAnchorRef.current = rootPoint;
     event.preventDefault();
-    handleMapPointerMove(contentPointFromRoot(rootPoint, mapViewport));
-  }, [handleMapPointerMove, mapRootPointFromClient, mapViewport]);
+    handleMapPointerMove(rootPoint, contentPoint);
+  }, [handleMapPointerMove, layout, mapRootPointFromClient, mapViewport]);
 
   const handleMapSurfacePointerEnd = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.pointerId !== mapPointerIdRef.current) return;
@@ -10763,9 +10830,10 @@ function App() {
                 ref={mapFrameRef}
                 className="motif-cs-map-frame"
                 data-map-mode={layout.mode}
+                data-map-pointer-action={mapPointerAction}
                 data-theme={mapTheme}
                 data-empty={!hasActiveRecord || undefined}
-                title="Wheel to pan; Shift-wheel pans horizontally; Ctrl/Command-wheel zooms; drag selects a range"
+                title="Wheel or blank-canvas drag to pan; Shift-wheel pans horizontally; Ctrl/Command-wheel zooms; drag near the sequence to select a range"
               >
                 <div
                   className="motif-pm-container"
@@ -11910,7 +11978,7 @@ function App() {
               />
               <div className="motif-cs-about-block">
                 <strong>Motif for Claude Science</strong>
-                <span>Version {MOTIF_ARTIFACT_VERSION}</span>
+                <span title={`Runtime build ${MOTIF_ARTIFACT_BUILD_ID}`}>Version {MOTIF_ARTIFACT_VERSION} · Build {MOTIF_ARTIFACT_BUILD_LABEL}</span>
                 <p>Motif is an open-source, AI-native molecular biology suite for researchers.</p>
                 <p className="motif-cs-share-note">Share the generated HTML for local browser review. Download a workspace backup to carry records, alignments, notes, results, and display-independent session state to another copy.</p>
                 <span>By Jacob Vogan</span>
@@ -17216,14 +17284,19 @@ function SequenceText({
     const node = container?.querySelector<HTMLElement>('[data-seq-focus="true"]');
     if (!container || !node) return;
     window.requestAnimationFrame(() => {
-      const containerRect = container.getBoundingClientRect();
+      const scroller = effectiveSequenceScroller(container);
+      const containerRect = scroller.getBoundingClientRect();
       const nodeRect = node.getBoundingClientRect();
       const margin = 32;
       if (nodeRect.top >= containerRect.top + margin && nodeRect.bottom <= containerRect.bottom - margin) {
         return;
       }
-      const top = node.offsetTop - container.clientHeight / 2 + node.clientHeight / 2;
-      container.scrollTo({ top: Math.max(0, top), behavior: 'auto' });
+      const top = scroller.scrollTop
+        + nodeRect.top
+        - containerRect.top
+        - scroller.clientHeight / 2
+        + node.clientHeight / 2;
+      scroller.scrollTo({ top: Math.max(0, top), behavior: 'auto' });
     });
   }, [basesPerLine, detailMode, focusKey, focusStart, sequence.length, showComplement]);
 

--- a/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/SKILL.md
+++ b/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/SKILL.md
@@ -5,16 +5,23 @@ description: Creates a self-contained Motif for Claude Science workbench, option
 
 # Motif for Claude Science
 
-Open the connected Motif workbench when its MCP tools are available, or create
-a user-owned self-contained HTML workbench from the bundled resource.
+Create a user-owned self-contained HTML workbench from the connected Motif
+resource. Use the live MCP App when the current host is known to mount it.
 
 ## Connected Claude Science path
 
-When `motif_open_workbench` is available, prefer it for interactive review of
+For a dependable visual result, call `motif_create_workbench_artifact` with
 one bounded Motif payload or exact FASTA, GenBank, raw-sequence, or Motif JSON
 content. Pass either `payload` or `content`, never both. Include `filename`
 when it carries a useful format/provenance hint and include an explicit
-`molecule` for ambiguous raw sequence text.
+`molecule` for ambiguous raw sequence text. The tool returns status text and a
+separate HTML resource: preserve `content[].resource.text` exactly, save it as
+the suggested filename, and open it in Claude Science's right pane. Do not
+prepend the status text or strip text from the HTML resource.
+
+Use `motif_open_workbench` first only when the current host is already known to
+mount the live MCP App. Otherwise, use it after the portable artifact as an
+optional live-App check.
 
 Verify the returned `motif.mcp.workbench.v1` schema, mode, source name, record
 count, and residue count against the intended input. A successful tool call
@@ -25,12 +32,15 @@ only when Motif is actually listed. The host message
 `Sequence viewer unavailable—showing as text` is a generic fallback, not a
 Motif parse error.
 
-If the host does not mount MCP Apps, call
-`motif_create_workbench_artifact` with the same bounded input. It returns a
-self-contained HTML resource plus filename, byte count, and SHA-256 metadata;
-it does not write a file. Preserve the exact returned HTML, save it, and click
-or open it in Claude Science's right pane. Verify the visible workbench. It is
-interactive, but it is an immutable snapshot rather than a live MCP App.
+The artifact result includes filename, byte count, SHA-256 metadata, and the
+runtime build ID; it does not write a file. Verify the visible workbench after
+opening it. The file is interactive, but it is an immutable snapshot rather
+than a live MCP App.
+
+A request to open, show, reload, or retry an existing construct is a display
+request. Reuse the exact latest sequence, annotations, colors, and provenance.
+Do not add or remove biological content unless the user explicitly requests
+that change.
 
 These connector tools are ephemeral viewer/export operations. They do not
 write a sequence database, run external executables, or make AB1 binary data a
@@ -164,7 +174,8 @@ coordinates.
           "type": "cds",
           "start": 0,
           "end": 12,
-          "direction": "forward"
+          "direction": "forward",
+          "color": "#2EAD67"
         }
       ]
     }
@@ -215,6 +226,25 @@ also set `metadata.motifSubRangeOrder` to `biological`. Motif preserves an
 unmarked reverse multipart checkpoint, but keeps sequence-derived actions
 unavailable because older text-order and current biological-order arrays cannot
 be distinguished safely without that marker.
+
+Use `feature.color` for an explicit display color. When color is part of the
+request, prefer a Motif payload over interchange text so the requested colors
+reach the workbench directly. Use `misc_feature` for a named sequence motif or
+chromophore codons and `restriction_site` for a cloning or restriction site.
+Do not rely on editor-specific GenBank color qualifiers as the only color
+source.
+
+## Preserve scope and provenance
+
+- Keep display retries separate from sequence-design changes.
+- Preserve the exact accession and coordinate transformation used for sourced
+  sequence segments.
+- Describe estimated feature bounds as estimated. Do not call an annotation
+  set complete when any reported bounds remain approximate.
+- Do not describe a sequence as canonical, or generalize expression behavior
+  across hosts, unless the cited source and checks support that claim.
+- Verify final record length, topology, feature coordinates, and requested ORFs
+  before generating the workbench.
 
 Alignment payloads accept either one top-level `alignment` object or an
 `alignments` array. Each alignment accepts `rows` (alias: `sequences`) with

--- a/src/artifacts/motif-for-claude-science-skill/SKILL.md
+++ b/src/artifacts/motif-for-claude-science-skill/SKILL.md
@@ -65,7 +65,8 @@ Minimal payload:
           "type": "cds",
           "start": 0,
           "end": 12,
-          "direction": "forward"
+          "direction": "forward",
+          "color": "#2EAD67"
         }
       ]
     }
@@ -90,6 +91,20 @@ also set `metadata.motifSubRangeOrder` to `biological`. Motif preserves an
 unmarked reverse multipart checkpoint, but keeps sequence-derived actions
 unavailable because older text-order and current biological-order arrays cannot
 be distinguished safely without that marker.
+
+Use `feature.color` for an explicit display color. When color is part of the
+request, prefer a Motif payload over interchange text so the requested colors
+reach the workbench directly. Use `misc_feature` for a named sequence motif or
+chromophore codons and `restriction_site` for a cloning or restriction site.
+Do not rely on editor-specific GenBank color qualifiers as the only color
+source.
+
+Opening, showing, or retrying an existing construct does not authorize a
+sequence or annotation change. Reuse the exact latest payload unless the user
+explicitly requests a biological edit. Preserve source accessions and
+coordinate transformations, label estimated feature bounds as estimated, and
+verify the final record length, topology, feature coordinates, and requested
+ORFs before generating the workbench.
 
 ## Add a precomputed alignment
 

--- a/src/bio/__tests__/genbank-feature-colors.test.ts
+++ b/src/bio/__tests__/genbank-feature-colors.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseFeatures } from '../genbank-parser';
+
+describe('GenBank feature colors', () => {
+  it('uses safe strand-specific editor color qualifiers', () => {
+    const features = parseFeatures([
+      '     CDS             1..12',
+      '                     /label="forward color"',
+      '                     /ApEinfo_fwdcolor="#2EAD67"',
+      '                     /ApEinfo_revcolor="#C53D4D"',
+      '     CDS             complement(13..24)',
+      '                     /label="reverse color"',
+      '                     /apeinfo_fwdcolor="#2EAD67"',
+      '                     /apeinfo_revcolor="#C53D4D"',
+    ].join('\n'));
+
+    expect(features).toHaveLength(2);
+    expect(features[0]).toMatchObject({ name: 'forward color', strand: 1, color: '#2EAD67' });
+    expect(features[1]).toMatchObject({ name: 'reverse color', strand: -1, color: '#C53D4D' });
+    expect(features[0].metadata.ApEinfo_fwdcolor).toBe('#2EAD67');
+    expect(features[1].metadata.apeinfo_revcolor).toBe('#C53D4D');
+  });
+
+  it('falls back to the feature-type palette for unsafe color qualifiers', () => {
+    const [feature] = parseFeatures([
+      '     CDS             1..12',
+      '                     /label="unsafe color"',
+      '                     /ApEinfo_fwdcolor="url(javascript:alert(1))"',
+    ].join('\n'));
+
+    expect(feature.color).toBe('#7E9BBF');
+    expect(feature.metadata.ApEinfo_fwdcolor).toBe('url(javascript:alert(1))');
+  });
+});

--- a/src/bio/genbank-parser.ts
+++ b/src/bio/genbank-parser.ts
@@ -134,9 +134,9 @@ const FEATURE_TYPE_MAP: Record<string, FeatureType> = {
   restriction_site: 'restriction_site',
 };
 
-// De-color sweep: persisted feature.color uses the muted DARK palette keyed by
-// type. The renderer remaps these to the light --feature-* tokens on a light
-// theme, so this is the single canonical hex an imported feature carries.
+// Imported features use the muted palette by type unless the record supplies a
+// safe explicit feature color. The renderer adapts the palette defaults across
+// themes while preserving an explicit annotation color.
 const FEATURE_COLORS: Record<FeatureType, string> = {
   gene: '#7E9BBF',
   cds: '#7E9BBF',
@@ -164,6 +164,26 @@ const FEATURE_COLORS: Record<FeatureType, string> = {
   enhancer: '#C6A86B',
   custom: '#8B8F99',
 };
+
+const SAFE_IMPORTED_FEATURE_COLOR = /^(?:#[0-9a-f]{3,8}|(?:rgb|hsl)a?\([\d\s.,%+\-/]+\)|[a-z]+)$/i;
+
+function importedFeatureColor(
+  qualifiers: Readonly<Record<string, string | true>>,
+  strand: FeatureStrand,
+  fallback: string,
+): string {
+  const values = new Map(Object.entries(qualifiers).map(([key, value]) => [key.toLowerCase(), value]));
+  const preferredKeys = strand === -1
+    ? ['apeinfo_revcolor', 'apeinfo_fwdcolor']
+    : ['apeinfo_fwdcolor', 'apeinfo_revcolor'];
+  for (const key of preferredKeys) {
+    const value = values.get(key);
+    if (typeof value !== 'string') continue;
+    const color = value.trim();
+    if (color.length <= 80 && SAFE_IMPORTED_FEATURE_COLOR.test(color)) return color;
+  }
+  return fallback;
+}
 
 /**
  * Parse a location string like "100..200", "complement(100..200)",
@@ -467,7 +487,7 @@ export function parseFeatures(featuresText: string): Feature[] {
       end,
       strand,
       subRanges,
-      color: FEATURE_COLORS[mappedType],
+      color: importedFeatureColor(qualifiers, strand, FEATURE_COLORS[mappedType]),
       metadata: {
         ...qualifiers,
         ...(locationOperator ? { motifLocationOperator: locationOperator } : {}),

--- a/src/components/plasmid-map/__tests__/background-affordance.test.tsx
+++ b/src/components/plasmid-map/__tests__/background-affordance.test.tsx
@@ -1,19 +1,11 @@
 // @vitest-environment jsdom
 
 /**
- * The map background used to promise a drag it could not perform. Once the viewport
- * was transformed the rect flipped `data-pannable="true"` and the stylesheet answered
- * with `cursor: grab` / `grabbing`, but no host ever passed onPanStart/onPanMove/
- * onPanEnd, so the press was dropped on the first line of the handler and the map moved
- * by zero pixels. Grabbing something that does not move is a worse first impression
- * than a background that never invited the gesture.
- *
- * The affordance was deleted rather than wired: the background drag is already claimed
- * by the host's range selection, and plain wheel already translates the viewport while
- * ctrl/pinch scales it — so there is no free gesture, and inventing one (space-drag,
- * middle-drag) would hide the answer behind something undiscoverable.
- *
- * These tests hold the map to claiming only what it does.
+ * SequenceMapView supplies the drawing surface and wheel behavior. The Motif workbench
+ * host assigns blank-canvas pointer drags by geometry: near the circular backbone or
+ * linear axis they select a range; elsewhere they pan the viewport. Cursor rules must
+ * follow that explicit host state so the background advertises the gesture a press will
+ * perform at the current point.
  */
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
@@ -25,23 +17,12 @@ import { SequenceMapView } from '../SequenceMapView';
 import { computeMapLayout } from '../../../plasmid-map/layout';
 
 const here = dirname(fileURLToPath(import.meta.url));
-/**
- * Match against CODE, not prose: the comments in both files name the deleted
- * affordance on purpose, so that the next reader learns why it is gone rather than
- * re-adding it. (Crude but sufficient here — neither file contains a `//` inside a
- * string literal.)
- */
+/** Match code rather than explanatory comments. */
 const stripComments = (src: string) => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
 const viewSource = readFileSync(resolve(here, '..', 'SequenceMapView.tsx'), 'utf8');
 const viewCode = stripComments(viewSource);
 
-/**
- * BOTH stylesheets, because the affordance was declared in both: the component's own
- * `cursor: grab`, and a host override in motif-artifact.css that quietly restored
- * `crosshair` on top of it. Pinning the guard to only the copy that was fixed is the
- * exact failure this branch has hit before — one value declared twice, one copy
- * corrected, the test watching the corrected one.
- */
+/** Both stylesheets can style the shared background class. */
 const stylesheets = [
   ['plasmid-map.css', resolve(here, '..', 'plasmid-map.css')],
   ['motif-artifact.css', resolve(here, '..', '..', '..', 'artifacts', 'motif-artifact.css')],
@@ -51,13 +32,7 @@ const stylesheets = [
 });
 const mapCss = stylesheets[0].text;
 
-/**
- * Rule blocks whose SELECTOR targets the map background. `grab` has to be judged per
- * selector, not per file: motif-artifact.css uses grab/grabbing legitimately for window
- * drag handles and row grips, and claude-science-msa.css for the reorder grip. Those are
- * real affordances with real handlers. A blanket "no grab anywhere" rule would reject
- * those valid controls instead of guarding the map background.
- */
+/** Rule blocks whose selector targets the map background. */
 const backgroundRules = (css: string) =>
   css.split('}').map((chunk) => {
     const brace = chunk.lastIndexOf('{');
@@ -108,32 +83,40 @@ describe('the map background claims only the gestures it can perform', () => {
     expect(renderMap({ k: 1.953125, tx: -343.6, ty: -82.2 }).getAttribute('data-pannable')).toBeNull();
   });
 
-  it('never advertises a grab cursor, in either stylesheet that styles it', () => {
-    const offenders = stylesheets.flatMap(({ name, code }) =>
+  it('scopes grab cursors to the host pan state', () => {
+    const grabRules = stylesheets.flatMap(({ name, code }) =>
       backgroundRules(code)
-        .filter((rule) => /grab/.test(rule.body))
-        .map((rule) => `${name}: ${rule.selector}`),
+        .filter((rule) => /cursor\s*:\s*grabb?(?:ing)?/.test(rule.body))
+        .map((rule) => ({ name, ...rule })),
     );
 
-    expect(offenders).toEqual([]);
-    // Both files must actually contribute a rule, or "no offenders" is vacuous — a
-    // renamed class or a changed path would silently reduce this to scanning nothing.
+    expect(grabRules.length).toBe(2);
+    for (const rule of grabRules) {
+      expect(rule.selector, `${rule.name} has an unscoped map grab cursor`).toContain(
+        '[data-map-pointer-action="pan"]',
+      );
+    }
+    expect(grabRules.some((rule) => /cursor\s*:\s*grab\s*;/.test(rule.body))).toBe(true);
+    expect(grabRules.some((rule) => /cursor\s*:\s*grabbing\s*;/.test(rule.body))).toBe(true);
+
+    // Both files must still contribute a background rule, or this scan would miss a
+    // renamed class or moved stylesheet.
     for (const { name, code } of stylesheets) {
       expect(backgroundRules(code).length, `${name} contributed no .motif-pm-bg rule`).toBeGreaterThan(0);
     }
   });
 
-  it('would catch the grab rule coming back in either file', () => {
-    // Proof the detector fires without editing another stylesheet. The fixture
-    // is the rule this component used to ship, and the second
-    // block is a real grab affordance from the same stylesheet that must NOT trip it.
+  it('detects an unscoped grab rule while accepting the host pan state', () => {
     const reintroduced = `
-      .motif-pm-bg[data-pannable='true'] { cursor: grab; touch-action: none; }
-      .motif-cs-window-titlebar { cursor: grab; }
+      .motif-pm-bg { cursor: grab; touch-action: none; }
+      .motif-cs-map-frame[data-map-pointer-action="pan"] .motif-pm-bg { cursor: grab; }
     `;
-    const caught = backgroundRules(reintroduced).filter((rule) => /grab/.test(rule.body));
+    const caught = backgroundRules(reintroduced).filter((rule) => (
+      /cursor\s*:\s*grab/.test(rule.body)
+      && !rule.selector.includes('[data-map-pointer-action="pan"]')
+    ));
 
-    expect(caught.map((rule) => rule.selector)).toEqual([".motif-pm-bg[data-pannable='true']"]);
+    expect(caught.map((rule) => rule.selector)).toEqual(['.motif-pm-bg']);
   });
 
   it('leaves the pan attributes declared in neither stylesheet', () => {
@@ -154,9 +137,7 @@ describe('the map background claims only the gestures it can perform', () => {
     expect(bgJsx).not.toMatch(/onPointer|data-pannable/);
   });
 
-  it('carries no pan plumbing left over to be re-enabled by accident', () => {
-    // Dead props are an invitation to re-wire the wrong gesture; the viewport API is
-    // deliberately wheel-only now.
+  it('keeps host pointer handling out of the drawing component', () => {
     expect(viewCode).not.toMatch(/onPanStart|onPanMove|onPanEnd|isPanning|panPointerRef/);
     expect(viewCode).toContain('onWheelZoom?:');
   });

--- a/src/components/plasmid-map/plasmid-map.css
+++ b/src/components/plasmid-map/plasmid-map.css
@@ -231,7 +231,7 @@
 .motif-pm-overview-selection {
   fill: var(--accent, #0169cc);
   fill-opacity: 0.22;
-  stroke: var(--accent, #0169cc);
+  stroke: var(--accent);
   stroke-width: 0.6;
   vector-effect: non-scaling-stroke;
 }
@@ -611,8 +611,8 @@
   vector-effect: non-scaling-stroke;
   transition: fill 90ms ease-out, stroke 90ms ease-out, stroke-width 90ms ease-out;
 }
-/* Add a light interaction hairline without returning to the heavy selected
-   outlines that made features visually noisy at map scale. */
+/* Hover stays quiet; selection uses one continuous accent stroke on the same
+   path as the feature body, including directional arrowheads. */
 .motif-pm-feature:hover .motif-pm-feature-body {
   fill: color-mix(in srgb, var(--pm-base, #8a8a8a) 42%, var(--bg-primary, #ffffff));
   stroke: color-mix(in srgb, var(--pm-base, #8a8a8a) 52%, var(--accent, #0169cc));
@@ -620,8 +620,9 @@
 }
 .motif-pm-feature[data-selected='true'] .motif-pm-feature-body {
   fill: color-mix(in srgb, var(--pm-base, #8a8a8a) 52%, var(--bg-primary, #ffffff));
-  stroke: color-mix(in srgb, var(--pm-base, #8a8a8a) 42%, var(--border, #cbd5e1));
-  stroke-width: 0.45;
+  stroke: var(--accent, #0169cc);
+  stroke-width: 1.5;
+  stroke-linejoin: round;
 }
 .motif-pm-feature:focus {
   outline: none;

--- a/src/mcp-app/__tests__/motif-connector.test.ts
+++ b/src/mcp-app/__tests__/motif-connector.test.ts
@@ -15,7 +15,8 @@ import {
 } from '../../../mcp/motif/server.js';
 import { isMotifWorkbenchResult } from '../motif-workbench-bridge.js';
 
-const artifactTemplate = '<!doctype html><html><head><title>Motif for Claude Science</title></head><body><script type="application/json" id="motif-artifact-data">__SEQUENCE_INVENTORY__</script></body></html>';
+const runtimeBuildId = 'a'.repeat(64);
+const artifactTemplate = `<!doctype html><html><head><meta name="motif-build-id" content="${runtimeBuildId}"><title>Motif for Claude Science</title></head><body><script type="application/json" id="motif-artifact-data">__SEQUENCE_INVENTORY__</script></body></html>`;
 
 const openedClients: Client[] = [];
 const openedServers: ReturnType<typeof createMotifClaudeScienceServer>[] = [];
@@ -325,10 +326,14 @@ describe('Motif embedded artifact export', () => {
     const artifact = renderMotifArtifact({
       template: artifactTemplate,
       workbench,
+      runtimeBuildId,
       filename: '../Demo report.html',
     });
     expect(artifact.summary).toMatchObject({
       schema: 'motif.mcp.artifact-export.v1',
+      delivery: 'embedded-html-resource',
+      visibleMountConfirmed: false,
+      runtimeBuildId,
       filename: 'Demo-report.html',
       recordCount: 1,
       residueCount: 6,
@@ -344,6 +349,7 @@ describe('Motif for Claude Science MCP server', () => {
     const traceEvents: MotifMcpTraceEvent[] = [];
     const server = createMotifClaudeScienceServer({
       version: '0.2.1-test',
+      runtimeBuildId,
       readWorkbenchHtml: async () => '<!doctype html><title>Motif for Claude Science</title><div class="motif-cs-brand">Motif</div>',
       readArtifactTemplate: async () => artifactTemplate,
       trace: event => traceEvents.push(event),
@@ -387,6 +393,10 @@ describe('Motif for Claude Science MCP server', () => {
     expect(openResult.isError).not.toBe(true);
     expect(openResult.structuredContent).toMatchObject({
       schema: 'motif.mcp.workbench.v1',
+      delivery: 'live-app-request',
+      visibleMountConfirmed: false,
+      fallbackTool: 'motif_create_workbench_artifact',
+      runtimeBuildId,
       mode: 'artifact',
       sourceName: sensitiveFilename,
       recordCount: 1,
@@ -427,6 +437,9 @@ describe('Motif for Claude Science MCP server', () => {
     expect(artifactResult.isError, JSON.stringify(artifactResult)).not.toBe(true);
     expect(artifactResult.structuredContent).toMatchObject({
       schema: 'motif.mcp.artifact-export.v1',
+      delivery: 'embedded-html-resource',
+      visibleMountConfirmed: false,
+      runtimeBuildId,
       filename: 'motif-review.html',
       recordCount: 1,
       residueCount: sensitiveSequence.length,
@@ -457,6 +470,7 @@ describe('Motif for Claude Science MCP server', () => {
   it('bounds record summaries without presenting shortened identifiers as exact', async () => {
     const server = createMotifClaudeScienceServer({
       version: '0.2.1-test',
+      runtimeBuildId,
       readWorkbenchHtml: async () => '<title>Motif for Claude Science</title>',
       readArtifactTemplate: async () => artifactTemplate,
     });
@@ -500,6 +514,7 @@ describe('Motif for Claude Science MCP server', () => {
   it('returns bounded public errors without mounting malformed content', async () => {
     const server = createMotifClaudeScienceServer({
       version: '0.2.1-test',
+      runtimeBuildId,
       readWorkbenchHtml: async () => '<title>Motif for Claude Science</title>',
       readArtifactTemplate: async () => artifactTemplate,
     });


### PR DESCRIPTION
## Summary

- Makes the self-contained HTML workbench the default connector result when visible live-App mounting is not already known to work.
- Reports delivery state and a deterministic runtime build ID in connector results and the Motif Settings panel.
- Preserves safe strand-specific GenBank annotation colors and documents explicit payload colors.
- Adds blank-canvas panning for circular and linear maps while keeping range selection near the rendered sequence.
- Moves the Sequence pane to map feature and range selections in wide, stacked, and narrow layouts.
- Draws one complete accent outline around selected directional features, including the arrowhead.

## Validation

- npm run gate
  - 1,172 unit tests in 102 files
  - 25 plugin packaging checks
  - 23 connector tests in 3 files
  - CSS token and ARIA control checks
  - production build
  - artifact E2E: 140 passed, 61 skipped
  - MSA E2E: 59 passed
- npm run validate:plugin -- strict validation passed
- Unregistered connector protocol doctor passed
- Real-browser checks covered circular and linear maps, feature and range selection, mouse panning, wheel pan/zoom, keyboard controls, pane resizing, and Light, Dark, Claude Light, and Claude Dark at wide, stacked, and narrow sizes.
- Gitleaks and added-line scans found no secrets, local paths, or internal process text.

## Skips

The artifact E2E command skips the 59 MSA interaction tests because they run under the dedicated MSA configuration; all 59 passed there. Two non-vendored real-data Sanger audits require external AB1 and alignment fixtures and were not run.