### PR TITLE
Improve map selection and tools workflow

### DIFF
--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -2664,6 +2664,16 @@ test.describe('Claude Science artifact workflows', () => {
     expect(await page.locator('.motif-pm-restriction').count()).toBeLessThanOrEqual(512);
     await expect(page.locator('.motif-cs-map-hint')).toContainText(/512 of .* sites selectable/);
 
+    const restrictionTool = page.locator('details[data-rail-tool="restriction-sites"]');
+    await restrictionTool.locator(':scope > summary').click();
+    const denseSiteRows = restrictionTool.locator('.motif-cs-restriction-site-row');
+    await expect(denseSiteRows).toHaveCount(160);
+    await expect(restrictionTool.locator('.motif-cs-restriction-site-row:disabled')).toHaveCount(0);
+    const exactSiteOutsideMapBudget = denseSiteRows.nth(1);
+    await exactSiteOutsideMapBudget.click();
+    await expect(exactSiteOutsideMapBudget).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('details[data-rail-tool="inspector"]')).toContainText(/bp · 1 hit/);
+
     const inventoryRow = page.locator('.motif-cs-sidebar .motif-cs-row-compact').first();
     await expect(inventoryRow).toBeVisible();
     expect((await inventoryRow.boundingBox())!.height).toBeLessThanOrEqual(48);

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -311,6 +311,20 @@ test.describe('Claude Science artifact campaign', () => {
         expect(scrollPositions[1]).toBeLessThan(scrollPositions[0]);
         expect(scrollPositions[2]).toBeLessThan(scrollPositions[1]);
         expect(new Set(scrollOwners)).toEqual(new Set([viewport.label === 'stacked' ? 'pane' : 'sequence']));
+
+        const repeatedFeature = page.locator('.motif-pm-feature[data-feature-id="late-feature"]');
+        await repeatedFeature.locator('.motif-pm-feature-hit').click();
+        await expect.poll(async () => (await focusState()).fullyVisible).toBe(true);
+        await sequence.evaluate((element) => {
+          element.scrollTop = 0;
+          const pane = element.closest<HTMLElement>('.motif-cs-sequence-column');
+          if (pane) pane.scrollTop = 0;
+        });
+        await repeatedFeature.locator('.motif-pm-feature-hit').click();
+        await expect.poll(async () => {
+          const state = await focusState();
+          return state.fullyVisible && state.lineStart <= 10_800 && state.lineStart + state.lineLength > 10_800;
+        }).toBe(true);
       }
     }
   });
@@ -2405,6 +2419,44 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(exportPanel.getByRole('button', { name: 'Sequence' })).toBeDisabled();
     const emptyDatabase = JSON.parse(await exportPanel.getByLabel('Selected export preview').inputValue());
     expect(emptyDatabase.records).toEqual([]);
+  });
+
+  test('large-record Sequence follows repeated map feature selections', async ({ page }) => {
+    await openArtifact(page, 1180, 900);
+    const sequence = 'A'.repeat(50_001);
+    await page.evaluate((largeSequence) => window.motifRenderInventory?.([{
+      id: 'large-map-sync',
+      name: 'Large map sync',
+      type: 'dna',
+      topology: 'linear',
+      sequence: largeSequence,
+      annotations: [{
+        id: 'late-large-feature',
+        name: 'Late large feature',
+        type: 'misc_feature',
+        start: 45_000,
+        end: 49_000,
+        strand: 1,
+      }],
+    }]), sequence);
+
+    const densityView = page.getByTestId('large-sequence-viewer');
+    const value = densityView.locator('textarea');
+    const feature = page.locator('.motif-pm-feature[data-feature-id="late-large-feature"]');
+    const expectFocusedRange = async () => {
+      await expect(densityView.getByTestId('large-sequence-selection')).toHaveText('Map selection: 45,001–49,000.');
+      await expect.poll(() => value.evaluate((control) => ({
+        selectionStart: control.selectionStart,
+        selectionEnd: control.selectionEnd,
+      }))).toEqual({ selectionStart: 45_000, selectionEnd: 49_000 });
+      expect(await value.evaluate((control) => control.scrollTop)).toBeGreaterThan(0);
+    };
+
+    await feature.locator('.motif-pm-feature-hit').click();
+    await expectFocusedRange();
+    await value.evaluate((control) => { control.scrollTop = 0; });
+    await feature.locator('.motif-pm-feature-hit').click();
+    await expectFocusedRange();
   });
 
   test('desktop themes have no automatic WCAG A/AA violations', async ({ page }) => {

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -208,7 +208,8 @@ test.describe('Claude Science artifact campaign', () => {
     }]));
 
     const offPageFeature = page.locator('.motif-pm-feature[data-feature-id="feature-125"]');
-    const selectedFeatureName = (await offPageFeature.getAttribute('aria-label'))!.split(',')[0];
+    const selectedFeatureName = 'Feature 126';
+    await expect(offPageFeature).toHaveAttribute('aria-label', 'Feature 126 · cds · 3751–3774 →');
     // Dense circular features overlap at this scale; dispatch to the target node
     // so this regression isolates list paging rather than SVG hit ordering.
     await offPageFeature.dispatchEvent('click');

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -329,6 +329,22 @@ test.describe('Claude Science artifact campaign', () => {
     }
   });
 
+  test('restriction labels use one Tab stop and arrow-key navigation', async ({ page }) => {
+    await openArtifact(page, 1180, 900);
+    const labels = page.locator('.motif-cs-restriction-label');
+    expect(await labels.count()).toBeGreaterThan(2);
+    await expect(page.locator('.motif-cs-restriction-label[tabindex="0"]')).toHaveCount(1);
+
+    const first = page.locator('.motif-cs-restriction-label[tabindex="0"]');
+    const firstKey = await first.getAttribute('data-restriction-key');
+    await first.focus();
+    await page.keyboard.press('ArrowRight');
+    const focusedKey = await page.locator('.motif-cs-restriction-label:focus').getAttribute('data-restriction-key');
+    expect(focusedKey).toBeTruthy();
+    expect(focusedKey).not.toBe(firstKey);
+    await expect(page.locator('.motif-cs-restriction-label[tabindex="0"]')).toHaveCount(1);
+  });
+
   test('selected directional features outline the complete arrow shape', async ({ page }) => {
     await openArtifact(page, 1180, 900);
     for (const topology of ['circular', 'linear'] as const) {
@@ -359,6 +375,7 @@ test.describe('Claude Science artifact campaign', () => {
       });
       await page.mouse.click(clickPoint.x, clickPoint.y);
       await expect(feature).toHaveAttribute('data-selected', 'true');
+      await expect(feature).toHaveAttribute('aria-label', /501–2800/);
       await expect(page.locator('.motif-pm-selection')).toHaveCount(0);
       const style = await body.evaluate((path) => {
         const computed = getComputedStyle(path);
@@ -820,11 +837,20 @@ test.describe('Claude Science artifact campaign', () => {
     await page.getByRole('tab', { name: 'pUC19' }).click();
     await expect(labelToggle).toHaveText('Site labels');
 
+    const activeToggleStyle = await toolbarToggle.evaluate((button) => {
+      const style = getComputedStyle(button);
+      return { backgroundColor: style.backgroundColor, color: style.color };
+    });
     await toolbarToggle.click();
     await expect(page.locator('.motif-pm-restriction-label')).toHaveCount(0);
     await expect(toolbarToggle).toHaveText('Sites');
     await expect(toolbarToggle).toHaveAttribute('aria-label', 'Show restriction-site labels');
     await expect(toolbarToggle).toHaveAttribute('aria-pressed', 'false');
+    const inactiveHoveredStyle = await toolbarToggle.evaluate((button) => {
+      const style = getComputedStyle(button);
+      return { backgroundColor: style.backgroundColor, color: style.color };
+    });
+    expect(inactiveHoveredStyle).not.toEqual(activeToggleStyle);
     await mapVisibility.getByRole('button', { name: 'Show restriction-site labels' }).click();
     await expect(page.locator('.motif-pm-restriction-label').first()).toBeVisible();
   });

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -5,10 +5,10 @@ import path from 'node:path';
 import { buildAbiFixture } from './fidelity-fixtures';
 
 const artifactUrl = process.env.MOTIF_ARTIFACT_URL;
-const outputDir = path.resolve('output/playwright/resume-20260711-campaign');
-const msaCampaignOutputDir = path.resolve('output/playwright/msa-campaign-2-fixed');
+const outputDir = path.resolve('output/playwright/artifact-workflows');
+const msaOutputDir = path.resolve('output/playwright/msa-workflows');
 
-test.describe('Claude Science artifact campaign', () => {
+test.describe('Claude Science artifact workflows', () => {
   test.skip(!artifactUrl, 'Set MOTIF_ARTIFACT_URL to run the standalone artifact audit.');
 
   const pageDiagnostics = new WeakMap<Page, string[]>();
@@ -30,7 +30,7 @@ test.describe('Claude Science artifact campaign', () => {
 
   test.beforeAll(async () => {
     await mkdir(outputDir, { recursive: true });
-    await mkdir(msaCampaignOutputDir, { recursive: true });
+    await mkdir(msaOutputDir, { recursive: true });
   });
 
   async function openArtifact(page: Page, width = 1440, height = 1000) {
@@ -717,8 +717,8 @@ test.describe('Claude Science artifact campaign', () => {
     await enzymeName.fill('Wave3I');
     await mapVisibility.getByRole('button', { name: 'Add', exact: true }).click();
     await expect(enzymeName).toHaveAttribute('aria-invalid', 'true');
-    await expect(enzymeRecognition).toHaveAttribute('aria-describedby', 'motif-cs-add-enzyme-status');
-    await expect(mapVisibility.locator('#motif-cs-add-enzyme-status')).toContainText('recognition sequence');
+    await expect(enzymeRecognition).toHaveAttribute('aria-describedby', /^motif-cs-add-enzyme-status-/);
+    await expect(mapVisibility.locator('[id^="motif-cs-add-enzyme-status-"]')).toContainText('recognition sequence');
     await enzymeRecognition.fill('TTTTCG');
     await mapVisibility.getByRole('button', { name: 'Add', exact: true }).click();
 
@@ -757,6 +757,183 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(mapVisibility).toContainText('No enzymes match this filter.');
     await filter.fill('');
     expect(await mapVisibility.locator('.motif-cs-restriction-row input:checked').count()).toBe(visibleBefore);
+  });
+
+  test('Restriction Sites tool stays synchronized and works with the Map pane hidden', async ({ page }) => {
+    await openArtifact(page, 1180, 900);
+
+    const tool = page.locator('details[data-rail-tool="restriction-sites"]');
+    const toolSummary = tool.locator(':scope > summary');
+    const mapVisibility = page.locator('details').filter({ hasText: 'Map Visibility' }).first();
+    await mapVisibility.locator(':scope > summary').click();
+    await toolSummary.click();
+
+    const totalClusters = await page.locator('.motif-pm-restriction').count();
+    expect(totalClusters).toBeGreaterThan(0);
+    const initialToolCount = (await toolSummary.locator('.motif-cs-chip').innerText()).match(/^(\d+)\/(\d+)$/);
+    expect(initialToolCount).toBeTruthy();
+    const totalSites = Number(initialToolCount![2]);
+    expect(Number(initialToolCount![1])).toBe(totalSites);
+    await expect(mapVisibility.locator(':scope > summary')).toContainText(`${totalSites}/${totalSites} sites`);
+
+    await tool.getByRole('button', { name: 'Hide sites', exact: true }).click();
+    await expect(page.locator('.motif-pm-restriction')).toHaveCount(0);
+    await expect(page.locator('.motif-pm-restriction-density > *')).toHaveCount(0);
+    await expect(toolSummary.locator('.motif-cs-chip')).toHaveText(`0/${totalSites}`);
+    await expect(mapVisibility.locator(':scope > summary')).toContainText(`0/${totalSites} sites`);
+    await expect(page.locator('.motif-cs-map-sites-toggle')).toHaveAttribute('aria-pressed', 'false');
+
+    await tool.getByRole('button', { name: 'Show sites', exact: true }).click();
+    await expect(page.locator('.motif-pm-restriction').first()).toBeVisible();
+    await expect(page.locator('.motif-pm-restriction-density > *').first()).toBeVisible();
+    await expect(toolSummary.locator('.motif-cs-chip')).toHaveText(`${totalSites}/${totalSites}`);
+
+    const toolLabelToggle = tool.getByRole('button', { name: 'Hide restriction-site labels' });
+    await toolLabelToggle.click();
+    await expect(page.locator('.motif-pm-restriction-label')).toHaveCount(0);
+    await expect(page.locator('.motif-pm-restriction')).toHaveCount(totalClusters);
+    await expect(mapVisibility.getByRole('button', { name: 'Show restriction-site labels' })).toHaveAttribute('aria-pressed', 'false');
+
+    await toolSummary.click();
+    await page.getByRole('button', { name: 'Collapse map pane' }).click();
+    await expect(page.locator('.motif-cs-main')).toHaveAttribute('data-map-hidden', 'true');
+    await toolSummary.click();
+    await expect(tool).toHaveAttribute('open', '');
+
+    const firstSite = tool.locator('.motif-cs-restriction-site-row').first();
+    const firstSiteTitle = await firstSite.getAttribute('title');
+    expect(firstSiteTitle).toBeTruthy();
+    await firstSite.click();
+    await expect(firstSite).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('.motif-cs-restriction-label[data-selected="true"]')).toHaveCount(1);
+    await expect(page.locator('.motif-cs-seq-block[data-seq-focus="true"]')).toHaveCount(1);
+
+    await tool.getByRole('button', { name: 'Hide sites', exact: true }).click();
+    await expect(toolSummary.locator('.motif-cs-chip')).toHaveText(`0/${totalSites}`);
+  });
+
+  test('phone Restriction Sites popover uses the available width without clipping source names', async ({ page }) => {
+    await openArtifact(page, 390, 760);
+    const tool = page.locator('details[data-rail-tool="restriction-sites"]');
+    await tool.locator(':scope > summary').click();
+    const body = tool.locator(':scope > .motif-cs-tool-panel-body');
+    await expect(body).toBeVisible();
+    const bodyBox = (await body.boundingBox())!;
+    expect(bodyBox.width).toBeGreaterThanOrEqual(320);
+    expect(bodyBox.x).toBeGreaterThanOrEqual(8);
+    expect(bodyBox.x + bodyBox.width).toBeLessThanOrEqual(342);
+
+    const title = body.locator('.motif-cs-rail-popover-title strong');
+    await expect(title).toHaveText('Restriction Sites');
+    expect(await title.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(true);
+    for (const label of await body.locator('.motif-cs-source-label').all()) {
+      expect(await label.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(true);
+    }
+  });
+
+  test('Claude themes fill generic active UI while preserving feature-colored selections', async ({ page }) => {
+    await openArtifact(page, 1600, 900);
+    const toolsToggle = page.getByRole('button', { name: /Tools/ }).first();
+    if ((await toolsToggle.getAttribute('aria-pressed')) !== 'true') await toolsToggle.click();
+    const tool = page.locator('details[data-rail-tool="restriction-sites"]');
+    if ((await tool.getAttribute('open')) === null) await tool.locator(':scope > summary').click();
+    const annotations = page.locator('details[data-rail-tool="annotations"]');
+    if ((await annotations.getAttribute('open')) === null) await annotations.locator(':scope > summary').click();
+    const feature = annotations.locator('.motif-cs-feature-annotation-list .motif-cs-row').first();
+    await feature.click();
+    const site = tool.locator('.motif-cs-restriction-site-row').first();
+    await site.click();
+    const settings = page.locator('details[data-rail-tool="settings"]');
+    if ((await settings.getAttribute('open')) === null) await settings.locator(':scope > summary').click();
+
+    for (const label of ['Claude Light', 'Claude Dark']) {
+      await page.getByLabel('Theme').selectOption({ label });
+      await page.waitForTimeout(150);
+      await feature.click();
+      await page.waitForTimeout(150);
+      const styles = await tool.evaluate((details) => {
+        const summary = details.querySelector<HTMLElement>(':scope > summary')!;
+        const source = details.querySelector<HTMLElement>('.motif-cs-restriction-source[data-active="true"]')!;
+        const sourceState = source.querySelector<HTMLElement>('.motif-cs-source-state')!;
+        const feature = document.querySelector<HTMLElement>('details[data-rail-tool="annotations"] .motif-cs-feature-annotation-list .motif-cs-row[data-active="true"]')!;
+        const featureMeta = feature.querySelector<HTMLElement>('.motif-cs-row-meta')!;
+        const featureSwatch = feature.querySelector<HTMLElement>('.motif-cs-swatch')!;
+        const activeTheme = document.querySelector<HTMLElement>('.motif-cs-theme-choice[data-active="true"]')!;
+        const activeThemeNote = activeTheme.querySelector<HTMLElement>('small')!;
+        const sample = (color: string) => {
+          const canvas = document.createElement('canvas');
+          canvas.width = 1;
+          canvas.height = 1;
+          const context = canvas.getContext('2d')!;
+          context.fillStyle = color;
+          context.fillRect(0, 0, 1, 1);
+          return Array.from(context.getImageData(0, 0, 1, 1).data);
+        };
+        const probe = document.createElement('span');
+        probe.style.color = 'var(--accent-contrast)';
+        document.body.append(probe);
+        const contrast = getComputedStyle(probe).color;
+        probe.style.color = 'var(--text-primary)';
+        const primary = getComputedStyle(probe).color;
+        probe.style.background = 'var(--bg-primary)';
+        const surface = getComputedStyle(probe).backgroundColor;
+        probe.remove();
+        return {
+          summaryBackground: sample(getComputedStyle(summary).backgroundColor),
+          summaryColor: sample(getComputedStyle(summary).color),
+          sourceBackground: sample(getComputedStyle(source).backgroundColor),
+          sourceColor: sample(getComputedStyle(source).color),
+          sourceStateColor: sample(getComputedStyle(sourceState).color),
+          featureBackground: sample(getComputedStyle(feature).backgroundColor),
+          featureColor: sample(getComputedStyle(feature).color),
+          featureMetaColor: sample(getComputedStyle(featureMeta).color),
+          featureSwatchBackground: sample(getComputedStyle(featureSwatch).backgroundColor),
+          activeThemeBackground: sample(getComputedStyle(activeTheme).backgroundColor),
+          activeThemeColor: sample(getComputedStyle(activeTheme).color),
+          activeThemeNoteColor: sample(getComputedStyle(activeThemeNote).color),
+          contrast: sample(contrast),
+          primary: sample(primary),
+          surface: sample(surface),
+        };
+      });
+      expect(styles.summaryBackground).toEqual(styles.sourceBackground);
+      expect(styles.activeThemeBackground).toEqual(styles.sourceBackground);
+      expect(styles.featureBackground).not.toEqual(styles.sourceBackground);
+      expect(styles.featureBackground).not.toEqual(styles.surface);
+      expect(styles.summaryColor).toEqual(styles.contrast);
+      expect(styles.sourceColor).toEqual(styles.contrast);
+      expect(styles.sourceStateColor).toEqual(styles.contrast);
+      expect(styles.featureColor).toEqual(styles.primary);
+      expect(styles.featureMetaColor).toEqual(styles.primary);
+      expect(styles.activeThemeColor).toEqual(styles.contrast);
+      expect(styles.activeThemeNoteColor).toEqual(styles.contrast);
+      expect(styles.featureSwatchBackground).not.toEqual(styles.featureBackground);
+
+      await site.click();
+      await page.waitForTimeout(150);
+      const siteStyles = await site.evaluate((row) => {
+        const meta = row.querySelector<HTMLElement>('.motif-cs-row-meta')!;
+        const normalize = (color: string) => {
+          const canvas = document.createElement('canvas');
+          canvas.width = 1;
+          canvas.height = 1;
+          const context = canvas.getContext('2d')!;
+          context.fillStyle = color;
+          context.fillRect(0, 0, 1, 1);
+          return Array.from(context.getImageData(0, 0, 1, 1).data);
+        };
+        const source = document.querySelector<HTMLElement>('.motif-cs-restriction-source[data-active="true"]')!;
+        return {
+          background: normalize(getComputedStyle(row).backgroundColor),
+          color: normalize(getComputedStyle(row).color),
+          metaColor: normalize(getComputedStyle(meta).color),
+          sourceBackground: normalize(getComputedStyle(source).backgroundColor),
+        };
+      });
+      expect(siteStyles.background).toEqual(siteStyles.sourceBackground);
+      expect(siteStyles.color).toEqual(styles.contrast);
+      expect(siteStyles.metaColor).toEqual(styles.contrast);
+    }
   });
 
   test('a dense plasmid names its restriction clusters instead of drawing anonymous ticks', async ({ page }) => {
@@ -804,13 +981,13 @@ test.describe('Claude Science artifact campaign', () => {
       await expect(featureNames.filter({ hasText: name })).toHaveCount(1);
     }
 
-    // The labelling control reads the same on the dense record as on the sparse
-    // one — the density of a record is not a reason to flip a user-facing toggle.
+    // The detailed panel keeps a labels-only control. The compact scissors
+    // controls the complete restriction-site layer — ticks and labels together.
     const labelToggle = mapVisibility.getByRole('button', { name: 'Hide restriction-site labels' });
-    const toolbarToggle = page.locator('.motif-cs-map-toolbar .motif-cs-map-labels-toggle');
+    const toolbarToggle = page.locator('.motif-cs-map-toolbar .motif-cs-map-sites-toggle');
     await expect(labelToggle).toHaveText('Site labels');
     await expect(toolbarToggle.locator('svg')).toHaveCount(1);
-    await expect(toolbarToggle).toHaveAttribute('aria-label', 'Hide restriction-site labels');
+    await expect(toolbarToggle).toHaveAttribute('aria-label', 'Hide restriction sites');
     await expect(toolbarToggle).toHaveAttribute('aria-pressed', 'true');
 
     // Shrink to a laptop-sized window. This is the case that used to fail hardest:
@@ -844,16 +1021,20 @@ test.describe('Claude Science artifact campaign', () => {
       return { backgroundColor: style.backgroundColor, color: style.color };
     });
     await toolbarToggle.click();
+    await expect(page.locator('.motif-pm-restriction')).toHaveCount(0);
+    await expect(page.locator('.motif-pm-restriction-density > *')).toHaveCount(0);
     await expect(page.locator('.motif-pm-restriction-label')).toHaveCount(0);
     await expect(toolbarToggle.locator('svg')).toHaveCount(1);
-    await expect(toolbarToggle).toHaveAttribute('aria-label', 'Show restriction-site labels');
+    await expect(toolbarToggle).toHaveAttribute('aria-label', 'Show restriction sites');
     await expect(toolbarToggle).toHaveAttribute('aria-pressed', 'false');
     const inactiveHoveredStyle = await toolbarToggle.evaluate((button) => {
       const style = getComputedStyle(button);
       return { backgroundColor: style.backgroundColor, color: style.color };
     });
     expect(inactiveHoveredStyle).not.toEqual(activeToggleStyle);
-    await mapVisibility.getByRole('button', { name: 'Show restriction-site labels' }).click();
+    await toolbarToggle.click();
+    await expect(page.locator('.motif-pm-restriction').first()).toBeVisible();
+    await expect(page.locator('.motif-pm-restriction-density > *').first()).toBeVisible();
     await expect(page.locator('.motif-pm-restriction-label').first()).toBeVisible();
   });
 
@@ -975,7 +1156,7 @@ test.describe('Claude Science artifact campaign', () => {
     expect(await page.evaluate(() => window.motifGetInventory?.().length)).toBe(3);
   });
 
-  test('cloning campaign: Save & open gel persists once and produces a configurable saved gel result', async ({ page }) => {
+  test('cloning workflow: Save & open gel persists once and produces a configurable saved gel result', async ({ page }) => {
     await openArtifact(page, 1440, 900);
     await page.evaluate(() => window.motifRenderInventory?.([
       {
@@ -1143,7 +1324,7 @@ test.describe('Claude Science artifact campaign', () => {
     expect(await page.evaluate(() => window.motifGetWorkflowResults?.().length)).toBe(2);
   });
 
-  test('cloning campaign: blocked plans stay honest and a valid BsaI product saves atomically once', async ({ page }) => {
+  test('cloning workflow: blocked plans stay honest and a valid BsaI product saves atomically once', async ({ page }) => {
     await openArtifact(page, 1440, 900);
     const cloning = page.locator('details[data-rail-tool="cloning"]');
     await cloning.locator(':scope > summary').click();
@@ -1997,6 +2178,66 @@ test.describe('Claude Science artifact campaign', () => {
 
     await toolsToggle.click();
     await expect(primerPanel).not.toHaveAttribute('open', '');
+  });
+
+  test('opening pinned tools keeps earlier rows and the pane width fixed', async ({ page }) => {
+    await openArtifact(page, 1600, 900);
+    const toolsToggle = page.getByRole('button', { name: /Tools/ }).first();
+    if ((await toolsToggle.getAttribute('aria-pressed')) !== 'true') await toolsToggle.click();
+
+    const inspector = page.locator('.motif-cs-inspector[data-tools-pinned="true"]');
+    const paneTitle = inspector.locator(':scope > .motif-cs-pane-title');
+    const row = (tool: string) => inspector.locator(`details[data-rail-tool="${tool}"] > summary`);
+    const stableTools = ['notes', 'inspector', 'restriction-sites'] as const;
+    const geometry = async () => ({
+      inspector: await inspector.boundingBox(),
+      rows: await Promise.all(stableTools.map(async (tool) => ({ tool, box: await row(tool).boundingBox() }))),
+    });
+    const expectStable = (before: Awaited<ReturnType<typeof geometry>>, after: Awaited<ReturnType<typeof geometry>>) => {
+      expect(before.inspector && after.inspector).toBeTruthy();
+      expect(Math.abs(after.inspector!.x - before.inspector!.x)).toBeLessThan(1);
+      expect(Math.abs(after.inspector!.width - before.inspector!.width)).toBeLessThan(1);
+      for (let index = 0; index < before.rows.length; index += 1) {
+        const first = before.rows[index].box;
+        const second = after.rows[index].box;
+        expect(first && second).toBeTruthy();
+        expect(Math.abs(second!.x - first!.x), `${before.rows[index].tool} moved horizontally`).toBeLessThan(1);
+        expect(Math.abs(second!.y - first!.y), `${before.rows[index].tool} moved vertically`).toBeLessThan(1);
+        expect(Math.abs(second!.width - first!.width), `${before.rows[index].tool} changed width`).toBeLessThan(1);
+      }
+    };
+
+    const beforeTranslation = await geometry();
+    await row('translation').click();
+    await expect(inspector.locator('details[data-rail-tool="translation"]')).toHaveAttribute('open', '');
+    await page.waitForTimeout(50);
+    expectStable(beforeTranslation, await geometry());
+
+    await row('pattern-search').click();
+    await expect(inspector.locator('details[data-rail-tool="pattern-search"]')).toHaveAttribute('open', '');
+    await page.waitForTimeout(50);
+    expectStable(beforeTranslation, await geometry());
+
+    const titleBeforeScroll = (await paneTitle.boundingBox())!;
+    const guideRow = row('guide');
+    await guideRow.scrollIntoViewIfNeeded();
+    await guideRow.click();
+    await expect(inspector.locator('details[data-rail-tool="guide"]')).toHaveAttribute('open', '');
+    const titleAfterScroll = (await paneTitle.boundingBox())!;
+    expect(Math.abs(titleAfterScroll.x - titleBeforeScroll.x)).toBeLessThan(1);
+    expect(Math.abs(titleAfterScroll.y - titleBeforeScroll.y)).toBeLessThan(1);
+    expect(Math.abs(titleAfterScroll.width - titleBeforeScroll.width)).toBeLessThan(1);
+    expect(Math.abs(titleAfterScroll.height - titleBeforeScroll.height)).toBeLessThan(1);
+
+    await openArtifact(page, 1180, 820);
+    if ((await toolsToggle.getAttribute('aria-pressed')) !== 'true') await toolsToggle.click();
+    const compactTitleBefore = (await paneTitle.boundingBox())!;
+    await row('guide').scrollIntoViewIfNeeded();
+    await row('guide').click();
+    await expect(inspector.locator('details[data-rail-tool="guide"]')).toHaveAttribute('open', '');
+    const compactTitleAfter = (await paneTitle.boundingBox())!;
+    expect(Math.abs(compactTitleAfter.y - compactTitleBefore.y)).toBeLessThan(1);
+    expect(Math.abs(compactTitleAfter.height - compactTitleBefore.height)).toBeLessThan(1);
   });
 
   test('a short Tools rail popover keeps its resize grip on the visible corner after growing', async ({ page }) => {
@@ -3691,67 +3932,103 @@ test.describe('Claude Science artifact campaign', () => {
       molecule: 'dna',
       topology: 'linear',
       sequence: 'A'.repeat(4_000),
+      annotations: [
+        { id: 'linear-lane-1', name: 'Lane 1', type: 'cds', start: 400, end: 1_600, strand: 1 },
+        { id: 'linear-lane-2', name: 'Lane 2', type: 'promoter', start: 600, end: 1_400, strand: 1 },
+        { id: 'linear-lane-3', name: 'Lane 3', type: 'misc_feature', start: 800, end: 1_200, strand: 1 },
+      ],
     }]));
     await expect(mapFrame).toHaveAttribute('data-map-mode', 'linear');
     const linearSvgBox = (await svg.boundingBox())!;
     const linearBackbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
-    const belowAxis = {
+    const blankCanvas = {
       x: linearSvgBox.x + linearSvgBox.width / 2,
-      y: Math.min(linearSvgBox.y + linearSvgBox.height - 10, linearBackbone.y + 52),
+      y: linearSvgBox.y + linearSvgBox.height - 10,
     };
-    await page.mouse.move(belowAxis.x, belowAxis.y);
+    await page.mouse.move(blankCanvas.x, blankCanvas.y);
     await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
     await page.mouse.down();
-    await page.mouse.move(belowAxis.x + 260, belowAxis.y + 100, { steps: 10 });
+    await page.mouse.move(blankCanvas.x + 260, blankCanvas.y + 360, { steps: 12 });
     await page.mouse.up();
     await expect(viewport).toHaveAttribute('transform', /translate/);
     const linearPositive = await viewportOffset();
     expect(linearPositive.x).toBeGreaterThan(100);
-    expect(linearPositive.y).toBeGreaterThan(45);
+    expect(linearPositive.y).toBeGreaterThan(140);
     await expect(mapFrame.locator('.motif-cs-map-hint')).not.toContainText('range');
 
     await page.getByRole('button', { name: 'Reset map view' }).click();
-    await page.mouse.move(belowAxis.x, belowAxis.y);
+    await page.mouse.move(blankCanvas.x, blankCanvas.y);
     await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
     await page.mouse.down();
-    await page.mouse.move(belowAxis.x - 260, belowAxis.y - 100, { steps: 10 });
+    await page.mouse.move(blankCanvas.x - 260, blankCanvas.y - 360, { steps: 12 });
     await page.mouse.up();
     const linearNegative = await viewportOffset();
     expect(linearNegative.x).toBeLessThan(-100);
-    expect(linearNegative.y).toBeLessThan(-45);
+    expect(linearNegative.y).toBeLessThan(-140);
 
     await page.getByRole('button', { name: 'Reset map view' }).click();
-    const axisY = linearBackbone.y + linearBackbone.height / 2;
-    const axisStart = linearBackbone.x + linearBackbone.width * 0.25;
-    const axisEnd = linearBackbone.x + linearBackbone.width * 0.7;
-    await page.mouse.move(axisStart, axisY);
+    const lowerFeatureRow = (await mapFrame.locator('.motif-pm-feature[data-feature-id="linear-lane-3"]').boundingBox())!;
+    const lowerSelectionY = lowerFeatureRow.y + lowerFeatureRow.height / 2;
+    const axisStart = linearBackbone.x + linearBackbone.width * 0.55;
+    const axisEnd = linearBackbone.x + linearBackbone.width * 0.8;
+    await page.mouse.move(axisStart, lowerSelectionY);
     await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'range');
     await page.mouse.down();
-    await page.mouse.move(axisEnd, axisY, { steps: 8 });
+    await page.mouse.move(axisEnd, lowerSelectionY, { steps: 8 });
     await page.mouse.up();
     await expect(mapFrame.locator('.motif-cs-map-hint')).toContainText('range');
     await expect.poll(async () => {
       const focus = await sequenceFocus();
-      return focus.visible && focus.lineStart >= 800 && focus.lineStart <= 1_200;
+      return focus.visible && focus.lineStart >= 2_100 && focus.lineStart <= 2_300;
     }).toBe(true);
   });
 
-  test('map drawing controls stay visible and switch a circular record between circle and line', async ({ page }) => {
+  test('map controls keep one header position while circle and line canvases reflow', async ({ page }) => {
+    for (const viewport of [
+      { width: 1600, height: 900 },
+      { width: 900, height: 720 },
+      { width: 390, height: 760 },
+    ]) {
+      await openArtifact(page, viewport.width, viewport.height);
+      const mapColumn = page.locator('.motif-cs-map-column');
+      const mapFrame = mapColumn.locator('.motif-cs-map-frame');
+      const toolbar = mapColumn.locator('.motif-cs-map-toolbar');
+      const drawing = toolbar.locator('.motif-cs-map-mode-toggle');
+      await toolbar.scrollIntoViewIfNeeded();
+
+      await expect(toolbar).toBeVisible();
+      await expect(drawing).toHaveAttribute('aria-label', 'Draw map as line');
+      await expect(drawing.locator('svg')).toHaveCount(1);
+      const circularBox = (await toolbar.boundingBox())!;
+
+      await drawing.click();
+      await expect(mapFrame).toHaveAttribute('data-map-mode', 'linear');
+      await expect(drawing).toHaveAttribute('aria-label', 'Draw map as circle');
+      const linearBox = (await toolbar.boundingBox())!;
+      expect(Math.abs(linearBox.x - circularBox.x)).toBeLessThan(1);
+      expect(Math.abs(linearBox.y - circularBox.y)).toBeLessThan(1);
+
+      await drawing.click();
+      await expect(mapFrame).toHaveAttribute('data-map-mode', 'circular');
+      await expect(drawing).toHaveAttribute('aria-label', 'Draw map as line');
+    }
+
+    // Opening the dock changes the content below the canvas, but not the
+    // control group in the pane heading.
     await openArtifact(page, 900, 720);
-    const mapFrame = page.locator('.motif-cs-map-frame');
-    const drawing = mapFrame.locator('.motif-cs-map-mode-toggle');
-
-    await expect(drawing).toBeVisible();
-    await expect(drawing).toHaveAttribute('aria-label', 'Draw map as line');
-    await expect(drawing.locator('svg')).toHaveCount(1);
-
+    const mapColumn = page.locator('.motif-cs-map-column');
+    const mapFrame = mapColumn.locator('.motif-cs-map-frame');
+    const toolbar = mapColumn.locator('.motif-cs-map-toolbar');
+    const drawing = toolbar.locator('.motif-cs-map-mode-toggle');
+    const mapVisibility = mapColumn.locator('.motif-cs-map-visibility-panel');
+    await mapVisibility.locator(':scope > summary').click();
+    await toolbar.scrollIntoViewIfNeeded();
+    const circularOpenBox = (await toolbar.boundingBox())!;
     await drawing.click();
     await expect(mapFrame).toHaveAttribute('data-map-mode', 'linear');
-    await expect(drawing).toHaveAttribute('aria-label', 'Draw map as circle');
-
-    await drawing.click();
-    await expect(mapFrame).toHaveAttribute('data-map-mode', 'circular');
-    await expect(drawing).toHaveAttribute('aria-label', 'Draw map as line');
+    const linearOpenBox = (await toolbar.boundingBox())!;
+    expect(Math.abs(linearOpenBox.x - circularOpenBox.x)).toBeLessThan(1);
+    expect(Math.abs(linearOpenBox.y - circularOpenBox.y)).toBeLessThan(1);
   });
 
   test('high zoom keeps range bands compact and Fit preserves the selection', async ({ page }) => {
@@ -4050,9 +4327,11 @@ test.describe('Claude Science artifact campaign', () => {
 
     const hint = mapFrame.locator('.motif-cs-map-hint');
     await expect(hint).toContainText('range');
-    const toolbarBox = (await mapFrame.locator('.motif-cs-map-toolbar').boundingBox())!;
+    const toolbarBox = (await page.locator('.motif-cs-map-column .motif-cs-map-toolbar').boundingBox())!;
+    const frameBox = (await mapFrame.boundingBox())!;
     const hintBox = (await hint.boundingBox())!;
-    expect(hintBox.x).toBeGreaterThanOrEqual(toolbarBox.x + toolbarBox.width + 8);
+    expect(toolbarBox.y + toolbarBox.height).toBeLessThanOrEqual(frameBox.y + 1);
+    expect(hintBox.x).toBeGreaterThanOrEqual(svgBox!.x + 8);
     expect(hintBox.x + hintBox.width).toBeLessThanOrEqual(svgBox!.x + svgBox!.width - 8);
     await mapFrame.screenshot({ path: path.join(outputDir, 'linear-range-status-640x700.png') });
   });
@@ -4106,7 +4385,7 @@ test.describe('Claude Science artifact campaign', () => {
       expect(geometry.boundaryBeforeSettings).toBe(true);
       expect(geometry.containedHorizontally).toBe(true);
       expect(geometry.launcherHit).toBe(true);
-      await page.screenshot({ path: path.join(msaCampaignOutputDir, `alignment-launcher-${viewport.width}x${viewport.height}.png`) });
+      await page.screenshot({ path: path.join(msaOutputDir, `alignment-launcher-${viewport.width}x${viewport.height}.png`) });
     }
 
     for (const viewport of [
@@ -4166,7 +4445,7 @@ test.describe('Claude Science artifact campaign', () => {
       const settings = page.locator('details[data-rail-tool="settings"]');
       await settings.locator(':scope > summary').click();
       await expect(settings).toHaveAttribute('open', '');
-      await page.screenshot({ path: path.join(msaCampaignOutputDir, `alignment-rail-dark-settings-${viewport.width}x${viewport.height}.png`) });
+      await page.screenshot({ path: path.join(msaOutputDir, `alignment-rail-dark-settings-${viewport.width}x${viewport.height}.png`) });
     }
   });
 
@@ -4174,9 +4453,9 @@ test.describe('Claude Science artifact campaign', () => {
     await openArtifact(page, 1180, 820);
     await page.evaluate(() => {
       window.motifAddRecords([
-        { id: 'campaign-a', name: 'Campaign2_variant_A', type: 'dna', topology: 'linear', sequence: 'ACGT'.repeat(60), group: 'MSA Campaign 2' },
-        { id: 'campaign-b', name: 'Campaign2_variant_B_ins3', type: 'dna', topology: 'linear', sequence: `${'ACGT'.repeat(30)}AAA${'ACGT'.repeat(30)}`, group: 'MSA Campaign 2' },
-        { id: 'campaign-c', name: 'Campaign2_variant_C_del3', type: 'dna', topology: 'linear', sequence: 'ACGT'.repeat(59), group: 'MSA Campaign 2' },
+        { id: 'msa-example-a', name: 'Example_variant_A', type: 'dna', topology: 'linear', sequence: 'ACGT'.repeat(60), group: 'MSA examples' },
+        { id: 'msa-example-b', name: 'Example_variant_B_ins3', type: 'dna', topology: 'linear', sequence: `${'ACGT'.repeat(30)}AAA${'ACGT'.repeat(30)}`, group: 'MSA examples' },
+        { id: 'msa-example-c', name: 'Example_variant_C_del3', type: 'dna', topology: 'linear', sequence: 'ACGT'.repeat(59), group: 'MSA examples' },
       ]);
     });
 
@@ -4186,22 +4465,22 @@ test.describe('Claude Science artifact campaign', () => {
     const recordList = page.getByTestId('msa-record-list');
     const selectedOptions = recordList.locator('.motif-cs-msa-record-option[data-active="true"]');
     await expect(selectedOptions).toHaveCount(2);
-    await expect(selectedOptions.nth(0)).toContainText('Campaign2_variant_A');
-    await expect(selectedOptions.nth(1)).toContainText('Campaign2_variant_B_ins3');
+    await expect(selectedOptions.nth(0)).toContainText('Example_variant_A');
+    await expect(selectedOptions.nth(1)).toContainText('Example_variant_B_ins3');
     await expect(recordList.locator('.motif-cs-msa-record-option').filter({ hasText: 'pUC19' }).locator('input')).not.toBeChecked();
 
     await page.getByLabel('Filter records').fill('pUC19');
-    await expect(recordList.locator('.motif-cs-msa-record-option').nth(0)).toContainText('Campaign2_variant_A');
-    await expect(recordList.locator('.motif-cs-msa-record-option').nth(1)).toContainText('Campaign2_variant_B_ins3');
+    await expect(recordList.locator('.motif-cs-msa-record-option').nth(0)).toContainText('Example_variant_A');
+    await expect(recordList.locator('.motif-cs-msa-record-option').nth(1)).toContainText('Example_variant_B_ins3');
     await expect(recordList.locator('.motif-cs-msa-record-option').filter({ hasText: 'pUC19' })).toBeVisible();
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'selection-same-group-pinned.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'selection-same-group-pinned.png') });
     await page.getByTestId('msa-selected-only').click();
     await expect(recordList.locator('.motif-cs-msa-record-option')).toHaveCount(2);
     await page.getByTestId('msa-clear-selection').click();
     await expect(recordList.locator('input:checked')).toHaveCount(0);
     await expect(page.getByTestId('msa-selected-only')).toHaveAttribute('aria-pressed', 'false');
     await expect(page.getByTestId('msa-run-button')).toBeDisabled();
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'selection-same-group-and-clear.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'selection-same-group-and-clear.png') });
   });
 
   test('MSA accepts direct multi-file sequence drops, selects the new records, and keeps the shell importer out of the path', async ({ page }) => {
@@ -4245,7 +4524,7 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(selected.nth(2)).toContainText('drop-read-r');
     await expect(workspace.locator('.motif-cs-msa-intake-status')).toContainText('Imported 2 records');
     await expect(page.getByLabel('Choose sequence files for alignment')).toHaveAttribute('multiple', '');
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'direct-multifile-drop-selected.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'direct-multifile-drop-selected.png') });
 
     await page.setViewportSize({ width: 390, height: 760 });
     const compactDropzone = page.getByTestId('msa-record-dropzone');
@@ -4253,7 +4532,7 @@ test.describe('Claude Science artifact campaign', () => {
     expect(await compactDropzone.evaluate((element) => element.scrollWidth)).toBeLessThanOrEqual(
       await compactDropzone.evaluate((element) => element.clientWidth + 2),
     );
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'direct-multifile-drop-390x760.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'direct-multifile-drop-390x760.png') });
     await page.setViewportSize({ width: 1180, height: 820 });
 
     await page.getByTestId('msa-run-button').click();
@@ -4282,7 +4561,7 @@ test.describe('Claude Science artifact campaign', () => {
     expect((await selected.allTextContents()).join('\n')).not.toContain('pUC19');
     await expect(workspace.getByLabel('Initial template').locator('option:checked')).toHaveText('plate-read-a');
     await expect(workspace.getByTestId('msa-source-link-status')).toContainText('selected 2 imported AB1 reads');
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'direct-ab1-import-selection.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'direct-ab1-import-selection.png') });
   });
 
   test('MSA routes one aligned-file drop to a review step without flattening gaps into inventory records', async ({ page }) => {
@@ -4308,7 +4587,7 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(page.getByTestId('msa-workspace').locator('.motif-cs-msa-intake-status')).toContainText('review the molecule and engine');
     expect(await page.evaluate(() => window.motifGetInventory().length)).toBe(beforeCount);
     await expect(page.getByLabel('Choose a pre-aligned sequence file')).toHaveAttribute('type', 'file');
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'direct-aligned-file-review.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'direct-aligned-file-review.png') });
     await page.getByTestId('msa-import-button').click();
     await expect(page.getByTestId('msa-stats-bar')).toContainText('10 columns');
   });
@@ -4383,7 +4662,7 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(localOptions).toBeVisible();
     await expect(localOptions.locator('select')).toHaveValue('sanger-local-template');
     await expect(localOptions.getByRole('checkbox', { name: 'Auto-orient AB1 reads' })).toBeChecked();
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'local-sanger-source-options.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'local-sanger-source-options.png') });
     await page.getByTestId('msa-run-button').click();
     await expect(page.getByTestId('msa-stats-bar')).toContainText('100% conserved');
     await expect(page.locator('.motif-cs-msa-export-row')).toContainText('Auto-oriented 1 AB1 read');
@@ -4392,7 +4671,7 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(traceViewer.locator('.motif-cs-sanger-toolbar .motif-cs-chip')).toHaveText('reverse');
     await expect(traceViewer.locator('canvas')).toHaveAttribute('aria-label', /aligned reverse to template Chosen Sanger template/);
     await expect(traceViewer.locator('.motif-cs-sanger-warnings')).toContainText('no signal channels');
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'local-sanger-auto-orient.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'local-sanger-auto-orient.png') });
   });
 
   test('MSA local workflow is explicit, virtualized, movable, resizable, and focus-safe', async ({ page }) => {
@@ -4467,7 +4746,7 @@ test.describe('Claude Science artifact campaign', () => {
     expect(afterResize.width).toBeGreaterThanOrEqual(afterMove.width);
     expect(afterResize.height).toBeGreaterThanOrEqual(afterMove.height);
 
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'local-template-overview-and-stats.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'local-template-overview-and-stats.png') });
 
     await page.keyboard.press('Escape');
     await expect(windowPanel).toBeHidden();
@@ -4603,7 +4882,7 @@ test.describe('Claude Science artifact campaign', () => {
     expect(hitTest).toBe(true);
     await textButton.click();
     await expect(textButton).toHaveAttribute('aria-pressed', 'true');
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'msa-result-toolbar-sticky-390x760.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'msa-result-toolbar-sticky-390x760.png') });
     await toolbar.getByRole('button', { name: 'Viewer' }).click();
     await toolbar.getByTestId('msa-view-menu-button').click();
     const compactViewMenu = dialog.getByTestId('msa-view-menu');
@@ -4611,7 +4890,7 @@ test.describe('Claude Science artifact campaign', () => {
     const compactMenuBox = (await compactViewMenu.boundingBox())!;
     expect(compactMenuBox.x).toBeGreaterThanOrEqual(0);
     expect(compactMenuBox.x + compactMenuBox.width).toBeLessThanOrEqual(390);
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'msa-view-menu-sticky-390x760.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'msa-view-menu-sticky-390x760.png') });
   });
 
   test('MSA View menu persists visibility choices, resets them, and owns Escape before the window', async ({ page }) => {
@@ -4638,7 +4917,7 @@ test.describe('Claude Science artifact campaign', () => {
     const viewMenu = dialog.getByTestId('msa-view-menu');
     await expect(viewMenu).toBeVisible();
     await expect(viewButton).toHaveAttribute('aria-expanded', 'true');
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'msa-view-menu-1180x820.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'msa-view-menu-1180x820.png') });
 
     const defaultVisibleLabels = [
       'Overview',
@@ -4737,7 +5016,7 @@ test.describe('Claude Science artifact campaign', () => {
     const inputFasta = await readFile(inputDownloadPath!, 'utf8');
     expect(inputFasta).toMatch(/^>pUC19\n[ACGT]+/);
     expect(inputFasta).toContain('\n>pACYC184\n');
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'edit-inputs-preserves-setup.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'edit-inputs-preserves-setup.png') });
 
     await page.setViewportSize({ width: 390, height: 760 });
     const handoff = windowPanel.locator('.motif-cs-msa-external-handoff');
@@ -4750,7 +5029,7 @@ test.describe('Claude Science artifact campaign', () => {
     expect(compactGeometry.scrollWidth).toBeLessThanOrEqual(compactGeometry.clientWidth + 1);
     await expect(page.getByTestId('msa-copy-input-fasta')).toBeVisible();
     await expect(page.getByTestId('msa-download-input-fasta')).toBeVisible();
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'edit-inputs-external-handoff-390x760.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'edit-inputs-external-handoff-390x760.png') });
     await page.setViewportSize({ width: 1180, height: 820 });
 
     await page.getByTestId('msa-run-button').click();
@@ -5066,7 +5345,7 @@ test.describe('Claude Science artifact campaign', () => {
       cells.map((cell) => cell.getAttribute('data-template-position'))
     ));
     expect(alternatePositions).toEqual(['1', '2', 'gap', '3', 'gap', '4', '5', '6', '7']);
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'template-axis-and-column-lookup.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'template-axis-and-column-lookup.png') });
   });
 
   test('MSA template-position lookup maps through gaps exactly and enforces ungapped bounds', async ({ page }) => {
@@ -5209,7 +5488,7 @@ test.describe('Claude Science artifact campaign', () => {
     expect(await windowBody.evaluate((element) => element.scrollTop)).toBe(0);
     expect(await matrix.evaluate((element) => element.scrollLeft)).toBe(panBefore);
 
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, `msa-pan-rail-${browserName}-1440x900.png`) });
+    await page.screenshot({ path: path.join(msaOutputDir, `msa-pan-rail-${browserName}-1440x900.png`) });
   });
 
   test('MSA aligned-FASTA import records honest provenance and rejects malformed replacement atomically', async ({ page }) => {
@@ -5300,9 +5579,9 @@ test.describe('Claude Science artifact campaign', () => {
       window.motifAddAlignments({
         id: 'mafft-demo', name: 'Kinase homologs', molecule: 'dna', referenceRowId: 'reference',
         rows: [
-          { id: 'reference', name: 'Campaign2_reference', aligned: reference },
-          { id: 'variant-b', name: 'Campaign2_variant_B_ins3', aligned: variantB.join('') },
-          { id: 'variant-c', name: 'Campaign2_variant_C_del3', aligned: variantC.join('') },
+          { id: 'reference', name: 'Example_reference', aligned: reference },
+          { id: 'variant-b', name: 'Example_variant_B_ins3', aligned: variantB.join('') },
+          { id: 'variant-c', name: 'Example_variant_C_del3', aligned: variantC.join('') },
         ],
         engine: { id: 'mafft', label: 'MAFFT', version: '7.526', mode: 'local-command', parameters: ['--auto'] },
       });
@@ -5333,16 +5612,16 @@ test.describe('Claude Science artifact campaign', () => {
     expect(geometry.right).toBeLessThanOrEqual(geometry.viewportWidth);
     expect(geometry.bottom).toBeLessThanOrEqual(geometry.viewportHeight);
 
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'msa-claude-dark-viewer-390x760.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'msa-claude-dark-viewer-390x760.png') });
     await page.getByRole('button', { name: 'Text' }).click();
-    await expect(page.getByLabel('Aligned FASTA alignment text')).toHaveValue(/>Campaign2_reference/);
+    await expect(page.getByLabel('Aligned FASTA alignment text')).toHaveValue(/>Example_reference/);
     await windowPanel.getByTestId('msa-export-menu-button').click();
     await windowPanel.getByRole('combobox', { name: 'Export', exact: true }).selectOption('clustal');
     await expect(page.getByLabel('CLUSTAL alignment text')).toHaveValue(/CLUSTAL W/);
 
     const accessibility = await new AxeBuilder({ page }).include('.motif-cs-window').analyze();
     expect(accessibility.violations).toEqual([]);
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'msa-claude-dark-390x760.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'msa-claude-dark-390x760.png') });
   });
 
   test('MSA 100-row density preserves suffixes, semantics, and panel-owned scrolling', async ({ page }) => {
@@ -5443,7 +5722,7 @@ test.describe('Claude Science artifact campaign', () => {
 
     const accessibility = await new AxeBuilder({ page }).include('.motif-cs-window').analyze();
     expect(accessibility.violations).toEqual([]);
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'msa-density-100-row-fixed.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'msa-density-100-row-fixed.png') });
   });
 
   test('MSA 50k-column overview stays bounded and navigates without column-sized DOM', async ({ page }) => {
@@ -5479,7 +5758,7 @@ test.describe('Claude Science artifact campaign', () => {
     await page.keyboard.press('End');
     await expect.poll(() => matrixViewport.evaluate((element) => element.scrollLeft)).toBeGreaterThan(400_000);
     await expect(windowPanel.locator('.motif-cs-msa-window-note')).toContainText('50,000');
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'msa-50k-columns.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'msa-50k-columns.png') });
   });
 
   test('aligned AB1 reads expose interactive forward and reverse chromatograms', async ({ page }) => {
@@ -5596,19 +5875,19 @@ test.describe('Claude Science artifact campaign', () => {
 
     const accessibility = await new AxeBuilder({ page }).include('.motif-cs-window').analyze();
     expect(accessibility.violations).toEqual([]);
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'sanger-traces-claude-light.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'sanger-traces-claude-light.png') });
 
     await page.setViewportSize({ width: 390, height: 760 });
     await expect(traceViewer).toBeVisible();
     expect(await traceViewer.evaluate((element) => element.scrollWidth)).toBeLessThanOrEqual(await traceViewer.evaluate((element) => element.clientWidth + 2));
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'sanger-traces-phone.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'sanger-traces-phone.png') });
 
     await page.setViewportSize({ width: 900, height: 760 });
     for (const theme of ['light', 'dark', 'claude-light', 'claude-dark'] as const) {
       await page.locator('select[name="artifact-theme"]').selectOption(theme);
       await page.waitForTimeout(80);
       await expect(traceViewer).toBeVisible();
-      await page.screenshot({ path: path.join(msaCampaignOutputDir, `sanger-traces-${theme}.png`) });
+      await page.screenshot({ path: path.join(msaOutputDir, `sanger-traces-${theme}.png`) });
     }
   });
 
@@ -5742,7 +6021,7 @@ test.describe('Claude Science artifact campaign', () => {
 
     const accessibility = await new AxeBuilder({ page }).include('.motif-cs-window').analyze();
     expect(accessibility.violations).toEqual([]);
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'sanger-stacked-eight-claude-light.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'sanger-stacked-eight-claude-light.png') });
 
     await page.setViewportSize({ width: 390, height: 760 });
     await expect(traceViewer).toBeVisible();
@@ -5755,12 +6034,12 @@ test.describe('Claude Science artifact campaign', () => {
       return context.getImageData(0, 0, element.width, element.height).data.some((value, index) => index % 4 === 3 && value > 0);
     })).toBe(true);
     await traceViewer.getByRole('button', { name: 'Stacked', exact: true }).click();
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'sanger-stacked-eight-phone.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'sanger-stacked-eight-phone.png') });
 
     await page.setViewportSize({ width: 900, height: 760 });
     await page.locator('select[name="artifact-theme"]').selectOption('claude-dark');
     await page.waitForTimeout(80);
-    await page.screenshot({ path: path.join(msaCampaignOutputDir, 'sanger-stacked-eight-claude-dark.png') });
+    await page.screenshot({ path: path.join(msaOutputDir, 'sanger-stacked-eight-claude-dark.png') });
   });
 
   for (const theme of ['light', 'dark', 'claude-light', 'claude-dark'] as const) {

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -809,7 +809,7 @@ test.describe('Claude Science artifact campaign', () => {
     const labelToggle = mapVisibility.getByRole('button', { name: 'Hide restriction-site labels' });
     const toolbarToggle = page.locator('.motif-cs-map-toolbar .motif-cs-map-labels-toggle');
     await expect(labelToggle).toHaveText('Site labels');
-    await expect(toolbarToggle).toHaveText('Sites');
+    await expect(toolbarToggle.locator('svg')).toHaveCount(1);
     await expect(toolbarToggle).toHaveAttribute('aria-label', 'Hide restriction-site labels');
     await expect(toolbarToggle).toHaveAttribute('aria-pressed', 'true');
 
@@ -845,7 +845,7 @@ test.describe('Claude Science artifact campaign', () => {
     });
     await toolbarToggle.click();
     await expect(page.locator('.motif-pm-restriction-label')).toHaveCount(0);
-    await expect(toolbarToggle).toHaveText('Sites');
+    await expect(toolbarToggle.locator('svg')).toHaveCount(1);
     await expect(toolbarToggle).toHaveAttribute('aria-label', 'Show restriction-site labels');
     await expect(toolbarToggle).toHaveAttribute('aria-pressed', 'false');
     const inactiveHoveredStyle = await toolbarToggle.evaluate((button) => {
@@ -3556,6 +3556,10 @@ test.describe('Claude Science artifact campaign', () => {
     const mapFrame = page.locator('.motif-cs-map-frame');
     const viewport = page.locator('.motif-cs-map-frame .motif-pm-viewport');
     const svg = page.locator('.motif-cs-map-frame svg.motif-plasmid-map');
+    const viewportOffset = () => viewport.evaluate((element) => {
+      const matrix = (element as SVGGElement).transform.baseVal.consolidate()?.matrix;
+      return { x: matrix?.e ?? 0, y: matrix?.f ?? 0 };
+    });
     const sequenceFocus = () => page.locator('.motif-cs-sequence').evaluate((container) => {
       const pane = container.closest<HTMLElement>('.motif-cs-sequence-column');
       const scroller = container.scrollHeight > container.clientHeight + 1
@@ -3599,6 +3603,28 @@ test.describe('Claude Science artifact campaign', () => {
       annotations: [],
     }]));
     await expect(mapFrame).toHaveAttribute('data-map-mode', 'circular');
+    await svg.dispatchEvent('wheel', {
+      deltaY: -55,
+      clientX: center.x,
+      clientY: center.y,
+      ctrlKey: true,
+    });
+    await expect(mapFrame.locator('.motif-cs-map-hint')).toContainText('%');
+    const zoomedBackbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
+    const zoomedOutsideRing = {
+      x: svgBox!.x + 10,
+      y: zoomedBackbone.y + zoomedBackbone.height / 2,
+    };
+    await page.mouse.move(zoomedOutsideRing.x, zoomedOutsideRing.y);
+    await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
+    await page.mouse.down();
+    await page.mouse.move(zoomedOutsideRing.x + 420, zoomedOutsideRing.y + 180, { steps: 12 });
+    await page.mouse.up();
+    const zoomedPositive = await viewportOffset();
+    expect(zoomedPositive.x).toBeGreaterThan(80);
+    expect(zoomedPositive.y).toBeGreaterThan(100);
+
+    await page.getByRole('button', { name: 'Reset map view' }).click();
     const circularBackbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
     const circularCenter = {
       x: circularBackbone.x + circularBackbone.width / 2,
@@ -3611,10 +3637,27 @@ test.describe('Claude Science artifact campaign', () => {
     await page.mouse.move(outsideRing.x, outsideRing.y);
     await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
     await page.mouse.down();
-    await page.mouse.move(outsideRing.x + 48, outsideRing.y + 22, { steps: 8 });
+    await page.mouse.move(outsideRing.x + 420, outsideRing.y + 180, { steps: 12 });
     await page.mouse.up();
     await expect(viewport).toHaveAttribute('transform', /translate/);
+    const circularPositive = await viewportOffset();
+    expect(circularPositive.x).toBeGreaterThan(100);
+    expect(circularPositive.y).toBeGreaterThan(100);
     await expect(mapFrame.locator('.motif-cs-map-hint')).not.toContainText('range');
+
+    await page.getByRole('button', { name: 'Reset map view' }).click();
+    const outsideRingRight = {
+      x: svgBox!.x + svgBox!.width - Math.max(12, (circularBackbone.x - svgBox!.x) * 0.45),
+      y: circularBackbone.y + circularBackbone.height / 2,
+    };
+    await page.mouse.move(outsideRingRight.x, outsideRingRight.y);
+    await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
+    await page.mouse.down();
+    await page.mouse.move(outsideRingRight.x - 420, outsideRingRight.y - 180, { steps: 12 });
+    await page.mouse.up();
+    const circularNegative = await viewportOffset();
+    expect(circularNegative.x).toBeLessThan(-100);
+    expect(circularNegative.y).toBeLessThan(-100);
 
     await page.getByRole('button', { name: 'Reset map view' }).click();
     const radius = circularBackbone.width / 2;
@@ -3659,10 +3702,23 @@ test.describe('Claude Science artifact campaign', () => {
     await page.mouse.move(belowAxis.x, belowAxis.y);
     await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
     await page.mouse.down();
-    await page.mouse.move(belowAxis.x + 46, belowAxis.y + 18, { steps: 8 });
+    await page.mouse.move(belowAxis.x + 260, belowAxis.y + 100, { steps: 10 });
     await page.mouse.up();
     await expect(viewport).toHaveAttribute('transform', /translate/);
+    const linearPositive = await viewportOffset();
+    expect(linearPositive.x).toBeGreaterThan(100);
+    expect(linearPositive.y).toBeGreaterThan(45);
     await expect(mapFrame.locator('.motif-cs-map-hint')).not.toContainText('range');
+
+    await page.getByRole('button', { name: 'Reset map view' }).click();
+    await page.mouse.move(belowAxis.x, belowAxis.y);
+    await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
+    await page.mouse.down();
+    await page.mouse.move(belowAxis.x - 260, belowAxis.y - 100, { steps: 10 });
+    await page.mouse.up();
+    const linearNegative = await viewportOffset();
+    expect(linearNegative.x).toBeLessThan(-100);
+    expect(linearNegative.y).toBeLessThan(-45);
 
     await page.getByRole('button', { name: 'Reset map view' }).click();
     const axisY = linearBackbone.y + linearBackbone.height / 2;
@@ -3684,20 +3740,18 @@ test.describe('Claude Science artifact campaign', () => {
     await openArtifact(page, 900, 720);
     const mapFrame = page.locator('.motif-cs-map-frame');
     const drawing = mapFrame.locator('.motif-cs-map-mode-toggle');
-    const circular = drawing.getByRole('button', { name: 'Circular', exact: true });
-    const linear = drawing.getByRole('button', { name: 'Linear', exact: true });
 
     await expect(drawing).toBeVisible();
-    await expect(circular).toHaveAttribute('aria-pressed', 'true');
-    await expect(linear).toHaveAttribute('aria-pressed', 'false');
+    await expect(drawing).toHaveAttribute('aria-label', 'Draw map as line');
+    await expect(drawing.locator('svg')).toHaveCount(1);
 
-    await linear.click();
+    await drawing.click();
     await expect(mapFrame).toHaveAttribute('data-map-mode', 'linear');
-    await expect(linear).toHaveAttribute('aria-pressed', 'true');
+    await expect(drawing).toHaveAttribute('aria-label', 'Draw map as circle');
 
-    await circular.click();
+    await drawing.click();
     await expect(mapFrame).toHaveAttribute('data-map-mode', 'circular');
-    await expect(circular).toHaveAttribute('aria-pressed', 'true');
+    await expect(drawing).toHaveAttribute('aria-label', 'Draw map as line');
   });
 
   test('high zoom keeps range bands compact and Fit preserves the selection', async ({ page }) => {

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -2418,6 +2418,8 @@ test.describe('Claude Science artifact campaign', () => {
     expect(densityMetrics.sourceCount).toBeGreaterThan(512);
     expect(densityMetrics.renderedCount).toBeLessThanOrEqual(512);
     expect(densityMetrics.representedCount).toBe(densityMetrics.sourceCount);
+    expect(await page.locator('.motif-pm-restriction').count()).toBeLessThanOrEqual(512);
+    await expect(page.locator('.motif-cs-map-hint')).toContainText(/512 of .* sites selectable/);
 
     const inventoryRow = page.locator('.motif-cs-sidebar .motif-cs-row-compact').first();
     await expect(inventoryRow).toBeVisible();

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -296,6 +296,7 @@ test.describe('Claude Science artifact campaign', () => {
           const mapFeature = page.locator(`.motif-pm-feature[data-feature-id="${feature.id}"]`);
           await mapFeature.locator('.motif-pm-feature-hit').click();
           await expect(mapFeature).toHaveAttribute('aria-pressed', 'true');
+          await expect(page.locator('.motif-cs-map-frame .motif-pm-selection').first()).toBeVisible();
           await expect.poll(async () => {
             const state = await focusState();
             return state.fullyVisible
@@ -377,7 +378,7 @@ test.describe('Claude Science artifact campaign', () => {
       await page.mouse.click(clickPoint.x, clickPoint.y);
       await expect(feature).toHaveAttribute('data-selected', 'true');
       await expect(feature).toHaveAttribute('aria-label', /501–2800/);
-      await expect(page.locator('.motif-pm-selection')).toHaveCount(0);
+      await expect(page.locator('.motif-pm-selection')).toHaveCount(topology === 'circular' ? 3 : 1);
       const style = await body.evaluate((path) => {
         const computed = getComputedStyle(path);
         const swatch = document.createElement('span');
@@ -475,7 +476,7 @@ test.describe('Claude Science artifact campaign', () => {
         await page.mouse.click(tip.x, tip.y);
         await expect(feature).toHaveAttribute('data-selected', 'true');
         await expect(page.locator('.motif-pm-feature[data-selected="true"]')).toHaveCount(1);
-        await expect(page.locator('.motif-pm-selection')).toHaveCount(0);
+        await expect(page.locator('.motif-pm-selection')).toHaveCount(topology === 'circular' ? 3 : 1);
         await expect.poll(async () => {
           const focus = await sequenceFocus();
           return focus.highlightCount > 0
@@ -3589,6 +3590,15 @@ test.describe('Claude Science artifact campaign', () => {
     await expect(viewport).toHaveAttribute('transform', /translate/);
 
     await page.getByRole('button', { name: 'Reset map view' }).click();
+    await page.evaluate(() => window.motifRenderInventory?.([{
+      id: 'circular-drag-zones',
+      name: 'Circular drag zones',
+      molecule: 'dna',
+      topology: 'circular',
+      sequence: 'A'.repeat(4_000),
+      annotations: [],
+    }]));
+    await expect(mapFrame).toHaveAttribute('data-map-mode', 'circular');
     const circularBackbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
     const circularCenter = {
       x: circularBackbone.x + circularBackbone.width / 2,
@@ -3608,17 +3618,21 @@ test.describe('Claude Science artifact campaign', () => {
 
     await page.getByRole('button', { name: 'Reset map view' }).click();
     const radius = circularBackbone.width / 2;
-    await page.mouse.move(circularCenter.x, circularCenter.y - radius);
+    const insideRing = {
+      x: circularCenter.x,
+      y: circularCenter.y - radius * 0.45,
+    };
+    await page.mouse.move(insideRing.x, insideRing.y);
     await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'range');
     await page.mouse.down();
-    await page.mouse.move(circularCenter.x + radius, circularCenter.y, { steps: 8 });
+    await page.mouse.move(circularCenter.x + radius * 0.45, circularCenter.y, { steps: 8 });
     await page.mouse.up();
     const clockwise = await mapFrame.locator('.motif-cs-map-hint').textContent();
     expect(clockwise).toContain('range');
 
-    await page.mouse.move(circularCenter.x, circularCenter.y - radius);
+    await page.mouse.move(insideRing.x, insideRing.y);
     await page.mouse.down();
-    await page.mouse.move(circularCenter.x - radius, circularCenter.y, { steps: 8 });
+    await page.mouse.move(circularCenter.x - radius * 0.45, circularCenter.y, { steps: 8 });
     await page.mouse.up();
     const counterclockwise = await mapFrame.locator('.motif-cs-map-hint').textContent();
     expect(counterclockwise).toContain('range');
@@ -3666,6 +3680,26 @@ test.describe('Claude Science artifact campaign', () => {
     }).toBe(true);
   });
 
+  test('map drawing controls stay visible and switch a circular record between circle and line', async ({ page }) => {
+    await openArtifact(page, 900, 720);
+    const mapFrame = page.locator('.motif-cs-map-frame');
+    const drawing = mapFrame.locator('.motif-cs-map-mode-toggle');
+    const circular = drawing.getByRole('button', { name: 'Circular', exact: true });
+    const linear = drawing.getByRole('button', { name: 'Linear', exact: true });
+
+    await expect(drawing).toBeVisible();
+    await expect(circular).toHaveAttribute('aria-pressed', 'true');
+    await expect(linear).toHaveAttribute('aria-pressed', 'false');
+
+    await linear.click();
+    await expect(mapFrame).toHaveAttribute('data-map-mode', 'linear');
+    await expect(linear).toHaveAttribute('aria-pressed', 'true');
+
+    await circular.click();
+    await expect(mapFrame).toHaveAttribute('data-map-mode', 'circular');
+    await expect(circular).toHaveAttribute('aria-pressed', 'true');
+  });
+
   test('high zoom keeps range bands compact and Fit preserves the selection', async ({ page }) => {
     await openArtifact(page, 1180, 900);
     const mapFrame = page.locator('.motif-cs-map-frame');
@@ -3702,11 +3736,11 @@ test.describe('Claude Science artifact campaign', () => {
     ringTop = { x: backbone.x + backbone.width / 2, y: backbone.y };
     await page.mouse.move(ringTop.x, ringTop.y + 10);
     await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'range');
-    await page.mouse.move(ringTop.x, ringTop.y + 50);
+    await page.mouse.move(ringTop.x, ringTop.y - 50);
     await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
     const beforeCircularPan = await viewport.getAttribute('transform');
     await page.mouse.down();
-    await page.mouse.move(ringTop.x + 36, ringTop.y + 68, { steps: 6 });
+    await page.mouse.move(ringTop.x + 36, ringTop.y - 68, { steps: 6 });
     await page.mouse.up();
     expect(await viewport.getAttribute('transform')).not.toBe(beforeCircularPan);
 

--- a/e2e/claude-science-msa-interactions.spec.ts
+++ b/e2e/claude-science-msa-interactions.spec.ts
@@ -310,7 +310,7 @@ test.describe('Motif MSA viewer interactions', () => {
     await page.locator('[data-pane-toggle="tools"]').click();
     await expect(page.locator('.motif-cs-inspector')).toHaveAttribute('data-tools-pinned', 'true');
 
-    const docked = page.locator('.motif-cs-inspector details[name="motif-cs-tools"]').first();
+    const docked = page.locator('.motif-cs-inspector details[data-rail-tool]').first();
     await docked.locator(':scope > summary').click();
     await expect(docked).toHaveAttribute('open', '');
 

--- a/src/artifacts/LargeSequenceViewer.tsx
+++ b/src/artifacts/LargeSequenceViewer.tsx
@@ -1,10 +1,12 @@
-import { memo } from 'react';
+import { memo, useLayoutEffect, useRef } from 'react';
 
 const numberFormatter = new Intl.NumberFormat();
 
 type LargeSequenceViewerProps = {
   sequence: string;
   threshold: number;
+  selectedRange: { start: number; end: number } | null;
+  focusRequest: number;
 };
 
 /**
@@ -16,9 +18,31 @@ type LargeSequenceViewerProps = {
 export const LargeSequenceViewer = memo(function LargeSequenceViewer({
   sequence,
   threshold,
+  selectedRange,
+  focusRequest,
 }: LargeSequenceViewerProps) {
+  const valueRef = useRef<HTMLTextAreaElement | null>(null);
   const lengthLabel = numberFormatter.format(sequence.length);
   const thresholdLabel = numberFormatter.format(threshold);
+  const selectionStart = selectedRange
+    ? Math.max(0, Math.min(sequence.length, Math.trunc(selectedRange.start)))
+    : null;
+  const selectionEnd = selectedRange
+    ? Math.max(selectionStart ?? 0, Math.min(sequence.length, Math.trunc(selectedRange.end)))
+    : null;
+
+  useLayoutEffect(() => {
+    const control = valueRef.current;
+    if (!control || selectionStart === null || selectionEnd === null) return undefined;
+    control.setSelectionRange(selectionStart, selectionEnd, 'forward');
+    const frame = window.requestAnimationFrame(() => {
+      const maxScroll = Math.max(0, control.scrollHeight - control.clientHeight);
+      const sequenceRatio = sequence.length > 0 ? selectionStart / sequence.length : 0;
+      const centeredTop = sequenceRatio * control.scrollHeight - control.clientHeight / 2;
+      control.scrollTo({ top: Math.max(0, Math.min(maxScroll, centeredTop)), behavior: 'auto' });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [focusRequest, selectionEnd, selectionStart, sequence.length]);
 
   return (
     <section
@@ -32,10 +56,18 @@ export const LargeSequenceViewer = memo(function LargeSequenceViewer({
           {lengthLabel} residues exceed the {thresholdLabel}-residue interactive Detail limit.
           The full sequence remains selectable here and is preserved in every export.
         </span>
+        {selectionStart !== null && selectionEnd !== null ? (
+          <span data-testid="large-sequence-selection">
+            Map selection: {numberFormatter.format(selectionStart + 1)}–{numberFormatter.format(selectionEnd)}.
+          </span>
+        ) : null}
       </div>
       <textarea
+        ref={valueRef}
         className="motif-cs-large-sequence-value"
         aria-label={`Read-only full sequence, ${lengthLabel} residues`}
+        data-selection-start={selectionStart ?? undefined}
+        data-selection-end={selectionEnd ?? undefined}
         autoComplete="off"
         readOnly
         spellCheck={false}

--- a/src/artifacts/__tests__/claude-science-accessibility-interaction-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-accessibility-interaction-guards.test.ts
@@ -196,8 +196,9 @@ describe('Claude Science accessibility and interaction guards', () => {
     expect(artifactSource).toContain('id="motif-cs-feature-range-error"');
     expect(artifactSource.match(/aria-describedby=\{!rangeValidation\.valid \? 'motif-cs-translation-range-error' : undefined\}/g)).toHaveLength(2);
     expect(artifactSource).toContain('id="motif-cs-translation-range-error"');
-    expect(artifactSource.match(/aria-describedby=\{status \? 'motif-cs-add-enzyme-status' : undefined\}/g)).toHaveLength(2);
-    expect(artifactSource).toContain('id="motif-cs-add-enzyme-status"');
+    expect(artifactSource.match(/aria-describedby=\{status \? statusId : undefined\}/g)).toHaveLength(2);
+    expect(artifactSource).toContain('id={statusId}');
+    expect(artifactSource).toContain('const instanceId = useId()');
   });
 
   it('gives every primer numeric field stable browser metadata', () => {

--- a/src/artifacts/__tests__/claude-science-map-workspace-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-map-workspace-guards.test.ts
@@ -34,6 +34,14 @@ describe('Claude Science map workspace regression guards', () => {
     );
   });
 
+  it('shares restriction controls between Map Visibility and the Tools rail', () => {
+    expect(artifactSource).toContain('const renderRestrictionSiteControls = (includeMapSummary = false): ReactNode => {');
+    expect(artifactSource).toContain('{isDnaRecord ? renderRestrictionSiteControls(true) : null}');
+    expect(artifactSource).toContain('data-rail-tool="restriction-sites"');
+    expect(artifactSource).toContain('{renderRestrictionSiteControls(false)}');
+    expect(artifactSource).toContain('requestSequenceFocus();\n    setLockedTranslateTarget(null);');
+  });
+
   it('defaults restriction labels on instead of pre-judging them by site count', () => {
     // A site-count threshold here switched labelling off wholesale on any record
     // past it, which on the bundled vectors meant 8 of 13 drew every tick and
@@ -59,20 +67,26 @@ describe('Claude Science map workspace regression guards', () => {
     expect(addCustomEnzyme).not.toContain('setEnzymeSourcesByRecord');
   });
 
-  it('anchors the circular map readout to the edge its column actually shows', () => {
-    // Between 768px and 1535px the circular map frame is floored taller than the
-    // column can display — measured 504px of frame in a 442px column at 1440x900,
-    // 141px of it scrolled away — so anything anchored to the frame's BOTTOM is
-    // off-screen in every state. The readout was; the zoom controls were not, and
-    // the only difference between them was which edge they hang off.
+  it('keeps map controls in the pane heading and the circular readout on a reachable edge', () => {
+    // The compact control group belongs inside the pane heading. Its position
+    // therefore cannot change when the canvas switches between the tall
+    // circular and short linear layouts.
     const base = sliceBetween(artifactCss, '.motif-cs-map-hint {', '}');
     const toolbar = sliceBetween(artifactCss, '.motif-cs-map-toolbar {', '}');
-    // The premise the fix rests on: the top edge is the safe one, because that is
-    // where the controls that survived are anchored. If the toolbar ever moves to
-    // the bottom this reasoning is void and this test should fail.
-    expect(toolbar, 'the zoom controls no longer anchor to the safe top edge').toMatch(/top:\s*12px/);
+    expect(toolbar).toMatch(/flex:\s*0 0 auto/);
+    expect(toolbar).toMatch(/min-height:\s*28px/);
+    expect(toolbar).not.toMatch(/position:\s*absolute/);
+    expect(toolbar).not.toMatch(/\btop:/);
+    expect(toolbar).not.toMatch(/\bbottom:/);
+    const toolbarIndex = artifactSource.indexOf('className="motif-cs-map-toolbar"');
+    const frameIndex = artifactSource.indexOf('ref={mapFrameRef}');
+    expect(toolbarIndex).toBeGreaterThanOrEqual(0);
+    expect(frameIndex).toBeGreaterThan(toolbarIndex);
     expect(base).toMatch(/bottom:\s*12px/);
 
+    // Between 768px and 1535px the circular map frame can extend below its
+    // column's visible edge, so keep the transient readout on the reachable top
+    // edge. This no longer has any relationship to toolbar placement.
     const circular = sliceBetween(
       artifactCss,
       '.motif-cs-map-frame[data-map-mode="circular"] .motif-cs-map-hint {',
@@ -85,8 +99,7 @@ describe('Claude Science map workspace regression guards', () => {
     expect(circular).toMatch(/bottom:\s*auto/);
 
     // Scope. The rule must not reach 1536px and up, where the column does fit its
-    // frame and the lower-left corner is both reachable and quieter — and it must
-    // not reach the linear map, which has its own placement for its own reason.
+    // frame and the lower-left corner is reachable, or the linear map.
     const scoped = sliceBetween(
       artifactCss,
       '@media (min-width: 768px) and (max-width: 1535px) {\n  .motif-cs-map-frame[data-map-mode="circular"] .motif-cs-map-hint {',

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -608,7 +608,9 @@ describe('Claude Science workspace layout guards', () => {
     );
     expect(pointerStart).toContain('mapPointerActionAtPoint(contentPoint, layout, mapViewport.k)');
     expect(artifactSource).toContain('MAP_CIRCULAR_RANGE_HIT_MAX) / contentScale');
-    expect(artifactSource).toContain('MAP_LINEAR_RANGE_HIT_Y / contentScale');
+    expect(artifactSource).toContain('MAP_LINEAR_RANGE_HIT_TOP_Y / contentScale');
+    expect(artifactSource).toContain('MAP_LINEAR_RANGE_HIT_BOTTOM_Y / (contentScale * Math.pow(contentScale, 0.75))');
+    expect(artifactSource).toContain('Math.min(layout.bg.y + layout.bg.height, axis.y + hitBottomY)');
     expect(pointerStart).toContain("mode: 'range'");
     expect(pointerStart).toContain("mode: 'pan'");
     expect(pointerStart).not.toContain('mapViewport.k >');
@@ -790,7 +792,7 @@ describe('Claude Science workspace layout guards', () => {
     // under 100% recovered them.
     const rule = sliceBetween(
       artifactCss,
-      '@media (max-height: 694px) {',
+      '@media (max-height: 731px) {',
       '\n}',
     );
     expect(rule).toContain('.motif-cs-inspector[data-tools-pinned="false"]');
@@ -810,15 +812,15 @@ describe('Claude Science workspace layout guards', () => {
     const collapsed = sliceBetween(artifactCss, '.motif-cs-inspector[data-tools-pinned="false"] {', '}');
     expect(collapsed).toContain('pointer-events: none');
 
-    // 694 is derived, not chosen: 15 heads x 34px + 14 gaps x 3px + title and
-    // 8px padding = 625px of content under a 70px top bar, so 695 is the last
+    // 731 is derived, not chosen: 16 heads x 34px + 15 gaps x 3px + title and
+    // 8px padding = 662px of content under a 70px top bar, so 732 is the last
     // height that fits. These are the inputs -- if any moves, re-derive.
     expect(collapsed).toContain('padding: 8px 5px');
     expect(collapsed).toContain('gap: 3px');
     expect(artifactCss).toMatch(/\.motif-cs-inspector\[data-tools-pinned="false"\] \.motif-cs-panel-head\s*\{[\s\S]*?min-height:\s*34px/);
-    // Tool count is the other input. 16 rail labels exist in the artifact, 15 of
+    // Tool count is the other input. 17 rail labels exist in the artifact, 16 of
     // them in this rail; adding one moves the breakpoint and must fail here.
     expect((artifactSource.match(/data-rail-label="/g) ?? []).length,
-      'rail tool count changed -- re-derive the 694px breakpoint').toBe(16);
+      'rail tool count changed -- re-derive the 731px breakpoint').toBe(17);
   });
 });

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -631,7 +631,9 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toContain('const [hoveredRestrictionTickIds, setHoveredRestrictionTickIds]');
     expect(artifactSource).toContain('restrictionSelectionHasSite(activeRestrictionTickSet, site)');
     expect(artifactSource).toContain('onPointerEnter={() => setHoveredRestrictionTickIds(label.sites.map(restrictionSiteTickId))}');
-    expect(artifactSource).toContain('onFocus={() => setHoveredRestrictionTickIds(label.sites.map(restrictionSiteTickId))}');
+    expect(artifactSource).toContain('onFocus={() => {');
+    expect(artifactSource).toContain('setRovingRestrictionKey(label.key);');
+    expect(artifactSource).toContain('setHoveredRestrictionTickIds(label.sites.map(restrictionSiteTickId));');
     expect(artifactSource).toContain('data-cut-bond={senseCut}');
     expect(artifactSource).toContain('data-cut-bond={antisenseCut}');
   });

--- a/src/artifacts/__tests__/large-sequence-viewer.test.tsx
+++ b/src/artifacts/__tests__/large-sequence-viewer.test.tsx
@@ -6,13 +6,30 @@ describe('LargeSequenceViewer', () => {
   it('keeps the exact sequence in one browser-native read-only control', () => {
     const sequence = 'ATGC'.repeat(20_000);
     const html = renderToStaticMarkup(
-      <LargeSequenceViewer sequence={sequence} threshold={50_000} />,
+      <LargeSequenceViewer sequence={sequence} threshold={50_000} selectedRange={null} focusRequest={0} />,
     );
 
     expect(html).toContain('Large-record density view');
     expect(html).toContain('80,000 residues exceed the 50,000-residue interactive Detail limit');
     expect(html).toContain('data-testid="large-sequence-viewer"');
     expect(html).toContain('readOnly=""');
+    expect(html).toContain(`>${sequence}</textarea>`);
+  });
+
+  it('reports an exact map-selected range without changing the sequence value', () => {
+    const sequence = 'ATGC'.repeat(20_000);
+    const html = renderToStaticMarkup(
+      <LargeSequenceViewer
+        sequence={sequence}
+        threshold={50_000}
+        selectedRange={{ start: 60_000, end: 62_000 }}
+        focusRequest={1}
+      />,
+    );
+
+    expect(html).toContain('Map selection: 60,001–62,000.');
+    expect(html).toContain('data-selection-start="60000"');
+    expect(html).toContain('data-selection-end="62000"');
     expect(html).toContain(`>${sequence}</textarea>`);
   });
 });

--- a/src/artifacts/claude-science-cloning-design-workspace.css
+++ b/src/artifacts/claude-science-cloning-design-workspace.css
@@ -1413,3 +1413,17 @@
     scroll-behavior: auto !important;
   }
 }
+
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-cloning-design-methods button[data-selected],
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-cloning-design-methods button[data-selected]:hover,
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-cloning-design-segmented label[data-selected],
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-cloning-design-orientation button[data-selected],
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-cloning-design-orientation button[data-selected]:hover {
+  border-color: var(--accent-base);
+  background: var(--accent-base);
+  color: var(--accent-contrast);
+}
+
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-cloning-design-methods button[data-selected] small {
+  color: var(--accent-contrast);
+}

--- a/src/artifacts/claude-science-msa.css
+++ b/src/artifacts/claude-science-msa.css
@@ -1141,6 +1141,17 @@
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
+
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-msa-workspace .motif-cs-msa-row-stats-scroll th > button[data-active='true'],
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-msa-workspace .motif-cs-msa-row-stats-scroll th > button[data-active='true']:hover,
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-msa-workspace .motif-cs-msa-row-stats-scroll th > button[data-active='true']:focus-visible {
+  background: var(--accent-base);
+  color: var(--accent-contrast);
+}
+
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-msa-workspace .motif-cs-msa-row-stats-scroll th > button[data-active='true'] .motif-cs-msa-row-stats-sort-indicator {
+  color: var(--accent-contrast);
+}
 .motif-cs-msa-workspace .motif-cs-msa-row-stats-sort-indicator {
   width: 1em;
   color: var(--text-muted);

--- a/src/artifacts/claude-science-primer-workspace.css
+++ b/src/artifacts/claude-science-primer-workspace.css
@@ -886,3 +886,18 @@
     transition-duration: 0.01ms !important;
   }
 }
+
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-primer-preset[data-active],
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-primer-preset[data-active]:hover,
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-primer-pair-row[data-selected],
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-primer-pair-row[data-selected]:hover {
+  border-color: var(--accent-base);
+  background: var(--accent-base);
+  color: var(--accent-contrast);
+}
+
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-primer-pair-row[data-selected] .motif-cs-primer-pair-rank,
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-primer-pair-row[data-selected] .motif-cs-primer-pair-arrow,
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-primer-pair-row[data-selected] small {
+  color: var(--accent-contrast);
+}

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -1736,11 +1736,11 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
    the reserve follows what is actually rendered instead of restating the gate
    that renders it. */
 .motif-cs-map-frame:has(.motif-cs-map-labels-toggle) {
-  --map-toolbar-reserve: 294px;
+  --map-toolbar-reserve: 190px;
 }
 
 .motif-cs-map-frame:has(.motif-cs-map-mode-toggle):not(:has(.motif-cs-map-labels-toggle)) {
-  --map-toolbar-reserve: 244px;
+  --map-toolbar-reserve: 158px;
 }
 
 /* A linear map is short and wide — don't reserve a tall square frame for it,
@@ -1880,45 +1880,23 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
 }
 
 .motif-cs-map-mode-toggle {
-  display: inline-flex;
-  overflow: hidden;
-  margin-inline: 3px 1px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 3px;
+  margin-left: 3px;
+  border-color: var(--border-subtle);
   background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
 }
 
-.motif-cs-map-mode-toggle .motif-cs-map-mode-button {
-  width: auto;
-  min-width: 45px;
-  padding-inline: 6px;
-  border: 0;
-  border-radius: 0;
-  font-size: 10px;
-  font-weight: 700;
-}
-
-.motif-cs-map-mode-toggle .motif-cs-map-mode-button + .motif-cs-map-mode-button {
-  border-left: 1px solid var(--border-subtle);
-}
-
-.motif-cs-map-mode-toggle .motif-cs-map-mode-button[data-active],
-.motif-cs-map-mode-toggle .motif-cs-map-mode-button[data-active]:hover,
-.motif-cs-map-mode-toggle .motif-cs-map-mode-button[data-active]:focus-visible {
-  background: var(--accent-base);
-  color: var(--accent-contrast);
+.motif-cs-map-mode-toggle svg,
+.motif-cs-map-labels-toggle svg {
+  display: block;
 }
 
 /* Puts restriction-label state on the map instead of only in the visibility
    panel. State comes from the filled/unfilled button and aria-pressed, so the
    visible caption stays compact and does not move when toggled. */
 .motif-cs-map-labels-toggle {
-  width: auto;
-  min-width: 40px;
-  padding-inline: 6px;
+  width: 28px;
+  min-width: 28px;
   color: var(--text-muted);
-  font-size: 10px;
-  font-weight: 700;
 }
 
 /* Labels default on, so this is the resting look: a filled chip is both the

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -17,6 +17,7 @@ html[data-theme="dark"] {
   --text-muted: #ababab;
   --accent-base: #0169cc;
   --accent: #339cff;
+  --accent-contrast: #ffffff;
   --green: #40c977;
   --purple: #ad7bf9;
   --amber: #f0b429;
@@ -50,6 +51,7 @@ html[data-theme="light"] {
   --text-muted: #6b6b6b;
   --accent-base: #0169cc;
   --accent: #0169cc;
+  --accent-contrast: #ffffff;
   --green: #137a46;
   --purple: #6d35c1;
   --amber: #865b00;
@@ -1887,18 +1889,20 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
 
 /* Labels default on, so this is the resting look: a filled chip is both the
    state and what makes the caption legible over map ink. */
-.motif-cs-map-labels-toggle[data-active] {
-  border-color: color-mix(in srgb, var(--border-strong) 55%, transparent);
-  background: color-mix(in srgb, var(--bg-primary) 82%, transparent);
-  color: var(--text-primary);
-}
-
 .motif-cs-map-button:hover,
 .motif-cs-map-button:focus-visible {
   border-color: color-mix(in srgb, var(--border-strong) 55%, transparent);
   background: color-mix(in srgb, var(--bg-primary) 82%, transparent);
   color: var(--text-primary);
   outline: none;
+}
+
+.motif-cs-map-labels-toggle[data-active],
+.motif-cs-map-labels-toggle[data-active]:hover,
+.motif-cs-map-labels-toggle[data-active]:focus-visible {
+  border-color: var(--accent-base);
+  background: var(--accent-base);
+  color: var(--accent-contrast);
 }
 
 .motif-cs-map-button:disabled {

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -111,28 +111,77 @@ html[data-theme="claude-light"] .motif-cs-window-toggle[data-active="true"] {
   color: var(--accent-contrast);
 }
 
+html[data-theme="claude-light"] .motif-cs-pane-toggle[data-active="true"]:disabled,
+html[data-theme="claude-light"] .motif-cs-pane-toggle[data-active="true"]:disabled:hover,
+html[data-theme="claude-light"] .motif-cs-pane-toggle[data-active="true"]:disabled:focus-visible,
+html[data-theme="claude-light"] .motif-cs-gel-source-row[data-selected],
+html[data-theme="claude-light"] .motif-cs-gel-source-row[data-selected]:hover,
+html[data-theme="claude-light"] .motif-cs-gel-ladder-picker .motif-cs-segmented label[data-selected],
+html[data-theme="claude-light"] .motif-cs-sanger-lane[data-active] .motif-cs-sanger-lane-header {
+  border-color: var(--accent-base);
+  background: var(--accent-base);
+  color: var(--accent-contrast);
+  box-shadow: none;
+}
+
+html[data-theme="claude-light"] .motif-cs-pane-toggle[data-active="true"]:disabled .motif-cs-nav-icon,
+html[data-theme="claude-light"] .motif-cs-gel-source-row[data-selected] strong,
+html[data-theme="claude-light"] .motif-cs-gel-source-row[data-selected] small,
+html[data-theme="claude-light"] .motif-cs-sanger-lane[data-active] .motif-cs-sanger-lane-header * {
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-light"] .motif-cs-sanger-lane[data-active] .motif-cs-sanger-lane-header .motif-cs-chip {
+  border-color: color-mix(in srgb, var(--accent-contrast) 48%, transparent);
+  background: transparent;
+}
+
 html[data-theme="claude-light"] .motif-cs-pane-toggle[data-active="true"] .motif-cs-nav-icon,
 html[data-theme="claude-light"] .motif-cs-window-toggle[data-active="true"] .motif-cs-nav-icon {
   color: var(--accent-contrast);
 }
 
-html[data-theme="claude-light"] .motif-cs-row[data-active="true"] {
-  background: color-mix(in srgb, var(--accent-base) 9%, var(--bg-primary));
-  box-shadow: inset 3px 0 0 var(--accent-base);
-}
-
-html[data-theme="claude-light"] .motif-cs-row.motif-cs-inventory-record-row[data-active="true"],
-html[data-theme="claude-light"] .motif-cs-row.motif-cs-inventory-record-row[data-active="true"]:hover,
-html[data-theme="claude-light"] .motif-cs-row.motif-cs-inventory-record-row[data-active="true"]:focus-visible {
+html[data-theme="claude-light"] .motif-cs-row[data-active="true"],
+html[data-theme="claude-light"] .motif-cs-row[data-active="true"]:hover,
+html[data-theme="claude-light"] .motif-cs-row[data-active="true"]:focus-visible,
+html[data-theme="claude-light"] .motif-cs-sidebar .motif-cs-row.motif-cs-row-compact[data-active="true"],
+html[data-theme="claude-light"] .motif-cs-inventory-group-head[data-active="true"],
+html[data-theme="claude-light"] .motif-cs-restriction-row[data-active="true"],
+html[data-theme="claude-light"] .motif-cs-restriction-site-row[data-active="true"],
+html[data-theme="claude-light"] .motif-cs-theme-choice[data-active="true"],
+html[data-theme="claude-light"] .motif-cs-theme-choice[data-active="true"]:hover,
+html[data-theme="claude-light"] .motif-cs-msa-record-option[data-active="true"],
+html[data-theme="claude-light"] .motif-cs-msa-record-option[data-active="true"]:hover {
   border-top-color: var(--accent-base);
+  border-color: var(--accent-base);
   background: var(--accent-base);
   box-shadow: none;
   color: var(--accent-contrast);
 }
 
-html[data-theme="claude-light"] .motif-cs-inventory-record-row[data-active="true"] .motif-cs-row-main > span:first-child,
-html[data-theme="claude-light"] .motif-cs-inventory-record-row[data-active="true"] .motif-cs-row-main small {
+html[data-theme="claude-light"] .motif-cs-row[data-active="true"] .motif-cs-row-main,
+html[data-theme="claude-light"] .motif-cs-row[data-active="true"] .motif-cs-row-main > span:first-child,
+html[data-theme="claude-light"] .motif-cs-row[data-active="true"] .motif-cs-row-main small,
+html[data-theme="claude-light"] .motif-cs-row[data-active="true"] .motif-cs-row-meta,
+html[data-theme="claude-light"] .motif-cs-row[data-active="true"] .motif-cs-chip,
+html[data-theme="claude-light"] .motif-cs-restriction-row[data-active="true"] .motif-cs-row-main,
+html[data-theme="claude-light"] .motif-cs-restriction-row[data-active="true"] .motif-cs-row-meta,
+html[data-theme="claude-light"] .motif-cs-restriction-site-row[data-active="true"] .motif-cs-row-main,
+html[data-theme="claude-light"] .motif-cs-restriction-site-row[data-active="true"] .motif-cs-row-main small,
+html[data-theme="claude-light"] .motif-cs-restriction-site-row[data-active="true"] .motif-cs-row-meta,
+html[data-theme="claude-light"] .motif-cs-theme-choice[data-active="true"] .motif-cs-theme-choice-copy small,
+html[data-theme="claude-light"] .motif-cs-msa-record-option[data-active="true"] small,
+html[data-theme="claude-light"] .motif-cs-msa-record-option[data-active="true"] em,
+html[data-theme="claude-light"] .motif-cs-translation-row-shell[data-active="true"] .motif-cs-translation-row-delete {
   color: var(--accent-contrast);
+}
+
+html[data-theme="claude-light"] .motif-cs-restriction-row[data-active="true"] .motif-cs-cut-dot {
+  border-color: var(--accent-contrast);
+}
+
+html[data-theme="claude-light"] .motif-cs-restriction-row[data-active="true"] .motif-cs-toggle input:checked + .motif-cs-cut-dot {
+  background: var(--accent-contrast);
 }
 
 html[data-theme="claude-light"] .motif-cs-mini-button[data-active="true"],
@@ -143,6 +192,27 @@ html[data-theme="claude-light"] .motif-cs-segmented button[data-active] {
   background: var(--accent-base);
   color: var(--accent-contrast);
   box-shadow: none;
+}
+
+html[data-theme="claude-light"] .motif-cs-inspector .motif-cs-panel[open] > .motif-cs-panel-head,
+html[data-theme="claude-light"] .motif-cs-restriction-source[data-active="true"] {
+  border-color: var(--accent-base);
+  background: var(--accent-base);
+  color: var(--accent-contrast);
+  box-shadow: none;
+}
+
+html[data-theme="claude-light"] .motif-cs-inspector .motif-cs-panel[open] > .motif-cs-panel-head > span,
+html[data-theme="claude-light"] .motif-cs-inspector .motif-cs-panel[open] > .motif-cs-panel-head > .motif-cs-chip,
+html[data-theme="claude-light"] .motif-cs-inspector .motif-cs-panel[open] > .motif-cs-panel-head > .motif-cs-panel-icon,
+html[data-theme="claude-light"] .motif-cs-inspector .motif-cs-panel[open] > .motif-cs-panel-head::after,
+html[data-theme="claude-light"] .motif-cs-restriction-source[data-active="true"] .motif-cs-source-state {
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-light"] .motif-cs-restriction-source[data-active="true"] .motif-cs-source-state {
+  border-color: color-mix(in srgb, var(--accent-contrast) 48%, transparent);
+  background: color-mix(in srgb, var(--accent-base) 84%, #000000);
 }
 
 html[data-theme="claude-dark"] {
@@ -198,28 +268,77 @@ html[data-theme="claude-dark"] .motif-cs-window-toggle[data-active="true"] {
   color: var(--accent-contrast);
 }
 
+html[data-theme="claude-dark"] .motif-cs-pane-toggle[data-active="true"]:disabled,
+html[data-theme="claude-dark"] .motif-cs-pane-toggle[data-active="true"]:disabled:hover,
+html[data-theme="claude-dark"] .motif-cs-pane-toggle[data-active="true"]:disabled:focus-visible,
+html[data-theme="claude-dark"] .motif-cs-gel-source-row[data-selected],
+html[data-theme="claude-dark"] .motif-cs-gel-source-row[data-selected]:hover,
+html[data-theme="claude-dark"] .motif-cs-gel-ladder-picker .motif-cs-segmented label[data-selected],
+html[data-theme="claude-dark"] .motif-cs-sanger-lane[data-active] .motif-cs-sanger-lane-header {
+  border-color: var(--accent-base);
+  background: var(--accent-base);
+  color: var(--accent-contrast);
+  box-shadow: none;
+}
+
+html[data-theme="claude-dark"] .motif-cs-pane-toggle[data-active="true"]:disabled .motif-cs-nav-icon,
+html[data-theme="claude-dark"] .motif-cs-gel-source-row[data-selected] strong,
+html[data-theme="claude-dark"] .motif-cs-gel-source-row[data-selected] small,
+html[data-theme="claude-dark"] .motif-cs-sanger-lane[data-active] .motif-cs-sanger-lane-header * {
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-dark"] .motif-cs-sanger-lane[data-active] .motif-cs-sanger-lane-header .motif-cs-chip {
+  border-color: color-mix(in srgb, var(--accent-contrast) 48%, transparent);
+  background: transparent;
+}
+
 html[data-theme="claude-dark"] .motif-cs-pane-toggle[data-active="true"] .motif-cs-nav-icon,
 html[data-theme="claude-dark"] .motif-cs-window-toggle[data-active="true"] .motif-cs-nav-icon {
   color: var(--accent-contrast);
 }
 
-html[data-theme="claude-dark"] .motif-cs-row[data-active="true"] {
-  background: color-mix(in srgb, var(--accent) 11%, var(--bg-primary));
-  box-shadow: inset 3px 0 0 var(--accent);
-}
-
-html[data-theme="claude-dark"] .motif-cs-row.motif-cs-inventory-record-row[data-active="true"],
-html[data-theme="claude-dark"] .motif-cs-row.motif-cs-inventory-record-row[data-active="true"]:hover,
-html[data-theme="claude-dark"] .motif-cs-row.motif-cs-inventory-record-row[data-active="true"]:focus-visible {
+html[data-theme="claude-dark"] .motif-cs-row[data-active="true"],
+html[data-theme="claude-dark"] .motif-cs-row[data-active="true"]:hover,
+html[data-theme="claude-dark"] .motif-cs-row[data-active="true"]:focus-visible,
+html[data-theme="claude-dark"] .motif-cs-sidebar .motif-cs-row.motif-cs-row-compact[data-active="true"],
+html[data-theme="claude-dark"] .motif-cs-inventory-group-head[data-active="true"],
+html[data-theme="claude-dark"] .motif-cs-restriction-row[data-active="true"],
+html[data-theme="claude-dark"] .motif-cs-restriction-site-row[data-active="true"],
+html[data-theme="claude-dark"] .motif-cs-theme-choice[data-active="true"],
+html[data-theme="claude-dark"] .motif-cs-theme-choice[data-active="true"]:hover,
+html[data-theme="claude-dark"] .motif-cs-msa-record-option[data-active="true"],
+html[data-theme="claude-dark"] .motif-cs-msa-record-option[data-active="true"]:hover {
   border-top-color: var(--accent-base);
+  border-color: var(--accent-base);
   background: var(--accent-base);
   box-shadow: none;
   color: var(--accent-contrast);
 }
 
-html[data-theme="claude-dark"] .motif-cs-inventory-record-row[data-active="true"] .motif-cs-row-main > span:first-child,
-html[data-theme="claude-dark"] .motif-cs-inventory-record-row[data-active="true"] .motif-cs-row-main small {
+html[data-theme="claude-dark"] .motif-cs-row[data-active="true"] .motif-cs-row-main,
+html[data-theme="claude-dark"] .motif-cs-row[data-active="true"] .motif-cs-row-main > span:first-child,
+html[data-theme="claude-dark"] .motif-cs-row[data-active="true"] .motif-cs-row-main small,
+html[data-theme="claude-dark"] .motif-cs-row[data-active="true"] .motif-cs-row-meta,
+html[data-theme="claude-dark"] .motif-cs-row[data-active="true"] .motif-cs-chip,
+html[data-theme="claude-dark"] .motif-cs-restriction-row[data-active="true"] .motif-cs-row-main,
+html[data-theme="claude-dark"] .motif-cs-restriction-row[data-active="true"] .motif-cs-row-meta,
+html[data-theme="claude-dark"] .motif-cs-restriction-site-row[data-active="true"] .motif-cs-row-main,
+html[data-theme="claude-dark"] .motif-cs-restriction-site-row[data-active="true"] .motif-cs-row-main small,
+html[data-theme="claude-dark"] .motif-cs-restriction-site-row[data-active="true"] .motif-cs-row-meta,
+html[data-theme="claude-dark"] .motif-cs-theme-choice[data-active="true"] .motif-cs-theme-choice-copy small,
+html[data-theme="claude-dark"] .motif-cs-msa-record-option[data-active="true"] small,
+html[data-theme="claude-dark"] .motif-cs-msa-record-option[data-active="true"] em,
+html[data-theme="claude-dark"] .motif-cs-translation-row-shell[data-active="true"] .motif-cs-translation-row-delete {
   color: var(--accent-contrast);
+}
+
+html[data-theme="claude-dark"] .motif-cs-restriction-row[data-active="true"] .motif-cs-cut-dot {
+  border-color: var(--accent-contrast);
+}
+
+html[data-theme="claude-dark"] .motif-cs-restriction-row[data-active="true"] .motif-cs-toggle input:checked + .motif-cs-cut-dot {
+  background: var(--accent-contrast);
 }
 
 html[data-theme="claude-dark"] .motif-cs-mini-button[data-active="true"],
@@ -230,6 +349,44 @@ html[data-theme="claude-dark"] .motif-cs-segmented button[data-active] {
   background: var(--accent-base);
   color: var(--accent-contrast);
   box-shadow: none;
+}
+
+html[data-theme="claude-dark"] .motif-cs-inspector .motif-cs-panel[open] > .motif-cs-panel-head,
+html[data-theme="claude-dark"] .motif-cs-restriction-source[data-active="true"] {
+  border-color: var(--accent-base);
+  background: var(--accent-base);
+  color: var(--accent-contrast);
+  box-shadow: none;
+}
+
+html[data-theme="claude-dark"] .motif-cs-inspector .motif-cs-panel[open] > .motif-cs-panel-head > span,
+html[data-theme="claude-dark"] .motif-cs-inspector .motif-cs-panel[open] > .motif-cs-panel-head > .motif-cs-chip,
+html[data-theme="claude-dark"] .motif-cs-inspector .motif-cs-panel[open] > .motif-cs-panel-head > .motif-cs-panel-icon,
+html[data-theme="claude-dark"] .motif-cs-inspector .motif-cs-panel[open] > .motif-cs-panel-head::after,
+html[data-theme="claude-dark"] .motif-cs-restriction-source[data-active="true"] .motif-cs-source-state {
+  color: var(--accent-contrast);
+}
+
+html[data-theme="claude-dark"] .motif-cs-restriction-source[data-active="true"] .motif-cs-source-state {
+  border-color: color-mix(in srgb, var(--accent-contrast) 48%, transparent);
+  background: color-mix(in srgb, var(--accent-base) 84%, #000000);
+}
+
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-annotation-list .motif-cs-row[data-active="true"],
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-annotation-list .motif-cs-row[data-active="true"]:hover,
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-annotation-list .motif-cs-row[data-active="true"]:focus-visible {
+  border-color: color-mix(in srgb, var(--motif-cs-row-color, var(--accent-base)) 34%, var(--border-subtle));
+  background: color-mix(in srgb, var(--motif-cs-row-color, var(--accent-base)) 15%, var(--bg-primary));
+  box-shadow: inset 3px 0 0 var(--motif-cs-row-color, var(--accent-base));
+  color: var(--text-primary);
+}
+
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-annotation-list .motif-cs-row[data-active="true"] .motif-cs-row-main,
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-annotation-list .motif-cs-row[data-active="true"] .motif-cs-row-main small,
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-annotation-list .motif-cs-row[data-active="true"] .motif-cs-row-meta,
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-annotation-list .motif-cs-row[data-active="true"] .motif-cs-chip,
+html:is([data-theme="claude-light"], [data-theme="claude-dark"]) .motif-cs-translation-row-shell[data-active="true"] .motif-cs-translation-row-delete {
+  color: var(--text-primary);
 }
 
 :root {
@@ -1020,7 +1177,7 @@ summary,
 }
 
 .motif-cs-map-column > .motif-cs-pane-title {
-  min-height: 22px;
+  min-height: 30px;
   padding: 0 2px 2px 10px;
 }
 
@@ -1032,6 +1189,16 @@ summary,
 
 .motif-cs-map-column > .motif-cs-pane-title small {
   font-size: 10px;
+}
+
+.motif-cs-map-title-full {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.motif-cs-map-title-compact {
+  display: none;
 }
 
 .motif-cs-map-column > .motif-cs-pane-title .motif-cs-pane-collapse {
@@ -1174,30 +1341,9 @@ body[data-motif-cs-rail-popover-resizing] {
   pointer-events: auto;
 }
 
-/* Below this height the rail's fifteen tools do not fit, and until now they
-   simply left the screen: Settings — theme, backup, Clear workspace — and
-   Alignment, the 14th icon, became unreachable with no way back. Measured at
-   1440x600: content 625 against 530 of room, and wheel, touch-drag and 120
-   presses of Tab all left it exactly where it was. Only page zoom under 100%
-   recovered them, which is a workaround a stuck user has to already know.
-
-   694px is not a chosen number. The rail holds 15 heads at 34px with 3px
-   between them plus its title and 8px padding, which is 625px of content under
-   a 70px top bar — so 695 is the last height where the last icon fits, and 694
-   is the first where something is hidden. It is exactly the boundary the
-   advisor observed independently. A 16th tool moves it; the guard test ties
-   this constant to the tool count so it cannot drift silently.
-
-   `pointer-events: auto` here does NOT weaken the rule above it. That rule
-   protects EMPTY rail space, and empty rail space is what has just run out:
-   measured 205px at 900, 65px at 760, 5px at 700 and 0px at 694 and below. The
-   passthrough is restored in full the moment there is anything to pass through.
-   Scoping it this way was not caution — with the rail left `pointer-events:
-   none`, `overflow-y: auto` alone is a mirage. The wheel then targets whatever
-   sits BENEATH the rail, so it scrolls only while the pointer is over an icon
-   and is dead in the 3px gaps between them (measured: 103 over an icon, 0 in a
-   gap, at the same height), and the thumb cannot be dragged at all. */
-@media (max-height: 694px) {
+/* Sixteen 34px tool heads, their gaps, the title, and padding need 662px below
+   the top bar. Once they no longer fit, the rail becomes its own scroll area. */
+@media (max-height: 731px) {
   .motif-cs-inspector[data-tools-pinned="false"] {
     overflow-y: auto;
     overflow-x: hidden;
@@ -1389,9 +1535,30 @@ body[data-motif-cs-rail-popover-resizing] {
 }
 
 @media (max-width: 520px) {
+  .motif-cs-map-title-full {
+    display: none;
+  }
+
+  .motif-cs-map-title-compact {
+    display: inline;
+  }
+
   .motif-cs-inspector[data-tools-pinned="false"] .motif-cs-panel[open] > .motif-cs-tool-panel-body {
     right: 50px;
     width: min(var(--rail-popover-width, 344px), calc(100vw - 62px));
+    max-width: calc(100vw - 62px);
+  }
+
+  .motif-cs-panel .motif-cs-restriction-source-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .motif-cs-panel .motif-cs-restriction-source:nth-child(even) {
+    border-left: 0;
+  }
+
+  .motif-cs-panel .motif-cs-restriction-source:nth-child(n + 2) {
+    border-top: 1px solid var(--border-subtle);
   }
 }
 
@@ -1527,12 +1694,18 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
 .motif-cs-inspector[data-tools-pinned="true"] {
   gap: 0;
   padding: 8px 0;
+  scrollbar-gutter: stable;
 }
 
 .motif-cs-inspector[data-tools-pinned="true"] .motif-cs-pane-title {
+  position: sticky;
+  z-index: 5;
+  top: 8px;
+  flex: 0 0 auto;
   min-height: 30px;
   padding: 0 10px 7px 12px;
   border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-primary);
 }
 
 .motif-cs-inspector[data-tools-pinned="true"] .motif-cs-panel {
@@ -1710,15 +1883,6 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
 
 .motif-cs-map-frame {
   position: relative;
-  /* How much of a row the zoom toolbar occupies, declared on the frame because
-     the toolbar and the status readout are SIBLINGS and in linear mode they
-     share the bottom edge from opposite ends — the readout subtracts this to
-     stay clear. It used to be a bare 126px written into the readout's own
-     max-width, which meant every control added to the toolbar had to remember
-     to go and re-guess a number living somewhere else. Protein and RNA records
-     get no Labels chip, so their toolbar is the original three zoom buttons
-     wide: 28 + 34 + 28, two 2px gaps, and the 12px inset at each end. */
-  --map-toolbar-reserve: 126px;
   /* Map-first workspace: keep the restriction/source panels below the primary
      canvas rather than letting them crowd it. */
   height: clamp(560px, 70vh, 820px);
@@ -1729,18 +1893,6 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
   border-bottom: 1px solid color-mix(in srgb, var(--border-subtle) 72%, transparent);
   border-radius: 0;
   overflow: hidden;
-}
-
-/* DNA records add the Sites chip, so the readout starts further in. Keyed off
-   the chip being present so
-   the reserve follows what is actually rendered instead of restating the gate
-   that renders it. */
-.motif-cs-map-frame:has(.motif-cs-map-labels-toggle) {
-  --map-toolbar-reserve: 190px;
-}
-
-.motif-cs-map-frame:has(.motif-cs-map-mode-toggle):not(:has(.motif-cs-map-labels-toggle)) {
-  --map-toolbar-reserve: 158px;
 }
 
 /* A linear map is short and wide — don't reserve a tall square frame for it,
@@ -1831,25 +1983,17 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
 }
 
 .motif-cs-map-toolbar {
-  position: absolute;
-  top: 12px;
-  left: 12px;
-  z-index: 3;
   display: inline-flex;
+  flex: 0 0 auto;
   align-items: center;
+  align-self: center;
   gap: 2px;
+  min-width: 0;
+  min-height: 28px;
   padding: 0;
   border: 0;
   border-radius: 0;
   background: transparent;
-}
-
-/* Linear maps place their axis and early restriction ticks across the top edge.
-   Keep zoom controls in the otherwise-empty lower corner so they never steal
-   pointer events from the first sites. */
-.motif-cs-map-frame[data-map-mode="linear"] .motif-cs-map-toolbar {
-  top: auto;
-  bottom: 10px;
 }
 
 .motif-cs-map-button {
@@ -1886,14 +2030,14 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
 }
 
 .motif-cs-map-mode-toggle svg,
-.motif-cs-map-labels-toggle svg {
+.motif-cs-map-sites-toggle svg {
   display: block;
 }
 
-/* Puts restriction-label state on the map instead of only in the visibility
-   panel. State comes from the filled/unfilled button and aria-pressed, so the
-   visible caption stays compact and does not move when toggled. */
-.motif-cs-map-labels-toggle {
+/* The compact scissors button controls the full restriction-site layer. The
+   detailed visibility panel still owns separate source, enzyme, and label
+   controls. */
+.motif-cs-map-sites-toggle {
   width: 28px;
   min-width: 28px;
   color: var(--text-muted);
@@ -1909,9 +2053,9 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
   outline: none;
 }
 
-.motif-cs-map-labels-toggle[data-active],
-.motif-cs-map-labels-toggle[data-active]:hover,
-.motif-cs-map-labels-toggle[data-active]:focus-visible {
+.motif-cs-map-sites-toggle[data-active],
+.motif-cs-map-sites-toggle[data-active]:hover,
+.motif-cs-map-sites-toggle[data-active]:focus-visible {
   border-color: var(--accent-base);
   background: var(--accent-base);
   color: var(--accent-contrast);
@@ -1947,7 +2091,7 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
 .motif-cs-map-frame[data-map-mode="linear"] .motif-cs-map-hint {
   right: 12px;
   left: auto;
-  max-width: min(320px, calc(100% - var(--map-toolbar-reserve)));
+  max-width: min(320px, calc(100% - 24px));
   text-align: right;
 }
 
@@ -10683,6 +10827,10 @@ summary.motif-cs-panel-head:focus-visible {
 
   .motif-cs-main[data-content-pane-count="3"] > .motif-cs-map-column .motif-cs-map-frame {
     min-height: 120px;
+  }
+
+  .motif-cs-main[data-content-pane-count="3"] > .motif-cs-map-column {
+    padding-block: 0;
   }
 }
 

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -1736,7 +1736,11 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
    the reserve follows what is actually rendered instead of restating the gate
    that renders it. */
 .motif-cs-map-frame:has(.motif-cs-map-labels-toggle) {
-  --map-toolbar-reserve: 176px;
+  --map-toolbar-reserve: 294px;
+}
+
+.motif-cs-map-frame:has(.motif-cs-map-mode-toggle):not(:has(.motif-cs-map-labels-toggle)) {
+  --map-toolbar-reserve: 244px;
 }
 
 /* A linear map is short and wide — don't reserve a tall square frame for it,
@@ -1873,6 +1877,36 @@ body[data-motif-cs-rail-popover-resizing] .motif-cs-rail-popover-resize::after {
 
 .motif-cs-map-reset:not(:disabled) {
   color: var(--text-primary);
+}
+
+.motif-cs-map-mode-toggle {
+  display: inline-flex;
+  overflow: hidden;
+  margin-inline: 3px 1px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
+}
+
+.motif-cs-map-mode-toggle .motif-cs-map-mode-button {
+  width: auto;
+  min-width: 45px;
+  padding-inline: 6px;
+  border: 0;
+  border-radius: 0;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.motif-cs-map-mode-toggle .motif-cs-map-mode-button + .motif-cs-map-mode-button {
+  border-left: 1px solid var(--border-subtle);
+}
+
+.motif-cs-map-mode-toggle .motif-cs-map-mode-button[data-active],
+.motif-cs-map-mode-toggle .motif-cs-map-mode-button[data-active]:hover,
+.motif-cs-map-mode-toggle .motif-cs-map-mode-button[data-active]:focus-visible {
+  background: var(--accent-base);
+  color: var(--accent-contrast);
 }
 
 /* Puts restriction-label state on the map instead of only in the visibility

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-refresh/only-export-components -- artifact entry exports pure runtime test seams */
-import { Component, useCallback, useDeferredValue, useEffect, useId, useLayoutEffect, useMemo, useReducer, useRef, useState, type ClipboardEvent as ReactClipboardEvent, type CSSProperties, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type RefObject } from 'react';
+import { Component, memo, useCallback, useDeferredValue, useEffect, useId, useLayoutEffect, useMemo, useReducer, useRef, useState, type ClipboardEvent as ReactClipboardEvent, type CSSProperties, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type RefObject } from 'react';
 import { createPortal } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { Activity, AlignCenter, Beaker, ChevronDown, ChevronLeft, ChevronRight, Crosshair, Dna, FileText, History, Info, Languages, LayoutGrid, List, Map as MapIcon, Maximize2, Minimize2, NotebookPen, Plus, Redo2, Search, Settings, ShieldCheck, Tag, Trash2, Undo2, Workflow, Wrench, X, type LucideIcon } from 'lucide-react';
@@ -4754,6 +4754,7 @@ function App() {
   const [mapRenderModeByRecord, setMapRenderModeByRecord] = useState<Record<string, MapMode>>({});
   const [mapRangesByRecord, setMapRangesByRecord] = useState<Record<string, MapSelectionRange | null>>({});
   const [selection, setSelection] = useState<Selection>(null);
+  const [sequenceFocusRequest, requestSequenceFocus] = useReducer((count: number) => count + 1, 0);
   const [featureEditorRequest, requestFeatureEditor] = useReducer((count: number) => count + 1, 0);
   const [sequenceViewMode, setSequenceViewMode] = useState<SequenceViewMode>('detail');
   // User-added inline translation layers (from a selection). Coding features
@@ -6759,6 +6760,11 @@ function App() {
       return { ...current, [recordId]: null };
     });
   }, [features, hiddenFeatureTranslationIds, recordId]);
+
+  const handleMapFeatureClick = useCallback((featureId: string) => {
+    requestSequenceFocus();
+    handleFeatureClick(featureId);
+  }, [handleFeatureClick]);
 
   const handleRestrictionClick = useCallback((clusterId: string, tickIds: readonly string[], enzyme?: string) => {
     setLockedTranslateTarget(null);
@@ -10860,7 +10866,7 @@ function App() {
                     activeClusterId={activeClusterId}
                     selectionPaths={selectionPaths}
                     viewport={mapViewport}
-                    onFeatureClick={handleFeatureClick}
+                    onFeatureClick={handleMapFeatureClick}
                     onRestrictionClick={handleRestrictionClick}
                     onBackgroundClick={handleMapBackgroundClick}
                     onWheelZoom={handleMapWheel}
@@ -11317,6 +11323,8 @@ function App() {
                 <LargeSequenceViewer
                   sequence={sequence}
                   threshold={LARGE_SEQUENCE_DETAIL_THRESHOLD}
+                  selectedRange={selectedFeatureSpans[0] ?? visibleMapRanges[0] ?? null}
+                  focusRequest={sequenceFocusRequest}
                 />
               ) : (
                 <SequenceText
@@ -11326,6 +11334,7 @@ function App() {
                 features={features}
                 selectedFeature={selectedFeature}
                 selectedMapRange={selectedMapRange}
+                focusRequest={sequenceFocusRequest}
                 motifHits={motifHits}
                 motifLength={cleanedMotifLength}
                 restrictionSites={visibleRestrictionSites}
@@ -16833,13 +16842,14 @@ function TranslationTrackRow({
   );
 }
 
-function SequenceText({
+const SequenceText = memo(function SequenceText({
   sequence,
   sequenceType,
   topology,
   features,
   selectedFeature,
   selectedMapRange,
+  focusRequest,
   motifHits,
   motifLength,
   restrictionSites,
@@ -16865,6 +16875,7 @@ function SequenceText({
   features: readonly Feature[];
   selectedFeature: Feature | null;
   selectedMapRange: MapSelectionRange | null;
+  focusRequest: number;
   motifHits: readonly number[];
   motifLength: number;
   restrictionSites: readonly RestrictionSite[];
@@ -17307,7 +17318,7 @@ function SequenceText({
         + node.clientHeight / 2;
       scroller.scrollTo({ top: Math.max(0, top), behavior: 'auto' });
     });
-  }, [basesPerLine, detailMode, focusKey, focusStart, sequence.length, showComplement]);
+  }, [basesPerLine, detailMode, focusKey, focusRequest, focusStart, sequence.length, showComplement]);
 
   // Clip a [start,end) range to a line, returning its ch offset+width or null.
   const clipRangeToLine = (range: { start: number; end: number }, lineStart: number, lineEnd: number) => {
@@ -17549,7 +17560,7 @@ function SequenceText({
       {grouped}
     </div>
   );
-}
+});
 
 if (typeof document !== 'undefined') {
   const rootElement = document.getElementById('root');

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -17231,6 +17231,84 @@ const SequenceText = memo(function SequenceText({
       return geometry ? [geometry] : [];
     });
   }, [detailMode, restrictionEnzymes, restrictionSites, sequence.length, sequenceType, topology]);
+  const restrictionLabelsByLine = useMemo(() => {
+    const labels = new Map<number, ReturnType<typeof restrictionLabelLanesForLine>>();
+    if (!detailMode || restrictionSites.length === 0) return labels;
+    for (let lineStart = 0; lineStart < sequence.length; lineStart += basesPerLine) {
+      const lineEnd = Math.min(sequence.length, lineStart + basesPerLine);
+      const lineLabels = restrictionLabelLanesForLine(restrictionSites, lineStart, lineEnd);
+      if (lineLabels.lanes.length > 0 || lineLabels.hidden > 0) labels.set(lineStart, lineLabels);
+    }
+    return labels;
+  }, [basesPerLine, detailMode, restrictionSites, sequence.length]);
+  const restrictionKeyboardKeys = useMemo(() => {
+    const keys: string[] = [];
+    for (const lineLabels of restrictionLabelsByLine.values()) {
+      for (const lane of lineLabels.lanes) {
+        for (const label of lane) keys.push(label.key);
+      }
+    }
+    return keys;
+  }, [restrictionLabelsByLine]);
+  const restrictionKeyboardKeySet = useMemo(
+    () => new Set(restrictionKeyboardKeys),
+    [restrictionKeyboardKeys],
+  );
+  const selectedRestrictionKey = useMemo(() => {
+    if (selectedRestrictionTickSet.size === 0) return null;
+    for (const lineLabels of restrictionLabelsByLine.values()) {
+      for (const lane of lineLabels.lanes) {
+        const selected = lane.find((label) => (
+          label.sites.some((site) => restrictionSelectionHasSite(selectedRestrictionTickSet, site))
+        ));
+        if (selected) return selected.key;
+      }
+    }
+    return null;
+  }, [restrictionLabelsByLine, selectedRestrictionTickSet]);
+  const [rovingRestrictionKey, setRovingRestrictionKey] = useState<string | null>(null);
+  const effectiveRovingRestrictionKey = rovingRestrictionKey && restrictionKeyboardKeySet.has(rovingRestrictionKey)
+    ? rovingRestrictionKey
+    : selectedRestrictionKey && restrictionKeyboardKeySet.has(selectedRestrictionKey)
+      ? selectedRestrictionKey
+      : restrictionKeyboardKeys[0] ?? null;
+  useEffect(() => {
+    if (selectedRestrictionKey) setRovingRestrictionKey(selectedRestrictionKey);
+  }, [selectedRestrictionKey]);
+  const handleRestrictionLabelKeyDown = useCallback((
+    event: ReactKeyboardEvent<HTMLButtonElement>,
+    key: string,
+  ) => {
+    if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'].includes(event.key)) return;
+    const index = restrictionKeyboardKeys.indexOf(key);
+    if (index < 0 || restrictionKeyboardKeys.length === 0) return;
+    const nextIndex = event.key === 'Home'
+      ? 0
+      : event.key === 'End'
+        ? restrictionKeyboardKeys.length - 1
+        : clamp(
+            index + (event.key === 'ArrowRight' || event.key === 'ArrowDown' ? 1 : -1),
+            0,
+            restrictionKeyboardKeys.length - 1,
+          );
+    const nextKey = restrictionKeyboardKeys[nextIndex];
+    const sequenceElement = event.currentTarget.closest<HTMLElement>('.motif-cs-sequence');
+    event.preventDefault();
+    setRovingRestrictionKey(nextKey);
+    window.requestAnimationFrame(() => {
+      const next = Array.from(
+        sequenceElement?.querySelectorAll<HTMLButtonElement>('.motif-cs-restriction-label[data-restriction-key]') ?? [],
+      ).find((candidate) => candidate.dataset.restrictionKey === nextKey);
+      if (!sequenceElement || !next) return;
+      next.focus({ preventScroll: true });
+      const scroller = effectiveSequenceScroller(sequenceElement);
+      const scrollerRect = scroller.getBoundingClientRect();
+      const nextRect = next.getBoundingClientRect();
+      if (nextRect.top < scrollerRect.top + 24 || nextRect.bottom > scrollerRect.bottom - 24) {
+        scroller.scrollBy({ top: nextRect.top - scrollerRect.top - scrollerRect.height / 2, behavior: 'auto' });
+      }
+    });
+  }, [restrictionKeyboardKeys]);
   const focusStart = selectedRanges[0]?.start ?? null;
   const focusKey = selectedFeature?.id ?? (selectedMapRange ? `${selectedMapRange.start}:${selectedMapRange.end}` : 'none');
   // Pre-build the inline amino-acid rows per line, memoized on the tracks (NOT the
@@ -17335,9 +17413,7 @@ const SequenceText = memo(function SequenceText({
     const lineLen = lineEnd - lineStart;
     const lineSequence = sequence.slice(lineStart, lineEnd);
     const lineFeatureLanes = detailMode ? featureLanesForLine(features, lineStart, lineEnd, sequence.length, topology) : [];
-    const lineRestrictionLabels = detailMode
-      ? restrictionLabelLanesForLine(restrictionSites, lineStart, lineEnd)
-      : { lanes: [], hidden: 0 };
+    const lineRestrictionLabels = restrictionLabelsByLine.get(lineStart) ?? { lanes: [], hidden: 0 };
     const lineRestrictionCuts = restrictionGeometry.filter(({ site, senseCut, antisenseCut }) => (
       restrictionSelectionHasSite(activeRestrictionTickSet, site)
       && (
@@ -17390,8 +17466,11 @@ const SequenceText = memo(function SequenceText({
                         type="button"
                         className="motif-cs-restriction-label"
                         data-selected={selected || undefined}
+                        data-restriction-key={label.key}
                         aria-pressed={selected}
+                        aria-keyshortcuts="ArrowLeft ArrowRight ArrowUp ArrowDown Home End"
                         aria-label={`${label.label}, restriction ${label.sites.length === 1 ? 'site' : 'cluster'} at ${primary.position + 1} bp, ${primaryCutLabel}, ${primary.overhang === 'blunt' ? 'blunt' : `${primary.overhang === '5prime' ? "5 prime" : "3 prime"} overhang`}, ${primary.strand === -1 ? 'reverse' : 'forward'} strand`}
+                        tabIndex={label.key === effectiveRovingRestrictionKey ? 0 : -1}
                         data-type-iis={typeIIS || undefined}
                         data-site-position={primary.position}
                         data-recognition-length={primary.recognitionSequence.length}
@@ -17399,8 +17478,12 @@ const SequenceText = memo(function SequenceText({
                         onPointerDown={(event) => event.stopPropagation()}
                         onPointerEnter={() => setHoveredRestrictionTickIds(label.sites.map(restrictionSiteTickId))}
                         onPointerLeave={() => setHoveredRestrictionTickIds([])}
-                        onFocus={() => setHoveredRestrictionTickIds(label.sites.map(restrictionSiteTickId))}
+                        onFocus={() => {
+                          setRovingRestrictionKey(label.key);
+                          setHoveredRestrictionTickIds(label.sites.map(restrictionSiteTickId));
+                        }}
                         onBlur={() => setHoveredRestrictionTickIds([])}
+                        onKeyDown={(event) => handleRestrictionLabelKeyDown(event, label.key)}
                         onClick={(event) => {
                           event.stopPropagation();
                           suppressNextFocusScrollRef.current = true;

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -42,6 +42,10 @@ import { featureSegments as mapFeatureSegments, featureSpans, normalizeSpan } fr
 import { selectionOverlayPaths } from '../plasmid-map/selection-overlay';
 import { mapModeForBlock, type MapLayout, type MapMode, type MapSpan } from '../plasmid-map/types';
 import {
+  restrictionDensitySourcesForMap,
+  restrictionSitesForInteractiveMap,
+} from '../plasmid-map/restriction-display';
+import {
   contentPointFromRoot,
   mapContentPoint,
   mapRootPoint,
@@ -5287,6 +5291,15 @@ function App() {
     () => restrictionSites.filter((site) => !hiddenEnzymes.has(site.enzyme)),
     [hiddenEnzymes, restrictionSites],
   );
+  const interactiveMapRestrictionSites = useMemo(
+    () => restrictionSitesForInteractiveMap(visibleRestrictionSites),
+    [visibleRestrictionSites],
+  );
+  const mapRestrictionDensitySources = useMemo(
+    () => restrictionDensitySourcesForMap(visibleRestrictionSites, sequence.length),
+    [sequence.length, visibleRestrictionSites],
+  );
+  const mapRestrictionSitesOmitted = visibleRestrictionSites.length - interactiveMapRestrictionSites.length;
   const { ref: mapFrameRef, size: mapSize } = useElementSize();
   const mapColumnRef = useRef<HTMLElement | null>(null);
   // Labels default ON, with no site-count pre-gate. The layout engine already
@@ -6236,7 +6249,8 @@ function App() {
       topology,
       sequenceType,
       features: mapFeatures,
-      restrictionSites: visibleRestrictionSites,
+      restrictionSites: interactiveMapRestrictionSites,
+      restrictionDensitySources: mapRestrictionDensitySources,
       width: mapSize.width,
       height: mapSize.height,
       // Cap the linear lane pitch (LINEAR_LANE_PITCH_MAX) so rows pack tightly
@@ -6256,7 +6270,7 @@ function App() {
     // `mapRenderMode` belongs here now that it is no longer a pure function of
     // `topology`: without it the map keeps its old drawing until some other
     // dependency happens to change.
-    [mapFeatures, mapRenderMode, visibleRestrictionSites, mapSize.height, mapSize.width, sequence.length, sequenceType, showRestrictionLabels, topology, vector.name],
+    [interactiveMapRestrictionSites, mapFeatures, mapRenderMode, mapRestrictionDensitySources, mapSize.height, mapSize.width, sequence.length, sequenceType, showRestrictionLabels, topology, vector.name],
   );
 
   useEffect(() => {
@@ -6342,6 +6356,9 @@ function App() {
       ? `${Math.round(mapViewport.k * 100)}%`
       : null,
     selectedMapRange ? `range ${mapRangeLabel(selectedMapRange, sequence.length)}` : null,
+    mapRestrictionSitesOmitted > 0
+      ? `${interactiveMapRestrictionSites.length.toLocaleString()} of ${visibleRestrictionSites.length.toLocaleString()} sites selectable`
+      : null,
   ].filter(Boolean).join(' · ');
 
   // How many restriction sites the map is drawing without a label. The map says this
@@ -11018,7 +11035,14 @@ function App() {
                                 next to "39 single-cutters" a bare number reads as one more
                                 statistic instead of "the map is not showing you everything". */}
                             {mapUnlabelledSiteCount > 0 ? (
-                              <span className="motif-cs-muted">{mapUnlabelledSiteCount.toLocaleString()} sites without labels on the map</span>
+                              <span className="motif-cs-muted">
+                                {mapUnlabelledSiteCount.toLocaleString()} {mapRestrictionSitesOmitted > 0 ? 'selectable sites' : 'sites'} without labels on the map
+                              </span>
+                            ) : null}
+                            {mapRestrictionSitesOmitted > 0 ? (
+                              <span className="motif-cs-muted">
+                                Density marks include all {visibleRestrictionSites.length.toLocaleString()} visible sites; {interactiveMapRestrictionSites.length.toLocaleString()} evenly distributed sites can be selected from the map.
+                              </span>
                             ) : null}
 
                           </>
@@ -17231,6 +17255,16 @@ const SequenceText = memo(function SequenceText({
       return geometry ? [geometry] : [];
     });
   }, [detailMode, restrictionEnzymes, restrictionSites, sequence.length, sequenceType, topology]);
+  const featureLanesByLine = useMemo(() => {
+    const lanes = new Map<number, LineFeatureBlock[][]>();
+    if (!detailMode || features.length === 0) return lanes;
+    for (let lineStart = 0; lineStart < sequence.length; lineStart += basesPerLine) {
+      const lineEnd = Math.min(sequence.length, lineStart + basesPerLine);
+      const lineLanes = featureLanesForLine(features, lineStart, lineEnd, sequence.length, topology);
+      if (lineLanes.length > 0) lanes.set(lineStart, lineLanes);
+    }
+    return lanes;
+  }, [basesPerLine, detailMode, features, sequence.length, topology]);
   const restrictionLabelsByLine = useMemo(() => {
     const labels = new Map<number, ReturnType<typeof restrictionLabelLanesForLine>>();
     if (!detailMode || restrictionSites.length === 0) return labels;
@@ -17309,6 +17343,26 @@ const SequenceText = memo(function SequenceText({
       }
     });
   }, [restrictionKeyboardKeys]);
+  const activeRestrictionCutsByLine = useMemo(() => {
+    const cuts = new Map<number, RestrictionCutGeometry[]>();
+    if (activeRestrictionTickSet.size === 0) return cuts;
+    for (const geometry of restrictionGeometry) {
+      if (!restrictionSelectionHasSite(activeRestrictionTickSet, geometry.site)) continue;
+      const lineStarts = new Set<number>();
+      for (const cut of [geometry.senseCut, geometry.antisenseCut]) {
+        const lineStart = cut === sequence.length
+          ? Math.max(0, Math.floor((sequence.length - 1) / basesPerLine) * basesPerLine)
+          : Math.floor(cut / basesPerLine) * basesPerLine;
+        lineStarts.add(lineStart);
+      }
+      for (const lineStart of lineStarts) {
+        const lineCuts = cuts.get(lineStart);
+        if (lineCuts) lineCuts.push(geometry);
+        else cuts.set(lineStart, [geometry]);
+      }
+    }
+    return cuts;
+  }, [activeRestrictionTickSet, basesPerLine, restrictionGeometry, sequence.length]);
   const focusStart = selectedRanges[0]?.start ?? null;
   const focusKey = selectedFeature?.id ?? (selectedMapRange ? `${selectedMapRange.start}:${selectedMapRange.end}` : 'none');
   // Pre-build the inline amino-acid rows per line, memoized on the tracks (NOT the
@@ -17412,15 +17466,9 @@ const SequenceText = memo(function SequenceText({
     const lineEnd = Math.min(sequence.length, lineStart + basesPerLine);
     const lineLen = lineEnd - lineStart;
     const lineSequence = sequence.slice(lineStart, lineEnd);
-    const lineFeatureLanes = detailMode ? featureLanesForLine(features, lineStart, lineEnd, sequence.length, topology) : [];
+    const lineFeatureLanes = featureLanesByLine.get(lineStart) ?? [];
     const lineRestrictionLabels = restrictionLabelsByLine.get(lineStart) ?? { lanes: [], hidden: 0 };
-    const lineRestrictionCuts = restrictionGeometry.filter(({ site, senseCut, antisenseCut }) => (
-      restrictionSelectionHasSite(activeRestrictionTickSet, site)
-      && (
-        restrictionCutBelongsToLine(senseCut, lineStart, lineEnd, sequence.length)
-        || restrictionCutBelongsToLine(antisenseCut, lineStart, lineEnd, sequence.length)
-      )
-    ));
+    const lineRestrictionCuts = activeRestrictionCutsByLine.get(lineStart) ?? [];
     const isFocusLine = focusStart !== null && focusStart >= lineStart && focusStart < lineEnd;
     const lineTranslations = translationByLine.get(lineStart);
     // Selection + motif render as flat overlay rects behind static base text, so a

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -16509,8 +16509,7 @@ function RestrictionList({
                 className="motif-cs-restriction-site-row"
                 data-active={active || undefined}
                 aria-pressed={active}
-                onClick={() => cluster && onSelect(cluster.clusterId, [tickId], site.enzyme)}
-                disabled={!cluster}
+                onClick={() => onSelect(cluster?.clusterId ?? `site:${tickId}`, [tickId], site.enzyme)}
                 title={`${site.enzyme} ${site.recognitionSequence} at ${site.position + 1}, ${cutLabel}, ${overhangLabel} overhang, ${site.strand === -1 ? 'reverse' : 'forward'} strand`}
               >
                 <span className="motif-cs-row-main" translate="no">

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -2,7 +2,7 @@
 import { Component, memo, useCallback, useDeferredValue, useEffect, useId, useLayoutEffect, useMemo, useReducer, useRef, useState, type ClipboardEvent as ReactClipboardEvent, type CSSProperties, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type RefObject } from 'react';
 import { createPortal } from 'react-dom';
 import { createRoot } from 'react-dom/client';
-import { Activity, AlignCenter, Beaker, ChevronDown, ChevronLeft, ChevronRight, Crosshair, Dna, FileText, History, Info, Languages, LayoutGrid, List, Map as MapIcon, Maximize2, Minimize2, NotebookPen, Plus, Redo2, Search, Settings, ShieldCheck, Tag, Trash2, Undo2, Workflow, Wrench, X, type LucideIcon } from 'lucide-react';
+import { Activity, AlignCenter, Beaker, ChevronDown, ChevronLeft, ChevronRight, Circle, Crosshair, Dna, FileText, History, Info, Languages, LayoutGrid, List, Map as MapIcon, Maximize2, Minimize2, MoveHorizontal, NotebookPen, Plus, Redo2, Scissors, Search, Settings, ShieldCheck, Tag, Trash2, Undo2, Workflow, Wrench, X, type LucideIcon } from 'lucide-react';
 import vectorsRaw from '../../public/data/vectors.json?raw';
 import type { Feature, FeatureStrand, FeatureType, ORF, RestrictionEnzyme, RestrictionSite, SequenceType, Topology } from '../bio/types';
 import { extractEmbeddedFastaContent, parseFasta } from '../bio/fasta-parser';
@@ -1178,7 +1178,8 @@ const SUMMARY_ORF_MIN_AA = 30;
 const MIN_ZOOM = 1;
 const MAX_ZOOM = 8;
 const ZOOM_STEP = 1.25;
-const MAP_FIT_PAN_MARGIN_SCALE = 0.08;
+const MAP_PAN_MARGIN_SCALE = 0.24;
+const MAP_PAN_MARGIN_MIN = 56;
 const MAP_FIT_WHEEL_PAN_SCALE = 0.22;
 const MAP_ZOOMED_WHEEL_PAN_SCALE = 0.78;
 const MAP_CIRCULAR_RANGE_HIT_MIN = 18;
@@ -1648,23 +1649,22 @@ function clampMapViewport(
   bg: { x: number; y: number; width: number; height: number },
 ): MapViewport {
   const k = clamp(Number.isFinite(viewport.k) ? viewport.k : 1, MIN_ZOOM, MAX_ZOOM);
+  const marginX = Math.max(MAP_PAN_MARGIN_MIN, bg.width * MAP_PAN_MARGIN_SCALE);
+  const marginY = Math.max(MAP_PAN_MARGIN_MIN, bg.height * MAP_PAN_MARGIN_SCALE);
   if (k <= MIN_ZOOM + 0.0001) {
-    // At "Fit", allow a small bounded pan. Otherwise a trackpad/mouse wheel over
-    // the map appears inert in a full-height workspace where the page itself
-    // cannot scroll, which makes the map feel stuck.
-    const marginX = Math.max(20, bg.width * MAP_FIT_PAN_MARGIN_SCALE);
-    const marginY = Math.max(20, bg.height * MAP_FIT_PAN_MARGIN_SCALE);
+    // Fit remains the exact reset position, but a subsequent drag gets enough
+    // symmetric travel to inspect labels near every edge.
     const tx = clamp(Number.isFinite(viewport.tx) ? viewport.tx : 0, -marginX, marginX);
     const ty = clamp(Number.isFinite(viewport.ty) ? viewport.ty : 0, -marginY, marginY);
     return Math.abs(tx) < 0.01 && Math.abs(ty) < 0.01 ? DEFAULT_MAP_VIEWPORT : { k: MIN_ZOOM, tx, ty };
   }
 
   const right = bg.x + bg.width;
-  const minTx = right - right * k;
-  const maxTx = bg.x - bg.x * k;
+  const minTx = right - right * k - marginX;
+  const maxTx = bg.x - bg.x * k + marginX;
   const bottom = bg.y + bg.height;
-  const minTy = bottom - bottom * k;
-  const maxTy = bg.y - bg.y * k;
+  const minTy = bottom - bottom * k - marginY;
+  const maxTy = bg.y - bg.y * k + marginY;
 
   return {
     k,
@@ -5329,6 +5329,8 @@ function App() {
   const mapRenderMode: MapMode = sequenceType === 'protein'
     ? 'linear'
     : mapRenderModeByRecord[recordId] ?? mapModeForBlock(topology, sequenceType);
+  const mapRenderModeTarget: MapMode = mapRenderMode === 'circular' ? 'linear' : 'circular';
+  const canUseMapRenderModeTarget = mapRenderModeTarget === 'linear' || canDrawAsRing;
   const setMapRenderMode = useCallback((mode: MapMode) => {
     setMapRenderModeByRecord((current) => (current[recordId] === mode ? current : { ...current, [recordId]: mode }));
   }, [recordId]);
@@ -10914,31 +10916,23 @@ function App() {
                   </button>
                   <button className="motif-cs-map-button" type="button" onClick={handleZoomIn} disabled={!hasActiveRecord || mapViewport.k >= MAX_ZOOM - 0.0001} aria-label="Zoom in">+</button>
                   {isNucleotideRecord ? (
-                    <div className="motif-cs-map-mode-toggle" role="group" aria-label="Map drawing">
-                      <button
-                        className="motif-cs-map-button motif-cs-map-mode-button"
-                        type="button"
-                        data-active={mapRenderMode === 'circular' || undefined}
-                        aria-pressed={mapRenderMode === 'circular'}
-                        disabled={!canDrawAsRing}
-                        title={canDrawAsRing
-                          ? 'Draw this map as a circle'
-                          : 'A linear molecule has two ends and cannot be drawn as a circle'}
-                        onClick={() => setMapRenderMode('circular')}
-                      >
-                        Circular
-                      </button>
-                      <button
-                        className="motif-cs-map-button motif-cs-map-mode-button"
-                        type="button"
-                        data-active={mapRenderMode === 'linear' || undefined}
-                        aria-pressed={mapRenderMode === 'linear'}
-                        title="Draw this map as a line. The record stays as it is."
-                        onClick={() => setMapRenderMode('linear')}
-                      >
-                        Linear
-                      </button>
-                    </div>
+                    <button
+                      className="motif-cs-map-button motif-cs-map-mode-toggle"
+                      type="button"
+                      data-current-mode={mapRenderMode}
+                      disabled={!canUseMapRenderModeTarget}
+                      aria-label={mapRenderModeTarget === 'linear' ? 'Draw map as line' : 'Draw map as circle'}
+                      title={canUseMapRenderModeTarget
+                        ? `Draw map as ${mapRenderModeTarget === 'linear' ? 'line' : 'circle'}`
+                        : 'A linear molecule has two ends and cannot be drawn as a circle'}
+                      onClick={() => setMapRenderMode(mapRenderModeTarget)}
+                    >
+                      {mapRenderModeTarget === 'linear' ? (
+                        <MoveHorizontal size={15} strokeWidth={2.2} aria-hidden="true" />
+                      ) : (
+                        <Circle size={14} strokeWidth={2.2} aria-hidden="true" />
+                      )}
+                    </button>
                   ) : null}
                   {/* Whether the ring is named is a property of the map, but the
                       only switch for it was in the Map Visibility panel, and at
@@ -10962,7 +10956,7 @@ function App() {
                       aria-label={`${showRestrictionLabels ? 'Hide' : 'Show'} restriction-site labels`}
                       title={`${showRestrictionLabels ? 'Hide' : 'Show'} restriction-site labels`}
                     >
-                      Sites
+                      <Scissors size={14} strokeWidth={2.1} aria-hidden="true" />
                     </button>
                   ) : null}
                 </div>

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -17327,21 +17327,19 @@ const SequenceText = memo(function SequenceText({
           );
     const nextKey = restrictionKeyboardKeys[nextIndex];
     const sequenceElement = event.currentTarget.closest<HTMLElement>('.motif-cs-sequence');
+    const next = Array.from(
+      sequenceElement?.querySelectorAll<HTMLButtonElement>('.motif-cs-restriction-label[data-restriction-key]') ?? [],
+    ).find((candidate) => candidate.dataset.restrictionKey === nextKey);
+    if (!sequenceElement || !next) return;
     event.preventDefault();
     setRovingRestrictionKey(nextKey);
-    window.requestAnimationFrame(() => {
-      const next = Array.from(
-        sequenceElement?.querySelectorAll<HTMLButtonElement>('.motif-cs-restriction-label[data-restriction-key]') ?? [],
-      ).find((candidate) => candidate.dataset.restrictionKey === nextKey);
-      if (!sequenceElement || !next) return;
-      next.focus({ preventScroll: true });
-      const scroller = effectiveSequenceScroller(sequenceElement);
-      const scrollerRect = scroller.getBoundingClientRect();
-      const nextRect = next.getBoundingClientRect();
-      if (nextRect.top < scrollerRect.top + 24 || nextRect.bottom > scrollerRect.bottom - 24) {
-        scroller.scrollBy({ top: nextRect.top - scrollerRect.top - scrollerRect.height / 2, behavior: 'auto' });
-      }
-    });
+    next.focus({ preventScroll: true });
+    const scroller = effectiveSequenceScroller(sequenceElement);
+    const scrollerRect = scroller.getBoundingClientRect();
+    const nextRect = next.getBoundingClientRect();
+    if (nextRect.top < scrollerRect.top + 24 || nextRect.bottom > scrollerRect.bottom - 24) {
+      scroller.scrollBy({ top: nextRect.top - scrollerRect.top - scrollerRect.height / 2, behavior: 'auto' });
+    }
   }, [restrictionKeyboardKeys]);
   const activeRestrictionCutsByLine = useMemo(() => {
     const cuts = new Map<number, RestrictionCutGeometry[]>();

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -3114,7 +3114,11 @@ function mapPointerActionAtPoint(point: MapContentPoint, layout: MapLayout, zoom
   if (layout.mode === 'circular') {
     const distance = Math.hypot(point.x - layout.center.x, point.y - layout.center.y);
     const tolerance = clamp(layout.radius * 0.14, MAP_CIRCULAR_RANGE_HIT_MIN, MAP_CIRCULAR_RANGE_HIT_MAX) / contentScale;
-    return Math.abs(distance - layout.radius) <= tolerance ? 'range' : 'pan';
+    // A ring has a large, otherwise-empty interior. Treat that whole interior
+    // as sequence-selection space: the drag angle identifies the bases, while
+    // blank canvas outside the molecule remains available for panning. A thin
+    // tolerance outside the backbone keeps the visible ring easy to acquire.
+    return distance <= layout.radius + tolerance ? 'range' : 'pan';
   }
 
   const axis = layout.linearAxis;
@@ -6305,14 +6309,14 @@ function App() {
     : selectedFeature
       ? null
       : selectedMapRange;
-  // A selected feature already has an exact outline on the map. The broad
-  // coordinate sector is reserved for an explicit range selection, where no
-  // feature glyph exists to carry the state.
+  // Keep the exact selected-feature outline and the coordinate overlay. The
+  // outline identifies the annotation; the overlay makes its sequence extent
+  // visible at normal zoom, including very short and nested features.
   const visibleMapRanges = useMemo(
     () => selectedMapRange
       ? normalizeSpan(selectedMapRange.start, selectedMapRange.end, sequence.length, topology)
-      : [],
-    [selectedMapRange, sequence.length, topology],
+      : selectedFeatureSpans,
+    [selectedFeatureSpans, selectedMapRange, sequence.length, topology],
   );
   const selectionPaths = useMemo(
     () => artifactSelectionOverlayPaths(layout, visibleMapRanges),
@@ -10863,7 +10867,7 @@ function App() {
                 data-map-pointer-action={mapPointerAction}
                 data-theme={mapTheme}
                 data-empty={!hasActiveRecord || undefined}
-                title="Wheel or blank-canvas drag to pan; Shift-wheel pans horizontally; Ctrl/Command-wheel zooms; drag near the sequence to select a range"
+                title="Wheel or drag outside the sequence to pan; Shift-wheel pans horizontally; Ctrl/Command-wheel zooms; drag inside a circular map or along a linear map to select a range"
               >
                 <div
                   className="motif-pm-container"
@@ -10909,6 +10913,33 @@ function App() {
                     Fit
                   </button>
                   <button className="motif-cs-map-button" type="button" onClick={handleZoomIn} disabled={!hasActiveRecord || mapViewport.k >= MAX_ZOOM - 0.0001} aria-label="Zoom in">+</button>
+                  {isNucleotideRecord ? (
+                    <div className="motif-cs-map-mode-toggle" role="group" aria-label="Map drawing">
+                      <button
+                        className="motif-cs-map-button motif-cs-map-mode-button"
+                        type="button"
+                        data-active={mapRenderMode === 'circular' || undefined}
+                        aria-pressed={mapRenderMode === 'circular'}
+                        disabled={!canDrawAsRing}
+                        title={canDrawAsRing
+                          ? 'Draw this map as a circle'
+                          : 'A linear molecule has two ends and cannot be drawn as a circle'}
+                        onClick={() => setMapRenderMode('circular')}
+                      >
+                        Circular
+                      </button>
+                      <button
+                        className="motif-cs-map-button motif-cs-map-mode-button"
+                        type="button"
+                        data-active={mapRenderMode === 'linear' || undefined}
+                        aria-pressed={mapRenderMode === 'linear'}
+                        title="Draw this map as a line. The record stays as it is."
+                        onClick={() => setMapRenderMode('linear')}
+                      >
+                        Linear
+                      </button>
+                    </div>
+                  ) : null}
                   {/* Whether the ring is named is a property of the map, but the
                       only switch for it was in the Map Visibility panel, and at
                       every laptop size measured — 1440x900, 1280x800, 1024x768,

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -1180,11 +1180,13 @@ const MAX_ZOOM = 8;
 const ZOOM_STEP = 1.25;
 const MAP_PAN_MARGIN_SCALE = 0.24;
 const MAP_PAN_MARGIN_MIN = 56;
+const MAP_LINEAR_PAN_MARGIN_Y_MIN = 160;
 const MAP_FIT_WHEEL_PAN_SCALE = 0.22;
 const MAP_ZOOMED_WHEEL_PAN_SCALE = 0.78;
 const MAP_CIRCULAR_RANGE_HIT_MIN = 18;
 const MAP_CIRCULAR_RANGE_HIT_MAX = 34;
-const MAP_LINEAR_RANGE_HIT_Y = 18;
+const MAP_LINEAR_RANGE_HIT_TOP_Y = 18;
+const MAP_LINEAR_RANGE_HIT_BOTTOM_Y = 176;
 const MAP_LINEAR_RANGE_HIT_X = 8;
 const DEFAULT_MAP_VIEWPORT: MapViewport = { k: 1, tx: 0, ty: 0 };
 const builtInRecords = JSON.parse(vectorsRaw) as ArtifactRecordInput[];
@@ -1647,10 +1649,13 @@ function sameViewport(a: MapViewport, b: MapViewport): boolean {
 function clampMapViewport(
   viewport: MapViewport,
   bg: { x: number; y: number; width: number; height: number },
+  mode: MapMode,
 ): MapViewport {
   const k = clamp(Number.isFinite(viewport.k) ? viewport.k : 1, MIN_ZOOM, MAX_ZOOM);
   const marginX = Math.max(MAP_PAN_MARGIN_MIN, bg.width * MAP_PAN_MARGIN_SCALE);
-  const marginY = Math.max(MAP_PAN_MARGIN_MIN, bg.height * MAP_PAN_MARGIN_SCALE);
+  const marginY = mode === 'linear'
+    ? Math.max(MAP_LINEAR_PAN_MARGIN_Y_MIN, bg.height * MAP_PAN_MARGIN_SCALE)
+    : Math.max(MAP_PAN_MARGIN_MIN, bg.height * MAP_PAN_MARGIN_SCALE);
   if (k <= MIN_ZOOM + 0.0001) {
     // Fit remains the exact reset position, but a subsequent drag gets enough
     // symmetric travel to inspect labels near every edge.
@@ -3124,10 +3129,16 @@ function mapPointerActionAtPoint(point: MapContentPoint, layout: MapLayout, zoom
   const axis = layout.linearAxis;
   if (!axis) return 'pan';
   const hitX = MAP_LINEAR_RANGE_HIT_X / contentScale;
-  const hitY = MAP_LINEAR_RANGE_HIT_Y / contentScale;
+  const hitTopY = MAP_LINEAR_RANGE_HIT_TOP_Y / contentScale;
+  const hitBottomY = MAP_LINEAR_RANGE_HIT_BOTTOM_Y / (contentScale * Math.pow(contentScale, 0.75));
   const alongAxis = point.x >= axis.startX - hitX
     && point.x <= axis.endX + hitX;
-  return alongAxis && Math.abs(point.y - axis.y) <= hitY ? 'range' : 'pan';
+  // The linear drawing uses the rows below its sequence axis for annotations.
+  // Keep those rows available at Fit, then narrow the screen-space range band
+  // as the drawing grows so a zoomed map still has blank canvas for panning.
+  const inSequenceBand = point.y >= axis.y - hitTopY
+    && point.y <= Math.min(layout.bg.y + layout.bg.height, axis.y + hitBottomY);
+  return alongAxis && inSequenceBand ? 'range' : 'pan';
 }
 
 function signedCircularAngleDelta(fromAngle: number, toAngle: number): number {
@@ -5295,6 +5306,7 @@ function App() {
     () => restrictionSites.filter((site) => !hiddenEnzymes.has(site.enzyme)),
     [hiddenEnzymes, restrictionSites],
   );
+  const restrictionLayerVisible = visibleRestrictionSites.length > 0;
   const interactiveMapRestrictionSites = useMemo(
     () => restrictionSitesForInteractiveMap(visibleRestrictionSites),
     [visibleRestrictionSites],
@@ -6289,11 +6301,11 @@ function App() {
     setMapViewportsByRecord((current) => {
       const currentViewport = current[recordId];
       if (!currentViewport) return current;
-      const nextViewport = clampMapViewport(currentViewport, layout.bg);
+      const nextViewport = clampMapViewport(currentViewport, layout.bg, layout.mode);
       if (sameViewport(currentViewport, nextViewport)) return current;
       return { ...current, [recordId]: nextViewport };
     });
-  }, [layout.bg, recordId]);
+  }, [layout.bg, layout.mode, recordId]);
 
   const selectedFeatureId = selection?.kind === 'feature' ? selection.id : null;
   const activeClusterId = selection?.kind === 'restriction' ? selection.clusterId : null;
@@ -6530,11 +6542,11 @@ function App() {
     setMapViewportsByRecord((current) => {
       const currentViewport = current[recordId] ?? DEFAULT_MAP_VIEWPORT;
       const rawNext = typeof updater === 'function' ? updater(currentViewport) : updater;
-      const nextViewport = clampMapViewport(rawNext, layout.bg);
+      const nextViewport = clampMapViewport(rawNext, layout.bg, layout.mode);
       if (sameViewport(currentViewport, nextViewport)) return current;
       return { ...current, [recordId]: nextViewport };
     });
-  }, [layout.bg, recordId]);
+  }, [layout.bg, layout.mode, recordId]);
 
   /** `point` is ROOT space — the new translate keeps that root point where it is. */
   const zoomAtPoint = useCallback((point: MapRootPoint, factor: number) => {
@@ -6790,6 +6802,7 @@ function App() {
   }, [handleFeatureClick]);
 
   const handleRestrictionClick = useCallback((clusterId: string, tickIds: readonly string[], enzyme?: string) => {
+    requestSequenceFocus();
     setLockedTranslateTarget(null);
     setSelectedTranslationLayerByRecord((current) => (
       current[recordId] ? { ...current, [recordId]: null } : current
@@ -6800,7 +6813,7 @@ function App() {
       if (!current[recordId]) return current;
       return { ...current, [recordId]: null };
     });
-  }, [recordId]);
+  }, [recordId, requestSequenceFocus]);
 
   const handleSequenceRestrictionClick = useCallback((site: RestrictionSite) => {
     const tickId = restrictionSiteTickId(site);
@@ -9059,7 +9072,7 @@ function App() {
 
   const closeOpenToolDetails = useCallback(() => {
     if (typeof document === 'undefined') return;
-    document.querySelectorAll<HTMLDetailsElement>('.motif-cs-inspector details[name="motif-cs-tools"][open]').forEach((panel) => {
+    document.querySelectorAll<HTMLDetailsElement>('.motif-cs-inspector details[data-rail-tool][open]').forEach((panel) => {
       panel.open = false;
     });
   }, []);
@@ -9755,26 +9768,20 @@ function App() {
     };
   }, [toolsPinned]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const inspector = toolsInspectorRef.current;
     if (!inspector) return undefined;
-    const handleToggle = (event: Event) => {
-      const panel = event.target;
-      if (!toolsPinned || !(panel instanceof HTMLDetailsElement) || !panel.open || panel.parentElement !== inspector) return;
-      window.requestAnimationFrame(() => {
-        const summary = panel.querySelector<HTMLElement>(':scope > summary');
-        if (!summary) return;
-        const inspectorRect = inspector.getBoundingClientRect();
-        const summaryRect = summary.getBoundingClientRect();
-        const desiredTop = inspectorRect.top + 4;
-        if (summaryRect.top < desiredTop || summaryRect.bottom > inspectorRect.bottom - 4) {
-          inspector.scrollTop += summaryRect.top - desiredTop;
-        }
+    const syncDisclosureGroups = () => {
+      inspector.querySelectorAll<HTMLDetailsElement>('details[data-rail-tool]').forEach((panel) => {
+        if (toolsPinned) panel.removeAttribute('name');
+        else panel.setAttribute('name', 'motif-cs-tools');
       });
     };
-    inspector.addEventListener('toggle', handleToggle, true);
-    return () => inspector.removeEventListener('toggle', handleToggle, true);
-  }, [toolsPinned]);
+    syncDisclosureGroups();
+    const observer = new MutationObserver(syncDisclosureGroups);
+    observer.observe(inspector, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [paneVisibility.tools, recordId, toolsPinned]);
 
   const handleMapDockOpen = useCallback(() => {
     closeOpenToolDetails();
@@ -10513,6 +10520,89 @@ function App() {
     } as CSSProperties;
   };
 
+  const renderRestrictionSiteControls = (includeMapSummary = false): ReactNode => {
+    if (!hasActiveRecord || !isDnaRecord) {
+      return (
+        <p className="motif-cs-muted">
+          {hasActiveRecord
+            ? 'Restriction sites are available for DNA records.'
+            : 'Add or select a DNA record to inspect restriction sites.'}
+        </p>
+      );
+    }
+    const restorableSourceCount = lastVisibleEnzymeSourcesRef.current[recordId]?.length ?? 0;
+    const canShowSites = visibleRestrictionSites.length < restrictionSites.length
+      || (scanEnzymes.length === 0 && restorableSourceCount > 0);
+    return (
+      <>
+        <div className="motif-cs-layer-actions">
+          <button
+            type="button"
+            className="motif-cs-mini-button"
+            onClick={() => setAllEnzymesVisible(true)}
+            disabled={!canShowSites}
+            title={scanEnzymes.length === 0
+              ? restorableSourceCount > 0
+                ? 'Restore the source groups hidden with Hide sites'
+                : 'Enable a source group first'
+              : 'Show every site in the enabled source groups'}
+          >
+            Show sites
+          </button>
+          <button
+            type="button"
+            className="motif-cs-mini-button"
+            onClick={() => setAllEnzymesVisible(false)}
+            disabled={!restrictionLayerVisible}
+            title="Hide all restriction sites"
+          >
+            Hide sites
+          </button>
+          <button
+            type="button"
+            className="motif-cs-mini-button"
+            data-active={showRestrictionLabels || undefined}
+            aria-pressed={showRestrictionLabels}
+            onClick={toggleRestrictionLabels}
+            aria-label={`${showRestrictionLabels ? 'Hide' : 'Show'} restriction-site labels`}
+            title={`${showRestrictionLabels ? 'Hide' : 'Show'} restriction-site labels`}
+          >
+            Site labels
+          </button>
+          <span className="motif-cs-muted">{singleCutters.length} single-cutters</span>
+          {includeMapSummary && mapUnlabelledSiteCount > 0 ? (
+            <span className="motif-cs-muted">
+              {mapUnlabelledSiteCount.toLocaleString()} {mapRestrictionSitesOmitted > 0 ? 'selectable sites' : 'sites'} without labels on the map
+            </span>
+          ) : null}
+          {includeMapSummary && mapRestrictionSitesOmitted > 0 ? (
+            <span className="motif-cs-muted">
+              Density marks include all {visibleRestrictionSites.length.toLocaleString()} visible sites; {interactiveMapRestrictionSites.length.toLocaleString()} evenly distributed sites can be selected from the map.
+            </span>
+          ) : null}
+        </div>
+        <RestrictionSourceControls
+          sources={enzymeSources}
+          enzymeCount={scanEnzymes.length}
+          onToggle={setEnzymeSourceEnabled}
+        />
+        <RestrictionList
+          sites={restrictionSites}
+          enzymes={scanEnzymes}
+          sequenceLength={sequence.length}
+          topology={topology}
+          layout={layout.restrictions}
+          hiddenEnzymes={hiddenEnzymes}
+          selectedClusterId={activeClusterId}
+          selectedTickIds={selectedRestrictionTickIds}
+          onSelect={handleRestrictionClick}
+          onToggle={setEnzymeVisible}
+        />
+        <AddEnzymeForm onAdd={addCustomEnzyme} knownEnzymes={RESTRICTION_ENZYMES_FULL} />
+      </>
+    );
+  };
+
   return (
     <div
       className="motif-cs-shell"
@@ -10836,9 +10926,58 @@ function App() {
                 onKeyDown={(event) => moveFloatingPaneFromKeyboard('map', event)}
               >
                 <div>
-                  <span>{hasActiveRecord ? mapPaneTitle : 'Map'}</span>
+                  <span className="motif-cs-map-title-full">{hasActiveRecord ? mapPaneTitle : 'Map'}</span>
+                  <span className="motif-cs-map-title-compact">Map</span>
                   <small>{hasActiveRecord ? `${topology} · ${sequenceLengthLabel(sequence.length, sequenceType)}` : 'No active record'}</small>
                 </div>
+                {hasActiveRecord ? (
+                  <div className="motif-cs-map-toolbar" role="group" aria-label="Map view controls">
+                    <button className="motif-cs-map-button" type="button" onClick={handleZoomOut} disabled={!hasActiveRecord || mapViewport.k <= MIN_ZOOM + 0.0001} aria-label="Zoom out">-</button>
+                    <button
+                      className="motif-cs-map-button motif-cs-map-reset"
+                      type="button"
+                      onClick={handleZoomReset}
+                      disabled={!hasActiveRecord || (mapViewport.k <= MIN_ZOOM + 0.0001 && Math.abs(mapViewport.tx) < 0.5 && Math.abs(mapViewport.ty) < 0.5)}
+                      aria-label="Reset map view"
+                      title="Reset map view"
+                    >
+                      Fit
+                    </button>
+                    <button className="motif-cs-map-button" type="button" onClick={handleZoomIn} disabled={!hasActiveRecord || mapViewport.k >= MAX_ZOOM - 0.0001} aria-label="Zoom in">+</button>
+                    {isNucleotideRecord ? (
+                      <button
+                        className="motif-cs-map-button motif-cs-map-mode-toggle"
+                        type="button"
+                        data-current-mode={mapRenderMode}
+                        disabled={!canUseMapRenderModeTarget}
+                        aria-label={mapRenderModeTarget === 'linear' ? 'Draw map as line' : 'Draw map as circle'}
+                        title={canUseMapRenderModeTarget
+                          ? `Draw map as ${mapRenderModeTarget === 'linear' ? 'line' : 'circle'}`
+                          : 'A linear molecule has two ends and cannot be drawn as a circle'}
+                        onClick={() => setMapRenderMode(mapRenderModeTarget)}
+                      >
+                        {mapRenderModeTarget === 'linear' ? (
+                          <MoveHorizontal size={15} strokeWidth={2.2} aria-hidden="true" />
+                        ) : (
+                          <Circle size={14} strokeWidth={2.2} aria-hidden="true" />
+                        )}
+                      </button>
+                    ) : null}
+                    {isDnaRecord ? (
+                      <button
+                        className="motif-cs-map-button motif-cs-map-sites-toggle"
+                        type="button"
+                        data-active={restrictionLayerVisible || undefined}
+                        aria-pressed={restrictionLayerVisible}
+                        onClick={() => setAllEnzymesVisible(!restrictionLayerVisible)}
+                        aria-label={`${restrictionLayerVisible ? 'Hide' : 'Show'} restriction sites`}
+                        title={`${restrictionLayerVisible ? 'Hide' : 'Show'} restriction sites`}
+                      >
+                        <Scissors size={14} strokeWidth={2.1} aria-hidden="true" />
+                      </button>
+                    ) : null}
+                  </div>
+                ) : null}
                 <PanePlacementControl
                   pane="map"
                   title="Map"
@@ -10901,66 +11040,6 @@ function App() {
                     <span>Add a DNA, RNA, or protein record to render its overview.</span>
                   </div>
                 ) : null}
-                {hasActiveRecord ? (
-                <div className="motif-cs-map-toolbar" role="group" aria-label="Map view controls">
-                  <button className="motif-cs-map-button" type="button" onClick={handleZoomOut} disabled={!hasActiveRecord || mapViewport.k <= MIN_ZOOM + 0.0001} aria-label="Zoom out">-</button>
-                  <button
-                    className="motif-cs-map-button motif-cs-map-reset"
-                    type="button"
-                    onClick={handleZoomReset}
-                    disabled={!hasActiveRecord || (mapViewport.k <= MIN_ZOOM + 0.0001 && Math.abs(mapViewport.tx) < 0.5 && Math.abs(mapViewport.ty) < 0.5)}
-                    aria-label="Reset map view"
-                    title="Reset map view"
-                  >
-                    Fit
-                  </button>
-                  <button className="motif-cs-map-button" type="button" onClick={handleZoomIn} disabled={!hasActiveRecord || mapViewport.k >= MAX_ZOOM - 0.0001} aria-label="Zoom in">+</button>
-                  {isNucleotideRecord ? (
-                    <button
-                      className="motif-cs-map-button motif-cs-map-mode-toggle"
-                      type="button"
-                      data-current-mode={mapRenderMode}
-                      disabled={!canUseMapRenderModeTarget}
-                      aria-label={mapRenderModeTarget === 'linear' ? 'Draw map as line' : 'Draw map as circle'}
-                      title={canUseMapRenderModeTarget
-                        ? `Draw map as ${mapRenderModeTarget === 'linear' ? 'line' : 'circle'}`
-                        : 'A linear molecule has two ends and cannot be drawn as a circle'}
-                      onClick={() => setMapRenderMode(mapRenderModeTarget)}
-                    >
-                      {mapRenderModeTarget === 'linear' ? (
-                        <MoveHorizontal size={15} strokeWidth={2.2} aria-hidden="true" />
-                      ) : (
-                        <Circle size={14} strokeWidth={2.2} aria-hidden="true" />
-                      )}
-                    </button>
-                  ) : null}
-                  {/* Whether the ring is named is a property of the map, but the
-                      only switch for it was in the Map Visibility panel, and at
-                      every laptop size measured — 1440x900, 1280x800, 1024x768,
-                      900x700 — that panel's own SUMMARY is already past the
-                      bottom of the map column, which hides 143-148px of itself.
-                      Reaching the toggle meant scrolling a pane nothing invites
-                      you to scroll and then opening a closed accordion, for a
-                      state you are looking straight at. Same handler and same
-                      wording as the panel button, so the two always agree; this
-                      is a second route to one control, not a second control.
-                      Gated on isDnaRecord exactly as the panel's is, since
-                      restriction labels are the only thing it governs. */}
-                  {isDnaRecord ? (
-                    <button
-                      className="motif-cs-map-button motif-cs-map-labels-toggle"
-                      type="button"
-                      data-active={showRestrictionLabels || undefined}
-                      aria-pressed={showRestrictionLabels}
-                      onClick={toggleRestrictionLabels}
-                      aria-label={`${showRestrictionLabels ? 'Hide' : 'Show'} restriction-site labels`}
-                      title={`${showRestrictionLabels ? 'Hide' : 'Show'} restriction-site labels`}
-                    >
-                      <Scissors size={14} strokeWidth={2.1} aria-hidden="true" />
-                    </button>
-                  ) : null}
-                </div>
-                ) : null}
                 {mapStatusHint ? (
                   <div className="motif-cs-map-hint">{mapStatusHint}</div>
                 ) : null}
@@ -11022,81 +11101,11 @@ function App() {
                         {mapRenderMode !== mapModeForBlock(topology, sequenceType) ? (
                           <span className="motif-cs-muted">Drawing only — still a {topology} {sequenceType.toUpperCase()}</span>
                         ) : null}
-                        {isDnaRecord ? (
-                          <>
-                            <button
-                              type="button"
-                              className="motif-cs-mini-button"
-                              onClick={() => setAllEnzymesVisible(true)}
-                              disabled={scanEnzymes.length === 0 && (lastVisibleEnzymeSourcesRef.current[recordId]?.length ?? 0) === 0}
-                              title={scanEnzymes.length === 0
-                                ? (lastVisibleEnzymeSourcesRef.current[recordId]?.length ?? 0) > 0
-                                  ? 'Restore the source groups hidden with Hide sites'
-                                  : 'Enable a source group first'
-                                : 'Show all sites in the enabled source groups'}
-                            >
-                              Show sites
-                            </button>
-                            <button type="button" className="motif-cs-mini-button" onClick={() => setAllEnzymesVisible(false)} title="Turn off source groups and hide restriction sites">Hide sites</button>
-                            <button
-                              type="button"
-                              className="motif-cs-mini-button"
-                              data-active={showRestrictionLabels || undefined}
-                              aria-pressed={showRestrictionLabels}
-                              onClick={toggleRestrictionLabels}
-                              aria-label={`${showRestrictionLabels ? 'Hide' : 'Show'} restriction-site labels`}
-                              title={`${showRestrictionLabels ? 'Hide' : 'Show'} restriction-site labels`}
-                            >
-                              Site labels
-                            </button>
-                            <span className="motif-cs-muted">{singleCutters.length} single-cutters</span>
-                            {/* The map's "+N more sites" chip carries this same number, but only
-                                to a pointer: it lives in an SVG <title>, which no browser opens
-                                on keyboard focus. Stated here it lands where a keyboard user is
-                                already going. Read off layout.overflows — the ARRAY THE CHIP
-                                RENDERS FROM — so the two cannot drift into disagreeing about the
-                                same quantity; a second derivation would be a second chance to be
-                                wrong. Worded as a caveat rather than a count, because sitting
-                                next to "39 single-cutters" a bare number reads as one more
-                                statistic instead of "the map is not showing you everything". */}
-                            {mapUnlabelledSiteCount > 0 ? (
-                              <span className="motif-cs-muted">
-                                {mapUnlabelledSiteCount.toLocaleString()} {mapRestrictionSitesOmitted > 0 ? 'selectable sites' : 'sites'} without labels on the map
-                              </span>
-                            ) : null}
-                            {mapRestrictionSitesOmitted > 0 ? (
-                              <span className="motif-cs-muted">
-                                Density marks include all {visibleRestrictionSites.length.toLocaleString()} visible sites; {interactiveMapRestrictionSites.length.toLocaleString()} evenly distributed sites can be selected from the map.
-                              </span>
-                            ) : null}
-
-                          </>
-                        ) : (
+                        {!isDnaRecord ? (
                           <span className="motif-cs-muted">Restriction enzymes act on DNA; RNA is not converted implicitly.</span>
-                        )}
+                        ) : null}
                       </div>
-                      {isDnaRecord ? (
-                        <>
-                          <RestrictionSourceControls
-                            sources={enzymeSources}
-                            enzymeCount={scanEnzymes.length}
-                            onToggle={setEnzymeSourceEnabled}
-                          />
-                          <RestrictionList
-                            sites={restrictionSites}
-                            enzymes={scanEnzymes}
-                            sequenceLength={sequence.length}
-                            topology={topology}
-                            layout={layout.restrictions}
-                            hiddenEnzymes={hiddenEnzymes}
-                            selectedClusterId={activeClusterId}
-                            selectedTickIds={selectedRestrictionTickIds}
-                            onSelect={handleRestrictionClick}
-                            onToggle={setEnzymeVisible}
-                          />
-                          <AddEnzymeForm onAdd={addCustomEnzyme} knownEnzymes={RESTRICTION_ENZYMES_FULL} />
-                        </>
-                      ) : null}
+                      {isDnaRecord ? renderRestrictionSiteControls(true) : null}
                     </>
                   ) : (
                     <p className="motif-cs-muted">Map shape and restriction controls are available for nucleotide records.</p>
@@ -11663,6 +11672,25 @@ function App() {
               ) : (
                 <span>Select a feature or restriction tick.</span>
               )}
+            </div>
+          </details>
+
+          <details className="motif-cs-panel" name="motif-cs-tools" data-rail-tool="restriction-sites">
+            <summary className="motif-cs-panel-head" data-rail-label="E" title="Restriction sites">
+              <Scissors className="motif-cs-panel-icon" size={14} strokeWidth={2.2} aria-hidden="true" />
+              <span>Restriction Sites</span>
+              <span className="motif-cs-chip">
+                {hasActiveRecord && isDnaRecord
+                  ? `${visibleRestrictionSites.length}/${restrictionSites.length}`
+                  : 'DNA'}
+              </span>
+            </summary>
+            <div className="motif-cs-tool-panel-body motif-cs-restriction-tool-body">
+              <RailPopoverTitle
+                title="Restriction Sites"
+                meta={hasActiveRecord && isDnaRecord ? restrictionVisibilityMeta.full : 'DNA only'}
+              />
+              {renderRestrictionSiteControls(false)}
             </div>
           </details>
 
@@ -13039,6 +13067,7 @@ function FeatureList({
               key={feature.id}
               className="motif-cs-row"
               data-active={feature.id === selectedFeatureId || undefined}
+              style={{ '--motif-cs-row-color': feature.color } as CSSProperties}
               type="button"
               aria-pressed={feature.id === selectedFeatureId}
               onMouseDown={(event) => event.preventDefault()}
@@ -13076,6 +13105,7 @@ function FeatureList({
                 <button
                   className="motif-cs-row motif-cs-translation-row"
                   data-active={active || undefined}
+                  style={{ '--motif-cs-row-color': track.color ?? 'var(--accent)' } as CSSProperties}
                   type="button"
                   aria-pressed={active}
                   onMouseDown={(event) => event.preventDefault()}
@@ -16277,6 +16307,9 @@ function AddEnzymeForm({
   const [recognition, setRecognition] = useState('');
   const [status, setStatus] = useState('');
   const [hasError, setHasError] = useState(false);
+  const instanceId = useId();
+  const statusId = `motif-cs-add-enzyme-status-${instanceId}`;
+  const knownEnzymesId = `motif-cs-known-enzymes-${instanceId}`;
 
   const submit = () => {
     const result = onAdd(name, recognition);
@@ -16295,7 +16328,7 @@ function AddEnzymeForm({
     <div className="motif-cs-add-enzyme">
       <div className="motif-cs-add-enzyme-head">
         <span className="motif-cs-add-enzyme-title">Add enzyme / site</span>
-        {status ? <span className="motif-cs-chip" role="status" aria-live="polite" aria-atomic="true" id="motif-cs-add-enzyme-status">{status}</span> : null}
+        {status ? <span className="motif-cs-chip" role="status" aria-live="polite" aria-atomic="true" id={statusId}>{status}</span> : null}
       </div>
       <div className="motif-cs-add-enzyme-row">
         <input
@@ -16308,10 +16341,10 @@ function AddEnzymeForm({
           placeholder="Known enzyme, e.g. EcoRV…"
           aria-label="Known or custom enzyme name"
           aria-invalid={hasError || undefined}
-          aria-describedby={status ? 'motif-cs-add-enzyme-status' : undefined}
-          list="motif-cs-known-enzymes"
+          aria-describedby={status ? statusId : undefined}
+          list={knownEnzymesId}
         />
-        <datalist id="motif-cs-known-enzymes">
+        <datalist id={knownEnzymesId}>
           {knownEnzymes.map((enzyme) => <option key={enzyme.name} value={enzyme.name} />)}
         </datalist>
         <input
@@ -16325,7 +16358,7 @@ function AddEnzymeForm({
           placeholder="Custom motif, e.g. GGTACC…"
           aria-label="Custom enzyme recognition sequence"
           aria-invalid={hasError || undefined}
-          aria-describedby={status ? 'motif-cs-add-enzyme-status' : undefined}
+          aria-describedby={status ? statusId : undefined}
           translate="no"
           spellCheck={false}
         />
@@ -17386,8 +17419,16 @@ const SequenceText = memo(function SequenceText({
     }
     return cuts;
   }, [activeRestrictionTickSet, basesPerLine, restrictionGeometry, sequence.length]);
-  const focusStart = selectedRanges[0]?.start ?? null;
-  const focusKey = selectedFeature?.id ?? (selectedMapRange ? `${selectedMapRange.start}:${selectedMapRange.end}` : 'none');
+  const selectedRestrictionFocusStart = selectedRestrictionTickSet.size > 0
+    ? restrictionSites.find((site) => restrictionSelectionHasSite(selectedRestrictionTickSet, site))?.position ?? null
+    : null;
+  const focusStart = selectedRanges[0]?.start ?? selectedRestrictionFocusStart;
+  const focusKey = selectedFeature?.id
+    ?? (selectedMapRange
+      ? `${selectedMapRange.start}:${selectedMapRange.end}`
+      : selectedRestrictionFocusStart === null
+        ? 'none'
+        : `restriction:${selectedRestrictionFocusStart}`);
   // Pre-build the inline amino-acid rows per line, memoized on the tracks (NOT the
   // selection). The rows are React elements with stable identity, so a selection
   // drag — which re-renders SequenceText every frame — reuses these exact nodes and

--- a/src/components/plasmid-map/SequenceMapView.tsx
+++ b/src/components/plasmid-map/SequenceMapView.tsx
@@ -323,7 +323,7 @@ const FeatureShape = memo(function FeatureShape({
       style={style}
       role={interactive ? 'button' : undefined}
       tabIndex={interactive ? tabIndex : undefined}
-      aria-label={`${feature.name}, ${feature.type}, ${strandLabel}`}
+      aria-label={feature.title ?? `${feature.name}, ${feature.type}, ${strandLabel}`}
       aria-pressed={interactive ? selected : undefined}
       onClick={interactive ? (e) => {
         e.stopPropagation();

--- a/src/components/plasmid-map/SequenceMapView.tsx
+++ b/src/components/plasmid-map/SequenceMapView.tsx
@@ -94,10 +94,7 @@ type RovingMapKeyDown = (
   activate: () => void,
 ) => void;
 
-type RenderedRestrictionDensityTick = MapRestrictionDensityTick & {
-  /** Number of raw sites represented by this projected mark. */
-  siteCount?: number;
-};
+type RenderedRestrictionDensityTick = MapRestrictionDensityTick;
 
 interface RestrictionDensityRender {
   ticks: readonly RenderedRestrictionDensityTick[];
@@ -142,7 +139,7 @@ function buildRestrictionDensityRender(
   sequenceLength: number,
 ): RestrictionDensityRender {
   if (densityTicks.length <= MAX_RESTRICTION_DENSITY_TICKS) {
-    return { ticks: densityTicks, binned: false };
+    return { ticks: densityTicks, binned: densityTicks.some((tick) => (tick.siteCount ?? 1) > 1) };
   }
 
   interface DensityBin {
@@ -164,24 +161,25 @@ function buildRestrictionDensityRender(
       : sourceIndex / densityTicks.length;
     const boundedRatio = Math.max(0, Math.min(1 - Number.EPSILON, sequenceRatio));
     const binIndex = Math.floor(boundedRatio * MAX_RESTRICTION_DENSITY_TICKS);
+    const sourceCount = densityTick.siteCount ?? 1;
     const bin = bins[binIndex];
     if (bin) {
-      bin.count += 1;
-      bin.anchorBp += densityTick.anchorBp;
-      bin.x1 += densityTick.tick.x1;
-      bin.y1 += densityTick.tick.y1;
-      bin.x2 += densityTick.tick.x2;
-      bin.y2 += densityTick.tick.y2;
+      bin.count += sourceCount;
+      bin.anchorBp += densityTick.anchorBp * sourceCount;
+      bin.x1 += densityTick.tick.x1 * sourceCount;
+      bin.y1 += densityTick.tick.y1 * sourceCount;
+      bin.x2 += densityTick.tick.x2 * sourceCount;
+      bin.y2 += densityTick.tick.y2 * sourceCount;
       return;
     }
     bins[binIndex] = {
       firstId: densityTick.id,
-      count: 1,
-      anchorBp: densityTick.anchorBp,
-      x1: densityTick.tick.x1,
-      y1: densityTick.tick.y1,
-      x2: densityTick.tick.x2,
-      y2: densityTick.tick.y2,
+      count: sourceCount,
+      anchorBp: densityTick.anchorBp * sourceCount,
+      x1: densityTick.tick.x1 * sourceCount,
+      y1: densityTick.tick.y1 * sourceCount,
+      x2: densityTick.tick.x2 * sourceCount,
+      y2: densityTick.tick.y2 * sourceCount,
     };
   });
 
@@ -548,6 +546,10 @@ export const SequenceMapView = memo(function SequenceMapView({
     () => buildRestrictionDensityRender(layout.restrictionDensityTicks, layout.length),
     [layout.length, layout.restrictionDensityTicks],
   );
+  const restrictionDensitySourceCount = useMemo(
+    () => layout.restrictionDensityTicks.reduce((sum, tick) => sum + (tick.siteCount ?? 1), 0),
+    [layout.restrictionDensityTicks],
+  );
 
   const handleMapItemFocus = useCallback((interactionIndex: number) => {
     const key = mapInteractionModel.keys[interactionIndex];
@@ -765,7 +767,7 @@ export const SequenceMapView = memo(function SequenceMapView({
           aria-hidden="true"
           pointerEvents="none"
           data-binned={restrictionDensityRender.binned || undefined}
-          data-source-count={layout.restrictionDensityTicks.length}
+          data-source-count={restrictionDensitySourceCount}
           data-rendered-count={restrictionDensityRender.ticks.length}
         >
           {restrictionDensityRender.ticks.map((densityTick) => (

--- a/src/plasmid-map/__tests__/overflow-chip-hit.test.ts
+++ b/src/plasmid-map/__tests__/overflow-chip-hit.test.ts
@@ -324,7 +324,9 @@ describe('overflow chip hit rect', () => {
     expect(read).toContain("overflow.kind === 'restriction-labels'");
     expect(read).toContain('.unlabelled');
     expect(read).not.toMatch(/hiddenBodies|\+/);
-    expect(artifactSource).toContain('{mapUnlabelledSiteCount.toLocaleString()} sites without labels on the map');
+    expect(artifactSource).toContain('{mapUnlabelledSiteCount.toLocaleString()} {mapRestrictionSitesOmitted > 0 ? \'selectable sites\' : \'sites\'} without labels on the map');
+    expect(artifactSource).toContain('Density marks include all {visibleRestrictionSites.length.toLocaleString()} visible sites');
+    expect(artifactSource).toContain('{interactiveMapRestrictionSites.length.toLocaleString()} evenly distributed sites can be selected from the map.');
   });
 
   it('sizes itself at the type size the stylesheet actually draws the chip at', () => {

--- a/src/plasmid-map/__tests__/restriction-display.test.ts
+++ b/src/plasmid-map/__tests__/restriction-display.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { RestrictionSite } from '../../bio/types';
+import {
+  MAX_INTERACTIVE_MAP_RESTRICTION_SITES,
+  MAX_MAP_RESTRICTION_DENSITY_MARKS,
+  restrictionDensitySourcesForMap,
+  restrictionSitesForInteractiveMap,
+} from '../restriction-display';
+
+function site(position: number, enzyme = `E${position}`): RestrictionSite {
+  return {
+    enzyme,
+    position,
+    cutPosition: position + 1,
+    recognitionSequence: 'AAAA',
+    overhang: 'blunt',
+    strand: 1,
+  };
+}
+
+describe('restriction map display budgets', () => {
+  it('returns the original site collection below the interactive boundary', () => {
+    const sites = [site(10), site(20)];
+    expect(restrictionSitesForInteractiveMap(sites)).toBe(sites);
+  });
+
+  it('samples interactive sites across the complete coordinate range', () => {
+    const sites = Array.from(
+      { length: MAX_INTERACTIVE_MAP_RESTRICTION_SITES * 4 },
+      (_, index) => site(index),
+    ).reverse();
+    const selected = restrictionSitesForInteractiveMap(sites);
+
+    expect(selected).toHaveLength(MAX_INTERACTIVE_MAP_RESTRICTION_SITES);
+    expect(selected[0].position).toBe(0);
+    expect(selected.at(-1)?.position).toBe(sites.length - 1);
+    expect(selected.every((entry, index) => index === 0 || entry.position > selected[index - 1].position)).toBe(true);
+  });
+
+  it('bins density marks while preserving the exact raw-site population', () => {
+    const sites = Array.from({ length: 125_000 }, (_, index) => site(index * 2, `E${index % 7}`));
+    const density = restrictionDensitySourcesForMap(sites, 250_000);
+
+    expect(density.length).toBeLessThanOrEqual(MAX_MAP_RESTRICTION_DENSITY_MARKS);
+    expect(density.reduce((sum, mark) => sum + mark.siteCount, 0)).toBe(sites.length);
+    expect(density[0].position).toBeGreaterThanOrEqual(0);
+    expect(density.at(-1)?.position).toBeLessThan(250_000);
+  });
+});

--- a/src/plasmid-map/layout.ts
+++ b/src/plasmid-map/layout.ts
@@ -808,13 +808,16 @@ function computeCircularLayout(input: MapInput): MapLayout {
   const recTickInner = R + REC_TICK_INNER_OFFSET;
   const recTickOuter = recTickInner + REC_TICK_LEN;
 
-  const restrictionDensityTicks: MapRestrictionDensityTick[] = restrictionTicks.map((t, i) => {
-    const angle = bpToAngle(t.position, length);
+  const densitySources = input.restrictionDensitySources
+    ?? restrictionTicks.map((tick) => ({ id: tick.id, position: tick.position, siteCount: 1 }));
+  const restrictionDensityTicks: MapRestrictionDensityTick[] = densitySources.map((source, i) => {
+    const angle = bpToAngle(source.position, length);
     const p1 = pointOnCircle(cx, cy, densityTickInner, angle);
     const p2 = pointOnCircle(cx, cy, densityTickOuter, angle);
     return {
-      id: `redt-${i}-${t.id}`,
-      anchorBp: t.position,
+      id: `redt-${i}-${source.id}`,
+      anchorBp: source.position,
+      ...(source.siteCount > 1 ? { siteCount: source.siteCount } : {}),
       tick: { x1: round(p1.x), y1: round(p1.y), x2: round(p2.x), y2: round(p2.y) },
     };
   });
@@ -1840,11 +1843,14 @@ function computeLinearLayout(input: MapInput): MapLayout {
     circular: false,
   });
 
-  const restrictionDensityTicks: MapRestrictionDensityTick[] = restrictionTicks.map((t, i) => {
-    const xc = x(t.position);
+  const densitySources = input.restrictionDensitySources
+    ?? restrictionTicks.map((tick) => ({ id: tick.id, position: tick.position, siteCount: 1 }));
+  const restrictionDensityTicks: MapRestrictionDensityTick[] = densitySources.map((source, i) => {
+    const xc = x(source.position);
     return {
-      id: `redt-${i}-${t.id}`,
-      anchorBp: t.position,
+      id: `redt-${i}-${source.id}`,
+      anchorBp: source.position,
+      ...(source.siteCount > 1 ? { siteCount: source.siteCount } : {}),
       tick: {
         x1: round(xc),
         y1: recDensityTickTopY,

--- a/src/plasmid-map/restriction-display.ts
+++ b/src/plasmid-map/restriction-display.ts
@@ -1,0 +1,80 @@
+import type { RestrictionSite } from '../bio/types';
+import type { MapRestrictionDensitySource } from './types';
+
+export const MAX_INTERACTIVE_MAP_RESTRICTION_SITES = 512;
+export const MAX_MAP_RESTRICTION_DENSITY_MARKS = 512;
+
+function compareRestrictionSites(a: RestrictionSite, b: RestrictionSite): number {
+  return a.position - b.position
+    || a.enzyme.localeCompare(b.enzyme)
+    || a.cutPosition - b.cutPosition
+    || (a.strand ?? 1) - (b.strand ?? 1)
+    || a.recognitionSequence.localeCompare(b.recognitionSequence);
+}
+
+/**
+ * Keep normal records exact. At the extreme boundary, choose evenly spaced sites
+ * from position-sorted data so interactive SVG controls stay bounded without
+ * favoring the beginning of a record.
+ */
+export function restrictionSitesForInteractiveMap(
+  sites: readonly RestrictionSite[],
+  limit = MAX_INTERACTIVE_MAP_RESTRICTION_SITES,
+): readonly RestrictionSite[] {
+  const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.floor(limit)) : MAX_INTERACTIVE_MAP_RESTRICTION_SITES;
+  if (sites.length <= safeLimit) return sites;
+  const sorted = [...sites].sort(compareRestrictionSites);
+  if (safeLimit === 1) return [sorted[Math.floor((sorted.length - 1) / 2)]];
+  return Array.from({ length: safeLimit }, (_, index) => (
+    sorted[Math.floor(index * (sorted.length - 1) / (safeLimit - 1))]
+  ));
+}
+
+/**
+ * Aggregate the decorative density substrate in sequence space before layout.
+ * Each returned mark carries its raw-site count, so the renderer and tests can
+ * reconcile the visible marks with the complete site list.
+ */
+export function restrictionDensitySourcesForMap(
+  sites: readonly RestrictionSite[],
+  sequenceLength: number,
+  limit = MAX_MAP_RESTRICTION_DENSITY_MARKS,
+): readonly MapRestrictionDensitySource[] {
+  const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.floor(limit)) : MAX_MAP_RESTRICTION_DENSITY_MARKS;
+  if (sites.length <= safeLimit) {
+    return sites.map((site, index) => ({
+      id: `site-${index}-${site.enzyme}-${site.position}`,
+      position: site.position,
+      siteCount: 1,
+    }));
+  }
+
+  type Bin = { count: number; positionTotal: number };
+  const bins: Array<Bin | undefined> = new Array(safeLimit);
+  const usableLength = Number.isFinite(sequenceLength) && sequenceLength > 0 ? sequenceLength : 0;
+  sites.forEach((site, index) => {
+    const sequenceRatio = usableLength > 0 && Number.isFinite(site.position)
+      ? site.position / usableLength
+      : index / sites.length;
+    const boundedRatio = Math.max(0, Math.min(1 - Number.EPSILON, sequenceRatio));
+    const binIndex = Math.floor(boundedRatio * safeLimit);
+    const bin = bins[binIndex];
+    if (bin) {
+      bin.count += 1;
+      bin.positionTotal += site.position;
+    } else {
+      bins[binIndex] = { count: 1, positionTotal: site.position };
+    }
+  });
+
+  const sources: MapRestrictionDensitySource[] = [];
+  bins.forEach((bin, binIndex) => {
+    if (!bin) return;
+    sources.push({
+      id: `bin-${binIndex}`,
+      position: bin.positionTotal / bin.count,
+      siteCount: bin.count,
+    });
+  });
+  return sources;
+}

--- a/src/plasmid-map/types.ts
+++ b/src/plasmid-map/types.ts
@@ -124,7 +124,15 @@ export interface MapFeatureRender {
 export interface MapRestrictionDensityTick {
   id: string;
   anchorBp: number;
+  /** Number of raw restriction sites represented by this density mark. */
+  siteCount?: number;
   tick: { x1: number; y1: number; x2: number; y2: number };
+}
+
+export interface MapRestrictionDensitySource {
+  id: string;
+  position: number;
+  siteCount: number;
 }
 
 export interface MapRestrictionRender {
@@ -282,6 +290,8 @@ export interface MapInput {
   sequenceType: SequenceType;
   features: readonly Feature[];
   restrictionSites: readonly RestrictionSite[];
+  /** Optional pre-aggregated density substrate; interactive clusters still use restrictionSites. */
+  restrictionDensitySources?: readonly MapRestrictionDensitySource[];
   /** viewport pixel size (roughly square for circular). */
   width: number;
   height: number;

--- a/vite.claude-science.config.ts
+++ b/vite.claude-science.config.ts
@@ -3,6 +3,10 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   base: './',
+  // The built-in vectors are imported into the self-contained bundle. Disable
+  // Vite's URL-only public-directory handling so development and E2E resolve
+  // that source import the same way as the production build.
+  publicDir: false,
   plugins: [react()],
   build: {
     outDir: 'dist-motif',


### PR DESCRIPTION
## Summary

- Keep Map feature, restriction-site, and range selections synchronized with the Sequence pane, including directional arrowheads and large-record views.
- Improve circular and linear Map navigation with stable controls, broader panning, reliable Fit behavior, and distinct selection and blank-canvas drag regions.
- Add a synchronized Restriction Sites tool, bounded dense-map rendering, and clearer keyboard and focus behavior.
- Keep the pinned Tools header and existing rows stable as panels open, and improve compact and phone layouts.
- Refine Claude Light and Claude Dark active states while preserving feature-specific annotation colors.

## Validation

- `npm run gate`
  - unit: 1,177 passed across 103 files
  - connector: 23 passed across 3 files
  - artifact E2E: 149 passed, 61 skipped
  - MSA E2E: 59 passed
- `npm run validate:plugin`
- commit-range secret scan: no findings

The artifact E2E skips consist of the 59 MSA interactions exercised by the dedicated MSA suite and 2 real-Sanger tests that require external AB1 fixtures.
