### PR TITLE
Stabilize sequence and map pane resizing

### DIFF
--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -3192,6 +3192,168 @@ test.describe('Claude Science artifact workflows', () => {
     expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + 2);
   });
 
+  test('the map keeps widening and the selected sequence location stays anchored during resize', async ({ page }) => {
+    await openArtifact(page, 1800, 1200);
+
+    const inventoryToggle = page.locator('[data-pane-toggle="inventory"]');
+    if ((await inventoryToggle.getAttribute('aria-pressed')) === 'true') await inventoryToggle.click();
+    const toolsToggle = page.locator('[data-pane-toggle="tools"]');
+    if ((await toolsToggle.getAttribute('aria-pressed')) !== 'true') await toolsToggle.click();
+
+    const inspector = page.locator('.motif-cs-inspector[data-tools-pinned="true"]');
+    const patternPanel = inspector.locator('details[data-rail-tool="pattern-search"]');
+    await patternPanel.locator(':scope > summary').scrollIntoViewIfNeeded();
+    await patternPanel.locator(':scope > summary').click();
+    await patternPanel.locator('input[name="motif-search"]').fill('GAATTC');
+    await patternPanel.locator('.motif-cs-motif-hit-row').first().click();
+    await expect(page.locator('.motif-cs-selection-name')).toHaveText('809-814 (6)');
+
+    const sequence = page.locator('.motif-cs-sequence-column');
+    const sequenceScroller = sequence.locator('.motif-cs-sequence');
+    const map = page.locator('.motif-cs-map-column');
+    const separator = page.getByRole('separator', { name: 'Resize sequence and map panes' });
+    const focusedBlock = sequenceScroller.locator('[data-seq-focus="true"]');
+    const focusOffset = async () => {
+      const [scrollerBox, blockBox] = await Promise.all([
+        sequenceScroller.boundingBox(),
+        focusedBlock.boundingBox(),
+      ]);
+      expect(scrollerBox && blockBox).toBeTruthy();
+      return blockBox!.y - scrollerBox!.y;
+    };
+
+    const sequenceBefore = (await sequence.boundingBox())!;
+    const mapBefore = (await map.boundingBox())!;
+    const handleBefore = (await separator.boundingBox())!;
+    const focusBefore = await focusOffset();
+    const pointerStart = handleBefore.x + handleBefore.width / 2;
+    const pointerY = handleBefore.y + handleBefore.height / 2;
+
+    await page.mouse.move(pointerStart, pointerY);
+    await page.mouse.down();
+    for (let step = 1; step <= 18; step += 1) {
+      await page.mouse.move(pointerStart - step * 10, pointerY);
+      await page.evaluate(() => new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }));
+      const handle = (await separator.boundingBox())!;
+      expect(Math.abs((handle.x + handle.width / 2) - (pointerStart - step * 10))).toBeLessThanOrEqual(4);
+    }
+    await page.mouse.up();
+
+    const sequenceAfter = (await sequence.boundingBox())!;
+    const mapAfter = (await map.boundingBox())!;
+    const focusAfter = await focusOffset();
+    expect(sequenceAfter.width).toBeLessThan(sequenceBefore.width - 160);
+    expect(sequenceAfter.width).toBeGreaterThanOrEqual(240);
+    expect(mapAfter.width).toBeGreaterThan(mapBefore.width + 160);
+    expect(mapAfter.width).toBeGreaterThan(900);
+    expect(Math.abs(focusAfter - focusBefore)).toBeLessThanOrEqual(3);
+    await expect(page.locator('.motif-cs-selection-name')).toHaveText('809-814 (6)');
+    await expect(focusedBlock).toBeInViewport();
+
+    const main = page.locator('.motif-cs-main');
+    const dimensions = await main.evaluate((element) => ({ clientWidth: element.clientWidth, scrollWidth: element.scrollWidth }));
+    expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + 2);
+  });
+
+  test('repeated keyboard pane resizing keeps the selected sequence location anchored', async ({ page }) => {
+    await openArtifact(page, 1800, 1200);
+
+    const inventoryToggle = page.locator('[data-pane-toggle="inventory"]');
+    if ((await inventoryToggle.getAttribute('aria-pressed')) === 'true') await inventoryToggle.click();
+    const toolsToggle = page.locator('[data-pane-toggle="tools"]');
+    if ((await toolsToggle.getAttribute('aria-pressed')) !== 'true') await toolsToggle.click();
+
+    const inspector = page.locator('.motif-cs-inspector[data-tools-pinned="true"]');
+    const patternPanel = inspector.locator('details[data-rail-tool="pattern-search"]');
+    await patternPanel.locator(':scope > summary').scrollIntoViewIfNeeded();
+    await patternPanel.locator(':scope > summary').click();
+    await patternPanel.locator('input[name="motif-search"]').fill('GAATTC');
+    await patternPanel.locator('.motif-cs-motif-hit-row').first().click();
+    await expect(page.locator('.motif-cs-selection-name')).toHaveText('809-814 (6)');
+
+    const sequence = page.locator('.motif-cs-sequence-column');
+    const sequenceScroller = sequence.locator('.motif-cs-sequence');
+    const map = page.locator('.motif-cs-map-column');
+    const separator = page.getByRole('separator', { name: 'Resize sequence and map panes' });
+    const focusedBlock = sequenceScroller.locator('[data-seq-focus="true"]');
+    const focusOffset = async () => {
+      const [scrollerBox, blockBox] = await Promise.all([
+        sequenceScroller.boundingBox(),
+        focusedBlock.boundingBox(),
+      ]);
+      expect(scrollerBox && blockBox).toBeTruthy();
+      return blockBox!.y - scrollerBox!.y;
+    };
+
+    const sequenceBefore = (await sequence.boundingBox())!.width;
+    const mapBefore = (await map.boundingBox())!.width;
+    const focusBefore = await focusOffset();
+    await separator.focus();
+    for (let step = 0; step < 12; step += 1) {
+      await separator.dispatchEvent('keydown', {
+        key: 'ArrowLeft',
+        code: 'ArrowLeft',
+        repeat: step > 0,
+      });
+      await page.waitForTimeout(20);
+    }
+    await page.waitForTimeout(180);
+    await page.evaluate(() => new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    }));
+
+    const sequenceAfter = (await sequence.boundingBox())!.width;
+    const mapAfter = (await map.boundingBox())!.width;
+    expect(sequenceAfter).toBeLessThan(sequenceBefore - 160);
+    expect(mapAfter).toBeGreaterThan(mapBefore + 160);
+    expect(Math.abs((await focusOffset()) - focusBefore)).toBeLessThanOrEqual(3);
+    await expect(page.locator('.motif-cs-selection-name')).toHaveText('809-814 (6)');
+    await expect(focusedBlock).toBeInViewport();
+  });
+
+  test('a new Pattern Search selection supersedes a pending pane-resize anchor', async ({ page }) => {
+    await openArtifact(page, 1800, 1200);
+
+    const inventoryToggle = page.locator('[data-pane-toggle="inventory"]');
+    if ((await inventoryToggle.getAttribute('aria-pressed')) === 'true') await inventoryToggle.click();
+    const toolsToggle = page.locator('[data-pane-toggle="tools"]');
+    if ((await toolsToggle.getAttribute('aria-pressed')) !== 'true') await toolsToggle.click();
+
+    const inspector = page.locator('.motif-cs-inspector[data-tools-pinned="true"]');
+    const patternPanel = inspector.locator('details[data-rail-tool="pattern-search"]');
+    await patternPanel.locator(':scope > summary').scrollIntoViewIfNeeded();
+    await patternPanel.locator(':scope > summary').click();
+    await patternPanel.locator('input[name="motif-search"]').fill('ATG');
+    const hits = patternPanel.locator('.motif-cs-motif-hit-row');
+    await expect.poll(() => hits.count()).toBeGreaterThan(8);
+    await hits.first().click();
+
+    const separator = page.getByRole('separator', { name: 'Resize sequence and map panes' });
+    const handle = (await separator.boundingBox())!;
+    const pointerX = handle.x + handle.width / 2;
+    const pointerY = handle.y + handle.height / 2;
+    await page.mouse.move(pointerX, pointerY);
+    await page.mouse.down();
+    await page.mouse.move(pointerX - 60, pointerY, { steps: 6 });
+
+    const nextHit = hits.nth(8);
+    const nextPosition = Number(await nextHit.locator('.motif-cs-motif-hit-position').textContent());
+    await nextHit.dispatchEvent('click');
+    await page.mouse.up();
+    await page.evaluate(() => new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    }));
+
+    await expect(page.locator('.motif-cs-selection-name')).toHaveText(
+      `${nextPosition}-${nextPosition + 2} (3)`,
+    );
+    const focusedBlock = page.locator('.motif-cs-sequence [data-seq-focus="true"]');
+    await expect(focusedBlock).toBeInViewport();
+    await expect(focusedBlock.locator('.motif-cs-seq-hl:not(.motif-cs-seq-hl-motif)').first()).toBeVisible();
+  });
+
   test('pane resize modes clean up on blur and Escape docking', async ({ page }) => {
     await openArtifact(page, 640, 500);
     const toolsToggle = page.getByRole('button', { name: /Tools/ }).first();

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -361,7 +361,7 @@ describe('Claude Science workspace layout guards', () => {
     expect(artifactSource).toContain("const TWO_ROW_LAYOUT_MEDIA = '(min-width: 640px) and (max-width: 1535px)';");
     expect(artifactSource).toContain("const OVERLAY_TOOLS_LAYOUT_MEDIA = '(max-width: 1535px)';");
     expect(artifactSource).toContain("sequence: { min: 240, max: 2000 }");
-    expect(artifactSource).toContain("map: { min: 300, max: 900 }");
+    expect(artifactSource).toContain("map: { min: 300, max: 2000 }");
     expect(artifactCss).toMatch(/\.motif-cs-resize-handle\[data-pane="sequence"\]\s*\{[\s\S]*?display:\s*block/);
     expect(artifactCss).toMatch(/@media \(min-width: 768px\) and \(max-width: 1535px\)[\s\S]*?\.motif-cs-resize-handle\[data-pane="inventory"\],[\s\S]*?\.motif-cs-resize-handle\[data-pane="sequence"\][\s\S]*?display:\s*block/);
     expect(artifactCss).toMatch(/@media \(min-width: 1536px\)[\s\S]*?\.motif-cs-resize-handle\[data-pane="tools"\][\s\S]*?display:\s*block/);

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -616,7 +616,11 @@ const DEFAULT_PANE_WIDTHS: PaneWidths = {
 const PANE_WIDTH_LIMITS: Record<ResizablePaneKey, { min: number; max: number }> = {
   inventory: { min: 160, max: 420 },
   sequence: { min: 240, max: 2000 },
-  map: { min: 300, max: 900 },
+  // Like Sequence, Map's maximum is a preference backstop rather than the
+  // working drag limit. The adjacent pane minimum and the workspace width are
+  // the physical bounds. A 900px cap stopped the divider after a few pixels in
+  // ordinary desktop layouts even while Sequence still had room to shrink.
+  map: { min: 300, max: 2000 },
   tools: { min: 220, max: 540 },
 };
 
@@ -648,6 +652,8 @@ const STACKED_LAYOUT_MEDIA = '(max-width: 767px)';
 const COMPACT_PINNED_LAYOUT_MEDIA = '(min-width: 640px) and (max-width: 1535px)';
 const TWO_ROW_LAYOUT_MEDIA = '(min-width: 640px) and (max-width: 1535px)';
 const OVERLAY_TOOLS_LAYOUT_MEDIA = '(max-width: 1535px)';
+const PANE_RESIZE_START_EVENT = 'motif-cs-pane-resize-start';
+const PANE_RESIZE_END_EVENT = 'motif-cs-pane-resize-end';
 const PANE_ORDER_FALLBACK: Record<PaneKey, number> = DEFAULT_PANE_ORDER.reduce(
   (acc, pane, index) => ({ ...acc, [pane]: index }),
   {} as Record<PaneKey, number>,
@@ -4946,6 +4952,7 @@ function App() {
   } | null>(null);
   const floatingPaneInteractionCleanupRef = useRef<(() => void) | null>(null);
   const paneResizeCleanupRef = useRef<(() => void) | null>(null);
+  const keyboardPaneResizeEndTimerRef = useRef<number | null>(null);
   const stackedPaneResizeCleanupRef = useRef<(() => void) | null>(null);
   const sequenceScrollByRecordRef = useRef<Record<string, number>>({});
   const mapDragRef = useRef<MapDragState | null>(null);
@@ -8398,7 +8405,14 @@ function App() {
   const stopPaneResize = useCallback(() => {
     paneResizeCleanupRef.current?.();
     paneResizeCleanupRef.current = null;
+    const hadKeyboardResize = keyboardPaneResizeEndTimerRef.current !== null;
+    if (keyboardPaneResizeEndTimerRef.current !== null) {
+      window.clearTimeout(keyboardPaneResizeEndTimerRef.current);
+      keyboardPaneResizeEndTimerRef.current = null;
+    }
+    const wasResizing = Boolean(document.body.dataset.motifCsResizing);
     delete document.body.dataset.motifCsResizing;
+    if (wasResizing || hadKeyboardResize) window.dispatchEvent(new Event(PANE_RESIZE_END_EVENT));
   }, []);
 
   const stopStackedPaneResize = useCallback(() => {
@@ -10347,6 +10361,7 @@ function App() {
     }
 
     paneResizeCleanupRef.current = removeListeners;
+    window.dispatchEvent(new Event(PANE_RESIZE_START_EVENT));
     document.body.dataset.motifCsResizing = pane;
     window.addEventListener('pointermove', handlePointerMove);
     window.addEventListener('pointerup', handlePointerEnd);
@@ -10362,6 +10377,15 @@ function App() {
   const resizePaneFromKeyboard = useCallback((pane: ResizablePaneKey, event: ReactKeyboardEvent<HTMLDivElement>, edge: ResizeEdge = 'after') => {
     if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
     event.preventDefault();
+    if (keyboardPaneResizeEndTimerRef.current === null) {
+      window.dispatchEvent(new Event(PANE_RESIZE_START_EVENT));
+    } else {
+      window.clearTimeout(keyboardPaneResizeEndTimerRef.current);
+    }
+    keyboardPaneResizeEndTimerRef.current = window.setTimeout(() => {
+      keyboardPaneResizeEndTimerRef.current = null;
+      window.dispatchEvent(new Event(PANE_RESIZE_END_EVENT));
+    }, 120);
     const direction = pane === 'tools' || edge === 'before' ? -1 : 1;
     const screenDirection = event.key === 'ArrowRight' ? 1 : -1;
     const step = event.shiftKey ? 32 : 16;
@@ -16986,6 +17010,18 @@ const SequenceText = memo(function SequenceText({
   const containerRef = useRef<HTMLDivElement>(null);
   const rulerRef = useRef<HTMLSpanElement>(null);
   const charWidthRef = useRef<number>(0);
+  const basesPerLineRef = useRef(60);
+  const resizeScrollAnchorRef = useRef<{
+    base: number;
+    blockOffset: number;
+    targetBasesPerLine: number;
+  } | null>(null);
+  const stableScrollAnchorRef = useRef<{
+    base: number;
+    blockOffset: number;
+  } | null>(null);
+  const paneResizeActiveRef = useRef(false);
+  const anchoredSequenceRef = useRef(sequence);
   const dragAnchorRef = useRef<number | null>(null);
   const dragPointerIdRef = useRef<number | null>(null);
   const dragStartPointRef = useRef<{ x: number; y: number } | null>(null);
@@ -17062,6 +17098,76 @@ const SequenceText = memo(function SequenceText({
     return () => document.removeEventListener('copy', handleDocumentCopy);
   }, [selectedAaTrackText, writeSelectedAaToClipboard]);
 
+  const captureStableScrollAnchor = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return null;
+    const scroller = effectiveSequenceScroller(container);
+    const scrollerRect = scroller.getBoundingClientRect();
+    const blocks = Array.from(container.querySelectorAll<HTMLElement>('.motif-cs-seq-block'));
+    const focusBlock = container.querySelector<HTMLElement>('[data-seq-focus="true"]');
+    const focusRect = focusBlock?.getBoundingClientRect();
+    const focusVisible = Boolean(
+      focusBlock
+      && focusRect
+      && focusRect.bottom > scrollerRect.top
+      && focusRect.top < scrollerRect.bottom,
+    );
+    const centreY = scrollerRect.top + scrollerRect.height / 2;
+    const anchorBlock = focusVisible
+      ? focusBlock
+      : blocks.reduce<HTMLElement | null>((best, block) => {
+          if (!best) return block;
+          const blockRect = block.getBoundingClientRect();
+          const bestRect = best.getBoundingClientRect();
+          const blockDistance = Math.abs((blockRect.top + blockRect.bottom) / 2 - centreY);
+          const bestDistance = Math.abs((bestRect.top + bestRect.bottom) / 2 - centreY);
+          return blockDistance < bestDistance ? block : best;
+        }, null);
+    const anchorBases = anchorBlock?.querySelector<HTMLElement>('.motif-cs-seq-bases');
+    const focusedBase = Number(focusBlock?.dataset.seqFocusStart);
+    const base = focusVisible && Number.isFinite(focusedBase)
+      ? focusedBase
+      : Number(anchorBases?.dataset.lineStart);
+    if (!anchorBlock || !Number.isFinite(base)) return null;
+    const anchor = {
+      base,
+      blockOffset: anchorBlock.getBoundingClientRect().top - scrollerRect.top,
+    };
+    stableScrollAnchorRef.current = anchor;
+    return anchor;
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+    const capture = () => {
+      captureStableScrollAnchor();
+    };
+    const begin = () => {
+      paneResizeActiveRef.current = true;
+      capture();
+    };
+    const release = () => {
+      paneResizeActiveRef.current = false;
+    };
+    capture();
+    window.addEventListener(PANE_RESIZE_START_EVENT, begin);
+    window.addEventListener(PANE_RESIZE_END_EVENT, release);
+    window.addEventListener('resize', capture);
+    return () => {
+      window.removeEventListener(PANE_RESIZE_START_EVENT, begin);
+      window.removeEventListener(PANE_RESIZE_END_EVENT, release);
+      window.removeEventListener('resize', capture);
+    };
+  }, [captureStableScrollAnchor]);
+
+  useLayoutEffect(() => {
+    if (anchoredSequenceRef.current === sequence) return;
+    anchoredSequenceRef.current = sequence;
+    stableScrollAnchorRef.current = null;
+    resizeScrollAnchorRef.current = null;
+  }, [sequence]);
+
   const handleCopy = useCallback((event: ReactClipboardEvent<HTMLDivElement>) => {
     if (selectedAaTrackText && writeSelectedAaToClipboard(event.clipboardData)) {
       event.preventDefault();
@@ -17108,13 +17214,65 @@ const SequenceText = memo(function SequenceText({
       const basesWidth = container.clientWidth - padX - 48 - 10 - 10;
       const fit = Math.floor(basesWidth / charW);
       const next = clamp(Math.floor(fit / 5) * 5, 15, 300);
-      setBasesPerLine((prev) => (prev === next ? prev : next));
+      if (basesPerLineRef.current === next) return;
+
+      // Rewrapping changes every line boundary. Preserve the biological region
+      // the user was looking at before the pane width changed. The resize-start
+      // snapshot keeps this anchor independent of intermediate
+      // scroll events while the pane is moving.
+      const stableAnchor = stableScrollAnchorRef.current ?? captureStableScrollAnchor();
+      if (stableAnchor) {
+        resizeScrollAnchorRef.current = {
+          ...stableAnchor,
+          targetBasesPerLine: next,
+        };
+      }
+
+      basesPerLineRef.current = next;
+      setBasesPerLine(next);
     };
     measure();
     const ro = new ResizeObserver(measure);
     ro.observe(container);
     return () => ro.disconnect();
-  }, []);
+  }, [captureStableScrollAnchor]);
+
+  useLayoutEffect(() => {
+    const anchor = resizeScrollAnchorRef.current;
+    const container = containerRef.current;
+    if (!anchor || !container || anchor.targetBasesPerLine !== basesPerLine) return;
+    let settleFrame = 0;
+    const frame = window.requestAnimationFrame(() => {
+      settleFrame = window.requestAnimationFrame(() => {
+        if (resizeScrollAnchorRef.current !== anchor) return;
+        const scroller = effectiveSequenceScroller(container);
+        const anchorRow = Array.from(container.querySelectorAll<HTMLElement>('.motif-cs-seq-bases'))
+          .find((row) => {
+            const start = Number(row.dataset.lineStart);
+            const length = Number(row.dataset.lineLen);
+            return Number.isFinite(start)
+              && Number.isFinite(length)
+              && anchor.base >= start
+              && anchor.base < start + length;
+          });
+        const anchorBlock = anchorRow?.closest<HTMLElement>('.motif-cs-seq-block');
+        if (anchorBlock) {
+          const currentOffset = anchorBlock.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+          const delta = currentOffset - anchor.blockOffset;
+          if (Math.abs(delta) > 0.5) scroller.scrollTop += delta;
+          stableScrollAnchorRef.current = {
+            base: anchor.base,
+            blockOffset: anchor.blockOffset,
+          };
+        }
+        resizeScrollAnchorRef.current = null;
+      });
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.cancelAnimationFrame(settleFrame);
+    };
+  }, [basesPerLine]);
 
   // Geometric hit-testing: map a pointer to a base index from the row's left edge
   // and the measured monospace char width. This is exact to the base under the
@@ -17428,6 +17586,8 @@ const SequenceText = memo(function SequenceText({
       : selectedRestrictionFocusStart === null
         ? 'none'
         : `restriction:${selectedRestrictionFocusStart}`);
+  const previousFocusKeyRef = useRef(focusKey);
+  const previousFocusRequestRef = useRef(focusRequest);
   // Pre-build the inline amino-acid rows per line, memoized on the tracks (NOT the
   // selection). The rows are React elements with stable identity, so a selection
   // drag — which re-renders SequenceText every frame — reuses these exact nodes and
@@ -17490,7 +17650,21 @@ const SequenceText = memo(function SequenceText({
   }, [sequence, sequenceType, topology, translationTracks, basesPerLine, selectedAaTrackId, selectInlineTranslationTrack, onTranslationCodonSelect]);
 
   useEffect(() => {
-    if (focusStart === null) return;
+    const selectionChanged = previousFocusKeyRef.current !== focusKey
+      || previousFocusRequestRef.current !== focusRequest;
+    previousFocusKeyRef.current = focusKey;
+    previousFocusRequestRef.current = focusRequest;
+    if (focusStart === null) {
+      if (selectionChanged) resizeScrollAnchorRef.current = null;
+      return;
+    }
+    if (selectionChanged) {
+      // A new selection owns the viewport. Cancel any delayed rewrap
+      // correction so it cannot pull the newly selected row away.
+      resizeScrollAnchorRef.current = null;
+    } else if (paneResizeActiveRef.current) {
+      return;
+    }
     if (suppressNextFocusScrollRef.current) {
       suppressNextFocusScrollRef.current = false;
       return;
@@ -17546,7 +17720,12 @@ const SequenceText = memo(function SequenceText({
     const caretOffset = caretInLine && caret !== null ? Math.min(caret - lineStart, lineLen) : -1;
 
     grouped.push(
-      <div className="motif-cs-seq-block" key={lineStart} data-seq-focus={isFocusLine || undefined}>
+      <div
+        className="motif-cs-seq-block"
+        key={lineStart}
+        data-seq-focus={isFocusLine || undefined}
+        data-seq-focus-start={isFocusLine ? focusStart : undefined}
+      >
         {lineRestrictionLabels.lanes.length > 0 ? (
           <div className="motif-cs-restriction-tracks" aria-label={`Restriction sites for ${lineStart + 1}-${lineEnd}`}>
             {lineRestrictionLabels.lanes.map((lane, laneIndex) => (


### PR DESCRIPTION
## Summary

- let the Map pane use the available desktop workspace while preserving pane minimums
- keep the visible Sequence region anchored while responsive line wrapping changes during mouse or keyboard resizing
- let new map and Pattern Search selections supersede any pending resize anchor
- add browser coverage for continuous mouse resizing, repeated keyboard resizing, and selection precedence

## Validation

- `npm run gate`
  - unit: 1,177 passed across 103 files
  - connector: 23 passed across 3 files
  - artifact E2E: 152 passed, 61 skipped
  - dedicated MSA E2E: 59 passed
- `npm run validate:plugin`
- wide and compact browser review in Light, Dark, Claude Light, and Claude Dark

The shared artifact run skips 59 MSA cases that run in the dedicated MSA suite. Two real Sanger cases require non-vendored AB1 and external-alignment inputs.