### PR TITLE
Prepare Motif v0.3.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -21,7 +21,7 @@ body:
     id: version
     attributes:
       label: Motif version or commit
-      placeholder: v0.3.1 or a commit hash
+      placeholder: v0.3.2 or a commit hash
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,13 @@ jobs:
       - name: Supply-chain policy
         run: npm run security:policy
 
-      - name: Reviewed lifecycle scripts
+      - name: Motif-owned dependency preparation
         run: npm run security:lifecycle
 
       - name: Dependency cooling-off policy
         run: npm run security:cooling-off
         env:
-          MOTIF_COOLING_OFF_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          MOTIF_COOLING_OFF_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
       - name: Plugin and connector checks
         run: npm run test:plugin && npm run test:connector

--- a/.github/workflows/metadata-policy.yml
+++ b/.github/workflows/metadata-policy.yml
@@ -1,0 +1,56 @@
+name: Metadata policy
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+  issues:
+    types: [opened, edited, closed, reopened, labeled, unlabeled]
+  issue_comment:
+    types: [created, edited, deleted]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  discussion:
+    types: [created, edited, deleted]
+  discussion_comment:
+    types: [created, edited, deleted]
+  release:
+    types: [published, edited, released, prereleased]
+
+permissions:
+  contents: read
+  discussions: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      # Event payloads are untrusted input. Only the trusted default branch is
+      # checked out and executed for these metadata-only events.
+      - name: Check out trusted main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.13.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Repository language policy
+        run: npm run check:repository-language
+        env:
+          # The full CI job scans the PR range. This trusted-main metadata job
+          # does not require a fork head object that is absent from main.
+          MOTIF_REPOSITORY_LANGUAGE_SKIP_EVENT_RANGE: "true"

--- a/.npmrc
+++ b/.npmrc
@@ -2,7 +2,7 @@
 # lockfile-diff policy below covers the pinned CI npm when it lacks this flag.
 min-release-age=7
 
-# Keep dependency lifecycle scripts disabled unless the reviewed lifecycle
-# helper invokes an exact allowlisted command after policy validation. This is
-# supported by the npm versions used by both the maintainer and CI toolchains.
+# Keep dependency lifecycle scripts disabled; the Motif-owned preparation
+# helper runs only its fixed, hash-verified binary step after policy validation.
+# This is supported by the npm versions used by both maintainer and CI tooling.
 ignore-scripts=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ A passing DOM assertion is not proof that a control is legible or reachable.
 
 - Product name: **Motif for Claude Science**
 - Package/plugin slug: `motif-for-claude-science`
-- Current release version is `0.3.1` and must stay aligned in runtime, package, manifest,
+- Current release version is `0.3.2` and must stay aligned in runtime, package, manifest,
   and changelog.
 - New schemas, environment variables, page APIs, output files, and provenance
   identifiers use `motif` / `MOTIF_` names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+## 0.3.2 — 2026-08-08
+
+- Unified restriction-enzyme sources, serialized complete cleavage geometry,
+  rejected incompatible co-located cuts, and prevented quarantined feature
+  placeholders from propagating into derived records.
+- Corrected mismatch-aware PCR materialization, made primer tails explicit,
+  bounded oligo and product sizes, and incorporated full cross-dimer evidence
+  into primer-pair ranking.
+- Strengthened Golden Gate normalization, exact synthetic-vector sequences,
+  feature-aware domestication, translation-exception handling, and ambiguous
+  initiator interpretation.
+- Preserved primer-pair state across preview changes and expanded responsive,
+  keyboard, theme, provenance, checkpoint, and pane-state browser coverage.
+- Replaced third-party lifecycle execution with Motif-owned, hash-verified
+  esbuild preparation; tightened connector environments, immutable dependency
+  baselines, GitHub metadata policy, and external release-trust messaging.
+
 ## 0.3.1 — 2026-08-08
 
 - Corrected restriction-digest geometry at linear boundaries, represented

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Report suspected vulnerabilities through the private process in
 
 Motif requires Node.js 22.13 or newer (22.x) or Node.js 24 or newer. Install
 the locked dependencies with lifecycle scripts disabled, then run the checked
-policy and reviewed lifecycle steps:
+policy and the Motif-owned dependency preparation step:
 
 ```bash
 npm ci --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ SHA-256 values are recorded beside it.
 
 The plugin ZIP is for Claude/plugin hosts. It does not install the Claude
 Science local connector. End users should extract the release ZIP and run its
-bundled `node install-motif-claude-science-release.mjs --bundle .` command;
+bundled installer with the separately downloaded release-manifest checksum;
 maintainers can run `npm run claude-science:setup` from a source checkout.
 
 To generate an additional repo-local artifact with preloaded data:

--- a/docs/CLAUDE_SCIENCE_INTEGRATION.md
+++ b/docs/CLAUDE_SCIENCE_INTEGRATION.md
@@ -1,6 +1,6 @@
 # Motif + Claude Science integration
 
-Last reviewed: August 8, 2026. Connector version: `0.3.1`.
+Last reviewed: August 8, 2026. Connector version: `0.3.2`.
 
 This is the maintainer and technical reference for the Motif-owned local
 connector. End users should start with the
@@ -75,12 +75,15 @@ npm run claude-science:setup
 ```
 
 For an end-user release, extract `motif-for-claude-science-release.zip` into a
-stable folder, compare its `release-manifest.json` with the published
+stable folder, verify both downloaded assets against the immutable GitHub
+release, and compare its `release-manifest.json` with the published
 `.manifest.sha256` file, then run the bundled standard-library-only installer:
 
 ```bash
-node install-motif-claude-science-release.mjs --bundle .
-node doctor-motif-claude-science-release.mjs --bundle .
+node install-motif-claude-science-release.mjs --bundle . \
+  --manifest-sha256-file /path/to/motif-for-claude-science-release.manifest.sha256
+node doctor-motif-claude-science-release.mjs --bundle . \
+  --manifest-sha256-file /path/to/motif-for-claude-science-release.manifest.sha256
 ```
 
 This path does not require `npm`, `npm ci`, or access to the source checkout.

--- a/docs/CLAUDE_SCIENCE_QUICKSTART.md
+++ b/docs/CLAUDE_SCIENCE_QUICKSTART.md
@@ -18,23 +18,37 @@ the folder later, rerun setup and update the sandbox grant.
 
 Download the release asset `motif-for-claude-science-release.zip` and its
 matching `motif-for-claude-science-release.manifest.sha256` file from the same
-GitHub release. Extract the ZIP into a stable, private folder. Before running
-the installer, compare the SHA-256 of the extracted `release-manifest.json`
-with the supplied manifest checksum:
+GitHub release. Before extracting or running anything, use GitHub CLI to verify
+both downloaded assets against the immutable release when available:
+
+```bash
+gh release verify-asset <release-tag> /path/to/motif-for-claude-science-release.zip --repo jvogan/motif
+gh release verify-asset <release-tag> /path/to/motif-for-claude-science-release.manifest.sha256 --repo jvogan/motif
+```
+
+Extract the verified ZIP into a stable, private folder. Independently compare
+the SHA-256 of its `release-manifest.json` with the separately downloaded
+manifest checksum before executing the bundled installer:
 
 ```bash
 shasum -a 256 /absolute/path/to/motif-for-claude-science-release/release-manifest.json
 cat /path/to/motif-for-claude-science-release.manifest.sha256
 ```
 
-The bundled verifier then checks the release identity, every installed-file
-checksum, file paths, and size bounds. It uses only Node.js's standard library;
-end users do not need `npm`, `npm ci`, or the source tree:
+The installer requires that separately downloaded checksum file and reports
+only that the supplied digest matched; bundled code cannot authenticate itself.
+Publisher identity comes from the independent GitHub release verification (or
+an equivalently trusted download channel). The bundled verifier then checks the
+release identity, every installed-file checksum, file paths, and size bounds.
+It uses only Node.js's standard library; end users do not need `npm`, `npm ci`,
+or the source tree:
 
 ```bash
 cd /absolute/path/to/motif-for-claude-science-release
-node install-motif-claude-science-release.mjs --bundle .
-node doctor-motif-claude-science-release.mjs --bundle .
+node install-motif-claude-science-release.mjs --bundle . \
+  --manifest-sha256-file /path/to/motif-for-claude-science-release.manifest.sha256
+node doctor-motif-claude-science-release.mjs --bundle . \
+  --manifest-sha256-file /path/to/motif-for-claude-science-release.manifest.sha256
 ```
 
 The installer registers exactly `motif-local`, preserves unrelated entries,
@@ -52,7 +66,7 @@ Use the latest published [Motif release](https://github.com/jvogan/motif/release
 or clone its tagged source into a fixed local folder:
 
 ```bash
-git clone --branch v0.3.1 --depth 1 https://github.com/jvogan/motif.git
+git clone --branch v0.3.2 --depth 1 https://github.com/jvogan/motif.git
 cd motif
 ```
 
@@ -129,7 +143,8 @@ extracted release directory as the registered root:
 
 ```bash
 node /absolute/path/to/motif-for-claude-science-release/doctor-motif-claude-science-release.mjs \
-  --bundle /absolute/path/to/motif-for-claude-science-release
+  --bundle /absolute/path/to/motif-for-claude-science-release \
+  --manifest-sha256-file /path/to/motif-for-claude-science-release.manifest.sha256
 ```
 
 For a source checkout, use:

--- a/docs/CLAUDE_SCIENCE_TROUBLESHOOTING.md
+++ b/docs/CLAUDE_SCIENCE_TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # Motif + Claude Science troubleshooting
 
-Last reviewed: August 8, 2026. Motif connector version: `0.3.1`.
+Last reviewed: August 8, 2026. Motif connector version: `0.3.2`.
 
 This guide covers the local `motif-local` connector only. It does not assume
 another application, connector, database, or product identity.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -36,9 +36,9 @@ git status --short
 installation requirement. Scripts remain disabled until
 `npm run security:policy` has checked exact lockfile identities, registry
 origins, integrity values, lifecycle metadata, binding files, and the bundled
-inventory. `npm run security:lifecycle` then runs only the reviewed exact
-install-time commands through the bounded helper; an unknown package, version,
-script, or binding fails before any lifecycle command executes.
+inventory. `npm run security:lifecycle` then runs the Motif-owned deterministic
+esbuild preparation through the bounded helper; an unknown package, version,
+manifest, binary, or binding fails before any dependency lifecycle script runs.
 `npm run build:motif` produces the dependency-free release bundle. The checked-in
 `.npmrc` asks npm versions that support `min-release-age` to keep new dependency
 resolutions seven days old; `npm run security:cooling-off` independently checks
@@ -84,7 +84,11 @@ Create the GitHub release as a draft with `--verify-tag`, and attach exactly:
 - `motif-for-claude-science-release.zip`
 - `motif-for-claude-science-release.manifest.sha256`
 
-The release ZIP is the supported no-npm end-user path. Its extracted root
+The release ZIP is the supported no-npm end-user path. Users verify both release
+assets against the immutable GitHub release before executing bundled code. The
+installer additionally requires the separately downloaded release-manifest
+checksum as an external integrity anchor; it does not claim to authenticate
+itself. Its extracted root
 contains the installer, doctor, rollback helper, compiled `motif-local`
 connector, self-contained App/template, checksums, SBOM, and dependency
 license inventory. The installer never runs npm or reads outside the bundle

--- a/e2e/claude-science-primer-responsive.spec.ts
+++ b/e2e/claude-science-primer-responsive.spec.ts
@@ -12,6 +12,7 @@ const footerActionNames = [
 ] as const;
 
 test.describe('Claude Science primer workspace responsive footer', () => {
+  test.describe.configure({ retries: 0 });
   test.skip(!artifactUrl, 'Set MOTIF_ARTIFACT_URL to run the standalone artifact audit.');
 
   test('keeps every action visible and mouse- and keyboard-operable at 760px', async ({ page }) => {
@@ -91,4 +92,50 @@ test.describe('Claude Science primer workspace responsive footer', () => {
       ...footerActionNames.map((label) => ({ label, input: 'keyboard', trusted: true })),
     ]);
   });
+
+  for (const width of [1440, 760, 390]) {
+    test(`keeps the explicit target, selected pair, status, and focus stable at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 900 });
+      await page.addInitScript(() => {
+        window.localStorage.clear();
+        window.sessionStorage.clear();
+      });
+      await page.goto(artifactUrl!);
+      await expect(page.locator('.motif-cs-shell')).toBeVisible();
+
+      const primerPanel = page.locator('details[data-rail-tool="primer-design"]');
+      await primerPanel.locator(':scope > summary').click();
+      await primerPanel.getByTestId('open-primer-workspace').click();
+
+      const workspace = page.getByTestId('primer-workspace');
+      const rows = workspace.locator('.motif-cs-primer-pair-row');
+      const targetStart = workspace.getByLabel('Target start');
+      const targetEnd = workspace.getByLabel('Target end');
+      await expect(rows).toHaveCount(10);
+      await expect(workspace).toBeVisible();
+      const initialTarget = {
+        start: await targetStart.inputValue(),
+        end: await targetEnd.inputValue(),
+      };
+
+      const pairTwo = rows.nth(1);
+      await pairTwo.scrollIntoViewIfNeeded();
+      await pairTwo.click();
+      await expect(pairTwo).toHaveAttribute('aria-selected', 'true');
+      await expect(workspace.getByRole('region', { name: 'Primer pair 2 evidence' })).toBeVisible();
+      await expect(workspace.locator('.motif-cs-primer-live-status')).toContainText('Pair 2 selected on the sequence.');
+      await expect(targetStart).toHaveValue(initialTarget.start);
+      await expect(targetEnd).toHaveValue(initialTarget.end);
+      await expect(pairTwo).toBeFocused();
+
+      const pairThree = rows.nth(2);
+      await pairTwo.press('ArrowDown');
+      await expect(pairThree).toHaveAttribute('aria-selected', 'true');
+      await expect(workspace.getByRole('region', { name: 'Primer pair 3 evidence' })).toBeVisible();
+      await expect(workspace.locator('.motif-cs-primer-live-status')).toContainText('Pair 3 selected on the sequence.');
+      await expect(targetStart).toHaveValue(initialTarget.start);
+      await expect(targetEnd).toHaveValue(initialTarget.end);
+      await expect(pairThree).toBeFocused();
+    });
+  }
 });

--- a/mcp/motif/stdio-server.ts
+++ b/mcp/motif/stdio-server.ts
@@ -43,7 +43,7 @@ async function readVersion(): Promise<string> {
       // Fall through to the next supported manifest location.
     }
   }
-  return '0.3.1';
+  return '0.3.2';
 }
 
 async function readRuntimeBuildId(workbenchPath: string): Promise<string> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "motif-for-claude-science",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "motif-for-claude-science",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "1.7.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "motif-for-claude-science",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "description": "Motif is a portable molecular-biology workbench, Claude plugin, and MCP App for sequence review, alignment, cloning design, traces, and analysis results.",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "src/artifacts/*.css"
   ],
   "allowScripts": {
-    "esbuild@0.28.1": true,
+    "esbuild@0.28.1": false,
     "fsevents@2.3.2": false,
     "fsevents@2.3.3": false
   },

--- a/scripts/__tests__/connector-launcher.test.mjs
+++ b/scripts/__tests__/connector-launcher.test.mjs
@@ -1,0 +1,40 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, cpSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const temporaryDirectories = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe('connector launcher', () => {
+  it('quotes an absolute Node.js path during both version probing and execution', () => {
+    const bundle = mkdtempSync(join(tmpdir(), 'motif connector launcher '));
+    temporaryDirectories.push(bundle);
+    mkdirSync(join(bundle, 'scripts'), { recursive: true });
+    mkdirSync(join(bundle, 'dist-motif', 'claude-science'), { recursive: true });
+    mkdirSync(join(bundle, 'bin with spaces'), { recursive: true });
+    const launcher = join(bundle, 'scripts', 'run-motif-claude-science-mcp.sh');
+    const server = join(bundle, 'dist-motif', 'claude-science', 'motif-mcp-server.mjs');
+    const nodeBinary = join(bundle, 'bin with spaces', 'node');
+    cpSync(join(root, 'scripts', 'run-motif-claude-science-mcp.sh'), launcher);
+    writeFileSync(server, 'server fixture\n');
+    writeFileSync(join(bundle, 'dist-motif', 'claude-science', 'motif-mcp-app.html'), 'app fixture\n');
+    writeFileSync(join(bundle, 'dist-motif', 'motif-template.html'), 'template fixture\n');
+    writeFileSync(nodeBinary, '#!/usr/bin/env bash\nif [[ "$1" == "-p" ]]; then printf "1\\n"; else printf "%s\\n" "$1"; fi\n');
+    chmodSync(launcher, 0o755);
+    chmodSync(nodeBinary, 0o755);
+
+    const result = spawnSync('/bin/bash', [launcher], {
+      encoding: 'utf8',
+      env: { PATH: '/usr/bin:/bin', MOTIF_NODE_BIN: nodeBinary },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(join(realpathSync(bundle), 'dist-motif', 'claude-science', 'motif-mcp-server.mjs'));
+  });
+});

--- a/scripts/__tests__/dependency-cooling-off.test.mjs
+++ b/scripts/__tests__/dependency-cooling-off.test.mjs
@@ -85,6 +85,17 @@ describe('dependency cooling-off policy', () => {
     rmSync(fixtureData.directory, { recursive: true, force: true });
   });
 
+  it('accepts an explicitly supplied baseline under ambient CI', async () => {
+    const fixtureData = fixture({ publishedAt: '2026-07-01T00:00:00.000Z' });
+    await expect(checkDependencyCoolingOff(fixtureData.directory, {
+      baseLockfileText: fixtureData.baseline,
+      environment: { CI: 'true' },
+      now: NOW,
+      fetchImpl: fetchFrom(fixtureData.metadata),
+    })).resolves.toMatchObject({ changedPackageCount: 1 });
+    rmSync(fixtureData.directory, { recursive: true, force: true });
+  });
+
   it('rejects abbreviated, malformed, and all-zero CI baselines', async () => {
     const fixtureData = fixture();
     for (const baseSha of ['a'.repeat(39), 'a'.repeat(41), `${'a'.repeat(63)}g`, '0'.repeat(64)]) {

--- a/scripts/__tests__/dependency-cooling-off.test.mjs
+++ b/scripts/__tests__/dependency-cooling-off.test.mjs
@@ -7,6 +7,8 @@ import { checkDependencyCoolingOff } from '../check-dependency-cooling-off.mjs';
 const NOW = Date.parse('2026-08-08T00:00:00.000Z');
 const RESOLVED = 'https://registry.npmjs.org/reviewed-package/-/reviewed-package-1.0.0.tgz';
 const INTEGRITY = 'sha512-AAAA=';
+const COMMIT_SHA_40 = 'a'.repeat(40);
+const COMMIT_SHA_64 = 'b'.repeat(64);
 
 function fixture({ publishedAt = '2026-07-01T00:00:00.000Z', currentVersion = '1.0.0', baselineVersion = '0.9.0', exceptions = [] } = {}) {
   const directory = mkdtempSync(join(tmpdir(), 'motif-cooling-off-test-'));
@@ -57,6 +59,45 @@ function fetchFrom(text) {
 }
 
 describe('dependency cooling-off policy', () => {
+  it('fails closed in CI without a real event baseline', async () => {
+    const fixtureData = fixture();
+    await expect(checkDependencyCoolingOff(fixtureData.directory, {
+      environment: { CI: 'true' },
+      now: NOW,
+      fetchImpl: fetchFrom(fixtureData.metadata),
+    })).rejects.toThrow(/full immutable 40- or 64-hex commit ID/);
+    await expect(checkDependencyCoolingOff(fixtureData.directory, {
+      environment: { CI: 'true', MOTIF_COOLING_OFF_BASE_SHA: '0000000000000000000000000000000000000000' },
+      now: NOW,
+      fetchImpl: fetchFrom(fixtureData.metadata),
+    })).rejects.toThrow(/full immutable 40- or 64-hex commit ID/);
+    rmSync(fixtureData.directory, { recursive: true, force: true });
+  });
+
+  it.each([COMMIT_SHA_40, COMMIT_SHA_64])('accepts a full immutable %s baseline in CI', async (baseSha) => {
+    const fixtureData = fixture({ publishedAt: '2026-07-01T00:00:00.000Z' });
+    await expect(checkDependencyCoolingOff(fixtureData.directory, {
+      baseLockfileText: fixtureData.baseline,
+      environment: { CI: 'true', MOTIF_COOLING_OFF_BASE_SHA: baseSha },
+      now: NOW,
+      fetchImpl: fetchFrom(fixtureData.metadata),
+    })).resolves.toMatchObject({ baseline: baseSha, changedPackageCount: 1 });
+    rmSync(fixtureData.directory, { recursive: true, force: true });
+  });
+
+  it('rejects abbreviated, malformed, and all-zero CI baselines', async () => {
+    const fixtureData = fixture();
+    for (const baseSha of ['a'.repeat(39), 'a'.repeat(41), `${'a'.repeat(63)}g`, '0'.repeat(64)]) {
+      await expect(checkDependencyCoolingOff(fixtureData.directory, {
+        baseLockfileText: fixtureData.baseline,
+        environment: { CI: 'true', MOTIF_COOLING_OFF_BASE_SHA: baseSha },
+        now: NOW,
+        fetchImpl: fetchFrom(fixtureData.metadata),
+      })).rejects.toThrow(/full immutable 40- or 64-hex commit ID/);
+    }
+    rmSync(fixtureData.directory, { recursive: true, force: true });
+  });
+
   it('rejects a changed dependency younger than seven days', async () => {
     const fixtureData = fixture({ publishedAt: '2026-08-06T00:00:00.000Z' });
     await expect(checkDependencyCoolingOff(fixtureData.directory, {
@@ -111,17 +152,6 @@ describe('dependency cooling-off policy', () => {
       fetchImpl: fetchFrom(JSON.stringify(metadata)),
     })).rejects.toThrow(/tarball mismatch/);
     rmSync(tampered.directory, { recursive: true, force: true });
-  });
-
-  it('rejects registry metadata that exceeds the bounded response budget', async () => {
-    const fixtureData = fixture();
-    const oversized = JSON.stringify({ padding: 'x'.repeat(8 * 1024 * 1024) });
-    await expect(checkDependencyCoolingOff(fixtureData.directory, {
-      baseLockfileText: fixtureData.baseline,
-      now: NOW,
-      fetchImpl: fetchFrom(oversized),
-    })).rejects.toThrow(/response exceeded 8388608 bytes/);
-    rmSync(fixtureData.directory, { recursive: true, force: true });
   });
 
   it('does not make registry requests when the lockfile has no changed entries', async () => {

--- a/scripts/__tests__/motif-local-mcp-config.test.mjs
+++ b/scripts/__tests__/motif-local-mcp-config.test.mjs
@@ -124,7 +124,7 @@ describe('Motif Claude Science local connector configuration', () => {
     expect(readdirSync(dirname(configPath)).some(name => name.includes('.tmp-'))).toBe(false);
   });
 
-  it('repairs only managed fields while retaining connector-local extensions', () => {
+  it('replaces the managed environment while retaining non-environment extensions', () => {
     const desired = desiredServer();
     const existing = {
       name: MOTIF_LOCAL_CONNECTOR_NAME,
@@ -133,7 +133,8 @@ describe('Motif Claude Science local connector configuration', () => {
       env: {
         MOTIF_NODE_BIN: '/absolute/stale/node',
         MOTIF_ROOT: '/absolute/stale/root',
-        USER_EXTENSION: 'retain-this-value',
+        NODE_OPTIONS: '--require=/untrusted/bootstrap.js',
+        USER_EXTENSION: 'remove-this-value',
       },
       disabled: false,
     };
@@ -143,8 +144,19 @@ describe('Motif Claude Science local connector configuration', () => {
     expect(result.config.servers[0]).toEqual({
       ...existing,
       ...desired,
-      env: { ...existing.env, ...desired.env },
+      env: desired.env,
     });
+  });
+
+  it('treats every unexpected managed-entry environment key as a mismatch', () => {
+    const desired = desiredServer();
+    const existing = {
+      ...desired,
+      env: { ...desired.env, NODE_PATH: '/untrusted/modules' },
+    };
+    const result = installMotifLocalServer({ servers: [existing] }, desired);
+    expect(result.changed).toBe(true);
+    expect(result.config.servers[0].env).toEqual(desired.env);
   });
 
   it('removes only the managed registration', () => {

--- a/scripts/__tests__/release-security-defaults.test.mjs
+++ b/scripts/__tests__/release-security-defaults.test.mjs
@@ -12,6 +12,6 @@ describe('release security defaults', () => {
   });
 
   it('includes the MCP stdio fallback in release-version alignment', () => {
-    expect(checkReleaseAlignment()).toMatchObject({ version: '0.3.1', surfaces: 10 });
+    expect(checkReleaseAlignment()).toMatchObject({ version: '0.3.2', surfaces: 10 });
   });
 });

--- a/scripts/__tests__/repository-language-policy.test.mjs
+++ b/scripts/__tests__/repository-language-policy.test.mjs
@@ -1,8 +1,9 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { containsDisallowedRepositoryLanguage, githubEventMetadataViolations } from '../check-repository-language.mjs';
+import { containsDisallowedRepositoryLanguage, checkRepositoryLanguage, githubEventMetadataViolations } from '../check-repository-language.mjs';
 
 const disallowedWords = (separator = '') => [
   String.fromCharCode(119, 101, 116),
@@ -30,6 +31,131 @@ describe('repository language policy', () => {
         violations: ['GitHub event metadata: pull request title'],
         fields: 17,
       });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed in CI when the event payload is missing or not a bounded regular file', () => {
+    expect(() => githubEventMetadataViolations({ CI: 'true' })).toThrow(/requires a GitHub event payload in CI/);
+
+    const directory = mkdtempSync(join(tmpdir(), 'motif-language-event-'));
+    const directoryPath = join(directory, 'event-directory');
+    const linkPath = join(directory, 'event-link');
+    mkdirSync(directoryPath);
+    writeFileSync(join(directory, 'event.json'), '{}');
+    symlinkSync(join(directory, 'event.json'), linkPath);
+    try {
+      expect(() => githubEventMetadataViolations({ CI: 'true', GITHUB_EVENT_PATH: directoryPath })).toThrow(/regular file/);
+      expect(() => githubEventMetadataViolations({ CI: 'true', GITHUB_EVENT_PATH: linkPath })).toThrow(/regular file/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+
+    const oversized = mkdtempSync(join(tmpdir(), 'motif-language-event-'));
+    const oversizedPath = join(oversized, 'event.json');
+    writeFileSync(oversizedPath, JSON.stringify({ body: 'x'.repeat(2 * 1024 * 1024) }));
+    try {
+      expect(() => githubEventMetadataViolations({ CI: 'true', GITHUB_EVENT_PATH: oversizedPath })).toThrow(/size limit/);
+    } finally {
+      rmSync(oversized, { recursive: true, force: true });
+    }
+  });
+
+  it('checks fork metadata, labels, comments, reviews, discussions, push messages, and release assets', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'motif-language-event-'));
+    const eventPath = join(directory, 'event.json');
+    writeFileSync(eventPath, JSON.stringify({
+      repository: { name: 'motif', parent: { description: `parent ${disallowedWords()}` } },
+      pull_request: {
+        title: 'neutral title',
+        head: { ref: 'topic', repo: { name: disallowedWords(' ') } },
+        base: { ref: 'main', repo: { description: `base ${disallowedWords('-')}` } },
+        labels: [{ name: disallowedWords() }],
+      },
+      comment: { body: `comment ${disallowedWords()}` },
+      review: { body: `review ${disallowedWords(' ')}` },
+      discussion: { body: `discussion ${disallowedWords('-')}` },
+      commits: [{ message: `push ${disallowedWords()}` }],
+      release: { assets: [{ name: `asset-${disallowedWords()}.zip` }] },
+    }));
+    try {
+      const result = githubEventMetadataViolations({ GITHUB_EVENT_PATH: eventPath });
+      expect(result.violations).toEqual(expect.arrayContaining([
+        'GitHub event metadata: pull request head repository metadata.name',
+        'GitHub event metadata: pull request base repository metadata.description',
+        'GitHub event metadata: pull request labels[0].name',
+        'GitHub event metadata: comment metadata.body',
+        'GitHub event metadata: review metadata.body',
+        'GitHub event metadata: discussion metadata.body',
+        'GitHub event metadata: push commit message 1',
+        'GitHub event metadata: release asset name 1',
+      ]));
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('scans every commit message in the explicit event base-to-head range', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'motif-language-history-'));
+    const runGit = (args) => execFileSync('git', args, { cwd: directory, encoding: 'utf8' }).trim();
+    const gitEnvironment = {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Motif Test',
+      GIT_AUTHOR_EMAIL: 'motif-test@example.invalid',
+      GIT_COMMITTER_NAME: 'Motif Test',
+      GIT_COMMITTER_EMAIL: 'motif-test@example.invalid',
+    };
+    const commit = (message, content) => {
+      writeFileSync(join(directory, 'tracked.txt'), content);
+      execFileSync('git', ['add', 'tracked.txt'], { cwd: directory, env: gitEnvironment });
+      execFileSync('git', ['commit', '-m', message], { cwd: directory, env: gitEnvironment, stdio: 'ignore' });
+      return runGit(['rev-parse', 'HEAD']);
+    };
+    try {
+      execFileSync('git', ['init', '-q'], { cwd: directory });
+      execFileSync('git', ['config', 'user.name', 'Motif Test'], { cwd: directory });
+      execFileSync('git', ['config', 'user.email', 'motif-test@example.invalid'], { cwd: directory });
+      const base = commit('baseline', 'base');
+      commit(`middle ${disallowedWords()}`, 'middle');
+      const head = commit('head', 'head');
+      const eventPath = join(directory, 'event.json');
+      writeFileSync(eventPath, JSON.stringify({ before: base, after: head }));
+      expect(() => checkRepositoryLanguage(directory, {
+        CI: 'true',
+        GITHUB_EVENT_NAME: 'push',
+        GITHUB_EVENT_PATH: eventPath,
+      })).toThrow(/base-to-head commit messages/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('scans all local branch and tag ref names plus their annotations', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'motif-language-refs-'));
+    const gitEnvironment = {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Motif Test',
+      GIT_AUTHOR_EMAIL: 'motif-test@example.invalid',
+      GIT_COMMITTER_NAME: 'Motif Test',
+      GIT_COMMITTER_EMAIL: 'motif-test@example.invalid',
+    };
+    try {
+      execFileSync('git', ['init', '-q'], { cwd: directory });
+      execFileSync('git', ['config', 'user.name', 'Motif Test'], { cwd: directory });
+      execFileSync('git', ['config', 'user.email', 'motif-test@example.invalid'], { cwd: directory });
+      writeFileSync(join(directory, 'tracked.txt'), 'neutral');
+      execFileSync('git', ['add', 'tracked.txt'], { cwd: directory, env: gitEnvironment });
+      execFileSync('git', ['commit', '-m', 'neutral'], { cwd: directory, env: gitEnvironment, stdio: 'ignore' });
+      execFileSync('git', ['branch', `${disallowedWords()}-branch`], { cwd: directory });
+      execFileSync('git', ['tag', '-a', 'annotated-release', '-m', `annotation ${disallowedWords()}`], { cwd: directory, env: gitEnvironment });
+      const eventPath = join(directory, 'event.json');
+      writeFileSync(eventPath, '{}');
+      expect(() => checkRepositoryLanguage(directory, {
+        CI: 'true',
+        GITHUB_EVENT_NAME: 'issues',
+        GITHUB_EVENT_PATH: eventPath,
+      })).toThrow(/all branch and tag/);
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/scripts/__tests__/reviewed-lifecycle.test.mjs
+++ b/scripts/__tests__/reviewed-lifecycle.test.mjs
@@ -1,86 +1,113 @@
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { arch, endianness, platform, tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
-import { runReviewedLifecycle } from '../run-reviewed-lifecycle.mjs';
+import { prepareEsbuild } from '../run-reviewed-lifecycle.mjs';
 
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const temporaryDirectories = [];
 
-function fixture({ version = '1.0.0', policyVersion = version, allowed = true } = {}) {
-  const root = mkdtempSync(join(tmpdir(), 'motif-reviewed-lifecycle-test-'));
-  temporaryDirectories.push(root);
-  const packageDirectory = join(root, 'node_modules', 'reviewed-package');
-  mkdirSync(packageDirectory, { recursive: true });
-  mkdirSync(join(root, 'security'), { recursive: true });
-  const markerPath = join(root, 'marker.txt');
-  writeFileSync(join(packageDirectory, 'write-marker.mjs'), `import { writeFileSync } from 'node:fs';\nwriteFileSync(${JSON.stringify(markerPath)}, process.env.npm_package_name + '@' + process.env.npm_package_version + ':' + process.env.npm_lifecycle_event);\n`);
-  writeFileSync(join(packageDirectory, 'package.json'), JSON.stringify({
-    name: 'reviewed-package',
-    version,
-    scripts: { postinstall: 'node write-marker.mjs' },
-  }));
-  writeFileSync(join(root, 'package.json'), JSON.stringify({
-    name: 'lifecycle-fixture',
-    version: '1.0.0',
-    private: true,
-    dependencies: { 'reviewed-package': version },
-    allowScripts: allowed ? { [`reviewed-package@${policyVersion}`]: true } : {},
-  }));
-  writeFileSync(join(root, 'package-lock.json'), JSON.stringify({
-    lockfileVersion: 3,
-    packages: {
-      '': { dependencies: { 'reviewed-package': version } },
-      'node_modules/reviewed-package': {
-        version,
-        resolved: `https://registry.npmjs.org/reviewed-package/-/reviewed-package-${version}.tgz`,
-        integrity: 'sha512-AAAA=',
-        hasInstallScript: true,
-      },
-    },
-  }));
-  writeFileSync(join(root, 'security', 'dependency-policy.json'), JSON.stringify({
-    schema: 'motif.dependency-policy.v1',
-    registry: 'https://registry.npmjs.org/',
-    directDependenciesMustBeExact: true,
-    allowedLifecycleScripts: allowed ? { [`reviewed-package@${policyVersion}`]: ['postinstall'] } : {},
-    allowedBindingGyp: [],
-    reviewedConnectorInventory: 'security/connector-inventory.json',
-  }));
-  writeFileSync(join(root, 'security', 'connector-inventory.json'), JSON.stringify({
-    schema: 'motif.reviewed-connector-inventory.v1',
-    packages: [{ name: 'reviewed-package', packagePath: ['reviewed-package'], licenseFile: 'reviewed-LICENSE.txt' }],
-  }));
-  return { root, markerPath };
+function platformKey() {
+  return `${platform()} ${arch()} ${endianness()}`;
+}
+
+function fixture() {
+  const directory = mkdtempSync(join(tmpdir(), 'motif-esbuild-preparation-test-'));
+  temporaryDirectories.push(directory);
+  cpSync(join(root, 'package.json'), join(directory, 'package.json'));
+  cpSync(join(root, 'package-lock.json'), join(directory, 'package-lock.json'));
+  cpSync(join(root, 'security'), join(directory, 'security'), { recursive: true });
+
+  const platformPackageName = ({
+    'darwin arm64 LE': '@esbuild/darwin-arm64',
+    'darwin x64 LE': '@esbuild/darwin-x64',
+    'linux x64 LE': '@esbuild/linux-x64',
+    'linux arm64 LE': '@esbuild/linux-arm64',
+  }[platformKey()]);
+  if (!platformPackageName) throw new Error(`Test fixture does not support ${platformKey()}`);
+
+  const esbuildDirectory = join(directory, 'node_modules/esbuild');
+  const platformDirectory = join(directory, 'node_modules', platformPackageName);
+  mkdirSync(join(esbuildDirectory, 'bin'), { recursive: true });
+  mkdirSync(join(platformDirectory, 'bin'), { recursive: true });
+  cpSync(join(root, 'node_modules/esbuild/package.json'), join(esbuildDirectory, 'package.json'));
+  cpSync(join(root, 'node_modules/esbuild/bin/esbuild'), join(esbuildDirectory, 'bin/esbuild'));
+  cpSync(join(root, 'node_modules', platformPackageName, 'package.json'), join(platformDirectory, 'package.json'));
+  cpSync(
+    join(root, 'node_modules', platformPackageName, platformPackageName.startsWith('@esbuild/win32-') ? 'esbuild.exe' : 'bin/esbuild'),
+    join(platformDirectory, platformPackageName.startsWith('@esbuild/win32-') ? 'esbuild.exe' : 'bin/esbuild'),
+  );
+
+  const markerPath = join(directory, 'install-js-ran.txt');
+  writeFileSync(join(esbuildDirectory, 'install.js'), `require('node:fs').writeFileSync(${JSON.stringify(markerPath)}, 'ran');\n`);
+  return {
+    directory,
+    markerPath,
+    manifestPath: join(esbuildDirectory, 'package.json'),
+    binaryPath: join(platformDirectory, platformPackageName.startsWith('@esbuild/win32-') ? 'esbuild.exe' : 'bin/esbuild'),
+  };
 }
 
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
 });
 
-describe('bounded reviewed lifecycle execution', () => {
-  it('fails policy before an unreviewed script can execute', () => {
-    const { root, markerPath } = fixture({ allowed: false });
-    expect(() => runReviewedLifecycle(root)).toThrow(/Lifecycle-script policy violation/);
-    expect(existsSync(markerPath)).toBe(false);
+describe('Motif-owned esbuild preparation', () => {
+  it('prepares the exact current-platform binary without executing install.js', () => {
+    const fixtureData = fixture();
+    const result = prepareEsbuild(fixtureData.directory);
+    expect(result.prepared).toHaveLength(1);
+    expect(result.prepared[0].version).toBe('0.28.1');
+    expect(existsSync(fixtureData.markerPath)).toBe(false);
+    expect(readFileSync(join(fixtureData.directory, 'node_modules/esbuild/bin/esbuild'))).toHaveLength(
+      readFileSync(fixtureData.binaryPath).length,
+    );
   });
 
-  it('executes only the exact approved package/version lifecycle command', () => {
-    const { root, markerPath } = fixture();
-    const result = runReviewedLifecycle(root);
-    expect(result.executed).toEqual([{ identity: 'reviewed-package@1.0.0', key: 'postinstall' }]);
-    expect(readFileSync(markerPath, 'utf8')).toBe('reviewed-package@1.0.0:postinstall');
+  it('rejects an esbuild manifest tamper before trusting its binary hash map', () => {
+    const fixtureData = fixture();
+    const manifest = JSON.parse(readFileSync(fixtureData.manifestPath, 'utf8'));
+    const key = Object.keys(manifest['esbuild.binaryHashes'])[0];
+    manifest['esbuild.binaryHashes'][key] = '0'.repeat(64);
+    writeFileSync(fixtureData.manifestPath, JSON.stringify(manifest));
+    expect(() => prepareEsbuild(fixtureData.directory)).toThrow(/esbuild package\.json SHA-256 mismatch/);
+    expect(existsSync(fixtureData.markerPath)).toBe(false);
   });
 
-  it('rejects a changed lifecycle version before execution', () => {
-    const { root, markerPath } = fixture({ version: '1.0.1', policyVersion: '1.0.0' });
-    expect(() => runReviewedLifecycle(root)).toThrow(/stale or unreviewed/);
-    expect(existsSync(markerPath)).toBe(false);
+  it('rejects current-platform binary tampering before materialization or execution', () => {
+    const fixtureData = fixture();
+    writeFileSync(fixtureData.binaryPath, Buffer.concat([readFileSync(fixtureData.binaryPath), Buffer.from('tampered')]));
+    expect(() => prepareEsbuild(fixtureData.directory)).toThrow(/current-platform esbuild binary SHA-256 mismatch/);
+    expect(existsSync(fixtureData.markerPath)).toBe(false);
+  });
+
+  it('rejects an esbuild lockfile integrity change', () => {
+    const fixtureData = fixture();
+    const lockPath = join(fixtureData.directory, 'package-lock.json');
+    const lock = JSON.parse(readFileSync(lockPath, 'utf8'));
+    lock.packages['node_modules/esbuild'].integrity = 'sha512-AAAA=';
+    writeFileSync(lockPath, JSON.stringify(lock));
+    expect(() => prepareEsbuild(fixtureData.directory)).toThrow(/lockfile entry does not match policy/);
+    expect(existsSync(fixtureData.markerPath)).toBe(false);
+  });
+
+  it('accepts no arbitrary command arguments', () => {
+    const result = spawnSync(process.execPath, [join(root, 'scripts/run-reviewed-lifecycle.mjs'), '--arbitrary'], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout ?? ''}${result.stderr ?? ''}`).toMatch(/accepts no command arguments/);
+  });
+
+  it('passes the repository lifecycle security command after ignore-scripts installation', () => {
+    const result = spawnSync(process.execPath, [join(root, 'scripts/run-reviewed-lifecycle.mjs')], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    expect(`${result.stdout ?? ''}${result.stderr ?? ''}`).toMatch(/Motif-owned dependency preparation passed/);
   });
 });

--- a/scripts/__tests__/secure-release-install.test.mjs
+++ b/scripts/__tests__/secure-release-install.test.mjs
@@ -9,6 +9,7 @@ import {
   realpathSync,
   rmSync,
   symlinkSync,
+  truncateSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -22,6 +23,7 @@ import {
   RELEASE_MAX_BUNDLE_ENTRIES,
   RELEASE_MAX_DIRECTORY_DEPTH,
   RELEASE_MAX_DIRECTORY_NODES,
+  RELEASE_MAX_TOTAL_BYTES,
   resolveReleaseBundleRoot,
   verifyReleaseBundle,
 } from '../lib/motif-release-bundle.mjs';
@@ -36,6 +38,22 @@ const runtimeBuildId = 'a'.repeat(64);
 
 function sha256(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
+}
+
+function trustedManifestDigest(bundle) {
+  return sha256(readFileSync(join(bundle, 'release-manifest.json')));
+}
+
+function trustedManifestArgs(bundle) {
+  return ['--manifest-sha256', trustedManifestDigest(bundle)];
+}
+
+function trustedManifestFile(bundle) {
+  const directory = mkdtempSync(join(tmpdir(), 'motif-release-digest-test-'));
+  temporaryDirectories.push(directory);
+  const path = join(directory, 'motif-for-claude-science-release.manifest.sha256');
+  writeFileSync(path, `${trustedManifestDigest(bundle)}  release-manifest.json\n`);
+  return path;
 }
 
 function writeFixture({ wrongProduct = false, unsafePath = false } = {}) {
@@ -137,7 +155,8 @@ describe('checksum-verified Motif release installation', () => {
       servers: [{ name: 'unrelated', command: '/private/unrelated', args: [] }],
     });
     expect(existsSync(join(bundle, 'node_modules'))).toBe(false);
-    const result = installRelease(['--bundle', bundle, '--config', configPath, '--node', process.execPath]);
+    const digestFile = trustedManifestFile(bundle);
+    const result = installRelease(['--bundle', bundle, '--manifest-sha256-file', digestFile, '--config', configPath, '--node', process.execPath]);
     expect(result.changed).toBe(true);
     expect(result.backupPath).toBeTruthy();
     expect(readFileSync(result.backupPath, 'utf8')).toBe(bytes);
@@ -148,7 +167,18 @@ describe('checksum-verified Motif release installation', () => {
       name: 'motif-local',
       env: { MOTIF_ROOT: canonicalBundle, MOTIF_NODE_BIN: process.execPath },
     });
-    expect(doctorRelease(['--bundle', bundle, '--config', configPath, '--node', process.execPath]).config).toBe('matched');
+    expect(result.externalManifestDigestMatched).toBe(true);
+    expect(doctorRelease(['--bundle', bundle, '--manifest-sha256-file', digestFile, '--config', configPath, '--node', process.execPath])).toMatchObject({ config: 'matched', externalManifestDigestMatched: true });
+  });
+
+  it('requires an external manifest digest and rejects a mismatch before configuration changes', () => {
+    const bundle = writeFixture();
+    const { configPath, bytes } = temporaryConfig({ servers: [] });
+    expect(() => installRelease(['--bundle', bundle, '--config', configPath, '--node', process.execPath]))
+      .toThrow(/externally trusted release-manifest SHA-256/);
+    expect(() => installRelease(['--bundle', bundle, '--manifest-sha256', '0'.repeat(64), '--config', configPath, '--node', process.execPath]))
+      .toThrow(/does not match the externally trusted SHA-256/);
+    expect(readFileSync(configPath, 'utf8')).toBe(bytes);
   });
 
   it('reports dry-run registration without claiming the configuration changed', () => {
@@ -156,6 +186,7 @@ describe('checksum-verified Motif release installation', () => {
     const { configPath, bytes } = temporaryConfig({ servers: [] });
     const result = installRelease([
       '--bundle', bundle,
+      ...trustedManifestArgs(bundle),
       '--config', configPath,
       '--node', process.execPath,
       '--dry-run',
@@ -177,6 +208,7 @@ describe('checksum-verified Motif release installation', () => {
     const { configPath, bytes } = temporaryConfig({ servers: [] });
 
     const install = runReleaseCli(aliasBundle, 'install-motif-claude-science-release.mjs', [
+      ...trustedManifestArgs(bundle),
       '--config', configPath,
       '--node', process.execPath,
     ]);
@@ -195,6 +227,7 @@ describe('checksum-verified Motif release installation', () => {
 
     const dryRun = runReleaseCli(aliasBundle, 'install-motif-claude-science-release.mjs', [
       '--bundle', aliasBundle,
+      ...trustedManifestArgs(bundle),
       '--config', configPath,
       '--node', process.execPath,
       '--dry-run',
@@ -222,7 +255,7 @@ describe('checksum-verified Motif release installation', () => {
     const bundle = writeFixture();
     const { configPath, bytes } = temporaryConfig({ servers: [] });
     writeFileSync(join(bundle, 'installer.mjs'), 'tampered\n');
-    expect(() => installRelease(['--bundle', bundle, '--config', configPath, '--node', process.execPath])).toThrow(/checksum mismatch/);
+    expect(() => installRelease(['--bundle', bundle, ...trustedManifestArgs(bundle), '--config', configPath, '--node', process.execPath])).toThrow(/checksum mismatch/);
     expect(readFileSync(configPath, 'utf8')).toBe(bytes);
   });
 
@@ -266,10 +299,21 @@ describe('checksum-verified Motif release installation', () => {
     expect(() => verifyReleaseBundle(bundle)).toThrow(/entry count exceeds/);
   });
 
+  it('rejects aggregate release size before hashing payload files', () => {
+    const bundle = writeFixture();
+    const first = join(bundle, 'oversized-total-a.bin');
+    const second = join(bundle, 'oversized-total-b.bin');
+    writeFileSync(first, '');
+    writeFileSync(second, '');
+    truncateSync(first, RELEASE_MAX_TOTAL_BYTES / 2);
+    truncateSync(second, RELEASE_MAX_TOTAL_BYTES / 2);
+    expect(() => verifyReleaseBundle(bundle)).toThrow(/total size limit/);
+  });
+
   it('restores the exact private backup and preserves the current state as a new backup', () => {
     const bundle = writeFixture();
     const { configPath, bytes } = temporaryConfig({ servers: [{ name: 'unrelated', command: '/private/unrelated', args: [] }] });
-    const installed = installRelease(['--bundle', bundle, '--config', configPath, '--node', process.execPath]);
+    const installed = installRelease(['--bundle', bundle, ...trustedManifestArgs(bundle), '--config', configPath, '--node', process.execPath]);
     const rollback = rollbackRelease(['--bundle', bundle, '--config', configPath, '--backup', installed.backupPath]);
     expect(rollback.changed).toBe(true);
     expect(readFileSync(configPath, 'utf8')).toBe(bytes);

--- a/scripts/check-dependency-cooling-off.mjs
+++ b/scripts/check-dependency-cooling-off.mjs
@@ -8,10 +8,12 @@ import { loadDependencyPolicy } from './lib/supply-chain-policy.mjs';
 
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const DAY_MS = 24 * 60 * 60 * 1000;
-// npm's full packument is required because its abbreviated representation and
-// exact-version endpoint omit publish timestamps. Keep the response bounded,
-// but allow established packages with long release histories.
-const MAX_METADATA_BYTES = 8 * 1024 * 1024;
+const MAX_METADATA_BYTES = 2 * 1024 * 1024;
+const IMMUTABLE_COMMIT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/iu;
+
+function isImmutableCommitId(value) {
+  return typeof value === 'string' && IMMUTABLE_COMMIT_ID.test(value) && !/^0+$/u.test(value);
+}
 
 function readJson(path, label) {
   try {
@@ -41,9 +43,22 @@ function lockEntries(lock) {
 }
 
 function readBaselineLockfile(workspace, options) {
+  const environment = options.environment ?? process.env;
+  const configuredRef = options.baseRef
+    ?? environment.MOTIF_COOLING_OFF_BASE_SHA
+    ?? environment.MOTIF_COOLING_OFF_BASE_REF;
+  if (environment.CI && !configuredRef) {
+    throw new Error('Cooling-off policy requires the event base commit in CI; it must be a full immutable 40- or 64-hex commit ID');
+  }
+  if (environment.CI && !isImmutableCommitId(configuredRef)) {
+    throw new Error('Cooling-off policy requires a valid nonzero baseline reference: the event base commit must be a full immutable 40- or 64-hex commit ID');
+  }
   if (options.baseLockfileText) return JSON.parse(options.baseLockfileText);
   if (options.baseLockfilePath) return readJson(resolve(workspace, options.baseLockfilePath), 'Cooling-off baseline lockfile');
-  const ref = options.baseRef ?? process.env.MOTIF_COOLING_OFF_BASE_REF ?? 'HEAD^';
+  const ref = configuredRef ?? 'HEAD^';
+  if (typeof ref !== 'string' || !ref.trim() || /^0+$/u.test(ref)) {
+    throw new Error('Cooling-off policy requires a valid nonzero baseline reference');
+  }
   try {
     const text = execFileSync('git', ['show', `${ref}:package-lock.json`], {
       cwd: workspace,
@@ -107,33 +122,8 @@ async function readRegistryMetadata(fetchImpl, url) {
     throw new Error(`Registry metadata request failed for ${url}: ${error instanceof Error ? error.message : String(error)}`);
   }
   if (!response?.ok) throw new Error(`Registry metadata request failed for ${url}: HTTP ${response?.status ?? 'unknown'}`);
-  const declaredBytes = Number(response.headers?.get?.('content-length'));
-  if (Number.isFinite(declaredBytes) && declaredBytes > MAX_METADATA_BYTES) {
-    throw new Error(`Registry metadata response exceeded ${MAX_METADATA_BYTES} bytes for ${url}`);
-  }
-  let text;
-  if (response.body?.getReader) {
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    const chunks = [];
-    let total = 0;
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      total += value.byteLength;
-      if (total > MAX_METADATA_BYTES) {
-        await reader.cancel().catch(() => undefined);
-        throw new Error(`Registry metadata response exceeded ${MAX_METADATA_BYTES} bytes for ${url}`);
-      }
-      chunks.push(decoder.decode(value, { stream: true }));
-    }
-    text = chunks.join('') + decoder.decode();
-  } else {
-    text = await response.text();
-    if (new TextEncoder().encode(text).byteLength > MAX_METADATA_BYTES) {
-      throw new Error(`Registry metadata response exceeded ${MAX_METADATA_BYTES} bytes for ${url}`);
-    }
-  }
+  const text = await response.text();
+  if (new TextEncoder().encode(text).byteLength > MAX_METADATA_BYTES) throw new Error(`Registry metadata response exceeded ${MAX_METADATA_BYTES} bytes for ${url}`);
   try {
     return JSON.parse(text);
   } catch (error) {
@@ -157,6 +147,7 @@ function assertRegistryIdentity(entry, metadata, registry) {
 
 export async function checkDependencyCoolingOff(rootPath = root, options = {}) {
   const workspace = resolve(rootPath);
+  const environment = options.environment ?? process.env;
   const { policy } = loadDependencyPolicy(workspace);
   const current = readJson(join(workspace, 'package-lock.json'), 'package-lock.json');
   const baseline = readBaselineLockfile(workspace, options);
@@ -184,7 +175,11 @@ export async function checkDependencyCoolingOff(rootPath = root, options = {}) {
     coolingOffDays: Number(policy.coolingOffDays ?? 7),
     changedPackageCount: unique.length,
     checked,
-    baseline: options.baseLockfilePath ?? options.baseRef ?? process.env.MOTIF_COOLING_OFF_BASE_REF ?? 'HEAD^',
+    baseline: options.baseLockfilePath
+      ?? options.baseRef
+      ?? environment.MOTIF_COOLING_OFF_BASE_SHA
+      ?? environment.MOTIF_COOLING_OFF_BASE_REF
+      ?? 'HEAD^',
   };
 }
 

--- a/scripts/check-dependency-cooling-off.mjs
+++ b/scripts/check-dependency-cooling-off.mjs
@@ -47,10 +47,12 @@ function readBaselineLockfile(workspace, options) {
   const configuredRef = options.baseRef
     ?? environment.MOTIF_COOLING_OFF_BASE_SHA
     ?? environment.MOTIF_COOLING_OFF_BASE_REF;
-  if (environment.CI && !configuredRef) {
+  const hasExplicitBaseline = options.baseLockfileText !== undefined
+    || options.baseLockfilePath !== undefined;
+  if (environment.CI && !hasExplicitBaseline && !configuredRef) {
     throw new Error('Cooling-off policy requires the event base commit in CI; it must be a full immutable 40- or 64-hex commit ID');
   }
-  if (environment.CI && !isImmutableCommitId(configuredRef)) {
+  if (environment.CI && configuredRef !== undefined && !isImmutableCommitId(configuredRef)) {
     throw new Error('Cooling-off policy requires a valid nonzero baseline reference: the event base commit must be a full immutable 40- or 64-hex commit ID');
   }
   if (options.baseLockfileText) return JSON.parse(options.baseLockfileText);

--- a/scripts/check-repository-language.mjs
+++ b/scripts/check-repository-language.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, lstatSync, readFileSync } from 'node:fs';
+import { lstatSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -11,6 +11,12 @@ const DISALLOWED_SUFFIX = String.fromCharCode(108, 97, 98);
 const DISALLOWED_PATTERN = new RegExp(`${DISALLOWED_STEM}[ -]?${DISALLOWED_SUFFIX}`, 'iu');
 const MAX_TRACKED_FILE_BYTES = 16 * 1024 * 1024;
 const MAX_GITHUB_EVENT_BYTES = 2 * 1024 * 1024;
+const MAX_GIT_METADATA_BYTES = 32 * 1024 * 1024;
+const IMMUTABLE_COMMIT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/iu;
+
+function isImmutableCommitId(value) {
+  return typeof value === 'string' && IMMUTABLE_COMMIT_ID.test(value) && !/^0+$/u.test(value);
+}
 
 export function containsDisallowedRepositoryLanguage(value) {
   return DISALLOWED_PATTERN.test(String(value));
@@ -22,7 +28,7 @@ function git(workspace, args, { allowFailure = false } = {}) {
       cwd: workspace,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
-      maxBuffer: 32 * 1024 * 1024,
+      maxBuffer: MAX_GIT_METADATA_BYTES,
     });
   } catch (error) {
     if (allowFailure) return '';
@@ -56,31 +62,25 @@ function trackedViolations(workspace) {
   return violations;
 }
 
-function localMetadataCandidates(workspace, environment) {
-  return [
-    ['HEAD commit message', git(workspace, ['log', '-1', '--format=%B'])],
-    ['current branch', git(workspace, ['symbolic-ref', '--short', '-q', 'HEAD'], { allowFailure: true })],
-    ['tags at HEAD', git(workspace, ['tag', '--points-at', 'HEAD', '--format=%(refname) %(contents)'])],
-    ['CI head ref', environment.GITHUB_HEAD_REF ?? ''],
-    ['CI ref name', environment.GITHUB_REF_NAME ?? ''],
-    ['CI workflow ref', environment.GITHUB_REF ?? ''],
-  ];
+function collectStringLeaves(candidates, label, value, depth = 0) {
+  if (typeof value === 'string') {
+    candidates.push([label, value]);
+    return;
+  }
+  if (value === null || value === undefined || depth > 8) return;
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => collectStringLeaves(candidates, `${label}[${index}]`, entry, depth + 1));
+    return;
+  }
+  if (typeof value !== 'object') return;
+  Object.entries(value).forEach(([key, entry]) => collectStringLeaves(candidates, `${label}.${key}`, entry, depth + 1));
 }
 
-export function githubEventMetadataViolations(environment = process.env) {
-  const eventPath = environment.GITHUB_EVENT_PATH;
-  if (!eventPath) return { violations: [], fields: 0 };
-  const path = resolve(eventPath);
-  if (!existsSync(path)) throw new Error('Repository-language check could not find the GitHub event payload');
-  const stat = lstatSync(path);
-  if (stat.isSymbolicLink() || !stat.isFile()) throw new Error('GitHub event payload must be a regular file');
-  if (stat.size > MAX_GITHUB_EVENT_BYTES) throw new Error('GitHub event payload exceeds the repository-language size limit');
-  let event;
-  try {
-    event = JSON.parse(readFileSync(path, 'utf8'));
-  } catch {
-    throw new Error('GitHub event payload is not valid JSON');
-  }
+function collectOptionalTree(candidates, label, value) {
+  if (value !== undefined && value !== null) collectStringLeaves(candidates, label, value);
+}
+
+function githubEventCandidates(event) {
   const candidates = [
     ['repository name', event.repository?.name ?? ''],
     ['repository full name', event.repository?.full_name ?? ''],
@@ -100,6 +100,110 @@ export function githubEventMetadataViolations(environment = process.env) {
     ['release tag', event.release?.tag_name ?? ''],
     ['push head commit message', event.head_commit?.message ?? ''],
   ];
+
+  for (const [label, value] of [
+    ['push ref', event.ref],
+    ['push base ref', event.base_ref],
+    ['push head ref', event.head_ref],
+    ['release target ref', event.release?.target_commitish],
+  ]) {
+    if (value !== undefined && value !== null) candidates.push([label, String(value)]);
+  }
+
+  if (Array.isArray(event.commits)) {
+    event.commits.forEach((commit, index) => {
+      if (typeof commit?.message === 'string') candidates.push([`push commit message ${index + 1}`, commit.message]);
+    });
+  }
+
+  collectOptionalTree(candidates, 'pull request head repository metadata', event.pull_request?.head?.repo);
+  collectOptionalTree(candidates, 'pull request base repository metadata', event.pull_request?.base?.repo);
+  collectOptionalTree(candidates, 'repository parent metadata', event.repository?.parent);
+  collectOptionalTree(candidates, 'repository source metadata', event.repository?.source);
+
+  collectOptionalTree(candidates, 'pull request labels', event.pull_request?.labels);
+  collectOptionalTree(candidates, 'pull request comments', event.pull_request?.comments);
+  collectOptionalTree(candidates, 'pull request reviews', event.pull_request?.reviews);
+  collectOptionalTree(candidates, 'pull request review comments', event.pull_request?.review_comments);
+  collectOptionalTree(candidates, 'issue labels', event.issue?.labels);
+  collectOptionalTree(candidates, 'issue comments', event.issue?.comments);
+  collectOptionalTree(candidates, 'event label', event.label);
+  collectOptionalTree(candidates, 'event labels', event.labels);
+
+  for (const [key, label] of [
+    ['comment', 'comment metadata'],
+    ['comments', 'comments metadata'],
+    ['issue_comment', 'issue comment metadata'],
+    ['review', 'review metadata'],
+    ['reviews', 'reviews metadata'],
+    ['pull_request_review', 'pull request review metadata'],
+    ['pull_request_review_comment', 'pull request review comment metadata'],
+    ['review_comments', 'review comments metadata'],
+    ['discussion', 'discussion metadata'],
+    ['discussions', 'discussions metadata'],
+    ['discussion_comment', 'discussion comment metadata'],
+    ['discussion_comments', 'discussion comments metadata'],
+  ]) {
+    collectOptionalTree(candidates, label, event[key]);
+  }
+
+  if (Array.isArray(event.release?.assets)) {
+    event.release.assets.forEach((asset, index) => {
+      if (typeof asset?.name === 'string') candidates.push([`release asset name ${index + 1}`, asset.name]);
+    });
+  }
+
+  return candidates;
+}
+
+function readGithubEvent(environment) {
+  const eventPath = environment.GITHUB_EVENT_PATH;
+  if (eventPath === undefined || eventPath === null || (typeof eventPath === 'string' && !eventPath.trim())) {
+    if (environment.CI) throw new Error('Repository-language check requires a GitHub event payload in CI');
+    return null;
+  }
+  if (typeof eventPath !== 'string') throw new Error('GitHub event payload path must be a string');
+  const path = resolve(eventPath);
+  let stat;
+  try {
+    stat = lstatSync(path);
+  } catch {
+    throw new Error('Repository-language check could not find the GitHub event payload');
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) throw new Error('GitHub event payload must be a regular file');
+  if (stat.size > MAX_GITHUB_EVENT_BYTES) throw new Error('GitHub event payload exceeds the repository-language size limit');
+  let event;
+  try {
+    event = JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    throw new Error('GitHub event payload is not valid JSON');
+  }
+  if (!event || typeof event !== 'object' || Array.isArray(event)) {
+    throw new Error('GitHub event payload must be a JSON object');
+  }
+  return event;
+}
+
+function localMetadataCandidates(workspace, environment) {
+  const refs = git(workspace, ['for-each-ref', '--format=%(refname)', 'refs/heads', 'refs/tags']);
+  const annotations = git(workspace, ['for-each-ref', '--format=%(contents)', 'refs/heads', 'refs/tags']);
+  return [
+    ['HEAD commit message', git(workspace, ['log', '-1', '--format=%B'])],
+    ['current branch', git(workspace, ['symbolic-ref', '--short', '-q', 'HEAD'], { allowFailure: true })],
+    ['all branch and tag ref names', refs],
+    ['all branch and tag annotations', annotations],
+    ['tags at HEAD', git(workspace, ['tag', '--points-at', 'HEAD', '--format=%(refname) %(contents)'])],
+    ['CI head ref', environment.GITHUB_HEAD_REF ?? ''],
+    ['CI ref name', environment.GITHUB_REF_NAME ?? ''],
+    ['CI workflow ref', environment.GITHUB_REF ?? ''],
+    ['CI ref type', environment.GITHUB_REF_TYPE ?? ''],
+  ];
+}
+
+export function githubEventMetadataViolations(environment = process.env) {
+  const event = readGithubEvent(environment);
+  if (!event) return { violations: [], fields: 0 };
+  const candidates = githubEventCandidates(event);
   return {
     violations: candidates
       .filter(([, value]) => containsDisallowedRepositoryLanguage(value))
@@ -108,17 +212,45 @@ export function githubEventMetadataViolations(environment = process.env) {
   };
 }
 
+function eventCommitRange(event, environment) {
+  if (environment.MOTIF_REPOSITORY_LANGUAGE_SKIP_EVENT_RANGE === 'true') return null;
+  const eventName = environment.GITHUB_EVENT_NAME;
+  if (eventName && eventName !== 'push' && eventName !== 'pull_request') return null;
+  const pullRequest = event.pull_request;
+  const base = pullRequest?.base?.sha ?? event.before;
+  const head = pullRequest?.head?.sha ?? event.after;
+  if (base === undefined && head === undefined) return null;
+  if (!isImmutableCommitId(base) || !isImmutableCommitId(head)) {
+    throw new Error('GitHub event payload must provide full immutable base and head commits for the history scan');
+  }
+  return { base, head };
+}
+
+function eventCommitMessageCandidates(workspace, event, environment) {
+  const range = eventCommitRange(event, environment);
+  if (!range) return [];
+  const messages = git(workspace, ['log', '--format=%B', '--no-decorate', `${range.base}..${range.head}`]);
+  return [['event base-to-head commit messages', messages]];
+}
+
 function metadataViolations(workspace, environment) {
+  const event = readGithubEvent(environment);
   const localCandidates = localMetadataCandidates(workspace, environment);
-  const event = githubEventMetadataViolations(environment);
+  const eventCandidates = event ? githubEventCandidates(event) : [];
+  const historyCandidates = event ? eventCommitMessageCandidates(workspace, event, environment) : [];
   return {
     violations: [
       ...localCandidates
         .filter(([, value]) => containsDisallowedRepositoryLanguage(value))
         .map(([label]) => `metadata: ${label}`),
-      ...event.violations,
+      ...eventCandidates
+        .filter(([, value]) => containsDisallowedRepositoryLanguage(value))
+        .map(([label]) => `GitHub event metadata: ${label}`),
+      ...historyCandidates
+        .filter(([, value]) => containsDisallowedRepositoryLanguage(value))
+        .map(([label]) => `metadata: ${label}`),
     ],
-    fields: localCandidates.length + event.fields,
+    fields: localCandidates.length + eventCandidates.length + historyCandidates.length,
   };
 }
 

--- a/scripts/doctor-motif-claude-science-release.mjs
+++ b/scripts/doctor-motif-claude-science-release.mjs
@@ -9,23 +9,28 @@ import {
   readLocalMcpConfig,
   resolveNodeBinary,
 } from './lib/motif-local-mcp-config.mjs';
-import { resolveReleaseBundleRoot, verifyReleaseBundle } from './lib/motif-release-bundle.mjs';
+import { readTrustedManifestDigest, resolveReleaseBundleRoot, verifyReleaseBundle } from './lib/motif-release-bundle.mjs';
 import { isDirectScriptExecution } from './lib/direct-script.mjs';
 
 const defaultBundle = resolveReleaseBundleRoot(fileURLToPath(import.meta.url));
 
 function parseArgs(args) {
-  const options = { bundle: defaultBundle, config: DEFAULT_CLAUDE_SCIENCE_CONFIG_PATH, node: null, skipConfig: false, help: false };
+  const options = { bundle: defaultBundle, config: DEFAULT_CLAUDE_SCIENCE_CONFIG_PATH, node: null, manifestSha256: null, manifestSha256File: null, skipConfig: false, help: false };
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === '--help' || arg === '-h') options.help = true;
     else if (arg === '--skip-config') options.skipConfig = true;
-    else if (arg === '--bundle' || arg === '--config' || arg === '--node') {
+    else if (arg === '--manifest-sha256') {
+      const value = args[++index];
+      if (!value || value.startsWith('--')) throw new Error(`${arg} requires a SHA-256 value`);
+      options.manifestSha256 = value;
+    } else if (arg === '--bundle' || arg === '--config' || arg === '--node' || arg === '--manifest-sha256-file') {
       const value = args[++index];
       if (!value || value.startsWith('--')) throw new Error(`${arg} requires a path`);
       if (arg === '--bundle') options.bundle = resolve(value);
       if (arg === '--config') options.config = resolve(value);
       if (arg === '--node') options.node = resolve(value);
+      if (arg === '--manifest-sha256-file') options.manifestSha256File = resolve(value);
     } else throw new Error(`Unknown option: ${arg}`);
   }
   return options;
@@ -33,13 +38,17 @@ function parseArgs(args) {
 
 export function doctorRelease(args = process.argv.slice(2), environment = process.env) {
   const options = parseArgs(args);
-  if (options.help) return { help: 'node doctor-motif-claude-science-release.mjs [--bundle <directory>] [--config <path>] [--skip-config]\n' };
-  const verified = verifyReleaseBundle(options.bundle);
+  if (options.help) return { help: 'node doctor-motif-claude-science-release.mjs [--bundle <directory>] [--manifest-sha256-file <path>] [--config <path>] [--skip-config]\n' };
+  if (options.manifestSha256 && options.manifestSha256File) throw new Error('Choose either --manifest-sha256 or --manifest-sha256-file, not both');
+  const expectedManifestSha256 = options.manifestSha256File
+    ? readTrustedManifestDigest(options.manifestSha256File)
+    : options.manifestSha256;
+  const verified = verifyReleaseBundle(options.bundle, { expectedManifestSha256 });
   const nodeBinary = resolveNodeBinary({
     environment: options.node ? { ...environment, MOTIF_NODE_BIN: options.node } : environment,
     current: process.execPath,
   });
-  const result = { bundle: verified.root, version: verified.manifest.version, runtimeBuildId: verified.manifest.runtimeBuildId, nodeBinary };
+  const result = { bundle: verified.root, version: verified.manifest.version, runtimeBuildId: verified.manifest.runtimeBuildId, manifestSha256: verified.manifestSha256, externalManifestDigestMatched: verified.externalManifestDigestMatched, nodeBinary };
   if (options.skipConfig) return { ...result, config: 'skipped' };
   const document = readLocalMcpConfig(options.config);
   const desired = desiredMotifLocalServer(verified.root, { nodeBinary });
@@ -52,7 +61,7 @@ if (isDirectScriptExecution(process.argv[1], fileURLToPath(import.meta.url))) {
   try {
     const result = doctorRelease();
     if (result.help) process.stdout.write(result.help);
-    else process.stdout.write(`Motif release verified: v${result.version} (${result.runtimeBuildId.slice(0, 12)}). ${result.config === 'skipped' ? 'Configuration check skipped.' : 'motif-local registration matches.'}\n`);
+    else process.stdout.write(`Motif bundle integrity verified: v${result.version} (${result.runtimeBuildId.slice(0, 12)}). ${result.externalManifestDigestMatched ? 'External manifest digest matched.' : 'No external manifest digest was supplied.'} ${result.config === 'skipped' ? 'Configuration check skipped.' : 'motif-local registration matches.'}\n`);
   } catch (error) {
     process.stderr.write(`Motif release doctor failed: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;

--- a/scripts/install-motif-claude-science-release.mjs
+++ b/scripts/install-motif-claude-science-release.mjs
@@ -8,23 +8,28 @@ import {
   resolveNodeBinary,
   updateLocalMcpConfigFile,
 } from './lib/motif-local-mcp-config.mjs';
-import { resolveReleaseBundleRoot, verifyReleaseBundle } from './lib/motif-release-bundle.mjs';
+import { readTrustedManifestDigest, resolveReleaseBundleRoot, verifyReleaseBundle } from './lib/motif-release-bundle.mjs';
 import { isDirectScriptExecution } from './lib/direct-script.mjs';
 
 const defaultBundle = resolveReleaseBundleRoot(fileURLToPath(import.meta.url));
 
 function parseArgs(args) {
-  const options = { bundle: defaultBundle, config: DEFAULT_CLAUDE_SCIENCE_CONFIG_PATH, node: null, dryRun: false, help: false };
+  const options = { bundle: defaultBundle, config: DEFAULT_CLAUDE_SCIENCE_CONFIG_PATH, node: null, manifestSha256: null, manifestSha256File: null, dryRun: false, help: false };
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === '--help' || arg === '-h') options.help = true;
     else if (arg === '--dry-run') options.dryRun = true;
-    else if (arg === '--bundle' || arg === '--config' || arg === '--node') {
+    else if (arg === '--manifest-sha256') {
+      const value = args[++index];
+      if (!value || value.startsWith('--')) throw new Error(`${arg} requires a SHA-256 value`);
+      options.manifestSha256 = value;
+    } else if (arg === '--bundle' || arg === '--config' || arg === '--node' || arg === '--manifest-sha256-file') {
       const value = args[++index];
       if (!value || value.startsWith('--')) throw new Error(`${arg} requires a path`);
       if (arg === '--bundle') options.bundle = resolve(value);
       if (arg === '--config') options.config = resolve(value);
       if (arg === '--node') options.node = resolve(value);
+      if (arg === '--manifest-sha256-file') options.manifestSha256File = resolve(value);
     } else throw new Error(`Unknown option: ${arg}`);
   }
   return options;
@@ -34,15 +39,24 @@ function usage() {
   return `Install the checksum-verified Motif connector from this extracted release bundle.
 
 Usage:
-  node install-motif-claude-science-release.mjs [--config <path>] [--node <path>]
-  node install-motif-claude-science-release.mjs --bundle <directory> [--dry-run]
+  node install-motif-claude-science-release.mjs --manifest-sha256-file <path> [--config <path>] [--node <path>]
+  node install-motif-claude-science-release.mjs --bundle <directory> --manifest-sha256 <digest> [--dry-run]
 `;
+}
+
+function trustedManifestDigest(options) {
+  if (options.manifestSha256 && options.manifestSha256File) {
+    throw new Error('Choose either --manifest-sha256 or --manifest-sha256-file, not both');
+  }
+  if (options.manifestSha256File) return readTrustedManifestDigest(options.manifestSha256File);
+  if (options.manifestSha256) return options.manifestSha256;
+  throw new Error('Installation requires an externally trusted release-manifest SHA-256');
 }
 
 export function installRelease(args = process.argv.slice(2), environment = process.env) {
   const options = parseArgs(args);
   if (options.help) return { help: usage() };
-  const verified = verifyReleaseBundle(options.bundle);
+  const verified = verifyReleaseBundle(options.bundle, { expectedManifestSha256: trustedManifestDigest(options) });
   const nodeBinary = resolveNodeBinary({
     environment: options.node ? { ...environment, MOTIF_NODE_BIN: options.node } : environment,
     current: process.execPath,
@@ -59,12 +73,14 @@ export function installRelease(args = process.argv.slice(2), environment = proce
     bundle: verified.root,
     version: verified.manifest.version,
     runtimeBuildId: verified.manifest.runtimeBuildId,
+    manifestSha256: verified.manifestSha256,
+    externalManifestDigestMatched: verified.externalManifestDigestMatched,
     nodeBinary,
   };
 }
 
 export function formatInstallResult(result) {
-  const lines = [`Motif ${result.version} release verified.`];
+  const lines = [`Motif ${result.version} external manifest digest matched; bundle integrity verified.`];
   if (result.dryRun) {
     lines.push(result.changed
       ? 'Dry run: motif-local would be registered; Claude Science configuration was not changed.'

--- a/scripts/lib/motif-local-mcp-config.mjs
+++ b/scripts/lib/motif-local-mcp-config.mjs
@@ -186,6 +186,9 @@ export function describeMotifLocalMismatch(server, desired) {
   if (!isPlainObject(server.env)) {
     mismatches.push('env');
   } else {
+    const actualKeys = Object.keys(server.env).sort();
+    const desiredKeys = Object.keys(desired.env).sort();
+    if (!arraysEqual(actualKeys, desiredKeys)) mismatches.push('env.keys');
     for (const key of MANAGED_ENVIRONMENT_KEYS) {
       if (server.env[key] !== desired.env[key]) mismatches.push(`env.${key}`);
     }
@@ -214,10 +217,7 @@ export function installMotifLocalServer(config, desired) {
   const updated = {
     ...existing,
     ...desired,
-    env: {
-      ...(isPlainObject(existing.env) ? existing.env : {}),
-      ...desired.env,
-    },
+    env: { ...desired.env },
   };
   const servers = [...config.servers];
   servers[index] = updated;

--- a/scripts/lib/motif-release-bundle.mjs
+++ b/scripts/lib/motif-release-bundle.mjs
@@ -25,6 +25,7 @@ export const RELEASE_MAX_DIRECTORY_DEPTH = 32;
 export const RELEASE_MAX_BUNDLE_ENTRIES = RELEASE_MAX_BUNDLE_FILES + RELEASE_MAX_DIRECTORY_NODES;
 export const RELEASE_MAX_FILE_BYTES = 64 * 1024 * 1024;
 export const RELEASE_MAX_TOTAL_BYTES = 128 * 1024 * 1024;
+export const RELEASE_MAX_TRUSTED_DIGEST_FILE_BYTES = 512;
 
 /**
  * Resolve the bundle root for a release helper. Source helpers live in the
@@ -39,6 +40,24 @@ export function resolveReleaseBundleRoot(scriptPath) {
 
 function sha256(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
+}
+
+function normalizeTrustedManifestDigest(value) {
+  const digest = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  if (!/^[a-f0-9]{64}$/u.test(digest)) throw new Error('Trusted release-manifest SHA-256 is invalid');
+  return digest;
+}
+
+export function readTrustedManifestDigest(digestPath) {
+  const path = resolve(digestPath);
+  if (!existsSync(path)) throw new Error('Trusted release-manifest checksum file does not exist');
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isFile()) throw new Error('Trusted release-manifest checksum must be a regular file');
+  if (stat.size > RELEASE_MAX_TRUSTED_DIGEST_FILE_BYTES) throw new Error('Trusted release-manifest checksum file is oversized');
+  const line = readFileSync(path, 'utf8').trim();
+  const match = line.match(/^([a-f0-9]{64})(?:\s+\*?release-manifest\.json)?$/iu);
+  if (!match) throw new Error('Trusted release-manifest checksum file has an invalid format');
+  return normalizeTrustedManifestDigest(match[1]);
 }
 
 function canonicalRoot(bundlePath) {
@@ -86,7 +105,7 @@ function assertRegularBundleFile(root, relativePath, label = relativePath) {
   return path;
 }
 
-function listFiles(root, directory = root, output = [], state = { directoryNodes: 0, entries: 0 }, depth = 0) {
+function listFiles(root, directory = root, output = [], state = { directoryNodes: 0, entries: 0, totalBytes: 0 }, depth = 0) {
   state.directoryNodes += 1;
   if (state.directoryNodes > RELEASE_MAX_DIRECTORY_NODES) {
     throw new Error(`Release bundle directory count exceeds the ${RELEASE_MAX_DIRECTORY_NODES}-directory limit`);
@@ -117,6 +136,10 @@ function listFiles(root, directory = root, output = [], state = { directoryNodes
     if (entry.isDirectory()) listFiles(root, path, output, state, depth + 1);
     else if (entry.isFile()) {
       if (stat.size > RELEASE_MAX_FILE_BYTES) throw new Error(`Release file exceeds the size limit: ${relative(root, path)}`);
+      state.totalBytes += stat.size;
+      if (state.totalBytes > RELEASE_MAX_TOTAL_BYTES) {
+        throw new Error('Release bundle exceeds the total size limit');
+      }
       if (output.length >= RELEASE_MAX_BUNDLE_FILES) {
         throw new Error(`Release bundle file count exceeds the ${RELEASE_MAX_BUNDLE_FILES}-file limit`);
       }
@@ -140,11 +163,23 @@ function assertArrayOfStrings(value, label) {
   if (!Array.isArray(value) || value.some(item => typeof item !== 'string')) throw new Error(`${label} must be an array of strings`);
 }
 
-export function verifyReleaseBundle(bundlePath, { expectedVersion = null } = {}) {
+export function verifyReleaseBundle(bundlePath, { expectedVersion = null, expectedManifestSha256 = null } = {}) {
   const root = canonicalRoot(bundlePath);
   const manifestPath = assertRegularBundleFile(root, RELEASE_MANIFEST_FILENAME, 'Release manifest');
   const checksumPath = assertRegularBundleFile(root, RELEASE_CHECKSUM_FILENAME, 'Release checksum manifest');
-  const manifest = readJson(manifestPath, 'Release manifest');
+  if (lstatSync(manifestPath).size > 4 * 1024 * 1024) throw new Error('Release manifest exceeds the JSON size limit');
+  const manifestBytes = readFileSync(manifestPath);
+  const manifestSha256 = sha256(manifestBytes);
+  const trustedManifestSha256 = expectedManifestSha256 === null ? null : normalizeTrustedManifestDigest(expectedManifestSha256);
+  if (trustedManifestSha256 !== null && manifestSha256 !== trustedManifestSha256) {
+    throw new Error('Release manifest does not match the externally trusted SHA-256');
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(manifestBytes.toString('utf8'));
+  } catch {
+    throw new Error('Release manifest is not valid JSON');
+  }
   const checksums = readJson(checksumPath, 'Release checksum manifest');
   if (manifest.schema !== 'motif.release.manifest.v1') throw new Error('Unsupported Motif release manifest schema');
   if (manifest.product !== RELEASE_PRODUCT) throw new Error('Release product identity is not Motif for Claude Science');
@@ -162,17 +197,19 @@ export function verifyReleaseBundle(bundlePath, { expectedVersion = null } = {})
   checksumEntries.forEach(([, digest]) => {
     if (!/^[a-f0-9]{64}$/u.test(digest)) throw new Error('Release checksum entries must be SHA-256 hex digests');
   });
-  const expectedFiles = [];
-  for (const [relativePath, digest] of checksumEntries.sort(([left], [right]) => left.localeCompare(right))) {
-    const path = assertRegularBundleFile(root, relativePath);
-    if (sha256(readFileSync(path)) !== digest) throw new Error(`Release checksum mismatch: ${relativePath}`);
-    expectedFiles.push(relativePath);
-  }
-  const actualFiles = listFiles(root);
+  const expectedFiles = checksumEntries
+    .map(([relativePath]) => safeRelativePath(relativePath, 'Release checksum path'))
+    .sort((left, right) => left.localeCompare(right));
+  const traversalState = { directoryNodes: 0, entries: 0, totalBytes: 0 };
+  const actualFiles = listFiles(root, root, [], traversalState);
   const metadataFiles = [RELEASE_MANIFEST_FILENAME, RELEASE_CHECKSUM_FILENAME];
   const expectedAll = [...expectedFiles, ...metadataFiles].sort((left, right) => left.localeCompare(right));
   if (JSON.stringify(actualFiles) !== JSON.stringify(expectedAll)) {
     throw new Error('Release bundle contains an unexpected or missing file');
+  }
+  for (const [relativePath, digest] of checksumEntries.sort(([left], [right]) => left.localeCompare(right))) {
+    const path = assertRegularBundleFile(root, relativePath);
+    if (sha256(readFileSync(path)) !== digest) throw new Error(`Release checksum mismatch: ${relativePath}`);
   }
   assertArrayOfStrings(manifest.requiredFiles, 'Release requiredFiles');
   for (const required of manifest.requiredFiles) assertRegularBundleFile(root, required, `Required release artifact ${required}`);
@@ -195,7 +232,12 @@ export function verifyReleaseBundle(bundlePath, { expectedVersion = null } = {})
     if (!server.includes(marker)) throw new Error(`Release connector server is missing identity marker ${marker}`);
   }
   if (!launcher.includes('MOTIF_ROOT') || !launcher.includes('motif-claude-science')) throw new Error('Release launcher identity is missing');
-  const totalSize = actualFiles.reduce((sum, relativePath) => sum + lstatSync(resolve(root, relativePath)).size, 0);
-  if (totalSize > RELEASE_MAX_TOTAL_BYTES) throw new Error('Release bundle exceeds the total size limit');
-  return { root, manifest, checksums, paths: { launcher: launcherPath, server: serverPath, app: appPath, template: templatePath } };
+  return {
+    root,
+    manifest,
+    checksums,
+    manifestSha256,
+    externalManifestDigestMatched: trustedManifestSha256 !== null,
+    paths: { launcher: launcherPath, server: serverPath, app: appPath, template: templatePath },
+  };
 }

--- a/scripts/lib/supply-chain-policy.mjs
+++ b/scripts/lib/supply-chain-policy.mjs
@@ -8,8 +8,11 @@ import {
 import { join, relative, resolve, sep } from 'node:path';
 
 const LIFECYCLE_KEYS = ['preinstall', 'install', 'postinstall', 'prepare'];
+const EXECUTED_LIFECYCLE_KEYS = new Set(['preinstall', 'install', 'postinstall']);
 const SHA512_INTEGRITY = /^sha512-[A-Za-z0-9+/=]+$/u;
+const SHA256_HEX = /^[a-f0-9]{64}$/u;
 const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
+const SAFE_POLICY_PATH = /^[^/\\][^\\]*$/u;
 
 function packageIdentity(name, version) {
   return `${name}@${version}`;
@@ -136,6 +139,9 @@ export function loadDependencyPolicy(root) {
   const inventory = readJson(inventoryPath, 'Reviewed connector inventory');
   if (policy.schema !== 'motif.dependency-policy.v1') throw new Error('Dependency policy schema is unsupported');
   if (policy.reviewedConnectorInventory !== 'security/connector-inventory.json') throw new Error('Dependency policy must point to the reviewed connector inventory');
+  if (policy.reviewedLifecycleCommands !== undefined) {
+    throw new Error('Dependency policy cannot contain generic lifecycle command approvals');
+  }
   if (inventory.schema !== 'motif.reviewed-connector-inventory.v1') throw new Error('Connector inventory schema is unsupported');
   if (!Array.isArray(inventory.packages) || inventory.packages.length === 0) throw new Error('Connector inventory must contain packages');
   return { policy, inventory, policyPath, inventoryPath };
@@ -151,6 +157,7 @@ export function checkLockfilePolicy(rootPath = process.cwd()) {
   if (!rootPackage) throw new Error('package-lock.json is missing its root package entry');
 
   const lifecyclePolicy = policy.allowedLifecycleScripts ?? {};
+  const ownedPreparations = policy.ownedPreparations ?? {};
   for (const [identity, scripts] of Object.entries(lifecyclePolicy)) {
     const parsed = splitPackageIdentity(identity);
     if (!parsed || !Array.isArray(scripts) || scripts.some(key => !LIFECYCLE_KEYS.includes(key))) {
@@ -158,6 +165,48 @@ export function checkLockfilePolicy(rootPath = process.cwd()) {
     }
     if (!lockContainsIdentity(lock, parsed.name, parsed.version)) {
       throw new Error(`Lifecycle policy entry is stale or unreviewed: ${identity}`);
+    }
+  }
+  for (const [identity, preparation] of Object.entries(ownedPreparations)) {
+    const parsed = splitPackageIdentity(identity);
+    if (!parsed || !preparation || typeof preparation !== 'object' || Array.isArray(preparation) || !lockContainsIdentity(lock, parsed.name, parsed.version)) {
+      throw new Error(`Owned dependency preparation entry is stale or unreviewed: ${identity}`);
+    }
+    if (preparation.lifecycle !== 'postinstall'
+      || typeof preparation.manifestPath !== 'string'
+      || preparation.manifestPath !== 'node_modules/esbuild/package.json'
+      || !SHA256_HEX.test(preparation.manifestSha256)
+      || !preparation.lockfile
+      || typeof preparation.lockfile !== 'object'
+      || preparation.lockfile.path !== 'node_modules/esbuild'
+      || preparation.lockfile.version !== parsed.version
+      || typeof preparation.lockfile.resolved !== 'string'
+      || typeof preparation.lockfile.integrity !== 'string'
+      || !SHA512_INTEGRITY.test(preparation.lockfile.integrity)
+      || !preparation.platforms
+      || typeof preparation.platforms !== 'object'
+      || Array.isArray(preparation.platforms)
+      || Object.keys(preparation.platforms).length === 0) {
+      throw new Error(`Owned dependency preparation entry is not an exact safe preparation: ${identity}`);
+    }
+    const lockedPreparation = lock.packages[preparation.lockfile.path];
+    if (!lockedPreparation
+      || lockedPreparation.version !== preparation.lockfile.version
+      || lockedPreparation.resolved !== preparation.lockfile.resolved
+      || lockedPreparation.integrity !== preparation.lockfile.integrity) {
+      throw new Error(`Owned dependency preparation lockfile entry does not match policy: ${identity}`);
+    }
+    for (const [platform, spec] of Object.entries(preparation.platforms)) {
+      if (!platform || !spec || typeof spec !== 'object' || Array.isArray(spec)
+        || typeof spec.package !== 'string'
+        || !spec.package.startsWith('@esbuild/')
+        || spec.version !== parsed.version
+        || !SHA256_HEX.test(spec.manifestSha256)
+        || typeof spec.binaryPath !== 'string'
+        || !SAFE_POLICY_PATH.test(spec.binaryPath)
+        || spec.binaryPath.includes('..')) {
+        throw new Error(`Owned dependency preparation platform entry is unsafe: ${identity} ${platform}`);
+      }
     }
   }
   const npmAllowScripts = packageJsonAllowScripts(packageJson);
@@ -206,12 +255,25 @@ export function checkLockfilePolicy(rootPath = process.cwd()) {
     const lifecycleKeys = LIFECYCLE_KEYS.filter(key => typeof scripts[key] === 'string' && scripts[key].trim());
     const identity = packageIdentity(name, version);
     if (metadata.hasInstallScript || lifecycleKeys.length > 0) {
-      const allowed = lifecyclePolicy[identity];
-      if (!Array.isArray(allowed)) lifecycleFindings.push(`${identity} is not in allowedLifecycleScripts`);
-      for (const key of lifecycleKeys) {
-        if (!allowed?.includes(key)) lifecycleFindings.push(`${identity} lifecycle script ${key} is not allowlisted`);
+      const ownedPreparation = ownedPreparations[identity];
+      if (ownedPreparation) {
+        if (lifecycleKeys.length !== 1 || lifecycleKeys[0] !== ownedPreparation.lifecycle) {
+          lifecycleFindings.push(`${identity} lifecycle entries do not match its exact Motif-owned preparation`);
+        }
+        if (metadata.hasInstallScript && npmAllowScripts[identity] !== false) {
+          lifecycleFindings.push(`${identity} must explicitly disable npm lifecycle execution`);
+        }
+      } else {
+        const allowed = lifecyclePolicy[identity];
+        if (!Array.isArray(allowed)) lifecycleFindings.push(`${identity} is not in allowedLifecycleScripts`);
+        for (const key of lifecycleKeys) {
+          if (!allowed?.includes(key)) lifecycleFindings.push(`${identity} lifecycle script ${key} is not allowlisted`);
+          if (EXECUTED_LIFECYCLE_KEYS.has(key)) {
+            lifecycleFindings.push(`${identity} lifecycle script ${key} has no exact Motif-owned preparation`);
+          }
+        }
+        if (metadata.hasInstallScript && npmAllowScripts[identity] === undefined) lifecycleFindings.push(`${identity} has an install script but no exact package.json allowScripts decision`);
       }
-      if (metadata.hasInstallScript && npmAllowScripts[identity] === undefined) lifecycleFindings.push(`${identity} has an install script but no exact package.json allowScripts decision`);
     }
     const packageDirectory = join(root, lockPath);
     const hasBinding = packageFiles(packageDirectory).some(path => path.endsWith('/binding.gyp') || path.endsWith('\\binding.gyp'));
@@ -238,6 +300,7 @@ export function checkLockfilePolicy(rootPath = process.cwd()) {
     packageCount: packages.length,
     connectorPackageCount: inventory.packages.length,
     lifecycleAllowlist: Object.keys(policy.allowedLifecycleScripts ?? {}).sort(),
+    ownedPreparationAllowlist: Object.keys(policy.ownedPreparations ?? {}).sort(),
     bindingAllowlist: [...(policy.allowedBindingGyp ?? [])].sort(),
   };
 }

--- a/scripts/report-gate-coverage.mjs
+++ b/scripts/report-gate-coverage.mjs
@@ -38,7 +38,7 @@ export function reportGateCoverage(env = process.env) {
     schema: 'motif.gate-coverage.v1',
     executed: [
       'typecheck', 'lint', 'repository language policy', 'unit tests', 'release alignment', 'runtime compatibility',
-      'npm audit', 'supply-chain policy', 'reviewed lifecycle scripts', 'dependency cooling-off policy', 'plugin checks', 'connector checks',
+      'npm audit', 'supply-chain policy', 'Motif-owned dependency preparation', 'dependency cooling-off policy', 'plugin checks', 'connector checks',
       'style/accessibility guards', 'build', 'reproducibility', 'release budgets',
       'core browser workflows', 'MSA interaction workflows',
     ],

--- a/scripts/run-motif-claude-science-mcp.sh
+++ b/scripts/run-motif-claude-science-mcp.sh
@@ -43,7 +43,7 @@ if [[ -z "$NODE_BIN" ]]; then
   exit 1
 fi
 
-NODE_SUPPORTED="$($NODE_BIN -p 'const [major, minor] = process.versions.node.split(".").map(Number); Number(major >= 24 || (major === 22 && minor >= 13))' 2>/dev/null || true)"
+NODE_SUPPORTED="$("$NODE_BIN" -p 'const [major, minor] = process.versions.node.split(".").map(Number); Number(major >= 24 || (major === 22 && minor >= 13))' 2>/dev/null || true)"
 if [[ "$NODE_SUPPORTED" != "1" ]]; then
   echo "[motif-claude-science] Node.js 22.13 or newer (22.x) or 24 or newer is required." >&2
   exit 1

--- a/scripts/run-reviewed-lifecycle.mjs
+++ b/scripts/run-reviewed-lifecycle.mjs
@@ -1,19 +1,64 @@
 #!/usr/bin/env node
 
-import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import {
+  chmodSync,
+  copyFileSync,
   existsSync,
   lstatSync,
   readFileSync,
 } from 'node:fs';
-import { delimiter, join, relative, resolve, sep } from 'node:path';
+import { arch, endianness, platform } from 'node:os';
+import { join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { checkLockfilePolicy, loadDependencyPolicy } from './lib/supply-chain-policy.mjs';
 
-const INSTALL_LIFECYCLE_KEYS = ['preinstall', 'install', 'postinstall'];
-const MAX_SCRIPT_BYTES = 4096;
-const MAX_SCRIPT_OUTPUT_BYTES = 2 * 1024 * 1024;
-const SCRIPT_TIMEOUT_MS = 120_000;
+const ESBUILD_NAME = 'esbuild';
+const ESBUILD_VERSION = '0.28.1';
+const ESBUILD_IDENTITY = `${ESBUILD_NAME}@${ESBUILD_VERSION}`;
+const ESBUILD_PACKAGE_PATH = 'node_modules/esbuild';
+const ESBUILD_MANIFEST_PATH = `${ESBUILD_PACKAGE_PATH}/package.json`;
+const VERSION_ARGS = ['--version'];
+const VERSION_TIMEOUT_MS = 10_000;
+const VERSION_OUTPUT_BYTES = 64 * 1024;
+const SHA256_HEX = /^[a-f0-9]{64}$/u;
+
+// This is intentionally a closed table. It mirrors the platform package names
+// published for this exact esbuild version; there is no package search or
+// fallback to a package for another operating system or CPU.
+const ESBUILD_PLATFORM_PACKAGES = Object.freeze({
+  'aix ppc64 BE': Object.freeze({ packageName: '@esbuild/aix-ppc64', binaryPath: 'bin/esbuild' }),
+  'android arm LE': Object.freeze({ packageName: '@esbuild/android-arm', binaryPath: 'bin/esbuild' }),
+  'android arm64 LE': Object.freeze({ packageName: '@esbuild/android-arm64', binaryPath: 'bin/esbuild' }),
+  'android x64 LE': Object.freeze({ packageName: '@esbuild/android-x64', binaryPath: 'bin/esbuild' }),
+  'darwin arm64 LE': Object.freeze({ packageName: '@esbuild/darwin-arm64', binaryPath: 'bin/esbuild' }),
+  'darwin x64 LE': Object.freeze({ packageName: '@esbuild/darwin-x64', binaryPath: 'bin/esbuild' }),
+  'freebsd arm64 LE': Object.freeze({ packageName: '@esbuild/freebsd-arm64', binaryPath: 'bin/esbuild' }),
+  'freebsd x64 LE': Object.freeze({ packageName: '@esbuild/freebsd-x64', binaryPath: 'bin/esbuild' }),
+  'linux arm LE': Object.freeze({ packageName: '@esbuild/linux-arm', binaryPath: 'bin/esbuild' }),
+  'linux arm64 LE': Object.freeze({ packageName: '@esbuild/linux-arm64', binaryPath: 'bin/esbuild' }),
+  'linux ia32 LE': Object.freeze({ packageName: '@esbuild/linux-ia32', binaryPath: 'bin/esbuild' }),
+  'linux loong64 LE': Object.freeze({ packageName: '@esbuild/linux-loong64', binaryPath: 'bin/esbuild' }),
+  'linux mips64el LE': Object.freeze({ packageName: '@esbuild/linux-mips64el', binaryPath: 'bin/esbuild' }),
+  'linux ppc64 LE': Object.freeze({ packageName: '@esbuild/linux-ppc64', binaryPath: 'bin/esbuild' }),
+  'linux riscv64 LE': Object.freeze({ packageName: '@esbuild/linux-riscv64', binaryPath: 'bin/esbuild' }),
+  'linux s390x BE': Object.freeze({ packageName: '@esbuild/linux-s390x', binaryPath: 'bin/esbuild' }),
+  'linux x64 LE': Object.freeze({ packageName: '@esbuild/linux-x64', binaryPath: 'bin/esbuild' }),
+  'netbsd arm64 LE': Object.freeze({ packageName: '@esbuild/netbsd-arm64', binaryPath: 'bin/esbuild' }),
+  'netbsd x64 LE': Object.freeze({ packageName: '@esbuild/netbsd-x64', binaryPath: 'bin/esbuild' }),
+  'openbsd arm64 LE': Object.freeze({ packageName: '@esbuild/openbsd-arm64', binaryPath: 'bin/esbuild' }),
+  'openbsd x64 LE': Object.freeze({ packageName: '@esbuild/openbsd-x64', binaryPath: 'bin/esbuild' }),
+  'openharmony arm64 LE': Object.freeze({ packageName: '@esbuild/openharmony-arm64', binaryPath: 'bin/esbuild' }),
+  'sunos x64 LE': Object.freeze({ packageName: '@esbuild/sunos-x64', binaryPath: 'bin/esbuild' }),
+  'win32 arm64 LE': Object.freeze({ packageName: '@esbuild/win32-arm64', binaryPath: 'esbuild.exe' }),
+  'win32 ia32 LE': Object.freeze({ packageName: '@esbuild/win32-ia32', binaryPath: 'esbuild.exe' }),
+  'win32 x64 LE': Object.freeze({ packageName: '@esbuild/win32-x64', binaryPath: 'esbuild.exe' }),
+});
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
 
 function readJson(path, label) {
   try {
@@ -23,132 +68,221 @@ function readJson(path, label) {
   }
 }
 
-function packageName(lockPath, manifest) {
-  if (typeof manifest?.name === 'string' && manifest.name.trim()) return manifest.name;
-  const relative = lockPath.replace(/^node_modules\//u, '');
-  const segments = relative.split('/node_modules/').at(-1)?.split('/') ?? [];
-  return segments[0]?.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0] ?? lockPath;
+function assertContained(root, path, label) {
+  const local = relative(root, path);
+  if (!local || local === '..' || local.startsWith(`..${sep}`) || local.startsWith('/') || local.startsWith('\\')) {
+    throw new Error(`${label} escapes the workspace`);
+  }
 }
 
-function packageDirectory(root, lockPath) {
-  const directory = resolve(root, lockPath);
-  const relativePath = relative(root, directory);
-  if (!relativePath || relativePath === '..' || relativePath.startsWith(`..${sep}`) || relativePath.startsWith('/')) {
-    throw new Error(`Lifecycle package path escapes the workspace: ${lockPath}`);
+function assertRelativePath(path, label) {
+  if (typeof path !== 'string' || !path || path.startsWith('/') || path.startsWith('\\') || path.includes('..') || path.includes('\\')) {
+    throw new Error(`${label} is unsafe`);
   }
-  if (!existsSync(directory)) return null;
-  const stat = lstatSync(directory);
-  if (stat.isSymbolicLink() || !stat.isDirectory()) {
-    throw new Error(`Lifecycle package directory must be a real directory: ${lockPath}`);
+}
+
+function regularDirectory(root, relativePath, label) {
+  assertRelativePath(relativePath, label);
+  const directory = resolve(root, relativePath);
+  assertContained(root, directory, label);
+  let current = root;
+  for (const segment of relativePath.split('/')) {
+    current = join(current, segment);
+    let stat;
+    try {
+      stat = lstatSync(current);
+    } catch (error) {
+      if (error?.code === 'ENOENT') throw new Error(`${label} is missing`);
+      throw error;
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory()) throw new Error(`${label} must be a real directory`);
   }
   return directory;
 }
 
-function lifecycleEnvironment(root, identity, version, key, metadata, manifestPath) {
-  const [name] = identity.lastIndexOf('@') > 0
-    ? [identity.slice(0, identity.lastIndexOf('@'))]
-    : [identity];
-  const binDirectory = join(root, 'node_modules', '.bin');
-  return {
-    ...process.env,
-    PATH: `${binDirectory}${delimiter}${process.env.PATH ?? ''}`,
-    INIT_CWD: root,
-    npm_lifecycle_event: key,
-    npm_package_name: name,
-    npm_package_version: version,
-    npm_package_json: manifestPath,
-    npm_package_resolved: metadata.resolved ?? '',
-    npm_package_integrity: metadata.integrity ?? '',
-    npm_package_optional: metadata.optional ? 'true' : 'false',
-    npm_package_dev: metadata.dev ? 'true' : 'false',
-    npm_package_peer: metadata.peer ? 'true' : 'false',
-    npm_package_dev_optional: metadata.devOptional ? 'true' : 'false',
-  };
+function regularFile(path, label) {
+  let stat;
+  try {
+    stat = lstatSync(path);
+  } catch (error) {
+    if (error?.code === 'ENOENT') throw new Error(`${label} is missing`);
+    throw error;
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) throw new Error(`${label} must be a regular file`);
+  return readFileSync(path);
 }
 
-function runScript({ root, identity, version, key, command, metadata, packagePath }) {
-  if (typeof command !== 'string' || command.length === 0 || Buffer.byteLength(command, 'utf8') > MAX_SCRIPT_BYTES || command.includes('\0')) {
-    throw new Error(`${identity} ${key} script is outside the bounded reviewed command format`);
+function readHashedFile(path, expectedDigest, label) {
+  if (!SHA256_HEX.test(expectedDigest)) throw new Error(`${label} has no valid expected SHA-256`);
+  const bytes = regularFile(path, label);
+  const actualDigest = sha256(bytes);
+  if (actualDigest !== expectedDigest) throw new Error(`${label} SHA-256 mismatch`);
+  return bytes;
+}
+
+function parseHashedJson(path, expectedDigest, label) {
+  const bytes = readHashedFile(path, expectedDigest, label);
+  try {
+    return JSON.parse(bytes.toString('utf8'));
+  } catch (error) {
+    throw new Error(`${label} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
   }
-  const manifestPath = join(packagePath, 'package.json');
-  const result = spawnSync(command, {
-    cwd: packagePath,
-    env: lifecycleEnvironment(root, identity, version, key, metadata, manifestPath),
-    encoding: 'utf8',
-    shell: true,
-    timeout: SCRIPT_TIMEOUT_MS,
-    maxBuffer: MAX_SCRIPT_OUTPUT_BYTES,
-    windowsHide: true,
-  });
-  if (result.error || result.status !== 0) {
-    const reason = result.error?.message ?? `exit status ${result.status ?? 'unknown'}${result.signal ? ` (${result.signal})` : ''}`;
-    throw new Error(`Reviewed lifecycle script failed for ${identity} ${key}: ${reason}`);
+}
+
+function currentPlatformKey() {
+  return `${platform()} ${arch()} ${endianness()}`;
+}
+
+function assertLockfileEntry(lock, preparation) {
+  const expected = preparation.lockfile;
+  const entry = lock.packages?.[expected.path];
+  if (!entry || typeof entry !== 'object') throw new Error('esbuild lockfile entry is missing');
+  if (entry.version !== expected.version || entry.resolved !== expected.resolved || entry.integrity !== expected.integrity) {
+    throw new Error('esbuild lockfile identity, resolved source, or integrity does not match policy');
   }
-  return { identity, key };
+  return entry;
+}
+
+function assertPlatformLockfileEntry(lock, platformSpec, preparationSpec) {
+  const path = `node_modules/${platformSpec.packageName}`;
+  const entry = lock.packages?.[path];
+  if (!entry || typeof entry !== 'object' || entry.version !== preparationSpec.version) {
+    throw new Error(`Current-platform esbuild package is missing or has the wrong version: ${platformSpec.packageName}`);
+  }
+  return entry;
+}
+
+function verifyVersion(binaryPath, root) {
+  let output;
+  try {
+    output = execFileSync(binaryPath, VERSION_ARGS, {
+      cwd: root,
+      encoding: 'utf8',
+      env: process.platform === 'win32' ? { SystemRoot: process.env.SystemRoot ?? 'C:\\Windows' } : {},
+      shell: false,
+      timeout: VERSION_TIMEOUT_MS,
+      maxBuffer: VERSION_OUTPUT_BYTES,
+      windowsHide: true,
+    });
+  } catch (error) {
+    throw new Error(`Verified esbuild binary failed its exact version check: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const actual = output.trim();
+  if (actual !== ESBUILD_VERSION) throw new Error(`Verified esbuild binary reported ${JSON.stringify(actual)} instead of ${JSON.stringify(ESBUILD_VERSION)}`);
+  return actual;
 }
 
 /**
- * Run only install-time scripts that passed the lockfile, registry, integrity,
- * exact identity, lifecycle, and binding policy. CI must install with
- * --ignore-scripts before calling this function.
+ * Prepare the exact locked esbuild binary without invoking its package
+ * lifecycle script. The helper reads only fixed package paths, verifies every
+ * installed file before trusting it, copies the current-platform executable to
+ * esbuild's expected bin path, and performs one exact version check.
  */
-export function runReviewedLifecycle(rootPath = process.cwd()) {
+export function prepareEsbuild(rootPath = process.cwd(), ...unexpectedArguments) {
+  if (unexpectedArguments.length > 0) throw new Error('The Motif-owned preparation helper accepts no command arguments');
   const root = resolve(rootPath);
+  const rootStat = lstatSync(root);
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) throw new Error('Preparation workspace must be a real directory');
   const policyResult = checkLockfilePolicy(root);
   const { policy } = loadDependencyPolicy(root);
+  const preparation = policy.ownedPreparations?.[ESBUILD_IDENTITY];
+  if (!preparation) throw new Error(`No exact Motif-owned preparation is registered for ${ESBUILD_IDENTITY}`);
+  if (preparation.manifestPath !== ESBUILD_MANIFEST_PATH) throw new Error('esbuild manifest path does not match the fixed preparation path');
+
   const packageJson = readJson(join(root, 'package.json'), 'package.json');
   const lock = readJson(join(root, 'package-lock.json'), 'package-lock.json');
-  const allowScripts = packageJson.allowScripts ?? {};
-  const allowedLifecycleScripts = policy.allowedLifecycleScripts ?? {};
-  const executed = [];
-
-  for (const [lockPath, metadata] of Object.entries(lock.packages ?? {}).sort(([left], [right]) => left.localeCompare(right))) {
-    if (lockPath === '' || !metadata || typeof metadata !== 'object') continue;
-    const directory = packageDirectory(root, lockPath);
-    if (!directory) {
-      if (!metadata.optional && metadata.hasInstallScript) {
-        throw new Error(`Reviewed lifecycle package is missing after --ignore-scripts install: ${lockPath}`);
-      }
-      continue;
-    }
-    const manifestPath = join(directory, 'package.json');
-    if (!existsSync(manifestPath)) {
-      if (metadata.hasInstallScript) throw new Error(`Reviewed lifecycle package manifest is missing: ${lockPath}`);
-      continue;
-    }
-    const manifest = readJson(manifestPath, `Package manifest ${manifestPath}`);
-    const name = packageName(lockPath, manifest);
-    const version = metadata.version;
-    const identity = `${name}@${version}`;
-    const allowed = allowedLifecycleScripts[identity];
-    const installKeys = INSTALL_LIFECYCLE_KEYS.filter(key => typeof manifest.scripts?.[key] === 'string' && manifest.scripts[key].trim());
-    if (installKeys.length === 0) continue;
-    if (!Array.isArray(allowed) || allowScripts[identity] !== true) {
-      throw new Error(`${identity} has an install-time script but no exact executable approval`);
-    }
-    for (const key of installKeys) {
-      if (!allowed.includes(key)) throw new Error(`${identity} ${key} is not in the exact executable lifecycle allowlist`);
-      executed.push(runScript({
-        root,
-        identity,
-        version,
-        key,
-        command: manifest.scripts[key],
-        metadata,
-        packagePath: directory,
-      }));
-    }
+  if (packageJson.devDependencies?.[ESBUILD_NAME] !== ESBUILD_VERSION
+    || lock.packages?.['']?.devDependencies?.[ESBUILD_NAME] !== ESBUILD_VERSION) {
+    throw new Error('esbuild is not an exact locked dev dependency');
   }
-  return { ...policyResult, executed };
+  assertLockfileEntry(lock, preparation);
+
+  const esbuildDirectory = regularDirectory(root, ESBUILD_PACKAGE_PATH, 'esbuild package directory');
+  const esbuildManifest = parseHashedJson(
+    join(root, ESBUILD_MANIFEST_PATH),
+    preparation.manifestSha256,
+    'esbuild package.json',
+  );
+  if (esbuildManifest.name !== ESBUILD_NAME || esbuildManifest.version !== ESBUILD_VERSION) {
+    throw new Error('esbuild package.json identity or version does not match policy');
+  }
+  const binaryHashes = esbuildManifest['esbuild.binaryHashes'];
+  if (!binaryHashes || typeof binaryHashes !== 'object' || Array.isArray(binaryHashes)) {
+    throw new Error('esbuild package.json has no usable binary hash map');
+  }
+
+  const platformKey = currentPlatformKey();
+  const platformSpec = ESBUILD_PLATFORM_PACKAGES[platformKey];
+  if (!platformSpec) throw new Error(`No exact esbuild package is reviewed for current platform ${platformKey}`);
+  const policyPlatformSpec = preparation.platforms?.[platformKey];
+  if (!policyPlatformSpec
+    || policyPlatformSpec.package !== platformSpec.packageName
+    || policyPlatformSpec.version !== ESBUILD_VERSION
+    || policyPlatformSpec.binaryPath !== platformSpec.binaryPath) {
+    throw new Error(`esbuild policy has no exact mapping for current platform ${platformKey}`);
+  }
+  const platformDirectory = regularDirectory(
+    root,
+    `node_modules/${platformSpec.packageName}`,
+    'current-platform esbuild package directory',
+  );
+  assertPlatformLockfileEntry(lock, platformSpec, policyPlatformSpec);
+  const platformManifest = parseHashedJson(
+    join(platformDirectory, 'package.json'),
+    policyPlatformSpec.manifestSha256,
+    'current-platform esbuild package.json',
+  );
+  if (platformManifest.name !== platformSpec.packageName || platformManifest.version !== ESBUILD_VERSION) {
+    throw new Error('current-platform esbuild package identity or version does not match policy');
+  }
+  if (esbuildManifest.optionalDependencies?.[platformSpec.packageName] !== ESBUILD_VERSION) {
+    throw new Error('esbuild optional dependency map does not select the exact current-platform package');
+  }
+
+  const binaryHashKey = `${platformSpec.packageName}/${platformSpec.binaryPath}`;
+  const expectedBinaryDigest = binaryHashes[binaryHashKey];
+  if (!SHA256_HEX.test(expectedBinaryDigest)) {
+    throw new Error(`esbuild package.json has no exact binary hash for ${binaryHashKey}`);
+  }
+  const sourceBinaryPath = join(platformDirectory, platformSpec.binaryPath);
+  readHashedFile(sourceBinaryPath, expectedBinaryDigest, 'current-platform esbuild binary');
+
+  const binDirectory = regularDirectory(esbuildDirectory, 'bin', 'esbuild bin directory');
+  const targetBinaryPath = join(binDirectory, 'esbuild');
+  if (existsSync(targetBinaryPath)) {
+    const targetStat = lstatSync(targetBinaryPath);
+    if (targetStat.isSymbolicLink() || !targetStat.isFile()) throw new Error('esbuild bin/esbuild must be a regular file');
+  }
+  copyFileSync(sourceBinaryPath, targetBinaryPath);
+  chmodSync(targetBinaryPath, 0o755);
+  const targetDigest = sha256(regularFile(targetBinaryPath, 'materialized esbuild binary'));
+  if (targetDigest !== expectedBinaryDigest) {
+    throw new Error('materialized esbuild binary SHA-256 mismatch');
+  }
+  const version = verifyVersion(targetBinaryPath, root);
+  return {
+    ...policyResult,
+    prepared: [{
+      identity: ESBUILD_IDENTITY,
+      platform: platformKey,
+      package: platformSpec.packageName,
+      binaryPath: targetBinaryPath,
+      binarySha256: targetDigest,
+      version,
+    }],
+  };
 }
+
+export const runReviewedLifecycle = prepareEsbuild;
 
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   try {
-    const result = runReviewedLifecycle(root);
-    console.log(`Reviewed lifecycle policy passed: ${result.executed.length} exact install script${result.executed.length === 1 ? '' : 's'} executed.`);
+    if (process.argv.length !== 2) throw new Error('The Motif-owned preparation helper accepts no command arguments');
+    const result = prepareEsbuild(root);
+    console.log(`Motif-owned dependency preparation passed: ${result.prepared.length} exact esbuild binary prepared.`);
   } catch (error) {
-    console.error(`Reviewed lifecycle policy failed: ${error instanceof Error ? error.message : String(error)}`);
+    console.error(`Motif-owned dependency preparation failed: ${error instanceof Error ? error.message : String(error)}`);
     process.exitCode = 1;
   }
 }

--- a/security/dependency-policy.json
+++ b/security/dependency-policy.json
@@ -2,22 +2,7 @@
   "schema": "motif.dependency-policy.v1",
   "registry": "https://registry.npmjs.org/",
   "coolingOffDays": 7,
-  "coolingOffExceptions": [
-    {
-      "name": "hono",
-      "version": "4.13.1",
-      "rationale": "Security maintenance release required to clear current Hono advisories before the seven-day window closes.",
-      "reviewer": "release-maintainer",
-      "expiresAt": "2026-08-15T07:00:00.000Z"
-    },
-    {
-      "name": "nanoid",
-      "version": "3.3.18",
-      "rationale": "Security maintenance release required to clear the current nanoid advisory before the seven-day window closes.",
-      "reviewer": "release-maintainer",
-      "expiresAt": "2026-08-15T17:00:00.000Z"
-    }
-  ],
+  "coolingOffExceptions": [],
   "directDependenciesMustBeExact": true,
   "allowedLifecycleScripts": {
     "@axe-core/playwright@4.11.1": ["prepare"],
@@ -31,7 +16,6 @@
     "balanced-match@4.0.4": ["prepare"],
     "brace-expansion@5.0.9": ["prepare"],
     "content-type@1.0.5": ["prepare"],
-    "esbuild@0.28.1": ["postinstall"],
     "eslint-visitor-keys@5.0.1": ["prepare"],
     "eventsource@3.0.7": ["prepare"],
     "express-rate-limit@8.5.2": ["prepare"],
@@ -54,6 +38,177 @@
     "zod-validation-error@4.0.2": ["prepare"],
     "content-type@2.0.0": ["prepare"],
     "eslint-visitor-keys@3.4.3": ["prepare"]
+  },
+  "ownedPreparations": {
+    "esbuild@0.28.1": {
+      "lifecycle": "postinstall",
+      "manifestPath": "node_modules/esbuild/package.json",
+      "manifestSha256": "d55d1d19fcc5b6079e4a71dd4111340c79c682bc36835ac7058a0c364c7db58a",
+      "lockfile": {
+        "path": "node_modules/esbuild",
+        "version": "0.28.1",
+        "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+        "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="
+      },
+      "platforms": {
+        "aix ppc64 BE": {
+          "package": "@esbuild/aix-ppc64",
+          "version": "0.28.1",
+          "manifestSha256": "c1edcdae4e205c937d4388898214151952d4f91f2b54b581e0cc3fe8b20c6972",
+          "binaryPath": "bin/esbuild"
+        },
+        "android arm LE": {
+          "package": "@esbuild/android-arm",
+          "version": "0.28.1",
+          "manifestSha256": "1dbe7a9d9aa3ca653a242e16fc20fd22078f2f7fdf71017fbc23f1a66d6db2a9",
+          "binaryPath": "bin/esbuild"
+        },
+        "android arm64 LE": {
+          "package": "@esbuild/android-arm64",
+          "version": "0.28.1",
+          "manifestSha256": "2b2092d3b64a478d1e12e5ddd7089e4467c188fab9d10c06f43d4565278b332e",
+          "binaryPath": "bin/esbuild"
+        },
+        "android x64 LE": {
+          "package": "@esbuild/android-x64",
+          "version": "0.28.1",
+          "manifestSha256": "15b54f3923932994b318c9f18d01ed3eca1c79e5ace09bd11782cc67b69c4a4f",
+          "binaryPath": "bin/esbuild"
+        },
+        "darwin arm64 LE": {
+          "package": "@esbuild/darwin-arm64",
+          "version": "0.28.1",
+          "manifestSha256": "4741fe8d75953474f275402d367368cf49c242b2bc04b85e25bad14bfd26eaad",
+          "binaryPath": "bin/esbuild"
+        },
+        "darwin x64 LE": {
+          "package": "@esbuild/darwin-x64",
+          "version": "0.28.1",
+          "manifestSha256": "a81c32a64667a9319c0cf8037094060f76e51cc8a847f7fa877623dd52bbcd1e",
+          "binaryPath": "bin/esbuild"
+        },
+        "freebsd arm64 LE": {
+          "package": "@esbuild/freebsd-arm64",
+          "version": "0.28.1",
+          "manifestSha256": "457b7275d91fd02d57f13799975c082b7eea3d9934cf7c2734a3c8950a3b8cb9",
+          "binaryPath": "bin/esbuild"
+        },
+        "freebsd x64 LE": {
+          "package": "@esbuild/freebsd-x64",
+          "version": "0.28.1",
+          "manifestSha256": "e0d180385a3abbdcf699b418948d5613cb33cc88e370fa7a7edaad722d53882a",
+          "binaryPath": "bin/esbuild"
+        },
+        "linux arm LE": {
+          "package": "@esbuild/linux-arm",
+          "version": "0.28.1",
+          "manifestSha256": "adc308e0459da082e2f69138ae0acaa74e2bf8a69f985282fac15ac90baddffb",
+          "binaryPath": "bin/esbuild"
+        },
+        "linux arm64 LE": {
+          "package": "@esbuild/linux-arm64",
+          "version": "0.28.1",
+          "manifestSha256": "92e8de40ebe8c9ecacec55a3ef23dc796aadba48015390af9e5c6798e87802de",
+          "binaryPath": "bin/esbuild"
+        },
+        "linux ia32 LE": {
+          "package": "@esbuild/linux-ia32",
+          "version": "0.28.1",
+          "manifestSha256": "d6139a19ea7a763671952808a9c0bf9c932be525754b441e84db9f9fb9542b46",
+          "binaryPath": "bin/esbuild"
+        },
+        "linux loong64 LE": {
+          "package": "@esbuild/linux-loong64",
+          "version": "0.28.1",
+          "manifestSha256": "8fe27efef2260c80909677718d00d7df6cae359f68a07d38743e3880706fa6dc",
+          "binaryPath": "bin/esbuild"
+        },
+        "linux mips64el LE": {
+          "package": "@esbuild/linux-mips64el",
+          "version": "0.28.1",
+          "manifestSha256": "5a9873c35926488a1d41009ac6881ec8a9410b5a499cfe239649269503db8158",
+          "binaryPath": "bin/esbuild"
+        },
+        "linux ppc64 LE": {
+          "package": "@esbuild/linux-ppc64",
+          "version": "0.28.1",
+          "manifestSha256": "f117c1fcfdf2ea5d6ed35c22058678a4ac3fb269d923252aa55127aee4e67bd7",
+          "binaryPath": "bin/esbuild"
+        },
+        "linux riscv64 LE": {
+          "package": "@esbuild/linux-riscv64",
+          "version": "0.28.1",
+          "manifestSha256": "f1d849e980474836849b1d04c3ab3e60d681c73edf704fcc03ab84d631bf92f5",
+          "binaryPath": "bin/esbuild"
+        },
+        "linux s390x BE": {
+          "package": "@esbuild/linux-s390x",
+          "version": "0.28.1",
+          "manifestSha256": "161386c2aa7326763740d2b5e414cc127c98e01ce47b32a49c5bb5878e4c2d96",
+          "binaryPath": "bin/esbuild"
+        },
+        "linux x64 LE": {
+          "package": "@esbuild/linux-x64",
+          "version": "0.28.1",
+          "manifestSha256": "2332dc7d04175b16730f136b5bf32b31203eecea5be03b66e9453a4658b3d971",
+          "binaryPath": "bin/esbuild"
+        },
+        "netbsd arm64 LE": {
+          "package": "@esbuild/netbsd-arm64",
+          "version": "0.28.1",
+          "manifestSha256": "28a59c1a2bd06e4094965d237663ca02760aec2cf0d5e121937ddf71465a54a0",
+          "binaryPath": "bin/esbuild"
+        },
+        "netbsd x64 LE": {
+          "package": "@esbuild/netbsd-x64",
+          "version": "0.28.1",
+          "manifestSha256": "e2f8202d1cc9b6c506db2f89bf4b46b60f7cb0566593b481f7a18bfbd8d7bfa6",
+          "binaryPath": "bin/esbuild"
+        },
+        "openbsd arm64 LE": {
+          "package": "@esbuild/openbsd-arm64",
+          "version": "0.28.1",
+          "manifestSha256": "8945e19e2acc6096985464fa2ed12ecf26991d9bc10073a9a61353cfd6ad0b6f",
+          "binaryPath": "bin/esbuild"
+        },
+        "openbsd x64 LE": {
+          "package": "@esbuild/openbsd-x64",
+          "version": "0.28.1",
+          "manifestSha256": "7daae7ac079d46a97aa0ccfaa7011dded7b0f62db5155009c8c01ba1713abc8d",
+          "binaryPath": "bin/esbuild"
+        },
+        "openharmony arm64 LE": {
+          "package": "@esbuild/openharmony-arm64",
+          "version": "0.28.1",
+          "manifestSha256": "2b687919e64fb175a08a0b08dfeaff72421f1f6eca00bd34157a2b38092bcd4d",
+          "binaryPath": "bin/esbuild"
+        },
+        "sunos x64 LE": {
+          "package": "@esbuild/sunos-x64",
+          "version": "0.28.1",
+          "manifestSha256": "38cf4162a527cfa9c5773bce2fcb7533f3ac1c38ee8bd596ff33c88dfda2a689",
+          "binaryPath": "bin/esbuild"
+        },
+        "win32 arm64 LE": {
+          "package": "@esbuild/win32-arm64",
+          "version": "0.28.1",
+          "manifestSha256": "3fd5be3bed3cec3847eceac5f2af62db5ae43097a4644a9641a8669048ca8cac",
+          "binaryPath": "esbuild.exe"
+        },
+        "win32 ia32 LE": {
+          "package": "@esbuild/win32-ia32",
+          "version": "0.28.1",
+          "manifestSha256": "338c5cfca02c73521a88fa5d831534d2022cc26c0929fa7b8ab1cd730177ae49",
+          "binaryPath": "esbuild.exe"
+        },
+        "win32 x64 LE": {
+          "package": "@esbuild/win32-x64",
+          "version": "0.28.1",
+          "manifestSha256": "4a63b84fa1059fef348e29e3a39c26168213bb7f0aa1ac0174e439cc1e62a9f8",
+          "binaryPath": "esbuild.exe"
+        }
+      }
+    }
   },
   "allowedBindingGyp": [],
   "reviewedConnectorInventory": "security/connector-inventory.json"

--- a/src/artifacts/ClaudeScienceCloningDesignWorkspace.tsx
+++ b/src/artifacts/ClaudeScienceCloningDesignWorkspace.tsx
@@ -52,6 +52,8 @@ export type ClaudeScienceCloningPrimerRequest = {
   actionIds: string[];
   recordIds: string[];
   junctionIndexes: number[];
+  /** Explicit opt-in for preloading exact Gibson overlaps as editable tails. */
+  autoInferHomologyTails?: boolean;
 };
 
 export type ClaudeScienceCloningSavePayload = {
@@ -272,6 +274,7 @@ export const ClaudeScienceCloningDesignWorkspace = forwardRef<
   const [gibsonTopology, setGibsonTopology] = useState<'linear' | 'circular'>('linear');
   const [minOverlap, setMinOverlap] = useState(20);
   const [maxOverlap, setMaxOverlap] = useState(60);
+  const [autoInferHomologyTails, setAutoInferHomologyTails] = useState(false);
   const [search, setSearch] = useState('');
   const [candidateId, setCandidateId] = useState('');
   const [dragIndex, setDragIndex] = useState<number | null>(null);
@@ -579,6 +582,7 @@ export const ClaudeScienceCloningDesignWorkspace = forwardRef<
         junctionIndexes: unique(actions.flatMap((action) => (
           action.junctionIndex === undefined ? [] : [String(action.junctionIndex)]
         ))).map(Number),
+        ...(autoInferHomologyTails ? { autoInferHomologyTails: true } : {}),
       });
       setStatus(actions.length === 1
         ? 'Primer workspace opened for the selected preparation item.'
@@ -588,7 +592,7 @@ export const ClaudeScienceCloningDesignWorkspace = forwardRef<
     } finally {
       setBusy(null);
     }
-  }, [busy, method, onDesignPrimers, plan]);
+  }, [autoInferHomologyTails, busy, method, onDesignPrimers, plan]);
 
   const save = useCallback(async (intent: SaveIntent) => {
     const name = currentName.trim();
@@ -876,6 +880,15 @@ export const ClaudeScienceCloningDesignWorkspace = forwardRef<
                       />
                       <small>bp</small>
                     </span>
+                  </label>
+                  <label className="motif-cs-cloning-design-check-field">
+                    <input
+                      type="checkbox"
+                      name="gibson-auto-infer-homology-tails"
+                      checked={autoInferHomologyTails}
+                      onChange={(event) => setAutoInferHomologyTails(event.target.checked)}
+                    />
+                    <span>Preload exact overlaps as editable 5′ tails <small>(opt in)</small></span>
                   </label>
                 </div>
               )}

--- a/src/artifacts/ClaudeSciencePrimerWorkspace.tsx
+++ b/src/artifacts/ClaudeSciencePrimerWorkspace.tsx
@@ -75,7 +75,10 @@ export type ClaudeSciencePrimerExport = ClaudeSciencePrimerHandoff & {
 
 export type ClaudeSciencePrimerWorkspaceProps = {
   record: ClaudeSciencePrimerRecord;
+  /** Live host selection used for sequence context and the optional reset action. */
   selectedRange?: { start: number; end: number } | null;
+  /** Explicit design target owned by the workspace host; null means use the whole-record default. */
+  targetRange?: { start: number; end: number } | null;
   onClose: () => void;
   onSelectRange?: (start: number, end: number) => void;
   onCopy?: (label: string, value: string) => void | Promise<void>;
@@ -268,6 +271,7 @@ function Metric({ label, value, state }: { label: string; value: string; state?:
 export function ClaudeSciencePrimerWorkspace({
   record,
   selectedRange = null,
+  targetRange,
   onClose,
   onSelectRange,
   onCopy,
@@ -291,10 +295,13 @@ export function ClaudeSciencePrimerWorkspace({
   const validationMessageId = useId();
   const workspaceRef = useRef<HTMLElement>(null);
   const initialFocusRef = useRef<HTMLButtonElement>(null);
+  const effectiveTargetRange = targetRange === undefined ? selectedRange : targetRange;
   const initialTarget = useMemo(
-    () => defaultTarget(record.sequence.length, selectedRange, initialIntent === 'cloning'),
-    [initialIntent, record.sequence.length, selectedRange],
+    () => defaultTarget(record.sequence.length, effectiveTargetRange, initialIntent === 'cloning'),
+    [effectiveTargetRange, initialIntent, record.sequence.length],
   );
+  const selectedRangeKey = selectedRange ? `${selectedRange.start}:${selectedRange.end}` : '';
+  const previewRangeKeyRef = useRef<string | null>(null);
   const initialPreset = initialPresetForIntent(initialIntent);
   const [intent, setIntent] = useState<ClaudeSciencePrimerIntent>(initialIntent);
   const [presetId, setPresetId] = useState(initialPreset.id);
@@ -315,10 +322,15 @@ export function ClaudeSciencePrimerWorkspace({
   const [busyAction, setBusyAction] = useState('');
 
   useEffect(() => {
+    if (previewRangeKeyRef.current && previewRangeKeyRef.current === selectedRangeKey) {
+      previewRangeKeyRef.current = null;
+      return;
+    }
+    previewRangeKeyRef.current = null;
     setTargetStart(initialTarget.start);
     setTargetEnd(initialTarget.end);
     setSelectedPairIndex(0);
-  }, [initialTarget.end, initialTarget.start, record.id]);
+  }, [initialTarget.end, initialTarget.start, record.id, selectedRangeKey]);
 
   useEffect(() => {
     const preset = initialPresetForIntent(initialIntent);
@@ -448,6 +460,7 @@ export function ClaudeSciencePrimerWorkspace({
   }) : null, [intent, pairs, parameters, preparationContext, record.id, record.name, selectedPair, targetEnd, targetStart]);
 
   const applyPreset = useCallback((preset: PrimerPreset) => {
+    previewRangeKeyRef.current = null;
     setPresetId(preset.id);
     setIntent(preset.intent);
     setMinLength(preset.minLength);
@@ -462,6 +475,7 @@ export function ClaudeSciencePrimerWorkspace({
   }, []);
 
   const markCustom = useCallback(() => {
+    previewRangeKeyRef.current = null;
     setPresetId('custom');
     setSelectedPairIndex(0);
   }, []);
@@ -470,6 +484,7 @@ export function ClaudeSciencePrimerWorkspace({
     const pair = pairs[index];
     if (!pair) return;
     setSelectedPairIndex(index);
+    previewRangeKeyRef.current = `${pair.forward.start}:${pair.reverse.end}`;
     onSelectRange?.(pair.forward.start, pair.reverse.end);
     setStatus(`Pair ${index + 1} selected on the sequence.`);
   }, [onSelectRange, pairs]);
@@ -627,7 +642,7 @@ export function ClaudeSciencePrimerWorkspace({
               </label>
             </div>
             {selectedRange ? (
-              <button className="motif-cs-primer-text-button" type="button" onClick={() => { const next = defaultTarget(normalizedSequence.length, selectedRange); setTargetStart(next.start); setTargetEnd(next.end); setSelectedPairIndex(0); }}>
+              <button className="motif-cs-primer-text-button" type="button" onClick={() => { previewRangeKeyRef.current = null; const next = defaultTarget(normalizedSequence.length, selectedRange); setTargetStart(next.start); setTargetEnd(next.end); setSelectedPairIndex(0); }}>
                 Use current selection ({selectedRange.start + 1}–{selectedRange.end})
               </button>
             ) : null}

--- a/src/artifacts/__tests__/ClaudeSciencePrimerWorkspace.jsdom.test.tsx
+++ b/src/artifacts/__tests__/ClaudeSciencePrimerWorkspace.jsdom.test.tsx
@@ -2,6 +2,7 @@
 
 import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ClaudeSciencePrimerWorkspace,
@@ -42,6 +43,18 @@ function preparationContext(overrides: Partial<ClaudeSciencePrimerPreparationCon
     fusionSites: { left: 'AATG', right: 'GCTT' },
     ...overrides,
   };
+}
+
+function EchoingPrimerHost() {
+  const [selectedRange, setSelectedRange] = useState({ start: 350, end: 750 });
+  return (
+    <ClaudeSciencePrimerWorkspace
+      {...props({
+        selectedRange,
+        onSelectRange: (start, end) => setSelectedRange({ start, end }),
+      })}
+    />
+  );
 }
 
 afterEach(() => {
@@ -179,6 +192,26 @@ describe('ClaudeSciencePrimerWorkspace', () => {
     expect(options[1].getAttribute('aria-selected')).toBe('true');
     expect(onSelectRange).toHaveBeenCalledTimes(1);
     expect(onSelectRange.mock.calls[0][0]).toBeLessThan(onSelectRange.mock.calls[0][1]);
+  });
+
+  it('keeps the explicit target and focus when the host echoes a pair preview selection', async () => {
+    const user = userEvent.setup();
+    render(<EchoingPrimerHost />);
+    const workspace = screen.getByRole('dialog', { name: 'Primer design' });
+    const listbox = within(workspace).getByRole('listbox', { name: 'Ranked primer pairs' });
+    const options = within(listbox).getAllByRole('option');
+
+    options[0].focus();
+    await user.keyboard('{ArrowDown}');
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Target start') as HTMLInputElement).value).toBe('351');
+      expect((screen.getByLabelText('Target end') as HTMLInputElement).value).toBe('750');
+      expect(within(listbox).getAllByRole('option')[1].getAttribute('aria-selected')).toBe('true');
+      expect(screen.getByRole('region', { name: 'Primer pair 2 evidence' })).toBeTruthy();
+      expect(screen.getByRole('status').textContent).toContain('Pair 2 selected on the sequence.');
+      expect(within(listbox).getAllByRole('option')[1]).toBe(document.activeElement);
+    });
   });
 
   it('hands the selected pair to copy, export, annotations, PCR, and cloning callbacks', async () => {

--- a/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
@@ -179,7 +179,13 @@ describe('Claude Science rail popover regression guards', () => {
     expect(artifactSource).toContain('data-testid="open-primer-workspace"');
     expect(artifactSource).toContain('<ClaudeSciencePrimerWorkspace');
     expect(artifactSource).toContain('selectedRange={cloningPrimerRequest ? null : guideScopeRange}');
+    expect(artifactSource).toContain('targetRange={cloningPrimerRequest ? null : primerTargetRange}');
+    expect(artifactSource).toContain('setPrimerTargetRange(guideScopeRange ? { ...guideScopeRange } : null);');
+    expect(artifactSource).toContain('setPrimerTargetRange(null);');
     expect(primerWorkspaceSource).toContain('targetStart: targetStart - 1');
+    expect(primerWorkspaceSource).toContain('const previewRangeKeyRef = useRef<string | null>(null);');
+    expect(primerWorkspaceSource).toContain('previewRangeKeyRef.current === selectedRangeKey');
+    expect(primerWorkspaceSource).toContain('previewRangeKeyRef.current = `${pair.forward.start}:${pair.reverse.end}`;');
     expect(artifactSource).toContain('const addFeatures = useCallback((featureInputs: readonly ArtifactFeatureInput[]) => {');
     expect(primerWorkspaceSource).toContain('primerToFeature(handoff.pair.forward');
     expect(primerWorkspaceSource).toContain('primerToFeature(handoff.pair.reverse');
@@ -269,7 +275,7 @@ describe('Claude Science rail popover regression guards', () => {
     expect(artifactSource).toContain('data-rail-tool="settings"');
     expect(artifactSource).toContain('<Settings className="motif-cs-panel-icon"');
     expect(artifactSource).toContain('<strong>Motif for Claude Science</strong>');
-    expect(artifactSource).toContain("const MOTIF_ARTIFACT_VERSION = '0.3.1';");
+    expect(artifactSource).toContain("const MOTIF_ARTIFACT_VERSION = '0.3.2';");
     expect(artifactSource).toContain('Version {MOTIF_ARTIFACT_VERSION} · Build {MOTIF_ARTIFACT_BUILD_LABEL}');
     expect(artifactSource).not.toContain('__APP_VERSION__');
     expect(artifactSource).toContain('Motif is an open-source, AI-native molecular biology suite for researchers.');

--- a/src/artifacts/claude-science-assembly-workflows.ts
+++ b/src/artifacts/claude-science-assembly-workflows.ts
@@ -14,6 +14,7 @@ import {
   type ArtifactWorkflowResult,
 } from './claude-science-workspace-collections';
 import { sha256HexSync } from './claude-science-sha256';
+import { materializeGoldenGateFlankSpacers } from './claude-science-golden-gate-normalization';
 
 /**
  * Pure planning helpers for the standalone Claude Science artifact.
@@ -825,7 +826,10 @@ export function planArtifactGoldenGateAssembly(input: {
     }
 
     const boundary = getGoldenGatePartBoundary(
-      { name: part.name, sequence: part.sequence },
+      {
+        name: part.name,
+        sequence: materializeGoldenGateFlankSpacers(part.sequence, enzyme.name).sequence,
+      },
       enzyme.name,
     );
     const partWarnings: ArtifactAssemblyIssue[] = [];

--- a/src/artifacts/claude-science-cloning-design.ts
+++ b/src/artifacts/claude-science-cloning-design.ts
@@ -18,6 +18,7 @@ import {
 import { analyzeOverlap, gibsonAssemble, type OverlapSearchResult } from '../bio/gibson-assembly';
 import { reverseComplement } from '../bio/reverse-complement';
 import { sha256HexSync } from './claude-science-sha256';
+import { materializeGoldenGateFlankSpacers } from './claude-science-golden-gate-normalization';
 
 /**
  * Store-free cloning adapters for the standalone Claude Science artifact.
@@ -904,7 +905,10 @@ export function planArtifactGoldenGateDesign(input: ArtifactGoldenGateProfileInp
         ? normalized.inputs.map(() => 'transcription_unit' as const)
         : organizationMode === 'golden_braid_tu'
           ? normalized.inputs.map((part) => classifyValidatedGoldenBraidBoundary(
-            getGoldenGatePartBoundary({ name: part.name, sequence: part.sequence }, enzyme),
+            getGoldenGatePartBoundary({
+              name: part.name,
+              sequence: materializeGoldenGateFlankSpacers(part.sequence, enzyme).sequence,
+            }, enzyme),
           ))
           : undefined,
     )
@@ -920,7 +924,10 @@ export function planArtifactGoldenGateDesign(input: ArtifactGoldenGateProfileInp
 
   const parts: ArtifactGoldenGatePartPreparation[] = canEvaluate && organization
     ? normalized.inputs.map((part, index) => {
-      const boundary = getGoldenGatePartBoundary({ name: part.name, sequence: part.sequence }, enzyme);
+      const boundary = getGoldenGatePartBoundary({
+        name: part.name,
+        sequence: materializeGoldenGateFlankSpacers(part.sequence, enzyme).sequence,
+      }, enzyme);
       const assignment = organization.assignments[index];
       const rawPart = rawParts[index];
       const requestedBoundary = requestedFusionBoundaries[index] ?? { left: null, right: null };
@@ -1064,7 +1071,11 @@ export function planArtifactGoldenGateDesign(input: ArtifactGoldenGateProfileInp
     && parts.every((part) => part.status === 'ready')
     && (organizationMode === 'freeform' || identityValidation.valid)
     ? goldenGateAssemble(
-      normalized.inputs.map((part) => ({ id: part.recordId, name: part.name, sequence: part.sequence })),
+      normalized.inputs.map((part) => ({
+        id: part.recordId,
+        name: part.name,
+        sequence: materializeGoldenGateFlankSpacers(part.sequence, enzyme).sequence,
+      })),
       enzyme,
     )
     : null;

--- a/src/artifacts/claude-science-digest-recipe.ts
+++ b/src/artifacts/claude-science-digest-recipe.ts
@@ -13,6 +13,7 @@ import type {
   SequenceType,
   Topology,
 } from '../bio/types';
+import { isActiveDoubleStrandRestrictionSite } from '../bio/restriction-sites';
 
 export type DigestRecipeIssueCode =
   | 'empty-enzyme-list'
@@ -25,7 +26,8 @@ export type DigestRecipeIssueCode =
   | 'methylation_unknown'
   | 'methylation_unmethylated'
   | 'methylation_context_unknown'
-  | 'invalid_geometry';
+  | 'invalid_geometry'
+  | 'incompatible_colocated_cleavage';
 
 export interface DigestRecipeIssue {
   code: DigestRecipeIssueCode;
@@ -227,12 +229,12 @@ export function buildDigestRecipe(input: BuildDigestRecipeInput): DigestRecipe {
   const enzymes = resolution.enzymes.map((enzyme): DigestRecipeEnzyme => {
     const enzymeSites = sites.filter((site) => site.enzyme.toLocaleLowerCase() === enzyme.name.toLocaleLowerCase());
     const cutSites = enzymeSites.filter((site) => (
-      (site.cleavageMode ?? 'double-strand') === 'double-strand'
-      && (site.cleavageStatus ?? 'ok') === 'ok'
+      isActiveDoubleStrandRestrictionSite(site)
     ));
     const nickSites = enzymeSites.filter((site) => (
-      (site.cleavageMode ?? 'double-strand') !== 'double-strand'
-      && (site.cleavageStatus ?? 'ok') === 'ok'
+      site.cleavageMode !== undefined
+      && site.cleavageStatus === 'ok'
+      && !isActiveDoubleStrandRestrictionSite(site)
     ));
     const methylationEvidence = enzyme.methylationEvidence ?? enzyme.methylationRequirement?.evidence;
     return {

--- a/src/artifacts/claude-science-digest-workflow.ts
+++ b/src/artifacts/claude-science-digest-workflow.ts
@@ -5,6 +5,7 @@ import {
   type RemappedFeatureLocation,
 } from '../bio/feature-location';
 import type { Feature, SequenceType, Topology } from '../bio/types';
+import { isActiveDoubleStrandRestrictionSite } from '../bio/restriction-sites';
 import type { DigestRecipe } from './claude-science-digest-recipe';
 import {
   MAX_ARTIFACT_ID_LENGTH,
@@ -335,10 +336,7 @@ function validateRecipe(source: DigestWorkflowSourceRecord, recipe: DigestRecipe
   // Recognition sites that are nicks, methylation-conditional, or physically
   // out of bounds are not ordinary double-strand digest boundaries.
   const distinctCuts = new Set(recipe.sites
-    .filter((site) => (
-      (site.cleavageMode ?? 'double-strand') === 'double-strand'
-      && (site.cleavageStatus ?? 'ok') === 'ok'
-    ))
+    .filter(isActiveDoubleStrandRestrictionSite)
     .map((site) => site.cutPosition));
   if (distinctCuts.size !== recipe.cutCount) {
     fail('incoherent-recipe', 'Digest recipe cut count does not match its distinct physical cut coordinates.');

--- a/src/artifacts/claude-science-golden-gate-normalization.ts
+++ b/src/artifacts/claude-science-golden-gate-normalization.ts
@@ -1,0 +1,56 @@
+import { getGoldenGateEnzyme } from '../bio/golden-gate';
+import { reverseComplement } from '../bio/reverse-complement';
+
+/**
+ * Legacy artifact records sometimes use a single N as a cut-site spacer in
+ * an otherwise fully specified Type IIS flank. The bio engine deliberately
+ * rejects ambiguous bases; this adapter-only materialization keeps those
+ * records readable without weakening the engine's strict contract.
+ */
+export type GoldenGateSpacerMaterialization = {
+  sequence: string;
+  /** Source offsets whose synthetic spacer was deterministically materialized. */
+  positions: number[];
+};
+
+export function materializeGoldenGateFlankSpacers(
+  sequence: string,
+  enzymeName: string,
+): GoldenGateSpacerMaterialization {
+  const normalized = sequence.replace(/\s+/g, '').toUpperCase();
+  const enzyme = getGoldenGateEnzyme(enzymeName);
+  if (!enzyme || normalized.length === 0) return { sequence: normalized, positions: [] };
+
+  const recognition = enzyme.recognitionSequence.toUpperCase();
+  const reverseRecognition = reverseComplement(recognition).toUpperCase();
+  const senseStart = normalized.indexOf(recognition);
+  const antisenseStart = senseStart === -1
+    ? -1
+    : normalized.indexOf(reverseRecognition, senseStart + recognition.length);
+  if (senseStart === -1 || antisenseStart === -1 || senseStart >= antisenseStart) {
+    return { sequence: normalized, positions: [] };
+  }
+
+  const overhangLength = enzyme.complementCutOffset - enzyme.cutOffset;
+  const chars = normalized.split('');
+  const positions = new Set<number>();
+  const materialize = (start: number, end: number): void => {
+    for (let position = Math.max(0, start); position < Math.min(chars.length, end); position += 1) {
+      if (chars[position] !== 'N') continue;
+      chars[position] = 'A';
+      positions.add(position);
+    }
+  };
+
+  // Synthetic records place an unspecified spacer between the recognition
+  // sequence and the inward-facing overhang on each side. Never rewrite the
+  // released insert or an arbitrary ambiguous base elsewhere in the record.
+  materialize(
+    senseStart + recognition.length,
+    Math.min(senseStart + enzyme.cutOffset, antisenseStart),
+  );
+  const rightCutStart = antisenseStart + recognition.length - enzyme.complementCutOffset;
+  materialize(rightCutStart + overhangLength, antisenseStart);
+
+  return { sequence: chars.join(''), positions: [...positions].sort((left, right) => left - right) };
+}

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -228,7 +228,7 @@ import {
 } from './claude-science-download';
 import './motif-artifact.css';
 
-const MOTIF_ARTIFACT_VERSION = '0.3.1';
+const MOTIF_ARTIFACT_VERSION = '0.3.2';
 const MOTIF_ARTIFACT_BUILD_ID = (() => {
   if (typeof document === 'undefined') return 'development';
   const value = document.querySelector<HTMLMetaElement>('meta[name="motif-build-id"]')?.content.trim() ?? '';
@@ -622,7 +622,13 @@ function restrictionEnzymesForSources(
   if (sources.length > 0) {
     for (const enzyme of resolveEnzymeUnion(sources)) byName.set(enzyme.name.toLowerCase(), enzyme);
   }
-  for (const enzyme of customEnzymes) byName.set(enzyme.name.toLowerCase(), enzyme);
+  for (const enzyme of customEnzymes) {
+    const key = enzyme.name.toLowerCase();
+    // Restored legacy custom state may contain a catalog name without the
+    // catalog's physical or methylation metadata. Built-in identities always
+    // win; only genuinely custom names are accepted from this layer.
+    byName.set(key, fullEnzymeByLowerName.get(key) ?? enzyme);
+  }
   return Array.from(byName.values());
 }
 
@@ -1866,6 +1872,15 @@ function normalizeSitePosition(position: unknown, defaultIndexBase: 0 | 1): numb
   return raw === 0 ? 0 : raw - 1;
 }
 
+/** Preserve signed physical cut coordinates so out-of-bounds sites remain
+ * explicitly unsafe instead of losing their safety receipt during restore. */
+function normalizeSiteCutCoordinate(position: unknown, defaultIndexBase: 0 | 1): number | null | undefined {
+  if (position === null) return null;
+  if (!Number.isFinite(position)) return undefined;
+  const raw = Math.floor(Number(position));
+  return defaultIndexBase === 0 ? raw : raw === 0 ? 0 : raw - 1;
+}
+
 function normalizeSites(sites: readonly InventorySiteInput[] | undefined, sequenceLength: number): RestrictionSite[] {
   if (!Array.isArray(sites) || sequenceLength <= 0) return [];
   const normalized: RestrictionSite[] = [];
@@ -1886,12 +1901,17 @@ function normalizeSites(sites: readonly InventorySiteInput[] | undefined, sequen
       const hitIndexBase = hit.indexBase === 0 || hit.indexBase === 1 ? hit.indexBase : defaultIndexBase;
       const position = normalizeSitePosition(hit.position, hitIndexBase);
       if (position === null || position >= sequenceLength) continue;
-      const cutPosition = normalizeSitePosition(hit.cutPosition, hitIndexBase)
-        ?? ((position + (enzyme?.cutOffset ?? 0)) % sequenceLength);
+      const normalizedCutPosition = normalizeSiteCutCoordinate(hit.cutPosition, hitIndexBase);
+      const cutPosition = normalizedCutPosition === undefined || normalizedCutPosition === null
+        ? ((position + (enzyme?.cutOffset ?? 0)) % sequenceLength)
+        : normalizedCutPosition;
+      const topCutPosition = normalizeSiteCutCoordinate(hit.topCutPosition, hitIndexBase);
+      const bottomCutPosition = normalizeSiteCutCoordinate(hit.bottomCutPosition, hitIndexBase);
       const cleavageStatus = hit.cleavageStatus === 'ok'
         || hit.cleavageStatus === 'insufficient_flanking_bases'
         || hit.cleavageStatus === 'methylation_unknown'
         || hit.cleavageStatus === 'methylation_unmethylated'
+        || hit.cleavageStatus === 'methylation_context_unknown'
         || hit.cleavageStatus === 'invalid_geometry'
         ? hit.cleavageStatus
         : undefined;
@@ -1907,12 +1927,8 @@ function normalizeSites(sites: readonly InventorySiteInput[] | undefined, sequen
         ...(site.cleavageMode === 'double-strand' || site.cleavageMode === 'nick_top' || site.cleavageMode === 'nick_bottom'
           ? { cleavageMode: site.cleavageMode }
           : {}),
-        ...(hit.topCutPosition === null || (typeof hit.topCutPosition === 'number' && Number.isFinite(hit.topCutPosition))
-          ? { topCutPosition: hit.topCutPosition }
-          : {}),
-        ...(hit.bottomCutPosition === null || (typeof hit.bottomCutPosition === 'number' && Number.isFinite(hit.bottomCutPosition))
-          ? { bottomCutPosition: hit.bottomCutPosition }
-          : {}),
+        ...(topCutPosition !== undefined ? { topCutPosition } : {}),
+        ...(bottomCutPosition !== undefined ? { bottomCutPosition } : {}),
         ...(cleavageStatus === undefined ? {} : { cleavageStatus }),
       });
     }
@@ -5314,6 +5330,10 @@ function App() {
   const [translationsWin, setTranslationsWin] = useState<WindowRect>(defaultTranslationsWindowRect);
   const [showPrimerDesign, setShowPrimerDesign] = useState(false);
   const [primerWin, setPrimerWin] = useState<WindowRect>(defaultPrimerWindowRect);
+  // Primer design owns its target once the workspace opens. Pair previews still
+  // update the shared sequence selection for context, but that preview must not
+  // become a new design target and reorder the ranked pairs underneath focus.
+  const [primerTargetRange, setPrimerTargetRange] = useState<MapSelectionRange | null>(null);
   const [cloningPrimerRequest, setCloningPrimerRequest] = useState<ClaudeScienceCloningPrimerRequest | null>(null);
   const [cloningPrimerRecordIndex, setCloningPrimerRecordIndex] = useState(0);
   const [completedCloningPrimerActionIds, setCompletedCloningPrimerActionIds] = useState<string[]>([]);
@@ -5651,6 +5671,7 @@ function App() {
   const cloningPrimerInitialTails = useMemo(() => {
     if (
       !cloningPrimerRequest
+      || cloningPrimerRequest.autoInferHomologyTails !== true
       || cloningPrimerRequest.plan.kind !== 'gibson_design'
       || !activeCloningPrimerItem
       || cloningPrimerContext?.orientation !== 'forward'
@@ -5659,6 +5680,12 @@ function App() {
       ? null
       : cloningPrimerRequest.plan.junctions[activeCloningPrimerItem.action.junctionIndex] ?? null;
     if (!junction?.overlapSequence) return { forward: undefined, reverse: undefined };
+    if (
+      !/^[ACGT]+$/.test(junction.overlapSequence)
+      || junction.overlapLength !== junction.overlapSequence.length
+      || junction.overlapState !== 'exact'
+      || junction.overlapUnique !== true
+    ) return { forward: undefined, reverse: undefined };
     if (activeCloningPrimerItem.recordId === junction.rightRecordId) {
       return { forward: junction.overlapSequence, reverse: undefined };
     }
@@ -9665,12 +9692,14 @@ function App() {
     setShowCloningDesign(false);
     setShowConstructVerification(false);
     setCloningPrimerRequest(null);
+    setPrimerTargetRange(guideScopeRange ? { ...guideScopeRange } : null);
     setShowPrimerDesign(true);
-  }, [closeOpenToolDetails, isEditable]);
+  }, [closeOpenToolDetails, guideScopeRange, isEditable]);
 
   const closePrimerWorkspace = useCallback(() => {
     const returnsToCloningDraft = cloningPrimerRequest !== null;
     setShowPrimerDesign(false);
+    setPrimerTargetRange(null);
     if (returnsToCloningDraft) showWorkbenchNotice('Returned to the existing cloning draft.');
   }, [cloningPrimerRequest, showWorkbenchNotice]);
 
@@ -9823,6 +9852,7 @@ function App() {
     selectRecord(targetId);
     setSelection(null);
     setMapRangesByRecord((current) => current[targetId] ? { ...current, [targetId]: null } : current);
+    setPrimerTargetRange(null);
     setCloningPrimerRecordIndex(0);
     setCompletedCloningPrimerActionIds([]);
     setCloningPrimerRequest(request);
@@ -12779,6 +12809,7 @@ function App() {
               molecule: sequenceType === 'rna' ? 'rna' : 'dna',
             }}
             selectedRange={cloningPrimerRequest ? null : guideScopeRange}
+            targetRange={cloningPrimerRequest ? null : primerTargetRange}
             initialIntent={cloningPrimerRequest ? 'cloning' : 'pcr'}
             preparationContext={cloningPrimerContext}
             initialForwardTail={cloningPrimerInitialTails.forward}

--- a/src/artifacts/motif-for-claude-science-plugin/.claude-plugin/plugin.json
+++ b/src/artifacts/motif-for-claude-science-plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "motif-for-claude-science",
   "displayName": "Motif for Claude Science",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Motif creates a portable molecular-biology workbench with alignment, Sanger review, cloning design, typed results, and recovery workflows.",
   "author": {
     "name": "Jacob Vogan"

--- a/src/artifacts/motif-for-claude-science-plugin/CHANGELOG.md
+++ b/src/artifacts/motif-for-claude-science-plugin/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.2 — 2026-08-08
+
+- Unified restriction geometry and methylation behavior across catalog views,
+  preserved typed cleavage state across serialization, and kept quarantined
+  annotations out of derived records.
+- Corrected mismatch-aware PCR products, explicit primer tails, cross-dimer
+  ranking, strict Golden Gate input, exact vector spacers, and specialized CDS
+  translation semantics.
+- Hardened dependency preparation, connector configuration, CI baselines,
+  repository metadata policy, and release verification language.
+
 ## 0.3.1 — 2026-08-08
 
 - Corrected restriction, translation, cloning, feature-remapping, and

--- a/src/bio/__tests__/feature-location.test.ts
+++ b/src/bio/__tests__/feature-location.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../feature-location';
 import { parseFeatures } from '../genbank-parser';
 import { reverseComplement, reverseComplementFeatures } from '../reverse-complement';
+import { mapFeatureThroughSourceCoordinates } from '../assembly-feature-mapping';
 import type { Feature } from '../types';
 
 const SEQUENCE = 'ATGCCCGGGCCATTTAAA';
@@ -268,6 +269,27 @@ describe('feature location semantics', () => {
         location,
       })],
     });
+  });
+
+  it('does not remap quarantined or non-materializable placeholders into derived records', () => {
+    const [quarantined] = parseFeatures([
+      '     misc_feature    J00194.1:100..200',
+      '                     /label="remote"',
+    ].join('\n'));
+    expect(remapFeatureLocation(quarantined, [{ start: 0, end: 1, targetStart: 0 }])).toBeNull();
+    expect(mapFeatureThroughSourceCoordinates(quarantined, {
+      sourceLength: 1,
+      productLength: 1,
+      sourceToProduct: [0],
+    })).toBeNull();
+
+    const ordered = parsedFeature('order(1..3,10..12)');
+    expect(remapFeatureLocation(ordered, [{ start: 0, end: 12, targetStart: 0 }])).toBeNull();
+    expect(mapFeatureThroughSourceCoordinates(ordered, {
+      sourceLength: 12,
+      productLength: 12,
+      sourceToProduct: Array.from({ length: 12 }, (_, index) => index),
+    })).toBeNull();
   });
 
   it('preserves repeated qualifier order, multiline values, and escaped quotes', () => {

--- a/src/bio/__tests__/golden-gate-domestication.test.ts
+++ b/src/bio/__tests__/golden-gate-domestication.test.ts
@@ -65,6 +65,54 @@ describe('feature-aware Golden Gate domestication', () => {
     expect(result.mutations.every((mutation) => mutation.position >= 4 && mutation.position < 4 + CDS_WITH_BSAI_SITE.length)).toBe(true);
   });
 
+  it('uses transl_except identity semantics while choosing synonymous domestication changes', () => {
+    const result = domesticateGoldenGateFeature({
+      sequence: CDS_WITH_BSAI_SITE,
+      feature: {
+        start: 0,
+        end: CDS_WITH_BSAI_SITE.length,
+        strand: 1,
+        type: 'cds',
+        metadata: { transl_except: '(pos:4..6,aa:Sec)' },
+      },
+      codonStart: 1,
+      translationTableId: 1,
+      forbiddenEnzymes: ['BsaI'],
+    });
+
+    expect(result.complete).toBe(true);
+    expect(result.remainingSites).toEqual([]);
+    expect(result.proteinIdentity).toBe(true);
+    expect(result.sourceProtein).toBe('MULE*');
+    expect(result.productProtein).toBe('MULE*');
+    expect(result.translationReceipt).toMatchObject({
+      rawQualifier: '(pos:4..6,aa:Sec)',
+      codonStart: 1,
+    });
+  });
+
+  it('surfaces malformed transl_except entries as typed domestication diagnostics', () => {
+    const result = domesticateGoldenGateFeature({
+      sequence: CDS_WITH_BSAI_SITE,
+      feature: {
+        start: 0,
+        end: CDS_WITH_BSAI_SITE.length,
+        strand: 1,
+        type: 'cds',
+        metadata: { transl_except: '(pos:4..5,aa:Sec)' },
+      },
+      codonStart: 1,
+      translationTableId: 1,
+      forbiddenEnzymes: ['BsaI'],
+    });
+
+    expect(result.complete).toBe(false);
+    expect(result.failures).toContainEqual(expect.objectContaining({
+      code: 'invalid_translation_exception',
+      diagnostics: [expect.objectContaining({ code: 'not_codon' })],
+    }));
+  });
+
   it('maps reverse-strand CDS mutations back to source coordinates', () => {
     const sequence = reverseComplement(CDS_WITH_BSAI_SITE);
     const result = domesticateGoldenGateFeature({

--- a/src/bio/__tests__/golden-gate-hardening.test.ts
+++ b/src/bio/__tests__/golden-gate-hardening.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildSyntheticGoldenGateVector,
+  findGoldenGateSites,
   GOLDEN_GATE_ENZYME_NAMES,
   getGoldenGatePartBoundary,
+  scanGoldenGateSites,
   validateGoldenGateOverhangs,
 } from '../golden-gate';
 
@@ -17,6 +19,7 @@ describe('Golden Gate hardening', () => {
       enzyme,
       filler: 'ACTGACTGACTGACTGACTG',
     });
+    expect(vector.sequence).toMatch(/^[ACGT]+$/);
     const boundary = getGoldenGatePartBoundary(vector, enzyme);
 
     expect(boundary).toMatchObject({
@@ -24,6 +27,73 @@ describe('Golden Gate hardening', () => {
       leftOverhang: left,
       rightOverhang: right,
     });
+    expect(boundary.provenance?.parts).toContainEqual(expect.objectContaining({
+      name: vector.name,
+      formattingNormalized: false,
+    }));
+  });
+
+  it('normalizes formatting with provenance but rejects ambiguous bases', () => {
+    const vector = buildSyntheticGoldenGateVector('ACGT', 'TGCA', {
+      enzyme: 'BsaI',
+      filler: 'ACTGACTGACTGACTGACTG',
+    });
+    const formatted = validateGoldenGateOverhangs([
+      { name: 'formatted', sequence: ` \n${vector.sequence.toLowerCase()}\t` },
+    ], 'BsaI');
+
+    expect(formatted.normalizationDiagnostics).toContainEqual(expect.objectContaining({
+      code: 'formatting_normalized',
+      partName: 'formatted',
+    }));
+    expect(formatted.provenance?.parts).toContainEqual(expect.objectContaining({
+      name: 'formatted',
+      formattingNormalized: true,
+      normalizedLength: vector.sequence.length,
+    }));
+
+    const ambiguous = getGoldenGatePartBoundary({
+      name: 'ambiguous',
+      sequence: `${vector.sequence.slice(0, 8)}N${vector.sequence.slice(9)}`,
+    }, 'BsaI');
+    expect(ambiguous.valid).toBe(false);
+    expect(ambiguous.normalizationDiagnostics).toContainEqual(expect.objectContaining({
+      code: 'ambiguous_base',
+      partName: 'ambiguous',
+    }));
+    expect(ambiguous.errors.join(' ')).toMatch(/canonical/i);
+
+    const rna = getGoldenGatePartBoundary({
+      name: 'rna',
+      sequence: `${vector.sequence.slice(0, 8)}U${vector.sequence.slice(9)}`,
+    }, 'BsaI');
+    expect(rna.valid).toBe(false);
+    expect(rna.normalizationDiagnostics).toContainEqual(expect.objectContaining({
+      code: 'invalid_character',
+      characters: ['U'],
+    }));
+  });
+
+  it('exposes strict direct-scan diagnostics instead of silently missing malformed input', () => {
+    const formatted = scanGoldenGateSites('  ggtctc aaaaa  ', 'BsaI');
+    expect(formatted.sequence).toBe('GGTCTCAAAAA');
+    expect(formatted.sites).toHaveLength(1);
+    expect(formatted.diagnostics).toContainEqual(expect.objectContaining({
+      code: 'formatting_normalized',
+    }));
+
+    const ambiguous = scanGoldenGateSites('GGTCTCNAAAA', 'BsaI');
+    expect(ambiguous.sites).toEqual([]);
+    expect(ambiguous.diagnostics).toContainEqual(expect.objectContaining({
+      code: 'ambiguous_base',
+    }));
+    expect(findGoldenGateSites('GGTCTC?AAAA', 'BsaI')).toEqual([]);
+
+    const unsupported = scanGoldenGateSites('GGTCTCAAAAA', 'not-an-enzyme');
+    expect(unsupported.sites).toEqual([]);
+    expect(unsupported.diagnostics).toContainEqual(expect.objectContaining({
+      code: 'unsupported_enzyme',
+    }));
   });
 
   it('rejects an empty part set', () => {

--- a/src/bio/__tests__/orf-detection-translation-tables.test.ts
+++ b/src/bio/__tests__/orf-detection-translation-tables.test.ts
@@ -25,6 +25,15 @@ describe('translation-table-aware ORF detection', () => {
     });
   });
 
+  it('recognizes a deterministic ambiguous initiator codon', () => {
+    expect(forwardOrfAtOrigin('ATHAAATAA', getTranslationTable(2))).toMatchObject({
+      start: 0,
+      end: 9,
+      startCodon: 'ATH',
+      stopCodon: 'TAA',
+    });
+  });
+
   it('ends an ORF at a table-specific mitochondrial stop', () => {
     const sequence = 'ATGAAAAGATTTTAA';
 

--- a/src/bio/__tests__/primer-pcr-integrity.test.ts
+++ b/src/bio/__tests__/primer-pcr-integrity.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { findPrimerBindings, simulatePCR } from '../pcr';
+import {
+  findPrimerBindings,
+  MAX_PCR_OLIGO_LENGTH,
+  MAX_PCR_PRODUCT_LENGTH,
+  simulatePCR,
+} from '../pcr';
 import { designForwardPrimerWithDiagnostics } from '../primer-design';
 import { predictHairpin, predictPrimerDimer } from '../primer-thermodynamics';
 import { calculateTm, saltCorrectedTm } from '../tm-calculator';
@@ -35,8 +40,13 @@ describe('primer, PCR, and Tm integrity', () => {
 
   it('enumerates repeated binding sites and exposes a configurable mismatch policy', () => {
     const template = `${binding}GGGG${binding}`;
-    const candidates = findPrimerBindings(template, `GGGG${binding}`, { minMatched3PrimeLength: 10 });
-    expect(candidates.map((candidate) => candidate.bindStart)).toEqual(expect.arrayContaining([0, 14]));
+    const exactOnly = findPrimerBindings(template, `GGGG${binding}`, { minMatched3PrimeLength: 10 });
+    expect(exactOnly.map((candidate) => candidate.bindStart)).toEqual([10]);
+    const candidates = findPrimerBindings(template, `GGGG${binding}`, {
+      minMatched3PrimeLength: 10,
+      allowImplicitTails: true,
+    });
+    expect(candidates.map((candidate) => candidate.bindStart)).toEqual(expect.arrayContaining([0, 10, 14]));
     expect(candidates.length).toBeGreaterThan(2);
     expect(candidates.every((candidate) => candidate.status === 'exact')).toBe(true);
 
@@ -98,6 +108,88 @@ describe('primer, PCR, and Tm integrity', () => {
     expect(competing?.warnings.join(' ')).toMatch(/competing/i);
   });
 
+  it('materializes permitted primer mismatches over the template interval with an edit receipt', () => {
+    const reverseBinding = 'TTGCAACGTA';
+    const template = `TCGTTGCAACGGGG${reverseBinding}`;
+    const result = simulatePCR(
+      template,
+      binding,
+      reverseComplement(reverseBinding),
+      [],
+      'linear',
+      {
+        forward: { start: 0, end: 10 },
+        reverse: { start: 14, end: 24 },
+      },
+      { minMatched3PrimeLength: 9, maxMismatches: 1 },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe('mismatch');
+    expect(result?.templateProduct.slice(0, binding.length)).toBe('TCGTTGCAAC');
+    expect(result?.product.slice(0, binding.length)).toBe(binding);
+    expect(result?.diagnostics).toContainEqual(expect.objectContaining({
+      code: 'primer_bases_overwrote_template',
+      positions: [0],
+    }));
+    expect(result?.provenance.bindingEdits).toContainEqual(expect.objectContaining({
+      productOffset: 0,
+      templatePosition: 0,
+      original: 'T',
+      replacement: 'A',
+      primer: 'forward',
+    }));
+  });
+
+  it('requires explicit selection or opt-in before inferring 5\u2032 tails', () => {
+    const reverseBinding = 'TTGCAACGTA';
+    const template = `${binding}GGGG${reverseBinding}`;
+    const forwardWithTail = `GGGG${binding}`;
+    const reversePrimer = reverseComplement(reverseBinding);
+
+    expect(simulatePCR(template, forwardWithTail, reversePrimer)).toBeNull();
+
+    const inferred = simulatePCR(
+      template,
+      forwardWithTail,
+      reversePrimer,
+      [],
+      'linear',
+      undefined,
+      { allowImplicitTails: true },
+    );
+    expect(inferred).not.toBeNull();
+    expect(inferred?.forward.tail).toBe('GGGG');
+    expect(inferred?.forward.tailSource).toBe('inferred');
+    expect(inferred?.diagnostics).toContainEqual(expect.objectContaining({
+      code: 'implicit_tail',
+      primer: 'forward',
+    }));
+    expect(inferred?.provenance.implicitTails.forward).toBe(true);
+  });
+
+  it('bounds oligos, inferred tails, and the final tailed amplicon', () => {
+    const oversizedPrimer = 'A'.repeat(MAX_PCR_OLIGO_LENGTH + 1);
+    expect(findPrimerBindings('A'.repeat(MAX_PCR_OLIGO_LENGTH + 20), oversizedPrimer)).toEqual([]);
+
+    const terminalBinding = 'ACGTTGCAAC';
+    const template = terminalBinding
+      + 'A'.repeat(MAX_PCR_PRODUCT_LENGTH - terminalBinding.length * 2)
+      + reverseComplement(terminalBinding);
+    const tail = 'A'.repeat(250);
+    expect(simulatePCR(
+      template,
+      tail + terminalBinding,
+      tail + terminalBinding,
+      [],
+      'linear',
+      {
+        forward: { start: 0, end: terminalBinding.length },
+        reverse: { start: template.length - terminalBinding.length, end: template.length },
+      },
+    )).toBeNull();
+  });
+
   it('does not fabricate a contiguous template from invalid characters', () => {
     expect(findPrimerBindings(`AAA-${binding}`, binding)).toEqual([]);
     expect(simulatePCR(`AAA-${binding}`, binding, reverseComplement(binding))).toBeNull();
@@ -146,6 +238,27 @@ describe('primer, PCR, and Tm integrity', () => {
     expect(hairpin.evaluatedSequence).toContain('N');
     expect(dimer.status).toBe('ambiguous');
     expect(dimer.evaluatedSequence).toContain('|');
+  });
+
+  it('reports the strongest dimer run and its 3′-end participation', () => {
+    const primer1 = 'GCGTACGGA';
+    const primer2 = reverseComplement(primer1);
+    const dimer = predictPrimerDimer(primer1, primer2);
+
+    expect(dimer.status).toBe('exact');
+    expect(dimer.pairLength).toBe(primer1.length);
+    expect(dimer.threePrimeOverlap).toEqual({ primer1: 5, primer2: 5 });
+    expect(dimer.threePrimeParticipation).toBe('both');
+  });
+
+  it('evaluates every contiguous dimer run instead of only the longest at an offset', () => {
+    const primer1 = 'AAAAATTTGCGC';
+    const alignedComplement = 'AAAAAGGGGCGC';
+    const dimer = predictPrimerDimer(primer1, reverseComplement(alignedComplement));
+
+    expect(dimer.structure).toContain('GCGC');
+    expect(dimer.pairLength).toBe(4);
+    expect(dimer.deltaG).toBeLessThan(0);
   });
 
   it('splits a circular origin feature into product coordinates', () => {

--- a/src/bio/__tests__/restriction-oracle-fixtures.ts
+++ b/src/bio/__tests__/restriction-oracle-fixtures.ts
@@ -3,9 +3,11 @@
  *
  * These are not a copied enzyme database. The expected facts were transcribed
  * from the first-party NEB product pages cited below and are deliberately
- * limited to the behaviors exercised by the tests. NEB content remains
- * subject to NEB's terms; this file cites the relevant first-party pages but
- * does not reproduce their protocols or database.
+ * limited to the behaviors exercised by the tests. `assayConditions` records
+ * the product-page unit assay, not a claim that Motif reproduces a complete
+ * lot-specific quality-control dataset. NEB content remains subject to NEB's
+ * terms; this file contains only original metadata/assertions and is
+ * distributed under Motif's MIT license.
  */
 export interface RestrictionOracleFixture {
   readonly name: string;
@@ -17,6 +19,8 @@ export interface RestrictionOracleFixture {
   readonly methylationTarget?: 'dam' | 'dcm' | 'cpg' | 'custom';
   readonly methylationState?: 'methylated' | 'unmethylated';
   readonly methylationBehavior?: 'context_dependent';
+  /** Product-page unit assay: substrate, time, temperature, volume, buffer. */
+  readonly assayConditions: string;
   /** Limits what this small oracle does and does not establish. */
   readonly caveats: string;
   readonly sourceUrl: string;
@@ -37,6 +41,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     cleavageMode: 'double-strand',
     cutOffsets: [1, 5],
     overhang: '5prime',
+    assayConditions: 'NEB unit assay: 1 µg λ DNA, 1 hour at 37°C, 50 µl; 1X NEBuffer EcoRI/SspI.',
     caveats: GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-us/products/r0101-ecori',
     sourceAccessed: ACCESSED,
@@ -50,6 +55,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     cleavageMode: 'double-strand',
     cutOffsets: [7, 11],
     overhang: '5prime',
+    assayConditions: 'NEB unit assay: 1 µg pXba DNA, 1 hour at 37°C, 50 µl; 1X rCutSmart Buffer.',
     caveats: 'Current source is BsaI-HFv2, which NEB describes as having BsaI specificity; this assertion does not reproduce the Golden Gate assembly protocol or ligase conditions. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en/products/r3733-bsai-hf-v2',
     sourceAccessed: ACCESSED,
@@ -63,6 +69,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     cleavageMode: 'double-strand',
     cutOffsets: [8, 12],
     overhang: '5prime',
+    assayConditions: 'NEB unit assay: 1 µg λ DNA, 1 hour at 37°C, 50 µl; 1X NEBuffer r2.1.',
     caveats: 'NEB reports GAAGAC(2/6); the stored offsets are measured from the recognition-sequence start. This does not claim BbsI-HF equivalence or a Golden Gate ligation result. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en/products/r0539-bbsi',
     sourceAccessed: ACCESSED,
@@ -76,6 +83,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     cleavageMode: 'double-strand',
     cutOffsets: [7, 11],
     overhang: '5prime',
+    assayConditions: 'NEB BsmBI-v2 unit assay: 1 µg λ DNA, 1 hour at 55°C, 50 µl; 1X NEBuffer r3.1.',
     caveats: 'The catalog identity is the model’s BsmBI name while the current first-party source is engineered BsmBI-v2; this does not assert historical R0580 equivalence or Golden Gate ligase performance. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-gb/products/r0739-bsmbi-v2',
     sourceAccessed: ACCESSED,
@@ -89,6 +97,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     cleavageMode: 'double-strand',
     cutOffsets: [8, 11],
     overhang: '5prime',
+    assayConditions: 'NEB unit assay: 1 µg λ DNA, 1 hour at 37°C, 50 µl; 1X rCutSmart Buffer.',
     caveats: 'NEB reports GCTCTTC(1/4); the stored offsets are measured from the seven-base recognition-sequence start. This does not reproduce the 13-fragment Golden Gate protocol. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-us/products/r0569-sapi',
     sourceAccessed: ACCESSED,
@@ -104,6 +113,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     overhang: 'blunt',
     methylationTarget: 'dam',
     methylationState: 'methylated',
+    assayConditions: 'NEB unit assay: 1 µg pBR322 DNA (dam methylated), 1 hour at 37°C, 50 µl; 1X rCutSmart Buffer.',
     caveats: 'The oracle captures the required methylated state and blunt geometry; site-specific, hemi-methylated, and overlapping CpG cases remain outside Motif’s global-state model. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-us/products/r0176-dpni',
     sourceAccessed: ACCESSED,
@@ -119,6 +129,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     overhang: '5prime',
     methylationTarget: 'dam',
     methylationState: 'unmethylated',
+    assayConditions: 'NEB unit assay: 1 µg λ DNA (dam−), 1 hour at 37°C, 50 µl; 1X NEBuffer DpnII.',
     caveats: 'The source reports dam methylation blocked and dcm/CpG not sensitive; this fixture does not infer behavior for hemi-methylated or mixed populations. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-us/products/r0543-dpnii',
     sourceAccessed: ACCESSED,
@@ -134,6 +145,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     overhang: '5prime',
     methylationTarget: 'dam',
     methylationState: 'unmethylated',
+    assayConditions: 'NEB unit assay: 1 µg λ DNA (dam−), 1 hour at 37°C, 50 µl; 1X rCutSmart Buffer.',
     caveats: 'The source reports dam methylation blocked and dcm/CpG not sensitive; this fixture does not infer behavior for hemi-methylated or mixed populations. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-us/products/r0147-mboi',
     sourceAccessed: ACCESSED,
@@ -149,6 +161,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     overhang: '5prime',
     methylationTarget: 'cpg',
     methylationState: 'unmethylated',
+    assayConditions: 'NEB unit assay: 1 µg λ DNA, 1 hour at 37°C, 50 µl; 1X rCutSmart Buffer.',
     caveats: 'The source reports CpG methylation blocked, while dam and dcm are not sensitive; Motif models the required unmethylated CpG state globally. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-us/products/r0171-hpaii',
     sourceAccessed: ACCESSED,
@@ -163,6 +176,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     cutOffsets: [1, 3],
     overhang: '5prime',
     methylationBehavior: 'context_dependent',
+    assayConditions: 'NEB unit assay: 1 µg λ DNA, 1 hour at 37°C, 50 µl; 1X rCutSmart Buffer.',
     caveats: 'NEB notes that external-C methylation blocks cleavage while internal-C methylation can be cleaved; a global CpG state cannot identify those positions, so Motif remains conditional. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-us/products/r0106-mspi',
     sourceAccessed: ACCESSED,
@@ -178,6 +192,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     overhang: '3prime',
     methylationTarget: 'cpg',
     methylationState: 'unmethylated',
+    assayConditions: 'NEB unit assay: 1 µg λ DNA, 1 hour at 37°C, 50 µl; 1X rCutSmart Buffer.',
     caveats: 'The source reports CpG methylation blocked and a 3′ extension; Motif does not infer site-specific or hemi-methylated behavior. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-us/products/r0139-hhai',
     sourceAccessed: ACCESSED,
@@ -190,6 +205,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     recognitionSequence: 'CCTCAGC',
     cleavageMode: 'nick_bottom',
     overhang: 'blunt',
+    assayConditions: 'NEB unit assay: 1 µg supercoiled pUB DNA to open circular form, 1 hour at 37°C, 50 µl; 1X rCutSmart Buffer.',
     caveats: 'NEB reports the nicking notation CCTCAGC (none/−2); Motif records continuity and nick mode, not a double-strand fragment boundary. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-us/products/r0631-nbbbvci',
     sourceAccessed: ACCESSED,
@@ -202,6 +218,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     recognitionSequence: 'CCTCAGC',
     cleavageMode: 'nick_top',
     overhang: 'blunt',
+    assayConditions: 'NEB unit assay: 1 µg supercoiled plasmid DNA to open circular form, 1 hour at 37°C, 50 µl; 1X rCutSmart Buffer.',
     caveats: 'NEB reports the nicking notation CCTCAGC (−5/none); Motif records continuity and nick mode, not a double-strand fragment boundary. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-us/products/r0632-ntbbvci',
     sourceAccessed: ACCESSED,
@@ -215,6 +232,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     cleavageMode: 'nick_top',
     cutOffsets: [9, 9],
     overhang: 'blunt',
+    assayConditions: 'NEB unit assay: 1 µg T7 DNA, 1 hour at 55°C, 50 µl; 1X NEBuffer r3.1.',
     caveats: 'NEB describes a single-strand nick four bases beyond the 3′ side of GAGTC; the stored offset is recognition length plus four. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-us/products/r0607-ntbstnbi',
     sourceAccessed: ACCESSED,
@@ -228,6 +246,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     cleavageMode: 'double-strand',
     cutOffsets: [3, 3],
     overhang: 'blunt',
+    assayConditions: 'NEB unit assay: 1 µg HindIII-digested λ DNA, 1 hour at 37°C, 50 µl; 1X rCutSmart Buffer.',
     caveats: 'The source notes a blunt CCC/GGG cut and CpG methylation blocking; this small oracle does not add a site-specific methylation model to the catalog. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/products/r0141-smai',
     sourceAccessed: ACCESSED,
@@ -241,6 +260,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     cleavageMode: 'double-strand',
     cutOffsets: [3, 3],
     overhang: 'blunt',
+    assayConditions: 'NEB unit assay: 1 µg λ DNA, 1 hour at 37°C, 50 µl; 1X NEBuffer r3.1.',
     caveats: 'The source notes a blunt GAT/ATC cut; overlapping CpG effects are not represented as a global Motif methylation requirement. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-ca/products/r0195-ecorv',
     sourceAccessed: ACCESSED,
@@ -254,6 +274,7 @@ export const RESTRICTION_ORACLE_FIXTURES: readonly RestrictionOracleFixture[] = 
     cleavageMode: 'double-strand',
     cutOffsets: [5, 1],
     overhang: '3prime',
+    assayConditions: 'NEB unit assay: 1 µg λ DNA, 1 hour at 37°C, 50 µl; 1X NEBuffer r3.1.',
     caveats: 'The source notes CTGCA/G and no dam, dcm, or CpG sensitivity; star activity and substrate context remain outside this geometry oracle. ' + GEOMETRY_CAVEAT,
     sourceUrl: 'https://www.neb.com/en-us/products/r0140-psti',
     sourceAccessed: ACCESSED,

--- a/src/bio/__tests__/restriction-oracle.test.ts
+++ b/src/bio/__tests__/restriction-oracle.test.ts
@@ -13,6 +13,11 @@ describe('first-party restriction behavior oracles', () => {
       expect(fixture.sourceLicense).toMatch(/NEB Terms of Use/u);
       expect(fixture.sourceLicense).toMatch(/terms-of-use/u);
       expect(fixture.fixtureLicense).toBe('MIT');
+      expect(fixture.assayConditions).toMatch(/1 µg/u);
+      expect(fixture.assayConditions).toMatch(/hour/u);
+      expect(fixture.assayConditions).toMatch(/°C/u);
+      expect(fixture.assayConditions).toMatch(/50 µl/u);
+      expect(fixture.assayConditions).toMatch(/1X/u);
       expect(fixture.caveats.length).toBeGreaterThan(20);
     }
   });

--- a/src/bio/__tests__/restriction-physical-model.test.ts
+++ b/src/bio/__tests__/restriction-physical-model.test.ts
@@ -196,4 +196,48 @@ describe('physical restriction model', () => {
     expect(edge.issues).toContainEqual(expect.objectContaining({ code: 'insufficient_flanking_bases' }));
     expect(nick).toMatchObject({ isValid: true, outcome: 'uncut', cutCount: 0, fragments: [{ length: 19 }] });
   });
+
+  it('reports incompatible co-located strand geometry instead of deduping on top cut', () => {
+    const first: RestrictionEnzyme = {
+      name: 'CoLocatedA',
+      recognitionSequence: 'GAATTC',
+      cutOffset: 1,
+      complementCutOffset: 5,
+      overhang: '5prime',
+    };
+    const second: RestrictionEnzyme = {
+      ...first,
+      name: 'CoLocatedB',
+      complementCutOffset: 4,
+    };
+    const result = restrictionDigestDetailed(
+      'AAAAAGAATTCAAAA',
+      [first.name, second.name],
+      'linear',
+      undefined,
+      [first, second],
+    );
+
+    expect(result.issues).toContainEqual(expect.objectContaining({
+      code: 'incompatible_colocated_cleavage',
+      position: 6,
+    }));
+    expect(result.cuts).toHaveLength(2);
+    expect(result.fragments).toEqual([]);
+  });
+
+  it('deduplicates only fully compatible co-located isoschizomer geometry', () => {
+    const result = restrictionDigestDetailed(
+      'AAAACCGGAAAA',
+      ['HpaII', 'MspI'],
+      'linear',
+      undefined,
+      RESTRICTION_ENZYMES_FULL,
+      { methylationAssumptions: { cpg: 'unmethylated' } },
+    );
+    expect(result.issues).toEqual([]);
+    expect(result.cuts).toHaveLength(1);
+    expect(result.cuts[0].enzymes).toEqual(['HpaII', 'MspI']);
+    expect(result.fragments).toHaveLength(2);
+  });
 });

--- a/src/bio/__tests__/restriction-sites.test.ts
+++ b/src/bio/__tests__/restriction-sites.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { RESTRICTION_ENZYMES_FULL } from '../enzyme-data';
 import { reverseComplement } from '../reverse-complement';
-import { RESTRICTION_ENZYMES, findRestrictionSites } from '../restriction-sites';
+import {
+  RESTRICTION_ENZYMES,
+  classifyRestrictionEnzymes,
+  findNonCutters,
+  findRestrictionSites,
+  isActiveDoubleStrandRestrictionSite,
+  restrictionSiteActivity,
+} from '../restriction-sites';
+import { resolveEnzymeUnion } from '../restriction-presets';
 
 function enzyme(name: string) {
   const match = RESTRICTION_ENZYMES.find((candidate) => candidate.name === name);
@@ -45,14 +53,17 @@ describe('restriction-site scanning', () => {
       const sequence = materializeRecognitionSequence(candidate.recognitionSequence);
       const sites = findRestrictionSites(sequence, [candidate]);
 
-      expect(sites, candidate.name).toContainEqual({
+      expect(sites, candidate.name).toContainEqual(expect.objectContaining({
         enzyme: candidate.name,
         position: 0,
         cutPosition: candidate.cutOffset,
         recognitionSequence: candidate.recognitionSequence,
         overhang: candidate.overhang,
         strand: 1,
-      });
+        cleavageMode: candidate.cleavageMode ?? 'double-strand',
+        topCutPosition: candidate.cleavageMode === 'nick_bottom' ? null : candidate.cutOffset,
+        bottomCutPosition: candidate.cleavageMode === 'nick_top' ? null : candidate.complementCutOffset,
+      }));
     }
   });
 
@@ -64,14 +75,21 @@ describe('restriction-site scanning', () => {
       checked += 1;
       const sites = findRestrictionSites(sequence, [candidate]);
 
-      expect(sites, candidate.name).toContainEqual({
+      expect(sites, candidate.name).toContainEqual(expect.objectContaining({
         enzyme: candidate.name,
         position: 0,
         cutPosition: candidate.recognitionSequence.length - candidate.complementCutOffset,
         recognitionSequence: candidate.recognitionSequence,
         overhang: candidate.overhang,
         strand: -1,
-      });
+        cleavageMode: candidate.cleavageMode ?? 'double-strand',
+        topCutPosition: candidate.cleavageMode === 'nick_bottom'
+          ? null
+          : candidate.recognitionSequence.length - candidate.complementCutOffset,
+        bottomCutPosition: candidate.cleavageMode === 'nick_top'
+          ? null
+          : candidate.recognitionSequence.length - candidate.cutOffset,
+      }));
     }
     expect(checked).toBeGreaterThan(15);
   });
@@ -79,14 +97,18 @@ describe('restriction-site scanning', () => {
   it('reports a non-palindromic reverse-strand Type IIS site with its mirrored cut', () => {
     const sites = findRestrictionSites('AAAAAAGAGACCTTTTT', [enzyme('BsaI')]);
 
-    expect(sites).toEqual([{
+    expect(sites).toEqual([expect.objectContaining({
       enzyme: 'BsaI',
       position: 6,
       cutPosition: 1,
       recognitionSequence: 'GGTCTC',
       overhang: '5prime',
       strand: -1,
-    }]);
+      cleavageMode: 'double-strand',
+      topCutPosition: 1,
+      bottomCutPosition: 5,
+      cleavageStatus: 'ok',
+    })]);
   });
 
   it('finds and wraps a palindromic site that crosses a circular origin once', () => {
@@ -94,13 +116,71 @@ describe('restriction-site scanning', () => {
     const ecoRI = enzyme('EcoRI');
 
     expect(findRestrictionSites(sequence, [ecoRI])).toEqual([]);
-    expect(findRestrictionSites(sequence, [ecoRI], { topology: 'circular' })).toEqual([{
+    expect(findRestrictionSites(sequence, [ecoRI], { topology: 'circular' })).toEqual([expect.objectContaining({
       enzyme: 'EcoRI',
       position: 9,
       cutPosition: 0,
       recognitionSequence: 'GAATTC',
       overhang: '5prime',
       strand: 1,
-    }]);
+      cleavageMode: 'double-strand',
+      topCutPosition: 0,
+      bottomCutPosition: 4,
+      cleavageStatus: 'ok',
+    })]);
+  });
+
+  it('keeps physical safety fields enumerable across spreads and JSON round trips', () => {
+    const [site] = findRestrictionSites('AAAAAGAATTCAAAA', [enzyme('EcoRI')]);
+    expect(Object.keys(site)).toEqual(expect.arrayContaining([
+      'cleavageMode',
+      'topCutPosition',
+      'bottomCutPosition',
+      'cleavageStatus',
+    ]));
+    const spread = { ...site };
+    const restored = JSON.parse(JSON.stringify(site)) as typeof site;
+    expect(spread).toMatchObject({
+      cleavageMode: 'double-strand',
+      topCutPosition: 6,
+      bottomCutPosition: 10,
+      cleavageStatus: 'ok',
+    });
+    expect(restored).toMatchObject(spread);
+    expect(isActiveDoubleStrandRestrictionSite(restored)).toBe(true);
+
+    const legacy = { ...site };
+    delete legacy.cleavageMode;
+    delete legacy.topCutPosition;
+    delete legacy.bottomCutPosition;
+    delete legacy.cleavageStatus;
+    expect(restrictionSiteActivity(legacy)).toBe('legacy-unsafe');
+    expect(isActiveDoubleStrandRestrictionSite(legacy)).toBe(false);
+  });
+
+  it('resolves Common enzymes to full catalog methylation records', () => {
+    const full = RESTRICTION_ENZYMES_FULL.find((candidate) => candidate.name === 'HpaII');
+    const common = RESTRICTION_ENZYMES.find((candidate) => candidate.name === 'HpaII');
+    const resolved = resolveEnzymeUnion(['common']).find((candidate) => candidate.name === 'HpaII');
+    expect(full?.methylationRequirement).toMatchObject({ target: 'cpg', state: 'unmethylated' });
+    expect(common).toBe(full);
+    expect(resolved).toBe(full);
+    expect(resolved?.methylationRequirement?.evidence?.source).toMatch(/^https:\/\/www\.neb\.com\//);
+  });
+
+  it('categorizes no-site, nick, conditional, and incomplete legacy outcomes', () => {
+    const nick = RESTRICTION_ENZYMES_FULL.find((candidate) => candidate.name === 'Nb.BbvCI');
+    const conditional = RESTRICTION_ENZYMES_FULL.find((candidate) => candidate.name === 'DpnI');
+    if (!nick || !conditional) throw new Error('Missing activity-category fixture');
+    const sequence = 'AAAAGATCAAAA';
+    const [noSite] = classifyRestrictionEnzymes('AAAAAAAAAAAA', [conditional]);
+    const [conditionalSite] = classifyRestrictionEnzymes(sequence, [conditional]);
+    const [nickSite] = classifyRestrictionEnzymes(nick.recognitionSequence + 'AAAAAAAA', [nick]);
+    expect(noSite.category).toBe('no-site');
+    expect(conditionalSite.category).toBe('conditional');
+    expect(nickSite.category).toBe('nick-only');
+    expect(classifyRestrictionEnzymes(sequence, [conditional])[0].activeDoubleStrandSiteCount).toBe(0);
+    expect(findNonCutters(sequence, [conditional, nick]).map((candidate) => candidate.name))
+      .toEqual([conditional.name, nick.name]);
   });
 });

--- a/src/bio/__tests__/translate.test.ts
+++ b/src/bio/__tests__/translate.test.ts
@@ -57,6 +57,14 @@ describe('translation-table-aware translation', () => {
     expect(translateFromFirstATG('CCCGTGAAATAA', STANDARD_CODE)).toBeNull();
   });
 
+  it('recognizes an ambiguous codon only when every expansion is an initiator', () => {
+    const mitochondrial = getTranslationTable(2);
+
+    expect(translateCompleteCds('ATHAAATAA', 0, mitochondrial)).toBe('MK*');
+    expect(translateCompleteCds('ATNAAATAA', 0, STANDARD_CODE)).toBe('XK*');
+    expect(translateFromFirstATG('CCCGTNAAAACC', mitochondrial)).toBeNull();
+  });
+
   it('applies codon_start after orienting a reverse feature into biological order', () => {
     const biological = 'AATGAAATAG';
     const genomic = reverseComplement(biological);

--- a/src/bio/assembly-feature-mapping.ts
+++ b/src/bio/assembly-feature-mapping.ts
@@ -1,3 +1,4 @@
+import { isMaterializableFeatureLocation } from './feature-location';
 import type { Feature } from './types';
 
 /**
@@ -67,6 +68,10 @@ export function mapFeatureThroughSourceCoordinates(
   feature: Feature,
   map: SourceToProductCoordinateMap,
 ): Feature | null {
+  // Imported quarantines and non-materializable multipart locations may carry
+  // a bounded placeholder range for display. A source-to-product map must not
+  // promote that placeholder into a derived record annotation.
+  if (!isMaterializableFeatureLocation(feature)) return null;
   const hasSubRanges = feature.subRanges !== undefined;
   const sourceRanges = hasSubRanges
     ? feature.subRanges!

--- a/src/bio/feature-location.ts
+++ b/src/bio/feature-location.ts
@@ -136,6 +136,11 @@ export function remapFeatureLocation(
   feature: FeatureLocation,
   sourceSpans: readonly FeatureCoordinateMapSpan[],
 ): RemappedFeatureLocation | null {
+  // A quarantined, ordered, or otherwise ambiguous location may have a
+  // bounded placeholder envelope solely to keep it visible in the source
+  // record. Never turn that placeholder into an authoritative feature in a
+  // derived digest/PCR/child sequence.
+  if (!isMaterializableFeatureLocation(feature)) return null;
   const hasStoredSubRanges = feature.subRanges !== undefined;
   const sourceSegments = hasStoredSubRanges
     ? feature.subRanges!

--- a/src/bio/golden-gate.ts
+++ b/src/bio/golden-gate.ts
@@ -5,17 +5,58 @@ import { getAminoAcidToCodons, resolveTranslationTable } from './codon-tables';
 import { featureLocationSegments } from './feature-location';
 import { translateCompleteCds } from './translate';
 import {
+  materializeTranslationExceptions,
+  type TranslationException,
+  type TranslationExceptionDiagnostic,
+  type TranslationExceptionReceipt,
+} from './transl-except';
+import {
   aliasRemovedProductCoordinates,
   emptySourceToProductMap,
   mapFeatureThroughSourceCoordinates,
   type SourceToProductCoordinateMap,
 } from './assembly-feature-mapping';
+import { inspectNucleotideSequence } from './nucleotide';
 
 export interface GoldenGatePart {
   id?: string;
   name: string;
   sequence: string;
   features?: Feature[];
+}
+
+export type GoldenGateNormalizationDiagnosticCode =
+  | 'formatting_normalized'
+  | 'invalid_character'
+  | 'ambiguous_base'
+  | 'unsupported_enzyme';
+
+export interface GoldenGateNormalizationDiagnostic {
+  code: GoldenGateNormalizationDiagnosticCode;
+  partName?: string;
+  partId?: string;
+  message: string;
+  characters?: string[];
+}
+
+export interface GoldenGateNormalizationProvenance {
+  engine: 'motif-golden-gate';
+  engineVersion: '2';
+  parts: Array<{
+    name: string;
+    id?: string;
+    sourceLength: number;
+    normalizedLength: number;
+    formattingNormalized: boolean;
+  }>;
+}
+
+export interface GoldenGateSiteScanResult {
+  sequence: string;
+  enzyme: string;
+  sites: GoldenGateSite[];
+  diagnostics: GoldenGateNormalizationDiagnostic[];
+  provenance: GoldenGateNormalizationProvenance;
 }
 
 export interface GoldenGateSite {
@@ -49,6 +90,8 @@ export interface GoldenGatePartBoundary {
   siteCount: number;
   internalSiteCount: number;
   errors: string[];
+  normalizationDiagnostics?: GoldenGateNormalizationDiagnostic[];
+  provenance?: GoldenGateNormalizationProvenance;
 }
 
 export interface GoldenGateResult {
@@ -62,6 +105,8 @@ export interface GoldenGateResult {
   success: boolean;
   errors: string[];
   warnings: string[];
+  normalizationDiagnostics?: GoldenGateNormalizationDiagnostic[];
+  provenance?: GoldenGateNormalizationProvenance;
   /**
    * Populated when a unique part-ordering exists but its endpoints do not
    * close to a circle. The caller can ligate a destination vector backbone
@@ -81,6 +126,8 @@ export interface OverhangValidation {
   }>;
   /** When the open-chain issue is reported, the overhangs a vector must expose. */
   missingVectorOverhangs?: { left: string; right: string };
+  normalizationDiagnostics?: GoldenGateNormalizationDiagnostic[];
+  provenance?: GoldenGateNormalizationProvenance;
 }
 
 const DEFAULT_ENZYME = 'BsaI';
@@ -154,6 +201,85 @@ export function getGoldenGateEnzyme(enzymeName: string): RestrictionEnzyme | nul
   return getEnzyme(enzymeName);
 }
 
+function normalizeGoldenGatePart(part: GoldenGatePart): {
+  part: GoldenGatePart | null;
+  diagnostics: GoldenGateNormalizationDiagnostic[];
+  provenance: NonNullable<GoldenGateNormalizationProvenance['parts']>[number];
+} {
+  const inspected = inspectNucleotideSequence(part.sequence);
+  const diagnostics: GoldenGateNormalizationDiagnostic[] = [];
+  const sourceLength = part.sequence.length;
+  const sourceWithoutWhitespace = part.sequence.replace(/\s+/g, '').toUpperCase();
+  const invalidRna = sourceWithoutWhitespace.includes('U');
+  if (inspected.invalidCharacters.length > 0 || invalidRna) {
+    const invalidCharacters = [...new Set([
+      ...inspected.invalidCharacters,
+      ...(invalidRna ? ['U'] : []),
+    ])];
+    diagnostics.push({
+      code: 'invalid_character',
+      partName: part.name,
+      ...(part.id ? { partId: part.id } : {}),
+      characters: invalidCharacters,
+      message: `Part "${part.name}" contains invalid DNA nucleotide characters: ${invalidCharacters.join(', ')}.`,
+    });
+  } else if (inspected.ambiguous) {
+    diagnostics.push({
+      code: 'ambiguous_base',
+      partName: part.name,
+      ...(part.id ? { partId: part.id } : {}),
+      message: `Part "${part.name}" contains IUPAC ambiguity symbols; Golden Gate boundaries require canonical A/C/G/T bases.`,
+    });
+  }
+  const formattingNormalized = inspected.sequence !== part.sequence;
+  if (formattingNormalized && diagnostics.length === 0) {
+    diagnostics.push({
+      code: 'formatting_normalized',
+      partName: part.name,
+      ...(part.id ? { partId: part.id } : {}),
+      message: `Part "${part.name}" was normalized by removing formatting whitespace and uppercasing bases before boundary analysis.`,
+    });
+  }
+  return {
+    part: diagnostics.some((diagnostic) => diagnostic.code !== 'formatting_normalized')
+      ? null
+      : { ...part, sequence: inspected.sequence },
+    diagnostics,
+    provenance: {
+      name: part.name,
+      ...(part.id ? { id: part.id } : {}),
+      sourceLength,
+      normalizedLength: inspected.sequence.length,
+      formattingNormalized,
+    },
+  };
+}
+
+function normalizationProvenance(
+  parts: readonly NonNullable<ReturnType<typeof normalizeGoldenGatePart>['part']>[],
+  entries: GoldenGateNormalizationProvenance['parts'],
+): GoldenGateNormalizationProvenance {
+  return {
+    engine: 'motif-golden-gate',
+    engineVersion: '2',
+    parts: entries.length > 0
+      ? entries
+      : parts.map((part) => ({
+        name: part.name,
+        ...(part.id ? { id: part.id } : {}),
+        sourceLength: part.sequence.length,
+        normalizedLength: part.sequence.length,
+        formattingNormalized: false,
+      })),
+  };
+}
+
+function normalizationProvenanceForParts(
+  entries: GoldenGateNormalizationProvenance['parts'],
+): GoldenGateNormalizationProvenance {
+  return normalizationProvenance([], entries);
+}
+
 /**
  * Find Type IIS recognition sites in a sequence and compute the overhangs
  * they would produce after digestion. Overhang length is per-enzyme (4 bp for
@@ -165,14 +291,11 @@ export function getGoldenGateEnzyme(enzymeName: string): RestrictionEnzyme | nul
  * enzyme reads the complement in the 5'→3' direction and cuts upstream,
  * producing an overhang that is the reverse complement of the sense-strand bases.
  */
-export function findGoldenGateSites(
-  seq: string,
-  enzyme = DEFAULT_ENZYME,
+function findGoldenGateSitesInNormalizedSequence(
+  upper: string,
+  enz: RestrictionEnzyme,
   options: FindGoldenGateSitesOptions = {},
 ): GoldenGateSite[] {
-  const enz = getEnzyme(enzyme);
-  if (!enz) return [];
-  const upper = seq.toUpperCase();
   const recog = enz.recognitionSequence.toUpperCase();
   const recogRC = reverseComplement(recog).toUpperCase();
   const overhangLength = overhangLengthFor(enz);
@@ -227,6 +350,64 @@ export function findGoldenGateSites(
 
   sites.sort((a, b) => a.position - b.position);
   return sites;
+}
+
+/**
+ * Strict, typed Golden Gate scan boundary. Formatting whitespace and case are
+ * normalized with provenance; ambiguity, invalid characters, and unsupported
+ * enzyme identities fail closed with machine-readable diagnostics.
+ */
+export function scanGoldenGateSites(
+  seq: string,
+  enzyme = DEFAULT_ENZYME,
+  options: FindGoldenGateSitesOptions = {},
+): GoldenGateSiteScanResult {
+  const normalized = normalizeGoldenGatePart({ name: 'sequence', sequence: seq });
+  const provenance = normalizationProvenance([], [normalized.provenance]);
+  const enz = getEnzyme(enzyme);
+  if (!enz) {
+    return {
+      sequence: normalized.part?.sequence ?? seq.replace(/\s+/g, '').toUpperCase(),
+      enzyme,
+      sites: [],
+      diagnostics: [
+        ...normalized.diagnostics,
+        {
+          code: 'unsupported_enzyme',
+          message: `Unsupported Golden Gate enzyme: ${enzyme}`,
+        },
+      ],
+      provenance,
+    };
+  }
+  if (!normalized.part) {
+    return {
+      sequence: seq.replace(/\s+/g, '').toUpperCase(),
+      enzyme: enz.name,
+      sites: [],
+      diagnostics: normalized.diagnostics,
+      provenance,
+    };
+  }
+  return {
+    sequence: normalized.part.sequence,
+    enzyme: enz.name,
+    sites: findGoldenGateSitesInNormalizedSequence(normalized.part.sequence, enz, options),
+    diagnostics: normalized.diagnostics,
+    provenance,
+  };
+}
+
+/**
+ * Compatibility projection for callers that need only sites. Invalid or
+ * ambiguous input returns no sites; use `scanGoldenGateSites` for diagnostics.
+ */
+export function findGoldenGateSites(
+  seq: string,
+  enzyme = DEFAULT_ENZYME,
+  options: FindGoldenGateSitesOptions = {},
+): GoldenGateSite[] {
+  return scanGoldenGateSites(seq, enzyme, options).sites;
 }
 
 /**
@@ -383,6 +564,8 @@ interface DigestedAssemblyPart {
 interface DigestPartsResult {
   digested: DigestedAssemblyPart[];
   errors: string[];
+  normalizationDiagnostics: GoldenGateNormalizationDiagnostic[];
+  provenanceParts: GoldenGateNormalizationProvenance['parts'];
 }
 
 /**
@@ -398,17 +581,27 @@ function digestGoldenGateParts(
 ): DigestPartsResult {
   const errors: string[] = [];
   const digested: DigestedAssemblyPart[] = [];
+  const normalizationDiagnostics: GoldenGateNormalizationDiagnostic[] = [];
+  const provenanceParts: GoldenGateNormalizationProvenance['parts'] = [];
   const recog = enz.recognitionSequence.toUpperCase();
   const recogRC = reverseComplement(recog).toUpperCase();
   const overhangLength = overhangLengthFor(enz);
 
   for (const part of parts) {
-    const upper = part.sequence.toUpperCase();
+    const normalized = normalizeGoldenGatePart(part);
+    normalizationDiagnostics.push(...normalized.diagnostics);
+    provenanceParts.push(normalized.provenance);
+    if (!normalized.part) {
+      errors.push(`Part "${part.name}": Golden Gate input must be canonical A/C/G/T after normalization.`);
+      continue;
+    }
+    const normalizedPart = normalized.part;
+    const upper = normalizedPart.sequence;
     const senseIdx = upper.indexOf(recog);
     const antiIdx = senseIdx !== -1 ? upper.indexOf(recogRC, senseIdx + recog.length) : -1;
 
     if (senseIdx === -1 || antiIdx === -1 || senseIdx >= antiIdx) {
-      const foundSites = findGoldenGateSites(part.sequence, enz.name);
+      const foundSites = findGoldenGateSites(normalizedPart.sequence, enz.name);
       const foundSummary = foundSites.length > 0
         ? `found ${foundSites.length} site${foundSites.length !== 1 ? 's' : ''}, but not a valid sense/antisense flank pair`
         : 'found none';
@@ -418,7 +611,7 @@ function digestGoldenGateParts(
       continue;
     }
 
-    const internalSites = findInternalGoldenGateSites(part.sequence, enz.name);
+    const internalSites = findInternalGoldenGateSites(normalizedPart.sequence, enz.name);
     if (internalSites.length > 0) {
       errors.push(
         `Part "${part.name}": contains ${internalSites.length} internal ${enz.name} site${internalSites.length !== 1 ? 's' : ''}`,
@@ -448,17 +641,17 @@ function digestGoldenGateParts(
     // outside the digest window are genuinely absent and therefore, and only
     // therefore, mark a surviving feature partial.
     const insertLength = insert.length;
-    const insertMap = sourceMapForInsert(part.sequence.length, leftCut, insertLength);
+    const insertMap = sourceMapForInsert(normalizedPart.sequence.length, leftCut, insertLength);
     const shiftedFeatures: Feature[] = [];
-    for (const feat of part.features ?? []) {
+    for (const feat of normalizedPart.features ?? []) {
       const shifted = mapFeatureThroughSourceCoordinates(feat, insertMap);
       if (shifted) shiftedFeatures.push(shifted);
     }
 
-    digested.push({ id: part.id, name: part.name, insert, oh5, oh3, rightOverhang, features: shiftedFeatures, insertStart: leftCut });
+    digested.push({ id: normalizedPart.id, name: normalizedPart.name, insert, oh5, oh3, rightOverhang, features: shiftedFeatures, insertStart: leftCut });
   }
 
-  return { digested, errors };
+  return { digested, errors, normalizationDiagnostics, provenanceParts };
 }
 
 export type GoldenGateChainReason =
@@ -674,11 +867,30 @@ export function getGoldenGatePartBoundary(
       errors: [unsupportedEnzymeError(enzyme)],
     };
   }
-  const upper = part.sequence.toUpperCase();
+  const normalized = normalizeGoldenGatePart({ name: part.name, sequence: part.sequence });
+  const normalizationDiagnostics = normalized.diagnostics;
+  const provenance = normalizationProvenance([], [normalized.provenance]);
+  if (!normalized.part) {
+    return {
+      valid: false,
+      enzyme: enz.name,
+      leftOverhang: null,
+      rightOverhang: null,
+      rightOverhangComplement: null,
+      insertStart: null,
+      insertEnd: null,
+      siteCount: 0,
+      internalSiteCount: 0,
+      errors: [`Part "${part.name}" must contain only canonical A/C/G/T bases.`],
+      normalizationDiagnostics,
+      provenance,
+    };
+  }
+  const upper = normalized.part.sequence;
   const recog = enz.recognitionSequence.toUpperCase();
   const recogRC = reverseComplement(recog).toUpperCase();
   const overhangLength = overhangLengthFor(enz);
-  const sites = findGoldenGateSites(part.sequence, enzyme, { includeOutOfBounds: true });
+  const sites = findGoldenGateSites(upper, enzyme, { includeOutOfBounds: true });
   const errors: string[] = [];
 
   const senseIdx = upper.indexOf(recog);
@@ -697,6 +909,8 @@ export function getGoldenGatePartBoundary(
       siteCount: sites.length,
       internalSiteCount: sites.length,
       errors,
+      normalizationDiagnostics,
+      provenance,
     };
   }
 
@@ -733,6 +947,8 @@ export function getGoldenGatePartBoundary(
     siteCount: sites.length,
     internalSiteCount: internalSites.length,
     errors,
+    normalizationDiagnostics,
+    provenance,
   };
 }
 
@@ -779,7 +995,12 @@ export function validateGoldenGateOverhangs(
     return { valid: false, overhangs: [], issues };
   }
 
-  const { digested, errors: digestErrors } = digestGoldenGateParts(parts, enz);
+  const {
+    digested,
+    errors: digestErrors,
+    normalizationDiagnostics,
+    provenanceParts,
+  } = digestGoldenGateParts(parts, enz);
   for (const error of digestErrors) {
     issues.push({
       type: 'preparation',
@@ -861,6 +1082,8 @@ export function validateGoldenGateOverhangs(
     valid: issues.length === 0,
     overhangs: unique,
     issues,
+    normalizationDiagnostics,
+    provenance: normalizationProvenance([], provenanceParts),
     ...(missingVectorOverhangs ? { missingVectorOverhangs } : {}),
   };
 }
@@ -924,11 +1147,17 @@ export function goldenGateAssemble(
   }
 
   // --- Step 1: Digest each part to extract the insert with its overhangs ---
-  const { digested, errors: digestErrors } = digestGoldenGateParts(parts, enz);
+  const {
+    digested,
+    errors: digestErrors,
+    normalizationDiagnostics,
+    provenanceParts,
+  } = digestGoldenGateParts(parts, enz);
+  const normalizationProvenance = normalizationProvenanceForParts(provenanceParts);
   errors.push(...digestErrors);
 
   if (errors.length > 0) {
-    return { sequence: '', features: [], parts: parts.map((p) => p.name), ...(inputPartIds ? { partIds: inputPartIds } : {}), overhangs: [], enzyme: enz.name, topology: 'linear', success: false, errors, warnings };
+    return { sequence: '', features: [], parts: parts.map((p) => p.name), ...(inputPartIds ? { partIds: inputPartIds } : {}), overhangs: [], enzyme: enz.name, topology: 'linear', success: false, errors, warnings, normalizationDiagnostics, provenance: normalizationProvenance };
   }
 
   // --- Step 2: Resolve the unique part ordering via chain analysis ---
@@ -941,7 +1170,7 @@ export function goldenGateAssemble(
         ? `Overhang ${oh} appears at every junction — ambiguous ligation order (every part can self-ligate or swap with another).`
         : 'Parts can be self-ligated or reordered — ambiguous ligation order.',
     );
-    return { sequence: '', features: [], parts: parts.map((p) => p.name), ...(inputPartIds ? { partIds: inputPartIds } : {}), overhangs: [], enzyme: enz.name, topology: 'linear', success: false, errors, warnings };
+    return { sequence: '', features: [], parts: parts.map((p) => p.name), ...(inputPartIds ? { partIds: inputPartIds } : {}), overhangs: [], enzyme: enz.name, topology: 'linear', success: false, errors, warnings, normalizationDiagnostics, provenance: normalizationProvenance };
   }
 
   if (analysis.reason === 'ambiguous-multiple-chains') {
@@ -957,14 +1186,14 @@ export function goldenGateAssemble(
         'Could not form a complete assembly chain — parts can be ordered in multiple ways.',
       );
     }
-    return { sequence: '', features: [], parts: parts.map((p) => p.name), ...(inputPartIds ? { partIds: inputPartIds } : {}), overhangs: [], enzyme: enz.name, topology: 'linear', success: false, errors, warnings };
+    return { sequence: '', features: [], parts: parts.map((p) => p.name), ...(inputPartIds ? { partIds: inputPartIds } : {}), overhangs: [], enzyme: enz.name, topology: 'linear', success: false, errors, warnings, normalizationDiagnostics, provenance: normalizationProvenance };
   }
 
   if (analysis.reason === 'no-chain' || !analysis.ordered) {
     errors.push(
       'Could not form a complete assembly chain — check that overhangs are unique and form a linear (or circular) order',
     );
-    return { sequence: '', features: [], parts: parts.map((p) => p.name), ...(inputPartIds ? { partIds: inputPartIds } : {}), overhangs: [], enzyme: enz.name, topology: 'linear', success: false, errors, warnings };
+    return { sequence: '', features: [], parts: parts.map((p) => p.name), ...(inputPartIds ? { partIds: inputPartIds } : {}), overhangs: [], enzyme: enz.name, topology: 'linear', success: false, errors, warnings, normalizationDiagnostics, provenance: normalizationProvenance };
   }
 
   const ordered = analysis.ordered;
@@ -987,6 +1216,8 @@ export function goldenGateAssemble(
       success: false,
       errors,
       warnings,
+      normalizationDiagnostics,
+      provenance: normalizationProvenance,
       missingVectorOverhangs: missing,
     };
   }
@@ -1035,7 +1266,7 @@ export function goldenGateAssemble(
   }
 
   if (errors.length > 0) {
-    return { sequence: '', features: [], parts: ordered.map((p) => p.name), ...(orderedPartIds ? { partIds: orderedPartIds } : {}), overhangs, enzyme: enz.name, topology: 'linear', success: false, errors, warnings };
+    return { sequence: '', features: [], parts: ordered.map((p) => p.name), ...(orderedPartIds ? { partIds: orderedPartIds } : {}), overhangs, enzyme: enz.name, topology: 'linear', success: false, errors, warnings, normalizationDiagnostics, provenance: normalizationProvenance };
   }
 
   const last = ordered[ordered.length - 1];
@@ -1045,7 +1276,7 @@ export function goldenGateAssemble(
     errors.push(
       `Assembly chain is open: "${last.name}" 3' overhang ${last.rightOverhang} does not close to "${first.name}" 5' overhang ${first.oh5}`,
     );
-    return { sequence: '', features: [], parts: ordered.map((p) => p.name), ...(orderedPartIds ? { partIds: orderedPartIds } : {}), overhangs, enzyme: enz.name, topology: 'linear', success: false, errors, warnings };
+    return { sequence: '', features: [], parts: ordered.map((p) => p.name), ...(orderedPartIds ? { partIds: orderedPartIds } : {}), overhangs, enzyme: enz.name, topology: 'linear', success: false, errors, warnings, normalizationDiagnostics, provenance: normalizationProvenance };
   }
 
   const preClosureLength = sequence.length;
@@ -1082,6 +1313,8 @@ export function goldenGateAssemble(
     success: true,
     errors: [],
     warnings,
+    normalizationDiagnostics,
+    provenance: normalizationProvenance,
   };
 }
 
@@ -1177,12 +1410,20 @@ export function buildSyntheticGoldenGateVector(
   ) {
     throw new Error(`Unsupported ${enz.name} synthetic-vector cut geometry`);
   }
-  const leftSpacer = 'N'.repeat(leftSpacerLength);
-  const rightSpacer = 'N'.repeat(rightSpacerLength);
+  // Materialize every otherwise unspecified cut spacer with canonical bases.
+  // Ambiguous `N` spacers make the synthetic vector impossible to hash or
+  // rescreen deterministically. `A` is the stable canonical choice; the full
+  // construct is rescanned below before it is returned.
+  const leftSpacer = 'A'.repeat(leftSpacerLength);
+  const rightSpacer = 'A'.repeat(rightSpacerLength);
   const padding = 'AAAA';
   // Layout: padding + sense site + left spacer + left overhang + filler
   //       + right overhang + right spacer + antisense site + padding.
   const sequence = `${padding}${recog}${leftSpacer}${left}${filler}${right}${rightSpacer}${recogRC}${padding}`;
+
+  if (!/^[ACGT]+$/.test(sequence)) {
+    throw new Error('Synthetic Golden Gate vector must be canonical A/C/G/T after spacer materialization.');
+  }
 
   // Verify the synthetic part has no internal Type IIS sites that would
   // sabotage the assembly. If the filler accidentally contains one, the
@@ -1223,7 +1464,8 @@ export type GoldenGateDomesticationFailureCode =
   | 'unmodifiable_authoritative_site'
   | 'remaining_forbidden_site'
   | 'introduced_forbidden_site'
-  | 'protein_identity_mismatch';
+  | 'protein_identity_mismatch'
+  | 'invalid_translation_exception';
 
 export interface GoldenGateDomesticationFailure {
   code: GoldenGateDomesticationFailureCode;
@@ -1231,11 +1473,13 @@ export interface GoldenGateDomesticationFailure {
   position?: number;
   enzyme?: string;
   motif?: string;
+  diagnostics?: TranslationExceptionDiagnostic[];
 }
 
 /** A feature location is authoritative only when every stored segment is valid. */
 export type GoldenGateCdsFeature = Pick<Feature, 'start' | 'end' | 'strand' | 'subRanges'> & {
   type?: Feature['type'];
+  metadata?: Feature['metadata'];
 };
 
 export interface DomesticateGoldenGateFeatureOptions {
@@ -1266,6 +1510,8 @@ export interface DomesticateGoldenGateFeatureResult {
   sourceProtein: string | null;
   productProtein: string | null;
   proteinIdentity: boolean;
+  /** Translation-exception receipt used for the protein-identity guarantee. */
+  translationReceipt?: TranslationExceptionReceipt;
 }
 
 function domesticationFailure(
@@ -1510,12 +1756,52 @@ export function domesticateGoldenGateFeature(
     return emptyResult({ translatedBaseRange });
   }
   let sourceProtein: string;
+  let translationReceipt: TranslationExceptionReceipt | undefined;
+  let translationExceptions: TranslationException[] = [];
   try {
     sourceProtein = translateCompleteCds(coding, 0, table);
   } catch (error) {
     failures.push(domesticationFailure('untranslatable_cds', error instanceof Error ? error.message : 'CDS could not be translated.'));
     return emptyResult({ translatedBaseRange });
   }
+
+  const rawTranslationException = options.feature.metadata?.transl_except
+    ?? options.feature.metadata?.translExcept;
+  if (rawTranslationException !== undefined) {
+    const materialized = materializeTranslationExceptions({
+      sequence: source,
+      feature: options.feature,
+      qualifier: rawTranslationException,
+      codonStart,
+      translationTableId: table.id,
+    });
+    if (!materialized.ok) {
+      failures.push(...materialized.diagnostics.map((entry) => domesticationFailure(
+        'invalid_translation_exception',
+        entry.message,
+        { diagnostics: [entry] },
+      )));
+      return emptyResult({
+        translatedBaseRange,
+        sourceProtein,
+        productProtein: null,
+        proteinIdentity: false,
+      });
+    }
+    translationReceipt = materialized.receipt;
+    translationExceptions = materialized.exceptions;
+    sourceProtein = materialized.materializedProtein;
+  }
+
+  const proteinForOrientedSequence = (orientedSequence: string): string => {
+    const translated = translateCompleteCds(orientedSequence.slice(frame), 0, table);
+    if (translationExceptions.length === 0) return translated;
+    return translationExceptions.reduce((protein, exception) => (
+      exception.codonIndex < 0 || exception.codonIndex >= protein.length
+        ? protein
+        : `${protein.slice(0, exception.codonIndex)}${exception.residue}${protein.slice(exception.codonIndex + 1)}`
+    ), translated);
+  };
 
   const selectedEnzymes: RestrictionEnzyme[] = [];
   for (const rawName of options.forbiddenEnzymes ?? []) {
@@ -1614,7 +1900,7 @@ export function domesticateGoldenGateFeature(
         for (const candidateCodon of alternatives) {
           if (candidateCodon === originalCodon) continue;
           const candidateOriented = `${workingOriented.slice(0, codonOffset)}${candidateCodon}${workingOriented.slice(codonOffset + 3)}`;
-          if (translateCompleteCds(candidateOriented.slice(frame), 0, table) !== sourceProtein) continue;
+          if (proteinForOrientedSequence(candidateOriented) !== sourceProtein) continue;
           const candidateSites = scanDomesticationSitesBySegments(
             candidateOriented,
             location.segments,
@@ -1682,10 +1968,9 @@ export function domesticateGoldenGateFeature(
       { position: site.position, enzyme: site.enzyme, motif: site.motif },
     ));
   }
-  const productCoding = workingOriented.slice(frame);
   let productProtein: string | null = null;
   try {
-    productProtein = translateCompleteCds(productCoding, 0, table);
+    productProtein = proteinForOrientedSequence(workingOriented);
   } catch {
     failures.push(domesticationFailure('untranslatable_cds', 'Domesticated CDS could not be translated.'));
   }
@@ -1704,6 +1989,7 @@ export function domesticateGoldenGateFeature(
     sourceProtein,
     productProtein,
     proteinIdentity,
+    ...(translationReceipt ? { translationReceipt } : {}),
   };
 }
 
@@ -1783,6 +2069,10 @@ export function domesticateLegacyProjection(
 }
 
 /**
+ * @deprecated Use `domesticateGoldenGateFeature()` with an explicit feature,
+ * frame, and translation table. This compatibility adapter is contained behind
+ * the same authoritative context requirement as `domesticate()`.
+ *
  * Domesticate ONLY the internal insert of a flanked Type IIS part, preserving
  * the structural flanking recognition sites the assembly depends on.
  *
@@ -1798,7 +2088,9 @@ export function domesticateLegacyProjection(
 export function domesticatePartInternals(
   seq: string,
   enzyme = DEFAULT_ENZYME,
-): { sequence: string; mutations: Array<{ position: number; original: string; replacement: string }> } {
+  options?: LegacyDomesticateOptions,
+): GoldenGateLegacyDomesticationProjection {
+  if (!options) throw new GoldenGateLegacyDomesticationError();
   const boundary = getGoldenGatePartBoundary({ name: 'part', sequence: seq }, enzyme);
   if (
     boundary.insertStart != null &&
@@ -1806,25 +2098,32 @@ export function domesticatePartInternals(
     boundary.insertEnd > boundary.insertStart
   ) {
     const insertStart = boundary.insertStart;
-    const insert = seq.slice(insertStart, boundary.insertEnd);
+    const insert = seq.toUpperCase().slice(insertStart, boundary.insertEnd);
     const cleaned = domesticateGoldenGateFeature({
       sequence: insert,
-      feature: { start: 0, end: insert.length, strand: 1, type: 'cds' },
-      codonStart: 1,
-      translationTableId: 1,
+      feature: options.feature,
+      codonStart: options.codonStart,
+      translationTableId: options.translationTableId,
       forbiddenEnzymes: [enzyme],
     });
     return {
-      sequence: seq.slice(0, insertStart) + cleaned.sequence + seq.slice(boundary.insertEnd),
+      sequence: seq.toUpperCase().slice(0, insertStart) + cleaned.sequence + seq.toUpperCase().slice(boundary.insertEnd),
       mutations: cleaned.mutations.map((m) => ({ ...m, position: m.position + insertStart })),
+      warning: GOLDEN_GATE_LEGACY_PROJECTION_WARNING,
+      deprecated: true,
     };
   }
   const cleaned = domesticateGoldenGateFeature({
-    sequence: seq,
-    feature: { start: 0, end: seq.length, strand: 1, type: 'cds' },
-    codonStart: 1,
-    translationTableId: 1,
+    sequence: seq.toUpperCase(),
+    feature: options.feature,
+    codonStart: options.codonStart,
+    translationTableId: options.translationTableId,
     forbiddenEnzymes: [enzyme],
   });
-  return { sequence: cleaned.sequence, mutations: cleaned.mutations };
+  return {
+    sequence: cleaned.sequence,
+    mutations: cleaned.mutations,
+    warning: GOLDEN_GATE_LEGACY_PROJECTION_WARNING,
+    deprecated: true,
+  };
 }

--- a/src/bio/orf-detection.ts
+++ b/src/bio/orf-detection.ts
@@ -1,6 +1,6 @@
 import type { ORF, CodonTable, Topology } from './types';
 import { STANDARD_CODE } from './codon-tables';
-import { expandIupacCodon, normalizeTranslationInput, resolveIupacCodon } from './translate';
+import { expandIupacCodon, isDefiniteInitiatorCodon, normalizeTranslationInput, resolveIupacCodon } from './translate';
 import { reverseComplement } from './reverse-complement';
 
 /**
@@ -153,14 +153,13 @@ function findORFsInFrame(
 ): ORF[] {
   const orfs: ORF[] = [];
   const stops = new Set(table.stops);
-  const starts = new Set(table.starts);
   const startPositions: number[] = [];
   const stopPositions: number[] = [];
   const hasAmbiguity = /[RYSWKMBDHVN]/.test(seq);
 
   for (let position = frameOffset; position + 2 < seq.length; position += 3) {
     const codon = seq.slice(position, position + 3);
-    if (isDefiniteCodonMember(codon, starts)) startPositions.push(position);
+    if (isDefiniteInitiatorCodon(codon, table)) startPositions.push(position);
     if (isDefiniteCodonMember(codon, stops)) stopPositions.push(position);
   }
 

--- a/src/bio/pcr.ts
+++ b/src/bio/pcr.ts
@@ -17,12 +17,48 @@ function primerBindingTm(seq: string): number | null {
 
 export const DEFAULT_MIN_MATCHED_3_PRIME_LENGTH = 10;
 export const DEFAULT_MAX_PRIMER_MISMATCHES = 0;
-const MAX_PRODUCT_LENGTH = 50_000;
+export const MAX_PCR_OLIGO_LENGTH = 500;
+export const MAX_PCR_TAIL_LENGTH = 250;
+export const MAX_PCR_PRODUCT_LENGTH = 50_000;
 const DEFAULT_MAX_BINDING_CANDIDATES = 10_000;
 const DEFAULT_MAX_COMPETING_PRODUCTS = 100;
 const MAX_PRODUCT_COMBINATIONS = 100_000;
 
 export type PCRBindingStatus = 'exact' | 'ambiguous' | 'mismatch';
+
+export type PCRTailSource = 'none' | 'explicit-selection' | 'inferred';
+
+export interface PCRBindingEdit {
+  /** Offset in the final 5′→3′ product (including the forward tail). */
+  productOffset: number;
+  /** Coordinate in the original forward-strand template. */
+  templatePosition: number;
+  original: string;
+  replacement: string;
+  primer: 'forward' | 'reverse';
+}
+
+export type PCRDiagnosticCode =
+  | 'implicit_tail'
+  | 'primer_bases_overwrote_template'
+  | 'overlapping_binding_regions';
+
+export interface PCRDiagnostic {
+  code: PCRDiagnosticCode;
+  message: string;
+  primer?: 'forward' | 'reverse';
+  positions?: number[];
+}
+
+export interface PCRProductProvenance {
+  engine: 'motif-pcr';
+  engineVersion: '2';
+  /** Product bases are the template interval overlaid with primer bases. */
+  productAssembly: 'template-plus-primer-binding';
+  tailPolicy: 'explicit-only' | 'allow-implicit';
+  implicitTails: { forward: boolean; reverse: boolean };
+  bindingEdits: PCRBindingEdit[];
+}
 
 export interface PCRSimulationOptions {
   /** Minimum consecutive compatible bases at the primer's 3′ end. */
@@ -33,6 +69,8 @@ export interface PCRSimulationOptions {
   maxBindingCandidates?: number;
   /** Number of competing product descriptions retained in the result. */
   maxCompetingProducts?: number;
+  /** Permit an unmatched 5′ primer prefix to be inferred as a tail. */
+  allowImplicitTails?: boolean;
 }
 
 export interface PCRBindingCandidate {
@@ -50,6 +88,8 @@ export interface PCRBindingCandidate {
   matched3PrimeLength: number;
   /** Exact/conditional/mismatch confidence for this candidate. */
   status: PCRBindingStatus;
+  /** Whether the prefix was selected explicitly or inferred from a shorter suffix. */
+  tailSource: PCRTailSource;
 }
 
 export interface PCRPrimerBinding {
@@ -62,6 +102,7 @@ export interface PCRPrimerBinding {
   mismatchCount?: number;
   matched3PrimeLength?: number;
   status?: PCRBindingStatus;
+  tailSource?: PCRTailSource;
   /** Melting temperature of the binding region only. */
   tm: number | null;
   /** GC% of the binding region; ambiguity is retained in status. */
@@ -98,12 +139,17 @@ export interface PCRResult {
   status: PCRBindingStatus;
   /** Explicit caveats; an ambiguous result must not be presented as exact. */
   warnings: string[];
+  /** Machine-readable caveats and product-overlay evidence. */
+  diagnostics: PCRDiagnostic[];
+  /** Deterministic product construction and primer/template edit receipt. */
+  provenance: PCRProductProvenance;
   /** Other valid products/sites found under the selected policy. */
   competingProducts: PCRCompetingProduct[];
   /** Search/policy evidence retained with the result. */
   policy: {
     minMatched3PrimeLength: number;
     maxMismatches: number;
+    allowImplicitTails: boolean;
   };
 }
 
@@ -121,15 +167,17 @@ function normalizePolicy(options?: PCRSimulationOptions): {
   maxMismatches: number;
   maxBindingCandidates: number;
   maxCompetingProducts: number;
+  allowImplicitTails: boolean;
 } | null {
   const minMatched3PrimeLength = options?.minMatched3PrimeLength ?? DEFAULT_MIN_MATCHED_3_PRIME_LENGTH;
   const maxMismatches = options?.maxMismatches ?? DEFAULT_MAX_PRIMER_MISMATCHES;
   const maxBindingCandidates = options?.maxBindingCandidates ?? DEFAULT_MAX_BINDING_CANDIDATES;
   const maxCompetingProducts = options?.maxCompetingProducts ?? DEFAULT_MAX_COMPETING_PRODUCTS;
+  const allowImplicitTails = options?.allowImplicitTails ?? false;
   if (
     !Number.isInteger(minMatched3PrimeLength)
     || minMatched3PrimeLength < 1
-    || minMatched3PrimeLength > 10_000
+    || minMatched3PrimeLength > MAX_PCR_OLIGO_LENGTH
     || !Number.isInteger(maxMismatches)
     || maxMismatches < 0
     || maxMismatches > 10_000
@@ -139,8 +187,9 @@ function normalizePolicy(options?: PCRSimulationOptions): {
     || !Number.isInteger(maxCompetingProducts)
     || maxCompetingProducts < 0
     || maxCompetingProducts > 10_000
+    || typeof allowImplicitTails !== 'boolean'
   ) return null;
-  return { minMatched3PrimeLength, maxMismatches, maxBindingCandidates, maxCompetingProducts };
+  return { minMatched3PrimeLength, maxMismatches, maxBindingCandidates, maxCompetingProducts, allowImplicitTails };
 }
 
 function statusForBinding(
@@ -162,8 +211,17 @@ function bindingAt(
   bindingLength: number,
   minMatched3PrimeLength: number,
   maxMismatches: number,
+  allowImplicitTails: boolean,
 ): PCRSearchCandidate | null {
-  if (bindingLength < minMatched3PrimeLength || position < 0 || position + bindingLength > template.length) return null;
+  if (
+    bindingLength < minMatched3PrimeLength
+    || bindingLength > primer.length
+    || primer.length > MAX_PCR_OLIGO_LENGTH
+    || primer.length - bindingLength > MAX_PCR_TAIL_LENGTH
+    || position < 0
+    || position + bindingLength > template.length
+  ) return null;
+  if (!allowImplicitTails && bindingLength !== primer.length) return null;
   const bindingSequence = primer.slice(primer.length - bindingLength);
   const templateSequence = template.slice(position, position + bindingLength);
   let mismatchCount = 0;
@@ -184,6 +242,7 @@ function bindingAt(
     mismatchCount,
     matched3PrimeLength,
     status: statusForBinding(bindingSequence, templateSequence, mismatchCount),
+    tailSource: bindingLength === primer.length ? 'none' : 'inferred',
   };
 }
 
@@ -202,6 +261,7 @@ export function findPrimerBindings(
   const templateInspection = inspectNucleotideSequence(template);
   const primerInspection = inspectNucleotideSequence(primer);
   if (templateInspection.invalidCharacters.length > 0 || primerInspection.invalidCharacters.length > 0) return [];
+  if (primerInspection.sequence.length > MAX_PCR_OLIGO_LENGTH) return [];
   const tmpl = templateInspection.sequence;
   const oligo = primerInspection.sequence;
   if (oligo.length < policy.minMatched3PrimeLength || tmpl.length === 0) return [];
@@ -210,8 +270,8 @@ export function findPrimerBindings(
   const seen = new Set<string>();
   const minBindingLength = Math.min(oligo.length, policy.minMatched3PrimeLength);
   // Prefer the full oligo when a safety cap is reached. Short suffixes are
-  // still retained as explicit tail alternatives, but must not crowd out the
-  // strongest/full-length binding evidence.
+  // considered only after an explicit allowImplicitTails opt-in and must not
+  // crowd out the strongest/full-length binding evidence.
   for (let bindingLength = oligo.length; bindingLength >= minBindingLength; bindingLength -= 1) {
     for (let position = 0; position + bindingLength <= tmpl.length; position += 1) {
       const candidate = bindingAt(
@@ -221,6 +281,7 @@ export function findPrimerBindings(
         bindingLength,
         policy.minMatched3PrimeLength,
         policy.maxMismatches,
+        policy.allowImplicitTails,
       );
       if (!candidate) continue;
       const key = `${candidate.bindStart}:${candidate.bindEnd}:${candidate.mismatchCount}`;
@@ -256,8 +317,11 @@ function selectedBindingCandidate(
     range.end - range.start,
     policy.minMatched3PrimeLength,
     policy.maxMismatches,
+    true,
   );
-  return candidate ? { ...candidate } : null;
+  return candidate
+    ? { ...candidate, tailSource: candidate.tail.length > 0 ? 'explicit-selection' : 'none' }
+    : null;
 }
 
 function asReverseBinding(
@@ -332,7 +396,72 @@ function productStatusWarnings(
   if (status === 'ambiguous') warnings.push('IUPAC ambiguity occurs in the binding or amplified template region; this product is conditional, not an exact sequence claim.');
   const mismatchCount = forward.mismatchCount + reverse.mismatchCount;
   if (mismatchCount > 0) warnings.push(`Primer binding uses ${mismatchCount} permitted mismatch${mismatchCount === 1 ? '' : 'es'}; review the 3′-end policy before ordering.`);
+  if (forward.tailSource === 'inferred' || reverse.tailSource === 'inferred') {
+    warnings.push('A 5′ primer tail was inferred from a shorter binding suffix; select binding coordinates or provide an explicit tail before ordering.');
+  }
   return warnings;
+}
+
+function materializeTemplateProduct(
+  template: string,
+  forward: PCRBindingCandidate,
+  reverse: PCRBindingCandidate,
+  wrapsOrigin: boolean,
+  forwardTailLength: number,
+): {
+  templateProduct: string;
+  bindingEdits: PCRBindingEdit[];
+  overlappingBindingPositions: number[];
+} {
+  const originalProduct = wrapsOrigin
+    ? template.slice(forward.bindStart) + template.slice(0, reverse.bindEnd)
+    : template.slice(forward.bindStart, reverse.bindEnd);
+  const segments = wrapsOrigin
+    ? [
+        { start: forward.bindStart, end: template.length, productStart: 0 },
+        { start: 0, end: reverse.bindEnd, productStart: template.length - forward.bindStart },
+      ]
+    : [{ start: forward.bindStart, end: reverse.bindEnd, productStart: 0 }];
+  const chars = originalProduct.split('');
+  const bindingEdits: PCRBindingEdit[] = [];
+  const touchedBy = new Map<number, 'forward' | 'reverse'>();
+  const overlappingBindingPositions: number[] = [];
+  const apply = (
+    templatePosition: number,
+    replacement: string,
+    primer: 'forward' | 'reverse',
+  ): void => {
+    const segment = segments.find((candidate) => (
+      templatePosition >= candidate.start && templatePosition < candidate.end
+    ));
+    if (!segment) return;
+    const productOffset = segment.productStart + templatePosition - segment.start;
+    const previousPrimer = touchedBy.get(productOffset);
+    if (previousPrimer && previousPrimer !== primer && !overlappingBindingPositions.includes(templatePosition)) {
+      overlappingBindingPositions.push(templatePosition);
+    }
+    touchedBy.set(productOffset, primer);
+    const original = chars[productOffset] ?? '';
+    if (original !== replacement) {
+      bindingEdits.push({
+        productOffset: forwardTailLength + productOffset,
+        templatePosition,
+        original,
+        replacement,
+        primer,
+      });
+      chars[productOffset] = replacement;
+    }
+  };
+
+  for (let offset = 0; offset < forward.bindingSequence.length; offset += 1) {
+    apply(forward.bindStart + offset, forward.bindingSequence[offset], 'forward');
+  }
+  const reversePlus = reverseComplement(reverse.bindingSequence);
+  for (let offset = 0; offset < reversePlus.length; offset += 1) {
+    apply(reverse.bindStart + offset, reversePlus[offset], 'reverse');
+  }
+  return { templateProduct: chars.join(''), bindingEdits, overlappingBindingPositions };
 }
 
 /**
@@ -363,6 +492,7 @@ export function simulatePCR(
   const tmpl = templateInspection.sequence;
   const fwd = forwardInspection.sequence;
   const rev = reverseInspection.sequence;
+  if (fwd.length > MAX_PCR_OLIGO_LENGTH || rev.length > MAX_PCR_OLIGO_LENGTH) return null;
   if (fwd.length < policy.minMatched3PrimeLength || rev.length < policy.minMatched3PrimeLength || tmpl.length === 0) return null;
 
   const validRange = (range: { start: number; end: number }) => (
@@ -413,7 +543,13 @@ export function simulatePCR(
       const templateProduct = wrapsOrigin
         ? tmpl.slice(forward.bindStart) + tmpl.slice(0, reverse.bindEnd)
         : tmpl.slice(forward.bindStart, reverse.bindEnd);
-      if (templateProduct.length === 0 || templateProduct.length > MAX_PRODUCT_LENGTH) continue;
+      const productLength = templateProduct.length + forward.tail.length + reverse.tail.length;
+      if (
+        templateProduct.length === 0
+        || forward.tail.length > MAX_PCR_TAIL_LENGTH
+        || reverse.tail.length > MAX_PCR_TAIL_LENGTH
+        || productLength > MAX_PCR_PRODUCT_LENGTH
+      ) continue;
       const productInspection = inspectNucleotideSequence(templateProduct);
       const candidateStatus = bindingStatus(forward, reverse);
       products.push({
@@ -422,7 +558,7 @@ export function simulatePCR(
         reverseRc,
         wrapsOrigin,
         templateProduct,
-        productLength: templateProduct.length + forward.tail.length + reverse.tail.length,
+        productLength,
         status: candidateStatus === 'exact' && productInspection.ambiguous ? 'ambiguous' : candidateStatus,
       });
     }
@@ -468,7 +604,41 @@ export function simulatePCR(
   if (productsTruncated) warnings.push(`PCR product enumeration stopped at ${MAX_PRODUCT_COMBINATIONS.toLocaleString()} combinations; narrow the binding policy before treating the result as exhaustive.`);
   const fwdTail = selected.forward.tail;
   const revTailRC = selected.reverse.tail.length > 0 ? reverseComplement(selected.reverse.tail) : '';
-  const product = fwdTail + selected.templateProduct + revTailRC;
+  const materialized = materializeTemplateProduct(
+    tmpl,
+    selected.forward,
+    selected.reverse,
+    selected.wrapsOrigin,
+    fwdTail.length,
+  );
+  const diagnostics: PCRDiagnostic[] = [];
+  const implicitForward = selected.forward.tailSource === 'inferred';
+  const implicitReverse = selected.reverse.tailSource === 'inferred';
+  if (implicitForward) diagnostics.push({
+    code: 'implicit_tail',
+    primer: 'forward',
+    message: 'The forward 5′ tail was inferred from a shorter binding suffix; an explicit binding selection is required for safe materialization.',
+  });
+  if (implicitReverse) diagnostics.push({
+    code: 'implicit_tail',
+    primer: 'reverse',
+    message: 'The reverse 5′ tail was inferred from a shorter binding suffix; an explicit binding selection is required for safe materialization.',
+  });
+  if (materialized.bindingEdits.length > 0) {
+    diagnostics.push({
+      code: 'primer_bases_overwrote_template',
+      message: `${materialized.bindingEdits.length} product base${materialized.bindingEdits.length === 1 ? '' : 's'} came from permitted primer/template mismatches rather than the template interval.`,
+      positions: materialized.bindingEdits.map((edit) => edit.templatePosition),
+    });
+  }
+  if (materialized.overlappingBindingPositions.length > 0) {
+    diagnostics.push({
+      code: 'overlapping_binding_regions',
+      message: 'Forward and reverse binding regions overlap; the reverse primer base was applied last at overlapping product coordinates.',
+      positions: materialized.overlappingBindingPositions,
+    });
+  }
+  const product = fwdTail + materialized.templateProduct + revTailRC;
   const sourceSpans: FeatureCoordinateMapSpan[] = selected.wrapsOrigin
     ? [
         { start: selected.forward.bindStart, end: tmpl.length, targetStart: fwdTail.length },
@@ -493,6 +663,15 @@ export function simulatePCR(
     wrapsOrigin: selected.wrapsOrigin,
     status,
     warnings,
+    diagnostics,
+    provenance: {
+      engine: 'motif-pcr',
+      engineVersion: '2',
+      productAssembly: 'template-plus-primer-binding',
+      tailPolicy: policy.allowImplicitTails ? 'allow-implicit' : 'explicit-only',
+      implicitTails: { forward: implicitForward, reverse: implicitReverse },
+      bindingEdits: materialized.bindingEdits,
+    },
     competingProducts: competing.map((candidate) => ({
       forward: candidate.forward,
       reverse: candidate.reverse,
@@ -503,6 +682,7 @@ export function simulatePCR(
     policy: {
       minMatched3PrimeLength: policy.minMatched3PrimeLength,
       maxMismatches: policy.maxMismatches,
+      allowImplicitTails: policy.allowImplicitTails,
     },
   };
 }

--- a/src/bio/primer-design.ts
+++ b/src/bio/primer-design.ts
@@ -5,8 +5,10 @@ import { reverseComplement } from './reverse-complement';
 import {
   predictHairpin,
   predictSelfDimer,
+  predictPrimerDimer,
   DEFAULT_MAX_HAIRPIN_DG,
   DEFAULT_MAX_DIMER_DG,
+  type DimerResult,
 } from './primer-thermodynamics';
 import { inspectNucleotideSequence } from './nucleotide';
 
@@ -112,6 +114,8 @@ export interface PrimerPair {
   reverse: PrimerCandidate;
   productLength: number;
   tmDifference: number;
+  /** Cross-primer interaction evidence retained for deterministic ranking. */
+  crossDimer?: DimerResult;
 }
 
 /**
@@ -270,7 +274,12 @@ function pairRankScore(pair: PrimerPair, targetTm: number, enforceTargetTm: bool
     : 0;
   const anchorPenalty = (pair.forward.anchorDistance + pair.reverse.anchorDistance) * ANCHOR_DISTANCE_PENALTY;
   const gcBalancePenalty = (Math.abs(pair.forward.gcPercent - 50) + Math.abs(pair.reverse.gcPercent - 50)) * 0.01;
-  return tmPairPenalty + targetPenalty + anchorPenalty + gcBalancePenalty;
+  const crossDimer = pair.crossDimer ?? predictPrimerDimer(pair.forward.fullSequence, pair.reverse.fullSequence);
+  const crossDimerPenalty = crossDimer.status === 'exact'
+    ? Math.max(0, -crossDimer.deltaG) * 0.1
+      + (crossDimer.threePrimeOverlap.primer1 + crossDimer.threePrimeOverlap.primer2) * 0.75
+    : 0;
+  return tmPairPenalty + targetPenalty + anchorPenalty + gcBalancePenalty + crossDimerPenalty;
 }
 
 /**
@@ -671,6 +680,7 @@ export function designPrimerPairWithDiagnostics(
         reverse: rev,
         productLength,
         tmDifference: tmDiff,
+        crossDimer: predictPrimerDimer(fwd.fullSequence, rev.fullSequence),
       });
     }
   }

--- a/src/bio/primer-thermodynamics.ts
+++ b/src/bio/primer-thermodynamics.ts
@@ -60,6 +60,10 @@ export interface DimerResult {
   pairLength: number;
   /** Offset of primer2 relative to primer1 (negative shifts primer2 left). */
   offset: number;
+  /** Number of paired bases touching each original primer's 3′ end. */
+  threePrimeOverlap: { primer1: number; primer2: number };
+  /** True when the strongest run reaches either extendable 3′ end. */
+  threePrimeParticipation: 'none' | 'primer1' | 'primer2' | 'both';
   /** ASCII rendering of the duplex alignment. */
   structure: string;
   /** Exact sequence after formatting normalization; no bases are discarded. */
@@ -205,6 +209,8 @@ export function predictPrimerDimer(p1: string, p2: string): DimerResult {
     deltaG: 0,
     pairLength: 0,
     offset: 0,
+    threePrimeOverlap: { primer1: 0, primer2: 0 },
+    threePrimeParticipation: 'none',
     structure: '',
     evaluatedSequence: `${a}|${b}`,
     status,
@@ -215,41 +221,59 @@ export function predictPrimerDimer(p1: string, p2: string): DimerResult {
   // The dimer alignment is p1 (5′→3′ top) vs p2 reverse-complement aligned at offset.
   const b_rc = reverseComplement(b);
 
-  // For each relative offset between [-len(b_rc)+1, len(a)-1], find the
-  // longest contiguous WC match.
+  // For each relative offset between [-len(b_rc)+1, len(a)-1], evaluate every
+  // maximal contiguous Watson-Crick run. A shorter GC-rich run at one offset
+  // can be more stable than a longer AT-rich run at the same offset.
   for (let offset = -(b_rc.length - 1); offset < a.length; offset++) {
     let runStart = -1;
-    let runLen = 0;
-    let bestRunLen = 0;
-    let bestRunStart = -1;
+    const evaluateRun = (start: number, length: number): void => {
+      if (start < 0 || length < 3) return;
+      const matched = a.slice(start, start + length);
+      const deltaG = Math.round(nnDeltaG(matched) * 100) / 100;
+      const matchedEnd = start + length;
+      const bRunStart = start + offset;
+      // Participation means the duplex reaches the actual terminal 3′ base;
+      // the overlap count is capped at the five terminal bases for ranking.
+      const primer1ThreePrime = matchedEnd === a.length ? Math.min(length, 5) : 0;
+      const primer2ThreePrime = bRunStart === 0 ? Math.min(length, 5) : 0;
+      const participation: DimerResult['threePrimeParticipation'] = primer1ThreePrime > 0 && primer2ThreePrime > 0
+        ? 'both'
+        : primer1ThreePrime > 0
+          ? 'primer1'
+          : primer2ThreePrime > 0
+            ? 'primer2'
+            : 'none';
+      const terminalBases = primer1ThreePrime + primer2ThreePrime;
+      const bestTerminalBases = best.threePrimeOverlap.primer1 + best.threePrimeOverlap.primer2;
+      const shouldReplace = deltaG < best.deltaG
+        || (deltaG === best.deltaG && (
+          terminalBases > bestTerminalBases
+          || (terminalBases === bestTerminalBases && length > best.pairLength)
+        ));
+      if (!shouldReplace) return;
+      best = {
+        deltaG,
+        pairLength: length,
+        offset,
+        threePrimeOverlap: { primer1: primer1ThreePrime, primer2: primer2ThreePrime },
+        threePrimeParticipation: participation,
+        structure: `5'-${matched}-3' (${length} bp duplex, offset ${offset})`,
+        evaluatedSequence: `${a}|${b}`,
+        status: 'exact',
+      };
+    };
     for (let i = Math.max(0, -offset); i < Math.min(a.length, b_rc.length - offset); i++) {
       const ai = a[i];
       const bi = b_rc[i + offset];
       if (ai === bi) {
-        if (runLen === 0) runStart = i;
-        runLen++;
-        if (runLen > bestRunLen) {
-          bestRunLen = runLen;
-          bestRunStart = runStart;
-        }
+        if (runStart === -1) runStart = i;
       } else {
-        runLen = 0;
+        evaluateRun(runStart, runStart === -1 ? 0 : i - runStart);
+        runStart = -1;
       }
     }
-    if (bestRunLen >= 3 && bestRunStart >= 0) {
-      const matched = a.slice(bestRunStart, bestRunStart + bestRunLen);
-      const dG = nnDeltaG(matched);
-      if (dG < best.deltaG) {
-        best = {
-          deltaG: Math.round(dG * 100) / 100,
-          pairLength: bestRunLen,
-          offset,
-          structure: `5'-${matched}-3' (${bestRunLen} bp duplex, offset ${offset})`,
-          evaluatedSequence: `${a}|${b}`,
-          status: 'exact',
-        };
-      }
-    }
+    const runEnd = Math.min(a.length, b_rc.length - offset);
+    evaluateRun(runStart, runStart === -1 ? 0 : runEnd - runStart);
   }
   return best;
 }

--- a/src/bio/restriction-digest.ts
+++ b/src/bio/restriction-digest.ts
@@ -8,6 +8,7 @@ import type {
 import {
   calculateRestrictionCleavageGeometry,
   findRestrictionSites,
+  isActiveDoubleStrandRestrictionSite,
   normalizeRestrictionSequence,
   scanRestrictionSites,
   type FindRestrictionSitesOptions,
@@ -27,7 +28,7 @@ export interface RestrictionDigestOptions {
   methylationAssumptions?: RestrictionMethylationState | Partial<Record<RestrictionMethylationTarget, RestrictionMethylationState>>;
 }
 
-export type RestrictionDigestIssueCode = RestrictionIssueCode | 'unknown_enzyme';
+export type RestrictionDigestIssueCode = RestrictionIssueCode | 'unknown_enzyme' | 'incompatible_colocated_cleavage';
 
 export interface RestrictionDigestIssue {
   code: RestrictionDigestIssueCode;
@@ -195,8 +196,7 @@ function resolveRequestedEnzymes(
 }
 
 function activeDoubleStrandSite(site: ReturnType<typeof findRestrictionSites>[number]): boolean {
-  const mode = site.cleavageMode ?? 'double-strand';
-  return mode === 'double-strand' && (site.cleavageStatus ?? 'ok') === 'ok';
+  return isActiveDoubleStrandRestrictionSite(site);
 }
 
 function restrictionDigestResultFor(
@@ -270,17 +270,56 @@ function restrictionDigestResultFor(
       },
     };
   });
-  const uniqueCutRecords = allCutRecords.filter((record, index) => (
-    index === allCutRecords.findIndex((candidate) => candidate.site.cutPosition === record.site.cutPosition)
-  ));
-  const enzymeNamesAtCut = (position: number): string[] => Array.from(new Set(
-    allCutRecords
-      .filter((record) => record.site.cutPosition === position)
-      .map((record) => record.enzyme.name),
-  ));
+
+  // A legacy top-strand coordinate is only a compatibility boundary. Two
+  // enzymes can share it while cleaving the opposite strand at different
+  // coordinates (and therefore producing different sticky ends). Group by
+  // the complete physical geometry and fail closed when one boundary has
+  // incompatible co-located cleavage records.
+  const geometryKey = (record: typeof allCutRecords[number]): string => JSON.stringify([
+    record.geometry.mode,
+    record.geometry.topCutPosition,
+    record.geometry.bottomCutPosition,
+    record.geometry.cutPosition,
+    record.geometry.overhangStart,
+    record.geometry.overhangEnd,
+    record.geometry.overhangLength,
+    record.geometry.valid,
+    record.enzyme.overhang,
+  ]);
+  const recordsByLegacyCut = new Map<number, typeof allCutRecords>();
+  for (const record of allCutRecords) {
+    const records = recordsByLegacyCut.get(record.site.cutPosition) ?? [];
+    records.push(record);
+    recordsByLegacyCut.set(record.site.cutPosition, records);
+  }
+  const uniqueCutRecords: typeof allCutRecords = [];
+  const enzymeNamesAtGeometry = new Map<string, string[]>();
+  for (const [legacyCutPosition, records] of recordsByLegacyCut) {
+    const byGeometry = new Map<string, typeof allCutRecords>();
+    for (const record of records) {
+      const key = geometryKey(record);
+      const matching = byGeometry.get(key) ?? [];
+      matching.push(record);
+      byGeometry.set(key, matching);
+    }
+    if (byGeometry.size > 1) {
+      const enzymes = Array.from(new Set(records.map((record) => record.enzyme.name)));
+      issues.push({
+        code: 'incompatible_colocated_cleavage',
+        position: legacyCutPosition,
+        enzyme: enzymes[0],
+        message: `Restriction enzymes ${enzymes.join(', ')} share cut coordinate ${legacyCutPosition} but have incompatible colocated cleavage geometry.`,
+      });
+    }
+    for (const [key, matching] of byGeometry) {
+      uniqueCutRecords.push(matching[0]);
+      enzymeNamesAtGeometry.set(key, Array.from(new Set(matching.map((record) => record.enzyme.name))));
+    }
+  }
   const cuts: RestrictionCleavageGeometry[] = uniqueCutRecords.map((record) => ({
     ...record.geometry,
-    enzymes: enzymeNamesAtCut(record.site.cutPosition),
+    enzymes: enzymeNamesAtGeometry.get(geometryKey(record)) ?? [record.enzyme.name],
   }));
 
   const base: RestrictionDigestResult = {
@@ -361,8 +400,8 @@ function restrictionDigestResultFor(
         endInOriginal: end,
         leftEnzyme: leftRecord?.enzyme.name ?? null,
         rightEnzyme: rightRecord?.enzyme.name ?? null,
-        leftEnzymes: leftRecord ? enzymeNamesAtCut(leftRecord.site.cutPosition) : [],
-        rightEnzymes: rightRecord ? enzymeNamesAtCut(rightRecord.site.cutPosition) : [],
+        leftEnzymes: leftRecord ? enzymeNamesAtGeometry.get(geometryKey(leftRecord)) ?? [leftRecord.enzyme.name] : [],
+        rightEnzymes: rightRecord ? enzymeNamesAtGeometry.get(geometryKey(rightRecord)) ?? [rightRecord.enzyme.name] : [],
         overhang5: left.overhang,
         overhang3: right.overhang,
         overhang5Type: left.type,
@@ -387,8 +426,8 @@ function restrictionDigestResultFor(
         endInOriginal: end > start ? end : end + normalized.length,
         leftEnzyme: current.enzyme.name,
         rightEnzyme: next.enzyme.name,
-        leftEnzymes: enzymeNamesAtCut(current.site.cutPosition),
-        rightEnzymes: enzymeNamesAtCut(next.site.cutPosition),
+        leftEnzymes: enzymeNamesAtGeometry.get(geometryKey(current)) ?? [current.enzyme.name],
+        rightEnzymes: enzymeNamesAtGeometry.get(geometryKey(next)) ?? [next.enzyme.name],
         overhang5: left.overhang,
         overhang3: right.overhang,
         overhang5Type: left.type,

--- a/src/bio/restriction-presets.ts
+++ b/src/bio/restriction-presets.ts
@@ -166,7 +166,9 @@ export function resolveRestrictionPresetEnzymes(
     : [...enzymeDb, ...RESTRICTION_ENZYMES];
 
   return preset.enzymeNames.map((name) => {
-    const enzyme = enzymeByName(name, enzymeDb) ?? enzymeByName(name, fallbackDb);
+    const enzyme = enzymeByName(name, RESTRICTION_ENZYMES_FULL)
+      ?? enzymeByName(name, enzymeDb)
+      ?? enzymeByName(name, fallbackDb);
     if (!enzyme) {
       throw new Error(`Restriction preset "${preset.id}" references unknown enzyme "${name}".`);
     }
@@ -207,7 +209,9 @@ export function resolveEnzymeUnion(
   };
   for (const source of sources) {
     if (source === 'common') {
-      for (const enzyme of RESTRICTION_ENZYMES) add(enzyme);
+      for (const enzyme of RESTRICTION_ENZYMES) {
+        add(fullByName.get(enzyme.name.toLowerCase()) ?? enzyme);
+      }
     } else if (source === 'favorites') {
       for (const name of favorites) add(fullByName.get(name.toLowerCase()));
     } else if (source.startsWith(CUSTOM_ENZYME_LIST_PREFIX)) {

--- a/src/bio/restriction-sites.ts
+++ b/src/bio/restriction-sites.ts
@@ -8,6 +8,7 @@ import type {
   RestrictionSite,
   Topology,
 } from './types';
+import { RESTRICTION_ENZYMES_FULL } from './enzyme-data';
 import { reverseComplement } from './reverse-complement';
 
 /**
@@ -71,6 +72,35 @@ export interface RestrictionScanResult {
   topology: Topology;
   sites: RestrictionSite[];
   issues: RestrictionScanIssue[];
+}
+
+/**
+ * The activity category for one requested enzyme after scanning. Categories
+ * are deliberately more precise than the historical `findNonCutters`
+ * boolean: a nick, a conditional site, and a legacy record without physical
+ * safety fields are not scientifically interchangeable with no recognition
+ * site.
+ */
+export type RestrictionEnzymeScanCategory =
+  | 'no-site'
+  | 'active-double-strand'
+  | 'nick-only'
+  | 'conditional'
+  | 'insufficient-flanking-bases'
+  | 'invalid-geometry'
+  | 'legacy-unsafe';
+
+export interface RestrictionEnzymeScanReceipt {
+  enzyme: RestrictionEnzyme;
+  sites: RestrictionSite[];
+  issues: RestrictionScanIssue[];
+  category: RestrictionEnzymeScanCategory;
+  activeDoubleStrandSiteCount: number;
+  nickSiteCount: number;
+  conditionalSiteCount: number;
+  insufficientFlankingSiteCount: number;
+  invalidGeometrySiteCount: number;
+  legacyUnsafeSiteCount: number;
 }
 
 export class RestrictionInputError extends Error {
@@ -198,6 +228,50 @@ export function calculateRestrictionCleavageGeometry(
     overhangLength,
     valid,
   };
+}
+
+/**
+ * Classify one site without guessing when it came from an older serialized
+ * payload. A scanner-produced double-strand site has both safety fields and
+ * both physical cut coordinates; a legacy object missing any of those facts
+ * is not safe to use as a physical cut assertion.
+ */
+export function restrictionSiteActivity(
+  site: Pick<RestrictionSite, 'cleavageMode' | 'cleavageStatus' | 'topCutPosition' | 'bottomCutPosition'>,
+): RestrictionEnzymeScanCategory {
+  const mode = site.cleavageMode;
+  const status = site.cleavageStatus;
+  if (mode === undefined || status === undefined) return 'legacy-unsafe';
+  if (mode !== 'double-strand' && mode !== 'nick_top' && mode !== 'nick_bottom') return 'legacy-unsafe';
+
+  // An explicit scanner status is itself a safety receipt. Preserve it even
+  // when the associated coordinates are intentionally non-materializable.
+  if (status === 'invalid_geometry') return 'invalid-geometry';
+  if (status === 'insufficient_flanking_bases') return 'insufficient-flanking-bases';
+  if (
+    status === 'methylation_unknown'
+    || status === 'methylation_unmethylated'
+    || status === 'methylation_context_unknown'
+  ) return 'conditional';
+  if (status !== 'ok') return 'legacy-unsafe';
+
+  const hasInteger = (value: number | null | undefined): value is number => (
+    value !== null && value !== undefined && Number.isInteger(value) && value >= 0
+  );
+  const completeGeometry = mode === 'double-strand'
+    ? hasInteger(site.topCutPosition) && hasInteger(site.bottomCutPosition)
+    : mode === 'nick_bottom'
+      ? site.topCutPosition === null && hasInteger(site.bottomCutPosition)
+      : site.bottomCutPosition === null && hasInteger(site.topCutPosition);
+  if (!completeGeometry) return 'legacy-unsafe';
+  return mode === 'double-strand' ? 'active-double-strand' : 'nick-only';
+}
+
+/** True only for a complete, scanner-safe physical double-strand site. */
+export function isActiveDoubleStrandRestrictionSite(
+  site: Pick<RestrictionSite, 'cleavageMode' | 'cleavageStatus' | 'topCutPosition' | 'bottomCutPosition'>,
+): boolean {
+  return restrictionSiteActivity(site) === 'active-double-strand';
 }
 
 function coordinateInLinearSequence(value: number | null, length: number): boolean {
@@ -348,6 +422,18 @@ for (const enzyme of RESTRICTION_ENZYMES) {
   enzyme.cleavageMode ??= 'double-strand';
 }
 
+// The compact working set predates the expanded catalog and historically
+// carried shallow copies of several records. Resolve every overlapping name
+// to the full catalog record so methylation rules, evidence, and future
+// physical metadata cannot drift between the Common and Full sources.
+const canonicalFullEnzymes = new Map(
+  RESTRICTION_ENZYMES_FULL.map((enzyme) => [enzyme.name.toLowerCase(), enzyme] as const),
+);
+for (let index = 0; index < RESTRICTION_ENZYMES.length; index += 1) {
+  const canonical = canonicalFullEnzymes.get(RESTRICTION_ENZYMES[index].name.toLowerCase());
+  if (canonical) RESTRICTION_ENZYMES[index] = canonical;
+}
+
 // For the full 200+ enzyme database, import directly from './enzyme-data'.
 
 // Recognition is matched base-by-base rather than interpolated into a RegExp.
@@ -445,16 +531,12 @@ export function scanRestrictionSites(
       cutPosition: circularGeometry.cutPosition,
       recognitionSequence: recognition,
       overhang: enzyme.overhang,
+      cleavageMode: enzyme.cleavageMode ?? 'double-strand',
+      topCutPosition: circularGeometry.topCutPosition,
+      bottomCutPosition: circularGeometry.bottomCutPosition,
+      cleavageStatus: status,
       strand,
     };
-    // Keep legacy object serialization/equality stable while exposing the new
-    // physical fields to typed/browser callers.
-    Object.defineProperties(site, {
-      cleavageMode: { value: enzyme.cleavageMode ?? 'double-strand', enumerable: false },
-      topCutPosition: { value: circularGeometry.topCutPosition, enumerable: false },
-      bottomCutPosition: { value: circularGeometry.bottomCutPosition, enumerable: false },
-      cleavageStatus: { value: status, enumerable: false },
-    });
     sites.push(site);
   };
 
@@ -476,6 +558,51 @@ export function scanRestrictionSites(
   return { sequence: upper, topology, sites, issues };
 }
 
+function scanCategoryForSites(sites: readonly RestrictionSite[]): RestrictionEnzymeScanCategory {
+  if (sites.length === 0) return 'no-site';
+  const categories = new Set(sites.map(restrictionSiteActivity));
+  // An active double-strand site is the only category that authorizes a cut;
+  // retain that precedence when a sequence contains mixed site outcomes.
+  if (categories.has('active-double-strand')) return 'active-double-strand';
+  if (categories.has('legacy-unsafe')) return 'legacy-unsafe';
+  if (categories.has('invalid-geometry')) return 'invalid-geometry';
+  if (categories.has('insufficient-flanking-bases')) return 'insufficient-flanking-bases';
+  if (categories.has('conditional')) return 'conditional';
+  return 'nick-only';
+}
+
+/**
+ * Return a structured activity receipt for each requested enzyme. This is the
+ * unambiguous replacement for treating every enzyme without an active
+ * double-strand site as a conventional "non-cutter".
+ */
+export function classifyRestrictionEnzymes(
+  seq: string,
+  enzymes: RestrictionEnzyme[] = RESTRICTION_ENZYMES,
+  options?: FindRestrictionSitesOptions,
+): RestrictionEnzymeScanReceipt[] {
+  const scan = scanRestrictionSites(seq, enzymes, options);
+  return enzymes.map((enzyme) => {
+    const sites = scan.sites.filter((site) => site.enzyme.toLowerCase() === enzyme.name.toLowerCase());
+    const activities = sites.map(restrictionSiteActivity);
+    return {
+      enzyme,
+      sites,
+      issues: scan.issues.filter((issue) => issue.enzyme?.toLowerCase() === enzyme.name.toLowerCase()),
+      category: scanCategoryForSites(sites),
+      activeDoubleStrandSiteCount: activities.filter((activity) => activity === 'active-double-strand').length,
+      nickSiteCount: activities.filter((activity) => activity === 'nick-only').length,
+      conditionalSiteCount: activities.filter((activity) => activity === 'conditional').length,
+      insufficientFlankingSiteCount: activities.filter((activity) => activity === 'insufficient-flanking-bases').length,
+      invalidGeometrySiteCount: activities.filter((activity) => activity === 'invalid-geometry').length,
+      legacyUnsafeSiteCount: activities.filter((activity) => activity === 'legacy-unsafe').length,
+    };
+  });
+}
+
+/** Descriptive alias for integrations that call the result a receipt. */
+export const restrictionEnzymeScanReceipts = classifyRestrictionEnzymes;
+
 /**
  * Find enzymes that cut exactly once (unique cutters).
  */
@@ -485,10 +612,7 @@ export function findUniqueCutters(
   options?: FindRestrictionSitesOptions,
 ): RestrictionSite[] {
   const allSites = findRestrictionSites(seq, enzymes, options)
-    .filter((site) => (
-      (site.cleavageMode ?? 'double-strand') === 'double-strand'
-      && (site.cleavageStatus ?? 'ok') === 'ok'
-    ));
+    .filter(isActiveDoubleStrandRestrictionSite);
 
   // Group by enzyme
   const byEnzyme = new Map<string, RestrictionSite[]>();
@@ -529,19 +653,21 @@ export function countAmbiguousBases(seq: string): number {
 }
 
 /**
- * Find enzymes that do NOT cut the sequence (non-cutters).
+ * Find enzymes without an active, complete double-strand cut.
+ *
+ * @deprecated Use `classifyRestrictionEnzymes` when the distinction between
+ * no-site, nick-only, conditional, invalid, and legacy data matters. This
+ * compatibility helper deliberately keeps the historical broad meaning.
  */
 export function findNonCutters(
   seq: string,
   enzymes: RestrictionEnzyme[] = RESTRICTION_ENZYMES,
   options?: FindRestrictionSitesOptions,
 ): RestrictionEnzyme[] {
-  const allSites = findRestrictionSites(seq, enzymes, options);
-  const cuttingEnzymes = new Set(allSites
-    .filter((site) => (
-      (site.cleavageMode ?? 'double-strand') === 'double-strand'
-      && (site.cleavageStatus ?? 'ok') === 'ok'
-    ))
-    .map((site) => site.enzyme));
-  return enzymes.filter(e => !cuttingEnzymes.has(e.name));
+  const activeEnzymes = new Set(
+    classifyRestrictionEnzymes(seq, enzymes, options)
+      .filter((receipt) => receipt.category === 'active-double-strand')
+      .map((receipt) => receipt.enzyme.name.toLowerCase()),
+  );
+  return enzymes.filter((enzyme) => !activeEnzymes.has(enzyme.name.toLowerCase()));
 }

--- a/src/bio/translate.ts
+++ b/src/bio/translate.ts
@@ -76,6 +76,18 @@ export function resolveIupacCodon(codon: string, table: CodonTable = STANDARD_CO
 }
 
 /**
+ * Return true only when every concrete expansion of an IUPAC codon is an
+ * initiator in the selected table. This preserves a definite-start contract:
+ * a codon such as ATH is a start in tables where ATA/ATC/ATT are all starts,
+ * while ATN is not a definite standard-code start because its expansions also
+ * include non-initiators.
+ */
+export function isDefiniteInitiatorCodon(codon: string, table: CodonTable = STANDARD_CODE): boolean {
+  const expansions = expandIupacCodon(codon);
+  return expansions.length > 0 && expansions.every((concreteCodon) => table.starts.includes(concreteCodon));
+}
+
+/**
  * Translate a DNA or RNA sequence to a protein string.
  * @param seq - DNA or RNA sequence
  * @param frame - Reading frame offset (0, 1, or 2)
@@ -121,7 +133,7 @@ export function translateCompleteCds(
   if (!protein) return protein;
   const dna = normalizeTranslationInput(seq);
   const initiator = dna.slice(frame, frame + 3);
-  return table.starts.includes(initiator) ? `M${protein.slice(1)}` : protein;
+  return isDefiniteInitiatorCodon(initiator, table) ? `M${protein.slice(1)}` : protein;
 }
 
 /**
@@ -151,7 +163,7 @@ export function translateFromFirstATG(
   const dna = normalizeTranslationInput(seq);
   let startIndex = -1;
   for (let index = 0; index + 2 < dna.length; index += 1) {
-    if (table.starts.includes(dna.slice(index, index + 3))) {
+    if (isDefiniteInitiatorCodon(dna.slice(index, index + 3), table)) {
       startIndex = index;
       break;
     }

--- a/src/mcp-app/motif-workbench-bridge.ts
+++ b/src/mcp-app/motif-workbench-bridge.ts
@@ -64,7 +64,7 @@ export async function applyMotifToolResult(result: CallToolResult): Promise<void
 export async function startMotifMcpBridge(): Promise<App> {
   setBridgeState('connecting');
   const app = new App(
-    { name: 'Motif for Claude Science', version: '0.3.1' },
+    { name: 'Motif for Claude Science', version: '0.3.2' },
     { availableDisplayModes: ['inline', 'fullscreen'] },
     { autoResize: false },
   );


### PR DESCRIPTION
## Summary

- unify restriction-enzyme metadata and serialized cleavage geometry, reject incompatible co-located cuts, and keep quarantined annotations out of derived records
- correct mismatch-aware PCR materialization, explicit primer tails, cross-dimer ranking, Golden Gate normalization, vector construction, and specialized translation behavior
- preserve primer-pair state across preview changes and expand focused responsive browser coverage
- replace dependency lifecycle execution with Motif-owned hash-verified esbuild preparation
- tighten connector environments, release verification receipts, immutable dependency baselines, and GitHub metadata policy
- align all release surfaces and public documentation on v0.3.2

## Validation

- `npm ci --ignore-scripts`
- `npm run gate`
  - 1,397 unit tests
  - 163 core browser tests
  - 59 MSA browser tests
  - 61 documented fixture-gated skips
- `npm run validate:plugin`
- two clean release builds matched across 67 files
- generated release scans passed for vocabulary and private-path policy
- `npm audit`: 0 vulnerabilities