### PR TITLE
Harden and stabilize automated checks

### DIFF
--- a/e2e/claude-science-msa-interactions.spec.ts
+++ b/e2e/claude-science-msa-interactions.spec.ts
@@ -193,6 +193,11 @@ test.describe('Motif MSA viewer interactions', () => {
     await expect(activeGridCell(page).locator('xpath=..').locator('xpath=..')).toHaveAttribute('data-msa-row-index', '1');
 
     await page.keyboard.press('End');
+    // The End navigation virtualizes a new cell at the far edge before focus
+    // follows it. Wait for that handoff so the next chord cannot land on the
+    // temporarily unfocused document under slower CI runners.
+    await expect(activeGridCell(page)).toBeFocused();
+    await expect(activeGridCell(page)).toHaveAttribute('data-alignment-column', '120');
     await page.keyboard.press('Control+Home');
     await expect(activeGridCell(page)).toBeFocused();
     await expect(activeGridCell(page)).toHaveAttribute('data-alignment-column', '1');

--- a/scripts/test-claude-science-plugin-packaging.mjs
+++ b/scripts/test-claude-science-plugin-packaging.mjs
@@ -165,7 +165,9 @@ check('plugin source has a matching, bounded manifest and skill', () => {
   assert.match(manifest.version, /^\d+\.\d+\.\d+$/);
   assert.equal(manifest.version, '0.2.1');
   assert.equal(manifest.version, artifactVersion);
-  assert.match(changelog, new RegExp(`^## ${manifest.version.replace(/\./g, '\\.')}(?:\\s|$)`, 'm'));
+  assert.ok(changelog.split(/\r?\n/u).some((line) => (
+    line === `## ${manifest.version}` || line.startsWith(`## ${manifest.version} `)
+  )));
   assert.ok(existsSync(join(pluginSource, runnerRelativePath)));
   assert.ok(existsSync(join(pluginSource, 'skills/motif-for-claude-science/scripts/analysis-validator.mjs')));
   assert.ok(existsSync(join(pluginSource, 'skills/motif-for-claude-science/scripts/workspace-validator.mjs')));

--- a/src/artifacts/__tests__/ClaudeScienceMsaViewer.overlays.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeScienceMsaViewer.overlays.jsdom.test.tsx
@@ -17,9 +17,13 @@ const overlayCss = readFileSync(resolve(here, '..', 'claude-science-msa.css'), '
 const artifactCss = readFileSync(resolve(here, '..', 'motif-artifact.css'), 'utf8');
 const viewerSource = readFileSync(resolve(here, '..', 'ClaudeScienceMsaViewer.tsx'), 'utf8');
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /** Body of the rule block for `selector` that carries `needle`. */
 function ruleBlockContaining(css: string, selector: string, needle: string): string | null {
-  const re = new RegExp(`${selector.replace(/[.[\]]/g, '\\$&')}\\s*\\{([^}]*)\\}`, 'g');
+  const re = new RegExp(`${escapeRegExp(selector)}\\s*\\{([^}]*)\\}`, 'g');
   for (const match of css.matchAll(re)) if (match[1].includes(needle)) return match[1];
   return null;
 }


### PR DESCRIPTION
## Summary

- wait for the virtualized MSA boundary cell to receive focus before sending the following keyboard chord on slower hosted runners
- use a complete regular-expression escape in the CSS test helper
- replace the dynamic changelog regex with a direct line comparison

The latter two changes resolve the initial CodeQL incomplete-sanitization findings. They are test/build-check helpers, not runtime data paths.

## Validation

- npm audit: 0 vulnerabilities
- npm run lint: passed
- targeted MSA boundary test: 30 repeated passes across the dependency baselines
- targeted overlay tests: 4 passed
- npm run test:plugin: passed
- Gitleaks history scan: passed with redaction
- git diff --check: passed

No runtime behavior, public schema, packaged file, or external data flow changes.