### PR TITLE
Tighten public repository maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,34 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      playwright:
+        patterns:
+          - playwright
+          - "@playwright/test"
+      node-types:
+        patterns:
+          - "@types/node"
+      development-minor-and-patch:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+        exclude-patterns:
+          - playwright
+          - "@playwright/test"
+          - "@types/node"
+      production-minor-and-patch:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+Describe the user-facing or maintenance outcome and the reason for the change.
+
+## Validation
+
+- [ ] `npm run gate`
+- [ ] `npm run validate:plugin`, or the Claude CLI skip is explained below
+- [ ] Visible changes were checked in wide, narrow, light, dark, mouse, and
+      keyboard states
+- [ ] Generated artifacts were inspected when packaging or connector code changed
+
+Skipped checks or external-tool assumptions:
+
+## Public data safety
+
+- [ ] No credentials, tokens, private filesystem paths, unpublished biological
+      data, workspace exports, connector configuration, or unredacted logs are
+      included
+- [ ] Examples and fixtures use synthetic or clearly public data
+- [ ] User-controlled content does not cross a raw HTML, shell, eval, generic
+      filesystem, or generic DOM bridge
+
+## Release impact
+
+State whether this changes the plugin/runtime version, public schemas, packaged
+files, provenance, or release notes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to Motif for Claude Science
+
+Thank you for helping improve Motif. This repository is public, so every
+commit, pull request, issue, test artifact, and CI log must be safe to publish.
+
+## Protect data and credentials
+
+Never include credentials, tokens, private filesystem paths, unpublished or
+sensitive biological data, Claude Science workspace exports, local connector
+configuration, or unredacted logs. Use a small synthetic sequence or a clearly
+public record for examples and reproductions.
+
+Report suspected vulnerabilities through the private process in
+[SECURITY.md](SECURITY.md), not through a public issue.
+
+## Set up and validate
+
+Motif requires Node.js 22.12 or newer. Install the locked dependencies with:
+
+```bash
+npm ci
+```
+
+Before opening a pull request, run:
+
+```bash
+npm run gate
+npm run validate:plugin
+```
+
+`npm run validate:plugin` requires the Claude CLI. If it is unavailable, say so
+in the pull request and report every other completed check.
+
+For a visible change, also run `npm run preview:motif` and exercise wide,
+narrow, light, dark, resized-panel, mouse, and keyboard states in a real
+browser. DOM assertions alone do not show whether a control is legible or
+reachable.
+
+## Keep the public boundary narrow
+
+- Keep the artifact self-contained and browser-safe.
+- Preserve keyboard, focus, ARIA, and `data-testid` contracts.
+- Use Motif-owned public names for new schemas, environment variables, page
+  APIs, output files, and provenance identifiers.
+- Do not introduce raw HTML insertion from user-controlled data.
+- Do not expose shell, eval, generic filesystem, or generic DOM bridges.
+- Treat Database JSON and workspace ZIP files as ordinary, unencrypted
+  checkpoints.
+- Keep model-facing connector tools narrow, typed, and bounded.
+
+Connector or remote-mutation changes need a separately reviewed integration
+campaign. See [AGENTS.md](AGENTS.md) for the repository contracts and full
+validation checklist.
+
+## Pull requests
+
+Keep each pull request focused, explain user-visible behavior and security
+boundaries, and update tests and changelogs where applicable. Generated release
+artifacts should come from a clean, validated commit and must not be committed
+unless the repository explicitly tracks them. Maintainers should follow
+[the release checklist](docs/RELEASING.md).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,76 @@
+# Release checklist
+
+Motif releases are immutable public artifacts. Build and inspect them from the
+exact tagged commit; never assemble a release from an unrelated or dirty
+working tree.
+
+## 1. Prepare the release pull request
+
+- Choose the semantic version and update the package, lockfile, plugin
+  manifest, artifact runtime, connector bridge, server, docs, tests, agent
+  guide, and changelogs together.
+- Move the root changelog's Unreleased entries under the dated release heading.
+- Run the complete repository gate and strict plugin validation.
+- Confirm the diff contains no credentials, private paths, unpublished
+  biological data, workspace exports, connector configuration, or unredacted
+  logs.
+- Merge only after the required hosted checks pass against the current
+  protected branch.
+
+## 2. Build from the release commit
+
+Start with a clean checkout of the merged commit:
+
+```bash
+npm ci
+npm audit
+npm run gate
+npm run validate:plugin
+git diff --check
+git status --short
+```
+
+Record the SHA-256 hashes:
+
+```bash
+shasum -a 256 \
+  dist-motif/motif-artifact.html \
+  dist-motif/motif-for-claude-science.zip \
+  dist-motif/motif-for-claude-science.checksums.json
+```
+
+Inspect the ZIP file list. It must use relative paths and include
+`THIRD_PARTY_NOTICES.md` plus a license file for every dependency bundled into
+the connector server.
+
+## 3. Tag and draft
+
+Create and push an annotated `vX.Y.Z` tag that names the validated commit.
+Create the GitHub release as a draft with `--verify-tag`, and attach exactly:
+
+- `motif-artifact.html`
+- `motif-for-claude-science.zip`
+- `motif-for-claude-science.checksums.json`
+
+Review the draft title, notes, tag, target commit, asset names, sizes, and
+GitHub-reported SHA-256 digests. Download the draft assets when practical and
+compare them with the local files before publishing.
+
+## 4. Publish and verify
+
+Publish only after every asset is present. Release immutability locks the tag
+and asset bytes at publication.
+
+After publication:
+
+```bash
+gh release verify vX.Y.Z
+gh release verify-asset vX.Y.Z dist-motif/motif-artifact.html
+gh release verify-asset vX.Y.Z dist-motif/motif-for-claude-science.zip
+gh release verify-asset vX.Y.Z \
+  dist-motif/motif-for-claude-science.checksums.json
+```
+
+Finally, confirm the release is marked immutable and latest, the public
+downloads match the recorded hashes, Dependabot and CodeQL have no unresolved
+release-blocking alerts, and the working tree remains clean.


### PR DESCRIPTION
## Summary

- group coupled Playwright packages, Node types, routine minor/patch npm updates, and GitHub Actions updates to reduce duplicate maintenance PRs
- add a pull-request checklist with explicit validation, public-data safety, and release-impact review
- add public contribution guidance that forbids credentials, private paths, unpublished biological data, workspace exports, connector configuration, and unredacted logs
- document the clean-tag, complete-license, draft-digest, and immutable-release checklist

The Dependabot policy intentionally does not ignore major versions: closing an unreviewed non-security major today must not suppress a future security update.

## Validation

- npm ci: 0 vulnerabilities
- Dependabot YAML parse: passed
- npm run typecheck: passed
- npm run lint: passed
- Gitleaks history scan: passed with redaction
- git diff --check: passed

No runtime code, schema, packaged artifact, or external data flow changes.