### PR TITLE
Enforce repository vocabulary policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Repository language policy
+        run: npm run check:repository-language
+
       - name: Unit tests
         run: npm test
 
@@ -64,6 +67,8 @@ jobs:
 
       - name: Dependency cooling-off policy
         run: npm run security:cooling-off
+        env:
+          MOTIF_COOLING_OFF_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
       - name: Plugin and connector checks
         run: npm run test:plugin && npm run test:connector

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "preview:claude-science": "npm run preview:motif",
     "typecheck": "tsc -b --pretty false",
     "lint": "eslint .",
+    "check:repository-language": "node scripts/check-repository-language.mjs",
     "test": "vitest run",
     "security:audit": "npm audit --audit-level=moderate",
     "security:policy": "node scripts/check-supply-chain-policy.mjs",
@@ -75,7 +76,7 @@
     "claude-science:setup": "npm run claude-science:build && npm run claude-science:doctor:unregistered && npm run claude-science:install-local && npm run claude-science:check-local",
     "check:css-tokens": "node scripts/check-css-tokens.mjs",
     "check:aria-controls": "node scripts/check-aria-controls.mjs",
-    "gate": "npm run typecheck && npm run lint && npm test && npm run check:release-alignment && npm run check:runtime-compatibility && npm run security:audit && npm run security:policy && npm run security:lifecycle && npm run security:cooling-off && npm run test:plugin && npm run test:connector && npm run check:css-tokens && npm run check:aria-controls && npm run build:motif && npm run security:reproducibility && npm run security:budgets && npm run test:e2e && npm run test:e2e:msa && npm run report:gate-coverage"
+    "gate": "npm run typecheck && npm run lint && npm run check:repository-language && npm test && npm run check:release-alignment && npm run check:runtime-compatibility && npm run security:audit && npm run security:policy && npm run security:lifecycle && npm run security:cooling-off && npm run test:plugin && npm run test:connector && npm run check:css-tokens && npm run check:aria-controls && npm run build:motif && npm run security:reproducibility && npm run security:budgets && npm run test:e2e && npm run test:e2e:msa && npm run report:gate-coverage"
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "1.7.5",

--- a/public/data/vectors.json
+++ b/public/data/vectors.json
@@ -110,7 +110,7 @@
       "source": "Motif curated reference data for common publicly documented cloning vectors",
       "license": "Included in the MIT-licensed Motif distribution as curated public reference data",
       "releaseStatus": "approved-public-reference",
-      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before wet-lab use. No customer, sponsor, or private import data was used. Annotations are limited to valid ranges within the bundled sequence record."
+      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before experimental use. No customer, sponsor, or private import data was used. Annotations are limited to valid ranges within the bundled sequence record."
     }
   },
   {
@@ -189,7 +189,7 @@
       "source": "Motif curated reference data for common publicly documented cloning vectors",
       "license": "Included in the MIT-licensed Motif distribution as curated public reference data",
       "releaseStatus": "approved-public-reference",
-      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before wet-lab use. No customer, sponsor, or private import data was used. Annotations are limited to valid ranges within the bundled sequence record."
+      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before experimental use. No customer, sponsor, or private import data was used. Annotations are limited to valid ranges within the bundled sequence record."
     }
   },
   {
@@ -231,7 +231,7 @@
       "source": "Motif curated reference data for common publicly documented cloning vectors",
       "license": "Included in the MIT-licensed Motif distribution as curated public reference data",
       "releaseStatus": "approved-public-reference",
-      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before wet-lab use. No customer, sponsor, or private import data was used. Annotations are limited to valid ranges within the bundled sequence record."
+      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before experimental use. No customer, sponsor, or private import data was used. Annotations are limited to valid ranges within the bundled sequence record."
     }
   },
   {
@@ -321,7 +321,7 @@
       "source": "Motif curated reference data for common publicly documented cloning vectors",
       "license": "Included in the MIT-licensed Motif distribution as curated public reference data",
       "releaseStatus": "approved-public-reference",
-      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before wet-lab use. No customer, sponsor, or private import data was used. Annotations are limited to valid ranges within the bundled sequence record."
+      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before experimental use. No customer, sponsor, or private import data was used. Annotations are limited to valid ranges within the bundled sequence record."
     }
   },
   {
@@ -411,7 +411,7 @@
       "source": "Motif curated reference data for common publicly documented cloning vectors",
       "license": "Included in the MIT-licensed Motif distribution as curated public reference data",
       "releaseStatus": "approved-public-reference",
-      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before wet-lab use. No customer, sponsor, or private import data was used. Annotations are limited to valid ranges within the bundled sequence record."
+      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before experimental use. No customer, sponsor, or private import data was used. Annotations are limited to valid ranges within the bundled sequence record."
     }
   },
   {
@@ -512,7 +512,7 @@
       "source": "Motif curated reference data for the Novagen pET-28a(+) T7lac expression vector. Nucleotide sequence obtained from the Addgene vector database (entry 2565) and cross-verified byte-for-byte against an independent repository (novoprolabs) as the same circular molecule, plus internally against the pET-28a/b/c(+) reading-frame trio.",
       "license": "Raw plasmid sequence is factual reference data, not subject to copyright; included in the MIT-licensed Motif distribution as curated public reference data. Feature annotations were generated independently by motif search, not copied from any annotated source.",
       "releaseStatus": "approved-public-reference",
-      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before wet-lab use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; KanR ORF confirmed by translation). No customer, sponsor, or private import data was used."
+      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before experimental use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; KanR ORF confirmed by translation). No customer, sponsor, or private import data was used."
     }
   },
   {
@@ -613,7 +613,7 @@
       "source": "Motif curated reference data for the Novagen pET-28b(+) T7lac expression vector. Nucleotide sequence obtained from the Addgene vector database (entry 2566) and cross-verified byte-for-byte against an independent repository (novoprolabs) as the same circular molecule, plus internally against the pET-28a/b/c(+) reading-frame trio.",
       "license": "Raw plasmid sequence is factual reference data, not subject to copyright; included in the MIT-licensed Motif distribution as curated public reference data. Feature annotations were generated independently by motif search, not copied from any annotated source.",
       "releaseStatus": "approved-public-reference",
-      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before wet-lab use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; KanR ORF confirmed by translation). No customer, sponsor, or private import data was used."
+      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before experimental use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; KanR ORF confirmed by translation). No customer, sponsor, or private import data was used."
     }
   },
   {
@@ -714,7 +714,7 @@
       "source": "Motif curated reference data for the Novagen pET-28c(+) T7lac expression vector. Nucleotide sequence obtained from the Addgene vector database (entry 2567) and cross-verified byte-for-byte against an independent repository (novoprolabs) as the same circular molecule, plus internally against the pET-28a/b/c(+) reading-frame trio.",
       "license": "Raw plasmid sequence is factual reference data, not subject to copyright; included in the MIT-licensed Motif distribution as curated public reference data. Feature annotations were generated independently by motif search, not copied from any annotated source.",
       "releaseStatus": "approved-public-reference",
-      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before wet-lab use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; KanR ORF confirmed by translation). No customer, sponsor, or private import data was used."
+      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before experimental use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; KanR ORF confirmed by translation). No customer, sponsor, or private import data was used."
     }
   },
   {
@@ -791,7 +791,7 @@
       "source": "Motif curated reference data for the Novagen pETDuet-1 dual-expression vector. Nucleotide sequence obtained byte-exact from the Addgene vector database (entry 2659); the resistance-gene ORF was translation-verified to confirm vector identity (AmpR), and the shared T7lac architecture is consistent across the pET Duet family. The Addgene extraction method was independently validated byte-for-byte (pET-28b vs a second repository).",
       "license": "Raw plasmid sequence is factual reference data, not subject to copyright; included in the MIT-licensed Motif distribution as curated public reference data. Feature annotations were generated independently by motif search, not copied from any annotated source.",
       "releaseStatus": "approved-public-reference",
-      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before wet-lab use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; resistance ORF confirmed by translation). No customer, sponsor, or private import data was used."
+      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before experimental use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; resistance ORF confirmed by translation). No customer, sponsor, or private import data was used."
     }
   },
   {
@@ -868,7 +868,7 @@
       "source": "Motif curated reference data for the Novagen pCOLADuet-1 dual-expression vector. Nucleotide sequence obtained byte-exact from the Addgene vector database (entry 2260); the resistance-gene ORF was translation-verified to confirm vector identity (KanR), and the shared T7lac architecture is consistent across the pET Duet family. The Addgene extraction method was independently validated byte-for-byte (pET-28b vs a second repository).",
       "license": "Raw plasmid sequence is factual reference data, not subject to copyright; included in the MIT-licensed Motif distribution as curated public reference data. Feature annotations were generated independently by motif search, not copied from any annotated source.",
       "releaseStatus": "approved-public-reference",
-      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before wet-lab use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; resistance ORF confirmed by translation). No customer, sponsor, or private import data was used."
+      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before experimental use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; resistance ORF confirmed by translation). No customer, sponsor, or private import data was used."
     }
   },
   {
@@ -945,7 +945,7 @@
       "source": "Motif curated reference data for the Novagen pACYCDuet-1 dual-expression vector. Nucleotide sequence obtained byte-exact from the Addgene vector database (entry 1680); the resistance-gene ORF was translation-verified to confirm vector identity (CmR), and the shared T7lac architecture is consistent across the pET Duet family. The Addgene extraction method was independently validated byte-for-byte (pET-28b vs a second repository).",
       "license": "Raw plasmid sequence is factual reference data, not subject to copyright; included in the MIT-licensed Motif distribution as curated public reference data. Feature annotations were generated independently by motif search, not copied from any annotated source.",
       "releaseStatus": "approved-public-reference",
-      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before wet-lab use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; resistance ORF confirmed by translation). No customer, sponsor, or private import data was used."
+      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before experimental use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; resistance ORF confirmed by translation). No customer, sponsor, or private import data was used."
     }
   },
   {
@@ -1022,7 +1022,7 @@
       "source": "Motif curated reference data for the Novagen pRSFDuet-1 dual-expression vector. Nucleotide sequence obtained byte-exact from the Addgene vector database (entry 4005); the resistance-gene ORF was translation-verified to confirm vector identity (KanR), and the shared T7lac architecture is consistent across the pET Duet family. The Addgene extraction method was independently validated byte-for-byte (pET-28b vs a second repository).",
       "license": "Raw plasmid sequence is factual reference data, not subject to copyright; included in the MIT-licensed Motif distribution as curated public reference data. Feature annotations were generated independently by motif search, not copied from any annotated source.",
       "releaseStatus": "approved-public-reference",
-      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before wet-lab use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; resistance ORF confirmed by translation). No customer, sponsor, or private import data was used."
+      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before experimental use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; resistance ORF confirmed by translation). No customer, sponsor, or private import data was used."
     }
   },
   {
@@ -1099,7 +1099,7 @@
       "source": "Motif curated reference data for the Novagen pCDFDuet-1 dual-expression vector. Nucleotide sequence obtained byte-exact from the Addgene vector database (entry 2080); the resistance-gene ORF was translation-verified to confirm vector identity (SmR/SpecR), and the shared T7lac architecture is consistent across the pET Duet family. The Addgene extraction method was independently validated byte-for-byte (pET-28b vs a second repository).",
       "license": "Raw plasmid sequence is factual reference data, not subject to copyright; included in the MIT-licensed Motif distribution as curated public reference data. Feature annotations were generated independently by motif search, not copied from any annotated source.",
       "releaseStatus": "approved-public-reference",
-      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before wet-lab use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; resistance ORF confirmed by translation). No customer, sponsor, or private import data was used."
+      "notes": "Bundled for workflow examples and software testing. Verify against an authoritative source before experimental use. Annotations are limited to valid ranges within the bundled sequence record (motif-located; resistance ORF confirmed by translation). No customer, sponsor, or private import data was used."
     }
   }
 ]

--- a/scripts/__tests__/repository-language-policy.test.mjs
+++ b/scripts/__tests__/repository-language-policy.test.mjs
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { containsDisallowedRepositoryLanguage } from '../check-repository-language.mjs';
+
+const disallowedWords = (separator = '') => [
+  String.fromCharCode(119, 101, 116),
+  separator,
+  String.fromCharCode(108, 97, 98),
+].join('');
+
+describe('repository language policy', () => {
+  it('rejects compact, spaced, and hyphenated variants without flagging neutral language', () => {
+    expect(containsDisallowedRepositoryLanguage(disallowedWords())).toBe(true);
+    expect(containsDisallowedRepositoryLanguage(disallowedWords(' '))).toBe(true);
+    expect(containsDisallowedRepositoryLanguage(disallowedWords('-'))).toBe(true);
+    expect(containsDisallowedRepositoryLanguage('experimental planning')).toBe(false);
+  });
+});

--- a/scripts/__tests__/repository-language-policy.test.mjs
+++ b/scripts/__tests__/repository-language-policy.test.mjs
@@ -1,5 +1,8 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { containsDisallowedRepositoryLanguage } from '../check-repository-language.mjs';
+import { containsDisallowedRepositoryLanguage, githubEventMetadataViolations } from '../check-repository-language.mjs';
 
 const disallowedWords = (separator = '') => [
   String.fromCharCode(119, 101, 116),
@@ -13,5 +16,22 @@ describe('repository language policy', () => {
     expect(containsDisallowedRepositoryLanguage(disallowedWords(' '))).toBe(true);
     expect(containsDisallowedRepositoryLanguage(disallowedWords('-'))).toBe(true);
     expect(containsDisallowedRepositoryLanguage('experimental planning')).toBe(false);
+  });
+
+  it('checks public pull-request and repository metadata from the GitHub event payload', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'motif-language-event-'));
+    const eventPath = join(directory, 'event.json');
+    writeFileSync(eventPath, JSON.stringify({
+      repository: { name: 'motif', description: 'Molecular biology workbench', topics: ['bioinformatics'] },
+      pull_request: { title: `Disallowed ${disallowedWords(' ')} wording`, body: 'neutral body', head: { ref: 'topic' }, base: { ref: 'main' } },
+    }));
+    try {
+      expect(githubEventMetadataViolations({ GITHUB_EVENT_PATH: eventPath })).toMatchObject({
+        violations: ['GitHub event metadata: pull request title'],
+        fields: 17,
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/check-repository-language.mjs
+++ b/scripts/check-repository-language.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { lstatSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const DISALLOWED_STEM = String.fromCharCode(119, 101, 116);
+const DISALLOWED_SUFFIX = String.fromCharCode(108, 97, 98);
+const DISALLOWED_PATTERN = new RegExp(`${DISALLOWED_STEM}[ -]?${DISALLOWED_SUFFIX}`, 'iu');
+const MAX_TRACKED_FILE_BYTES = 16 * 1024 * 1024;
+
+export function containsDisallowedRepositoryLanguage(value) {
+  return DISALLOWED_PATTERN.test(String(value));
+}
+
+function git(workspace, args, { allowFailure = false } = {}) {
+  try {
+    return execFileSync('git', args, {
+      cwd: workspace,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: 32 * 1024 * 1024,
+    });
+  } catch (error) {
+    if (allowFailure) return '';
+    throw new Error(`Repository-language check could not read Git metadata: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function trackedPaths(workspace) {
+  return git(workspace, ['ls-files', '-z'])
+    .split('\0')
+    .filter(Boolean);
+}
+
+function trackedViolations(workspace) {
+  const violations = [];
+  for (const relativePath of trackedPaths(workspace)) {
+    if (containsDisallowedRepositoryLanguage(relativePath)) {
+      violations.push(`tracked path: ${relativePath}`);
+      continue;
+    }
+    const path = join(workspace, relativePath);
+    const stat = lstatSync(path);
+    if (!stat.isFile()) continue;
+    if (stat.size > MAX_TRACKED_FILE_BYTES) {
+      throw new Error(`Repository-language check refuses oversized tracked file: ${relativePath}`);
+    }
+    if (containsDisallowedRepositoryLanguage(readFileSync(path).toString('utf8'))) {
+      violations.push(`tracked content: ${relativePath}`);
+    }
+  }
+  return violations;
+}
+
+function metadataViolations(workspace, environment) {
+  const candidates = [
+    ['HEAD commit message', git(workspace, ['log', '-1', '--format=%B'])],
+    ['current branch', git(workspace, ['symbolic-ref', '--short', '-q', 'HEAD'], { allowFailure: true })],
+    ['tags at HEAD', git(workspace, ['tag', '--points-at', 'HEAD', '--format=%(refname) %(contents)'])],
+    ['CI head ref', environment.GITHUB_HEAD_REF ?? ''],
+    ['CI ref name', environment.GITHUB_REF_NAME ?? ''],
+    ['CI workflow ref', environment.GITHUB_REF ?? ''],
+  ];
+  return candidates
+    .filter(([, value]) => containsDisallowedRepositoryLanguage(value))
+    .map(([label]) => `metadata: ${label}`);
+}
+
+export function checkRepositoryLanguage(workspace = root, environment = process.env) {
+  const resolved = resolve(workspace);
+  const violations = [
+    ...trackedViolations(resolved),
+    ...metadataViolations(resolved, environment),
+  ];
+  if (violations.length > 0) {
+    throw new Error(`Disallowed repository vocabulary found:\n${violations.map(value => `- ${value}`).join('\n')}`);
+  }
+  return { trackedFiles: trackedPaths(resolved).length, metadataFields: 6 };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const result = checkRepositoryLanguage();
+    console.log(`Repository-language policy passed: ${result.trackedFiles} tracked files and ${result.metadataFields} metadata fields checked.`);
+  } catch (error) {
+    console.error(`Repository-language policy failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-repository-language.mjs
+++ b/scripts/check-repository-language.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'node:child_process';
-import { lstatSync, readFileSync } from 'node:fs';
+import { existsSync, lstatSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -10,6 +10,7 @@ const DISALLOWED_STEM = String.fromCharCode(119, 101, 116);
 const DISALLOWED_SUFFIX = String.fromCharCode(108, 97, 98);
 const DISALLOWED_PATTERN = new RegExp(`${DISALLOWED_STEM}[ -]?${DISALLOWED_SUFFIX}`, 'iu');
 const MAX_TRACKED_FILE_BYTES = 16 * 1024 * 1024;
+const MAX_GITHUB_EVENT_BYTES = 2 * 1024 * 1024;
 
 export function containsDisallowedRepositoryLanguage(value) {
   return DISALLOWED_PATTERN.test(String(value));
@@ -55,8 +56,8 @@ function trackedViolations(workspace) {
   return violations;
 }
 
-function metadataViolations(workspace, environment) {
-  const candidates = [
+function localMetadataCandidates(workspace, environment) {
+  return [
     ['HEAD commit message', git(workspace, ['log', '-1', '--format=%B'])],
     ['current branch', git(workspace, ['symbolic-ref', '--short', '-q', 'HEAD'], { allowFailure: true })],
     ['tags at HEAD', git(workspace, ['tag', '--points-at', 'HEAD', '--format=%(refname) %(contents)'])],
@@ -64,21 +65,74 @@ function metadataViolations(workspace, environment) {
     ['CI ref name', environment.GITHUB_REF_NAME ?? ''],
     ['CI workflow ref', environment.GITHUB_REF ?? ''],
   ];
-  return candidates
-    .filter(([, value]) => containsDisallowedRepositoryLanguage(value))
-    .map(([label]) => `metadata: ${label}`);
+}
+
+export function githubEventMetadataViolations(environment = process.env) {
+  const eventPath = environment.GITHUB_EVENT_PATH;
+  if (!eventPath) return { violations: [], fields: 0 };
+  const path = resolve(eventPath);
+  if (!existsSync(path)) throw new Error('Repository-language check could not find the GitHub event payload');
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isFile()) throw new Error('GitHub event payload must be a regular file');
+  if (stat.size > MAX_GITHUB_EVENT_BYTES) throw new Error('GitHub event payload exceeds the repository-language size limit');
+  let event;
+  try {
+    event = JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    throw new Error('GitHub event payload is not valid JSON');
+  }
+  const candidates = [
+    ['repository name', event.repository?.name ?? ''],
+    ['repository full name', event.repository?.full_name ?? ''],
+    ['repository description', event.repository?.description ?? ''],
+    ['repository homepage', event.repository?.homepage ?? ''],
+    ['repository topics', Array.isArray(event.repository?.topics) ? event.repository.topics.join(' ') : ''],
+    ['pull request title', event.pull_request?.title ?? ''],
+    ['pull request body', event.pull_request?.body ?? ''],
+    ['pull request head ref', event.pull_request?.head?.ref ?? ''],
+    ['pull request base ref', event.pull_request?.base?.ref ?? ''],
+    ['pull request milestone', event.pull_request?.milestone?.title ?? ''],
+    ['issue title', event.issue?.title ?? ''],
+    ['issue body', event.issue?.body ?? ''],
+    ['issue milestone', event.issue?.milestone?.title ?? ''],
+    ['release name', event.release?.name ?? ''],
+    ['release body', event.release?.body ?? ''],
+    ['release tag', event.release?.tag_name ?? ''],
+    ['push head commit message', event.head_commit?.message ?? ''],
+  ];
+  return {
+    violations: candidates
+      .filter(([, value]) => containsDisallowedRepositoryLanguage(value))
+      .map(([label]) => `GitHub event metadata: ${label}`),
+    fields: candidates.length,
+  };
+}
+
+function metadataViolations(workspace, environment) {
+  const localCandidates = localMetadataCandidates(workspace, environment);
+  const event = githubEventMetadataViolations(environment);
+  return {
+    violations: [
+      ...localCandidates
+        .filter(([, value]) => containsDisallowedRepositoryLanguage(value))
+        .map(([label]) => `metadata: ${label}`),
+      ...event.violations,
+    ],
+    fields: localCandidates.length + event.fields,
+  };
 }
 
 export function checkRepositoryLanguage(workspace = root, environment = process.env) {
   const resolved = resolve(workspace);
+  const metadata = metadataViolations(resolved, environment);
   const violations = [
     ...trackedViolations(resolved),
-    ...metadataViolations(resolved, environment),
+    ...metadata.violations,
   ];
   if (violations.length > 0) {
     throw new Error(`Disallowed repository vocabulary found:\n${violations.map(value => `- ${value}`).join('\n')}`);
   }
-  return { trackedFiles: trackedPaths(resolved).length, metadataFields: 6 };
+  return { trackedFiles: trackedPaths(resolved).length, metadataFields: metadata.fields };
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/report-gate-coverage.mjs
+++ b/scripts/report-gate-coverage.mjs
@@ -37,7 +37,7 @@ export function reportGateCoverage(env = process.env) {
   const report = {
     schema: 'motif.gate-coverage.v1',
     executed: [
-      'typecheck', 'lint', 'unit tests', 'release alignment', 'runtime compatibility',
+      'typecheck', 'lint', 'repository language policy', 'unit tests', 'release alignment', 'runtime compatibility',
       'npm audit', 'supply-chain policy', 'reviewed lifecycle scripts', 'dependency cooling-off policy', 'plugin checks', 'connector checks',
       'style/accessibility guards', 'build', 'reproducibility', 'release budgets',
       'core browser workflows', 'MSA interaction workflows',


### PR DESCRIPTION
## Summary

- replace disallowed terminology in bundled vector notes with neutral experimental-use wording
- add a fail-closed current-tree and current commit/ref vocabulary check
- pass the true pull-request or push baseline to the dependency cooling-off check

## Validation

- repository-language policy
- 124 test files / 1,364 unit tests
- typecheck
- lint
- diff check
