### PR TITLE
Refine map selection and navigation

### DIFF
--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -345,6 +345,7 @@ test.describe('Claude Science artifact campaign', () => {
       });
       await page.mouse.click(clickPoint.x, clickPoint.y);
       await expect(feature).toHaveAttribute('data-selected', 'true');
+      await expect(page.locator('.motif-pm-selection')).toHaveCount(0);
       const style = await body.evaluate((path) => {
         const computed = getComputedStyle(path);
         const swatch = document.createElement('span');
@@ -364,6 +365,103 @@ test.describe('Claude Science artifact campaign', () => {
       expect(style.stroke).toBe(style.accent);
       expect(style.strokeWidth).toBeGreaterThanOrEqual(1.5);
       expect(style.strokeLinejoin).toBe('round');
+    }
+  });
+
+  test('high-zoom arrowheads select nested features and keep Sequence synchronized', async ({ page }) => {
+    await openArtifact(page, 1600, 900);
+    const features = [
+      { id: 'outer-forward', name: 'Outer forward', type: 'cds', start: 4_800, end: 6_000, strand: 1 },
+      { id: 'inner-forward', name: 'Inner forward', type: 'cds', start: 5_200, end: 6_000, strand: 1 },
+      { id: 'reverse-feature', name: 'Reverse feature', type: 'cds', start: 6_000, end: 7_200, strand: -1 },
+    ];
+    const featureTip = async (featureId: string, strand: number) => page
+      .locator(`.motif-pm-feature[data-feature-id="${featureId}"] .motif-pm-feature-body`)
+      .evaluate((path, direction) => {
+        const body = path as SVGPathElement;
+        const linePoints = [...(body.getAttribute('d') ?? '').matchAll(/L (-?\d+(?:\.\d+)?) (-?\d+(?:\.\d+)?)/g)]
+          .map((match) => ({ x: Number(match[1]), y: Number(match[2]) }));
+        const tip = direction === 1 ? linePoints[0] : linePoints.at(-1);
+        if (!tip) throw new Error('Directional feature path has no arrow tip');
+        const box = body.getBBox();
+        const center = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+        const dx = center.x - tip.x;
+        const dy = center.y - tip.y;
+        const distance = Math.max(1, Math.hypot(dx, dy));
+        const inside = { x: tip.x + dx / distance, y: tip.y + dy / distance };
+        const point = body.ownerSVGElement!.createSVGPoint();
+        point.x = inside.x;
+        point.y = inside.y;
+        const screen = point.matrixTransform(body.getScreenCTM()!);
+        return {
+          x: screen.x,
+          y: screen.y,
+          localX: inside.x,
+          localY: inside.y,
+          hitFeatureId: document.elementFromPoint(screen.x, screen.y)
+            ?.closest<SVGGElement>('.motif-pm-feature')?.dataset.featureId ?? null,
+        };
+      }, strand);
+    const sequenceFocus = () => page.locator('.motif-cs-sequence').evaluate((container) => {
+      const focus = container.querySelector<HTMLElement>('[data-seq-focus="true"]');
+      const bases = focus?.querySelector<HTMLElement>('[data-line-start]');
+      return {
+        highlightCount: focus?.querySelectorAll(
+          '.motif-cs-seq-hl:not(.motif-cs-seq-hl-motif):not(.motif-cs-seq-hl-restriction)',
+        ).length ?? 0,
+        lineStart: Number(bases?.dataset.lineStart),
+        lineLength: Number(bases?.dataset.lineLen),
+      };
+    });
+
+    for (const topology of ['circular', 'linear'] as const) {
+      await page.evaluate(({ recordTopology, recordFeatures }) => window.motifRenderInventory?.([{
+        id: `high-zoom-arrows-${recordTopology}`,
+        name: `High zoom arrows ${recordTopology}`,
+        molecule: 'dna',
+        topology: recordTopology,
+        sequence: 'A'.repeat(12_000),
+        annotations: recordFeatures,
+      }]), { recordTopology: topology, recordFeatures: features });
+
+      for (const featureInput of features) {
+        const feature = page.locator(`.motif-pm-feature[data-feature-id="${featureInput.id}"]`);
+        const initialTip = await featureTip(featureInput.id, featureInput.strand);
+        const svg = page.locator('.motif-cs-map-frame svg.motif-plasmid-map');
+        for (let step = 0; step < 5; step += 1) {
+          await svg.dispatchEvent('wheel', {
+            deltaY: -700,
+            clientX: initialTip.x,
+            clientY: initialTip.y,
+            ctrlKey: true,
+          });
+        }
+        await expect(page.locator('.motif-cs-map-hint')).toContainText('800%');
+
+        const tip = await featureTip(featureInput.id, featureInput.strand);
+        expect(tip.hitFeatureId, JSON.stringify(tip)).toBe(featureInput.id);
+        await page.mouse.click(tip.x, tip.y);
+        await expect(feature).toHaveAttribute('data-selected', 'true');
+        await expect(page.locator('.motif-pm-feature[data-selected="true"]')).toHaveCount(1);
+        await expect(page.locator('.motif-pm-selection')).toHaveCount(0);
+        await expect.poll(async () => {
+          const focus = await sequenceFocus();
+          return focus.highlightCount > 0
+            && focus.lineStart <= featureInput.start
+            && focus.lineStart + focus.lineLength > featureInput.start;
+        }).toBe(true);
+
+        if (topology === 'circular' && featureInput.id === 'outer-forward') {
+          await page.screenshot({ path: path.join(outputDir, 'map-arrow-selection-high-zoom-light.png'), fullPage: true });
+          await page.getByLabel('Theme').selectOption({ label: 'Claude Dark' });
+          await page.screenshot({ path: path.join(outputDir, 'map-arrow-selection-high-zoom-claude-dark.png'), fullPage: true });
+          await page.getByLabel('Theme').selectOption({ label: 'Light' });
+        }
+
+        await page.getByRole('button', { name: 'Reset map view' }).click();
+        await expect(page.locator('.motif-cs-map-frame .motif-pm-viewport')).not.toHaveAttribute('transform');
+        await expect(feature).toHaveAttribute('data-selected', 'true');
+      }
     }
   });
 
@@ -675,8 +773,12 @@ test.describe('Claude Science artifact campaign', () => {
 
     // The labelling control reads the same on the dense record as on the sparse
     // one — the density of a record is not a reason to flip a user-facing toggle.
-    const labelToggle = mapVisibility.getByRole('button', { name: /^Labels (On|Off)$/ });
-    await expect(labelToggle).toHaveText('Labels On');
+    const labelToggle = mapVisibility.getByRole('button', { name: 'Hide restriction-site labels' });
+    const toolbarToggle = page.locator('.motif-cs-map-toolbar .motif-cs-map-labels-toggle');
+    await expect(labelToggle).toHaveText('Site labels');
+    await expect(toolbarToggle).toHaveText('Sites');
+    await expect(toolbarToggle).toHaveAttribute('aria-label', 'Hide restriction-site labels');
+    await expect(toolbarToggle).toHaveAttribute('aria-pressed', 'true');
 
     // Shrink to a laptop-sized window. This is the case that used to fail hardest:
     // the old threshold halved once the map's smaller dimension fell under 580px,
@@ -692,7 +794,7 @@ test.describe('Claude Science artifact campaign', () => {
 
     const denseSmall = await readMap();
     expect(denseSmall.names).toBeGreaterThanOrEqual(15);
-    await expect(labelToggle).toHaveText('Labels On');
+    await expect(labelToggle).toHaveText('Site labels');
 
     await page.getByRole('tab', { name: 'pUC19' }).click();
     await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('pUC19');
@@ -702,7 +804,15 @@ test.describe('Claude Science artifact campaign', () => {
 
     await page.setViewportSize({ width: 1600, height: 1000 });
     await page.getByRole('tab', { name: 'pUC19' }).click();
-    await expect(labelToggle).toHaveText('Labels On');
+    await expect(labelToggle).toHaveText('Site labels');
+
+    await toolbarToggle.click();
+    await expect(page.locator('.motif-pm-restriction-label')).toHaveCount(0);
+    await expect(toolbarToggle).toHaveText('Sites');
+    await expect(toolbarToggle).toHaveAttribute('aria-label', 'Show restriction-site labels');
+    await expect(toolbarToggle).toHaveAttribute('aria-pressed', 'false');
+    await mapVisibility.getByRole('button', { name: 'Show restriction-site labels' }).click();
+    await expect(page.locator('.motif-pm-restriction-label').first()).toBeVisible();
   });
 
   test('digest recipes reject unknown enzymes and survive map-source changes', async ({ page }) => {
@@ -3473,6 +3583,99 @@ test.describe('Claude Science artifact campaign', () => {
       const focus = await sequenceFocus();
       return focus.visible && focus.lineStart >= 800 && focus.lineStart <= 1_200;
     }).toBe(true);
+  });
+
+  test('high zoom keeps range bands compact and Fit preserves the selection', async ({ page }) => {
+    await openArtifact(page, 1180, 900);
+    const mapFrame = page.locator('.motif-cs-map-frame');
+    const viewport = mapFrame.locator('.motif-pm-viewport');
+    const svg = mapFrame.locator('svg.motif-plasmid-map');
+
+    await page.evaluate(() => window.motifRenderInventory?.([{
+      id: 'high-zoom-range-circular',
+      name: 'High zoom range circular',
+      molecule: 'dna',
+      topology: 'circular',
+      sequence: 'A'.repeat(4_000),
+      annotations: [],
+    }]));
+    let backbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
+    let ringTop = { x: backbone.x + backbone.width / 2, y: backbone.y };
+    await page.mouse.move(ringTop.x, ringTop.y);
+    await page.mouse.down();
+    await page.mouse.move(backbone.x + backbone.width, backbone.y + backbone.height / 2, { steps: 8 });
+    await page.mouse.up();
+    const circularSelectionPaths = await mapFrame.locator('.motif-pm-selection').count();
+    expect(circularSelectionPaths).toBeGreaterThan(0);
+
+    for (let step = 0; step < 5; step += 1) {
+      await svg.dispatchEvent('wheel', {
+        deltaY: -700,
+        clientX: ringTop.x,
+        clientY: ringTop.y,
+        ctrlKey: true,
+      });
+    }
+    await expect(mapFrame.locator('.motif-cs-map-hint')).toContainText('800%');
+    backbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
+    ringTop = { x: backbone.x + backbone.width / 2, y: backbone.y };
+    await page.mouse.move(ringTop.x, ringTop.y + 10);
+    await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'range');
+    await page.mouse.move(ringTop.x, ringTop.y + 50);
+    await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
+    const beforeCircularPan = await viewport.getAttribute('transform');
+    await page.mouse.down();
+    await page.mouse.move(ringTop.x + 36, ringTop.y + 68, { steps: 6 });
+    await page.mouse.up();
+    expect(await viewport.getAttribute('transform')).not.toBe(beforeCircularPan);
+
+    await page.getByRole('button', { name: 'Reset map view' }).click();
+    await expect(viewport).not.toHaveAttribute('transform');
+    await expect(mapFrame.locator('.motif-pm-selection')).toHaveCount(circularSelectionPaths);
+    await expect(mapFrame.locator('.motif-cs-map-hint')).toContainText('range');
+    await expect(mapFrame.locator('.motif-cs-map-hint')).not.toContainText('%');
+
+    await page.evaluate(() => window.motifRenderInventory?.([{
+      id: 'high-zoom-range-linear',
+      name: 'High zoom range linear',
+      molecule: 'dna',
+      topology: 'linear',
+      sequence: 'A'.repeat(4_000),
+      annotations: [],
+    }]));
+    const linearBackbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
+    const axis = { x: linearBackbone.x + linearBackbone.width / 2, y: linearBackbone.y + linearBackbone.height / 2 };
+    await page.mouse.move(axis.x - 80, axis.y);
+    await page.mouse.down();
+    await page.mouse.move(axis.x + 80, axis.y, { steps: 8 });
+    await page.mouse.up();
+    const linearSelectionPaths = await mapFrame.locator('.motif-pm-selection').count();
+    expect(linearSelectionPaths).toBeGreaterThan(0);
+
+    for (let step = 0; step < 5; step += 1) {
+      await svg.dispatchEvent('wheel', {
+        deltaY: -700,
+        clientX: axis.x,
+        clientY: axis.y,
+        ctrlKey: true,
+      });
+    }
+    await expect(mapFrame.locator('.motif-cs-map-hint')).toContainText('800%');
+    const zoomedLinearBackbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
+    const zoomedAxis = {
+      x: zoomedLinearBackbone.x + zoomedLinearBackbone.width / 2,
+      y: zoomedLinearBackbone.y + zoomedLinearBackbone.height / 2,
+    };
+    await page.mouse.move(zoomedAxis.x, zoomedAxis.y + 10);
+    await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'range');
+    await page.mouse.move(zoomedAxis.x, zoomedAxis.y + 50);
+    await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
+
+    await page.getByRole('button', { name: 'Reset map view' }).click();
+    await expect(viewport).not.toHaveAttribute('transform');
+    await expect(mapFrame.locator('.motif-pm-selection')).toHaveCount(linearSelectionPaths);
+    await expect(mapFrame.locator('.motif-cs-map-hint')).toContainText('range');
+    await expect(mapFrame.locator('.motif-cs-map-hint')).not.toContainText('%');
   });
 
   test('the map keeps saying what is selected while the view is zoomed', async ({ page }) => {

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -606,7 +606,9 @@ describe('Claude Science workspace layout guards', () => {
       'const handleMapPointerStart = useCallback',
       'const handleMapPointerMove = useCallback',
     );
-    expect(pointerStart).toContain('mapPointerActionAtPoint(contentPoint, layout)');
+    expect(pointerStart).toContain('mapPointerActionAtPoint(contentPoint, layout, mapViewport.k)');
+    expect(artifactSource).toContain('MAP_CIRCULAR_RANGE_HIT_MAX) / contentScale');
+    expect(artifactSource).toContain('MAP_LINEAR_RANGE_HIT_Y / contentScale');
     expect(pointerStart).toContain("mode: 'range'");
     expect(pointerStart).toContain("mode: 'pan'");
     expect(pointerStart).not.toContain('mapViewport.k >');

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -1729,12 +1729,12 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
   overflow: hidden;
 }
 
-/* DNA records add the Labels chip, so their toolbar runs 163px rather than 94px
-   and the readout has to start further in. Keyed off the chip being present so
+/* DNA records add the Sites chip, so the readout starts further in. Keyed off
+   the chip being present so
    the reserve follows what is actually rendered instead of restating the gate
    that renders it. */
 .motif-cs-map-frame:has(.motif-cs-map-labels-toggle) {
-  --map-toolbar-reserve: 200px;
+  --map-toolbar-reserve: 176px;
 }
 
 /* A linear map is short and wide — don't reserve a tall square frame for it,
@@ -1869,14 +1869,17 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
   font-weight: 700;
 }
 
-/* Puts restriction-label state on the map instead of only in a panel whose own
-   heading is below the fold at every laptop size. Sized for the wider of its
-   two captions so the zoom buttons beside it do not shift when it is pressed —
-   a control that moves when you use it reads as two controls. */
+.motif-cs-map-reset:not(:disabled) {
+  color: var(--text-primary);
+}
+
+/* Puts restriction-label state on the map instead of only in the visibility
+   panel. State comes from the filled/unfilled button and aria-pressed, so the
+   visible caption stays compact and does not move when toggled. */
 .motif-cs-map-labels-toggle {
   width: auto;
-  min-width: 62px;
-  padding-inline: 7px;
+  min-width: 40px;
+  padding-inline: 6px;
   color: var(--text-muted);
   font-size: 10px;
   font-weight: 700;

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -3102,18 +3102,24 @@ function pointToSequenceOffset(point: MapContentPoint, layout: MapLayout): numbe
   return clamp(Math.round((angle / 360) * layout.length), 0, Math.max(0, layout.length - 1));
 }
 
-function mapPointerActionAtPoint(point: MapContentPoint, layout: MapLayout): MapPointerAction {
+function mapPointerActionAtPoint(point: MapContentPoint, layout: MapLayout, zoom: number): MapPointerAction {
+  // The pointer is converted into map-content coordinates before it reaches
+  // this function. Divide the intended screen-space hit widths by the current
+  // zoom so the range band does not expand over the canvas as the map grows.
+  const contentScale = Math.max(MIN_ZOOM, Number.isFinite(zoom) ? zoom : MIN_ZOOM);
   if (layout.mode === 'circular') {
     const distance = Math.hypot(point.x - layout.center.x, point.y - layout.center.y);
-    const tolerance = clamp(layout.radius * 0.14, MAP_CIRCULAR_RANGE_HIT_MIN, MAP_CIRCULAR_RANGE_HIT_MAX);
+    const tolerance = clamp(layout.radius * 0.14, MAP_CIRCULAR_RANGE_HIT_MIN, MAP_CIRCULAR_RANGE_HIT_MAX) / contentScale;
     return Math.abs(distance - layout.radius) <= tolerance ? 'range' : 'pan';
   }
 
   const axis = layout.linearAxis;
   if (!axis) return 'pan';
-  const alongAxis = point.x >= axis.startX - MAP_LINEAR_RANGE_HIT_X
-    && point.x <= axis.endX + MAP_LINEAR_RANGE_HIT_X;
-  return alongAxis && Math.abs(point.y - axis.y) <= MAP_LINEAR_RANGE_HIT_Y ? 'range' : 'pan';
+  const hitX = MAP_LINEAR_RANGE_HIT_X / contentScale;
+  const hitY = MAP_LINEAR_RANGE_HIT_Y / contentScale;
+  const alongAxis = point.x >= axis.startX - hitX
+    && point.x <= axis.endX + hitX;
+  return alongAxis && Math.abs(point.y - axis.y) <= hitY ? 'range' : 'pan';
 }
 
 function signedCircularAngleDelta(fromAngle: number, toAngle: number): number {
@@ -6284,13 +6290,14 @@ function App() {
     : selectedFeature
       ? null
       : selectedMapRange;
+  // A selected feature already has an exact outline on the map. The broad
+  // coordinate sector is reserved for an explicit range selection, where no
+  // feature glyph exists to carry the state.
   const visibleMapRanges = useMemo(
-    () => selectedFeature
-      ? selectedFeatureSpans
-      : selectedMapRange
-        ? normalizeSpan(selectedMapRange.start, selectedMapRange.end, sequence.length, topology)
-        : [],
-    [selectedFeature, selectedFeatureSpans, selectedMapRange, sequence.length, topology],
+    () => selectedMapRange
+      ? normalizeSpan(selectedMapRange.start, selectedMapRange.end, sequence.length, topology)
+      : [],
+    [selectedMapRange, sequence.length, topology],
   );
   const selectionPaths = useMemo(
     () => artifactSelectionOverlayPaths(layout, visibleMapRanges),
@@ -6571,7 +6578,7 @@ function App() {
   }, [mapFrameRef, mapViewport.k, setCurrentMapViewport, zoomAtPoint]);
 
   const handleMapPointerStart = useCallback((rootPoint: MapRootPoint, contentPoint: MapContentPoint) => {
-    const action = mapPointerActionAtPoint(contentPoint, layout);
+    const action = mapPointerActionAtPoint(contentPoint, layout, mapViewport.k);
     setMapPointerAction(action);
     if (action === 'pan') {
       mapDragRef.current = { mode: 'pan', start: rootPoint, viewport: mapViewport, moved: false };
@@ -6698,7 +6705,7 @@ function App() {
     if (!rootPoint) return;
     const contentPoint = contentPointFromRoot(rootPoint, mapViewport);
     if (mapPointerIdRef.current === null) {
-      setMapPointerAction(mapPointerActionAtPoint(contentPoint, layout));
+      setMapPointerAction(mapPointerActionAtPoint(contentPoint, layout, mapViewport.k));
       return;
     }
     if (event.pointerId !== mapPointerIdRef.current) return;
@@ -10898,9 +10905,10 @@ function App() {
                       data-active={showRestrictionLabels || undefined}
                       aria-pressed={showRestrictionLabels}
                       onClick={toggleRestrictionLabels}
-                      title={`Restriction labels ${showRestrictionLabels ? 'on' : 'off'}`}
+                      aria-label={`${showRestrictionLabels ? 'Hide' : 'Show'} restriction-site labels`}
+                      title={`${showRestrictionLabels ? 'Hide' : 'Show'} restriction-site labels`}
                     >
-                      Labels {showRestrictionLabels ? 'On' : 'Off'}
+                      Sites
                     </button>
                   ) : null}
                 </div>
@@ -10988,9 +10996,10 @@ function App() {
                               data-active={showRestrictionLabels || undefined}
                               aria-pressed={showRestrictionLabels}
                               onClick={toggleRestrictionLabels}
-                              title={`Restriction labels ${showRestrictionLabels ? 'on' : 'off'}`}
+                              aria-label={`${showRestrictionLabels ? 'Hide' : 'Show'} restriction-site labels`}
+                              title={`${showRestrictionLabels ? 'Hide' : 'Show'} restriction-site labels`}
                             >
-                              Labels {showRestrictionLabels ? 'On' : 'Off'}
+                              Site labels
                             </button>
                             <span className="motif-cs-muted">{singleCutters.length} single-cutters</span>
                             {/* The map's "+N more sites" chip carries this same number, but only


### PR DESCRIPTION
## Summary

- keep the map's range-selection hit band a consistent screen size while zooming, leaving practical blank-canvas space for panning
- use the feature's complete arrow outline for feature selection and reserve the center sector for explicit coordinate ranges
- keep map feature selection synchronized with the Sequence pane across circular, linear, nested, forward, and reverse features
- replace the wide restriction-label state caption with a compact `Sites` toggle and explicit accessible action labels
- strengthen the enabled `Fit` control and preserve biological selection when fitting the map

## Validation

- `npm run gate`
  - unit: 1,172 passed / 102 files
  - connector: 23 passed / 3 files
  - artifact browser: 142 passed / 61 skipped
  - MSA browser: 59 passed
- `npm run validate:plugin`: strict validation passed
- gitleaks staged scan: no leaks found
- runtime build: `4fc0ab9808f67fc0aee848687393d02cda642a03dd022fceedebf16a31c5f92a`

The artifact-browser skips comprise the 59 MSA cases run by the dedicated MSA suite and two real-data Sanger cases that require external AB1/alignment fixtures.
