### PR TITLE
Prepare Motif 0.3.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -21,7 +21,7 @@ body:
     id: version
     attributes:
       label: Motif version or commit
-      placeholder: v0.3.2 or a commit hash
+      placeholder: v0.3.3 or a commit hash
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,61 +38,56 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Repository language policy
-        run: npm run check:repository-language
-
-      - name: Unit tests
-        run: npm test
-
-      - name: Release alignment
-        run: npm run check:release-alignment
-
-      - name: Runtime compatibility
-        run: npm run check:runtime-compatibility
-
-      - name: Security audit
-        run: npm run security:audit
-
-      - name: Supply-chain policy
-        run: npm run security:policy
-
-      - name: Motif-owned dependency preparation
-        run: npm run security:lifecycle
-
-      - name: Dependency cooling-off policy
-        run: npm run security:cooling-off
-        env:
-          MOTIF_COOLING_OFF_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-
-      - name: Plugin and connector checks
-        run: npm run test:plugin && npm run test:connector
-
-      - name: Style and accessibility guards
-        run: npm run check:css-tokens && npm run check:aria-controls
-
-      - name: Build distributables
-        run: npm run build:motif
-
-      - name: Reproducible release build
-        run: npm run security:reproducibility
-
-      - name: Release budgets
-        run: npm run security:budgets
-
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
 
-      - name: Browser workflows
-        run: npm run test:e2e
+      - name: Canonical exact-commit gate
+        run: npm run gate
+        env:
+          MOTIF_COOLING_OFF_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
-      - name: MSA interaction workflows
-        run: npm run test:e2e:msa
+      - name: Retain gate and release evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: motif-gate-evidence-node-22
+          path: |
+            test-results/
+            dist-motif/gate-coverage.json
+            dist-motif/*.zip
+            dist-motif/*checksums*
+            dist-motif/*manifest*
+          if-no-files-found: warn
+          retention-days: 14
 
-      - name: Gate coverage report
-        run: npm run report:gate-coverage
+  node-24-compatibility:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts
+
+      - name: Check supply-chain policy before reviewed preparation
+        run: npm run security:policy
+
+      - name: Run reviewed dependency preparation
+        run: npm run security:lifecycle
+
+      - name: Typecheck on Node.js 24
+        run: npm run typecheck
+
+      - name: Unit tests on Node.js 24
+        run: npm test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,15 +12,9 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: Analyze JavaScript and TypeScript
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        language:
-          - actions
-          - javascript-typescript
     permissions:
       actions: read
       contents: read
@@ -36,10 +30,10 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
-          languages: ${{ matrix.language }}
+          languages: javascript-typescript
           build-mode: none
 
       - name: Analyze
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
-          category: /language:${{ matrix.language }}
+          category: /language:javascript-typescript

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ A passing DOM assertion is not proof that a control is legible or reachable.
 
 - Product name: **Motif for Claude Science**
 - Package/plugin slug: `motif-for-claude-science`
-- Current release version is `0.3.2` and must stay aligned in runtime, package, manifest,
+- Current release version is `0.3.3` and must stay aligned in runtime, package, manifest,
   and changelog.
 - New schemas, environment variables, page APIs, output files, and provenance
   identifiers use `motif` / `MOTIF_` names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 0.3.3 — 2026-08-08
+
+- Made Database JSON and workspace ZIP checkpoints provably restorable,
+  clarified active-record JSON scope, and expanded inventory-wide export-loss
+  receipts.
+- Hardened external MSA engine identity, execution isolation, executable
+  hashing, packaged-root selection, MCP output preflight, and portable paths.
+- Isolated destructive restore confirmation from background shortcuts and
+  stabilized high-zoom map and MSA edge-drag interactions.
+- Expanded canonical validation with MCP and browser typechecking, exact-commit
+  gate receipts, post-build release verification, accurate SBOM scope, Node 24
+  compatibility, and exact hosted-action pins.
+
 ## 0.3.2 — 2026-08-08
 
 - Unified restriction-enzyme sources, serialized complete cleavage geometry,

--- a/docs/CLAUDE_SCIENCE_INTEGRATION.md
+++ b/docs/CLAUDE_SCIENCE_INTEGRATION.md
@@ -1,6 +1,6 @@
 # Motif + Claude Science integration
 
-Last reviewed: August 8, 2026. Connector version: `0.3.2`.
+Last reviewed: August 8, 2026. Connector version: `0.3.3`.
 
 This is the maintainer and technical reference for the Motif-owned local
 connector. End users should start with the

--- a/docs/CLAUDE_SCIENCE_QUICKSTART.md
+++ b/docs/CLAUDE_SCIENCE_QUICKSTART.md
@@ -66,7 +66,7 @@ Use the latest published [Motif release](https://github.com/jvogan/motif/release
 or clone its tagged source into a fixed local folder:
 
 ```bash
-git clone --branch v0.3.2 --depth 1 https://github.com/jvogan/motif.git
+git clone --branch v0.3.3 --depth 1 https://github.com/jvogan/motif.git
 cd motif
 ```
 

--- a/docs/CLAUDE_SCIENCE_TROUBLESHOOTING.md
+++ b/docs/CLAUDE_SCIENCE_TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # Motif + Claude Science troubleshooting
 
-Last reviewed: August 8, 2026. Motif connector version: `0.3.2`.
+Last reviewed: August 8, 2026. Motif connector version: `0.3.3`.
 
 This guide covers the local `motif-local` connector only. It does not assume
 another application, connector, database, or product identity.

--- a/e2e/claude-science-artifact.spec.ts
+++ b/e2e/claude-science-artifact.spec.ts
@@ -1296,7 +1296,9 @@ test.describe('Claude Science artifact workflows', () => {
     await goldenGate.focus();
     await page.keyboard.press('ArrowRight');
     await expect(ligation).toBeFocused();
-    await expect(assembly.getByRole('tabpanel')).toHaveAttribute('aria-labelledby', await ligation.getAttribute('id'));
+    const ligationId = await ligation.getAttribute('id');
+    expect(ligationId).toBeTruthy();
+    await expect(assembly.getByRole('tabpanel')).toHaveAttribute('aria-labelledby', ligationId!);
 
     const productName = assembly.getByRole('textbox', { name: 'Product name' });
     await productName.scrollIntoViewIfNeeded();
@@ -2827,10 +2829,13 @@ test.describe('Claude Science artifact workflows', () => {
     const feature = page.locator('.motif-pm-feature[data-feature-id="late-large-feature"]');
     const expectFocusedRange = async () => {
       await expect(densityView.getByTestId('large-sequence-selection')).toHaveText('Map selection: 45,001–49,000.');
-      await expect.poll(() => value.evaluate((control) => ({
-        selectionStart: control.selectionStart,
-        selectionEnd: control.selectionEnd,
-      }))).toEqual({ selectionStart: 45_000, selectionEnd: 49_000 });
+      await expect.poll(() => value.evaluate((control) => {
+        const textarea = control as HTMLTextAreaElement;
+        return {
+          selectionStart: textarea.selectionStart,
+          selectionEnd: textarea.selectionEnd,
+        };
+      })).toEqual({ selectionStart: 45_000, selectionEnd: 49_000 });
       expect(await value.evaluate((control) => control.scrollTop)).toBeGreaterThan(0);
     };
 
@@ -4309,6 +4314,32 @@ test.describe('Claude Science artifact workflows', () => {
     const mapFrame = page.locator('.motif-cs-map-frame');
     const viewport = mapFrame.locator('.motif-pm-viewport');
     const svg = mapFrame.locator('svg.motif-plasmid-map');
+    const readBackboneBox = async () => {
+      const backbone = mapFrame.locator('.motif-pm-backbone');
+      await expect(backbone).toHaveCount(1);
+      await expect.poll(() => backbone.evaluate((element) => element.getBoundingClientRect().width)).toBeGreaterThan(0);
+      return backbone.evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+        return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+      });
+    };
+    const findPointerActionPoint = async (action: 'range' | 'pan') => {
+      const surface = mapFrame.locator('[data-map-interaction-surface]');
+      const box = await surface.boundingBox();
+      if (!box) throw new Error('map interaction surface has no visible box');
+      for (const yFraction of [0.05, 0.25, 0.5, 0.75, 0.95]) {
+        for (const xFraction of [0.05, 0.25, 0.5, 0.75, 0.95]) {
+          const point = {
+            x: box.x + box.width * xFraction,
+            y: box.y + box.height * yFraction,
+          };
+          await page.mouse.move(point.x, point.y);
+          await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+          if (await mapFrame.getAttribute('data-map-pointer-action') === action) return { ...point, surface: box };
+        }
+      }
+      throw new Error(`map exposes no visible ${action} interaction point at high zoom`);
+    };
 
     await page.evaluate(() => window.motifRenderInventory?.([{
       id: 'high-zoom-range-circular',
@@ -4318,8 +4349,9 @@ test.describe('Claude Science artifact workflows', () => {
       sequence: 'A'.repeat(4_000),
       annotations: [],
     }]));
-    let backbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
-    let ringTop = { x: backbone.x + backbone.width / 2, y: backbone.y };
+    await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('High zoom range circular');
+    const backbone = await readBackboneBox();
+    const ringTop = { x: backbone.x + backbone.width / 2, y: backbone.y };
     await page.mouse.move(ringTop.x, ringTop.y);
     await page.mouse.down();
     await page.mouse.move(backbone.x + backbone.width, backbone.y + backbone.height / 2, { steps: 8 });
@@ -4336,15 +4368,19 @@ test.describe('Claude Science artifact workflows', () => {
       });
     }
     await expect(mapFrame.locator('.motif-cs-map-hint')).toContainText('800%');
-    backbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
-    ringTop = { x: backbone.x + backbone.width / 2, y: backbone.y };
-    await page.mouse.move(ringTop.x, ringTop.y + 10);
+    const circularRangePoint = await findPointerActionPoint('range');
+    await page.mouse.move(circularRangePoint.x, circularRangePoint.y);
     await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'range');
-    await page.mouse.move(ringTop.x, ringTop.y - 50);
+    const circularPanPoint = await findPointerActionPoint('pan');
+    await page.mouse.move(circularPanPoint.x, circularPanPoint.y);
     await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
     const beforeCircularPan = await viewport.getAttribute('transform');
     await page.mouse.down();
-    await page.mouse.move(ringTop.x + 36, ringTop.y - 68, { steps: 6 });
+    await page.mouse.move(
+      Math.min(circularPanPoint.surface.x + circularPanPoint.surface.width - 4, circularPanPoint.x + 24),
+      Math.min(circularPanPoint.surface.y + circularPanPoint.surface.height - 4, circularPanPoint.y + 24),
+      { steps: 6 },
+    );
     await page.mouse.up();
     expect(await viewport.getAttribute('transform')).not.toBe(beforeCircularPan);
 
@@ -4362,7 +4398,9 @@ test.describe('Claude Science artifact workflows', () => {
       sequence: 'A'.repeat(4_000),
       annotations: [],
     }]));
-    const linearBackbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
+    await expect(page.locator('.motif-cs-record-tab[data-active="true"]')).toContainText('High zoom range linear');
+    await expect(mapFrame).toHaveAttribute('data-map-mode', 'linear');
+    const linearBackbone = await readBackboneBox();
     const axis = { x: linearBackbone.x + linearBackbone.width / 2, y: linearBackbone.y + linearBackbone.height / 2 };
     await page.mouse.move(axis.x - 80, axis.y);
     await page.mouse.down();
@@ -4380,14 +4418,11 @@ test.describe('Claude Science artifact workflows', () => {
       });
     }
     await expect(mapFrame.locator('.motif-cs-map-hint')).toContainText('800%');
-    const zoomedLinearBackbone = (await mapFrame.locator('.motif-pm-backbone').boundingBox())!;
-    const zoomedAxis = {
-      x: zoomedLinearBackbone.x + zoomedLinearBackbone.width / 2,
-      y: zoomedLinearBackbone.y + zoomedLinearBackbone.height / 2,
-    };
-    await page.mouse.move(zoomedAxis.x, zoomedAxis.y + 10);
+    const linearRangePoint = await findPointerActionPoint('range');
+    await page.mouse.move(linearRangePoint.x, linearRangePoint.y);
     await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'range');
-    await page.mouse.move(zoomedAxis.x, zoomedAxis.y + 50);
+    const linearPanPoint = await findPointerActionPoint('pan');
+    await page.mouse.move(linearPanPoint.x, linearPanPoint.y);
     await expect(mapFrame).toHaveAttribute('data-map-pointer-action', 'pan');
 
     await page.getByRole('button', { name: 'Reset map view' }).click();
@@ -5694,7 +5729,6 @@ test.describe('Claude Science artifact workflows', () => {
 
     const windowPanel = page.locator('.motif-cs-window').filter({ has: page.getByTestId('msa-workspace') });
     const matrix = page.getByRole('region', { name: 'Scrollable alignment matrix viewport', exact: true });
-    const panRow = page.getByTestId('msa-horizontal-scroll-row');
     const pan = page.getByTestId('msa-horizontal-scroll');
     await expect(windowPanel).toBeVisible();
     await expect(pan).toBeVisible();

--- a/e2e/claude-science-msa-interactions.spec.ts
+++ b/e2e/claude-science-msa-interactions.spec.ts
@@ -1261,7 +1261,8 @@ test.describe('Motif MSA viewer interactions', () => {
     const panel = page.getByTestId('msa-view-menu');
     await expect(panel).toBeVisible();
 
-    const read = () => panel.evaluate((el) => {
+    const read = () => panel.evaluate((element) => {
+      const el = element as HTMLElement;
       const host = el.closest('.motif-cs-window');
       if (!host) throw new Error('the view menu is not inside a window — this measures nothing');
       const panelBox = el.getBoundingClientRect();
@@ -1462,8 +1463,13 @@ test.describe('Motif MSA viewer interactions', () => {
     if (!box) throw new Error('export menu trigger has no box');
     const x = box.x + box.width / 2;
     const y = box.y + box.height / 2;
-    const mouse = (type: string, buttons: number) => client.send('Input.dispatchMouseEvent', { type, x, y, button: 'left', clickCount: 1, buttons });
-    const key = (type: string) => client.send('Input.dispatchKeyEvent', { type, key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27, nativeVirtualKeyCode: 27 });
+    const mouse = (
+      type: 'mousePressed' | 'mouseReleased' | 'mouseMoved' | 'mouseWheel',
+      buttons: number,
+    ) => client.send('Input.dispatchMouseEvent', { type, x, y, button: 'left', clickCount: 1, buttons });
+    const key = (
+      type: 'keyDown' | 'keyUp' | 'rawKeyDown' | 'char',
+    ) => client.send('Input.dispatchKeyEvent', { type, key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27, nativeVirtualKeyCode: 27 });
     await Promise.all([mouse('mousePressed', 1), mouse('mouseReleased', 0), key('keyDown'), key('keyUp')]);
     await page.waitForTimeout(400);
 

--- a/e2e/claude-science-pane-placement.spec.ts
+++ b/e2e/claude-science-pane-placement.spec.ts
@@ -181,7 +181,7 @@ test.describe('state-preserving pane placement', () => {
     expect(moved).not.toBeNull();
     expect(Math.abs(moved!.x - before!.x) + Math.abs(moved!.y - before!.y)).toBeGreaterThan(20);
 
-    const resize = tools.getByTestId('floating-pane-resize-tools');
+    const resize = page.getByTestId('floating-pane-resize-tools');
     const resizeBox = await resize.boundingBox();
     expect(resizeBox).not.toBeNull();
     await page.mouse.move(resizeBox!.x + resizeBox!.width / 2, resizeBox!.y + resizeBox!.height / 2);
@@ -234,6 +234,78 @@ test.describe('state-preserving pane placement', () => {
     ]);
   });
 
+  test('floating resize grips remain the trusted hit target across viewport layouts', async ({ page }) => {
+    const panes = [
+      { key: 'inventory', label: 'Inventory' },
+      { key: 'map', label: 'Map' },
+      { key: 'sequence', label: 'Sequence' },
+      { key: 'tools', label: 'Tools' },
+    ] as const;
+
+    for (const viewport of [{ width: 1440, height: 900 }, { width: 820, height: 900 }]) {
+      for (const pane of panes) {
+        await openArtifact(page, viewport.width, viewport.height);
+        if (pane.key === 'tools') {
+          const railToggle = page.getByRole('button', { name: 'Tools rail' });
+          if (await railToggle.getAttribute('aria-pressed') !== 'true') await railToggle.click();
+        }
+
+        const paneElement = page.locator(`[data-pane-key="${pane.key}"]`);
+        await paneElement.getByRole('button', { name: `Pop out ${pane.label} pane` }).click();
+        const resize = page.getByTestId(`floating-pane-resize-${pane.key}`);
+        await expect(resize).toBeVisible();
+        const before = await paneElement.boundingBox();
+        const resizeBox = await resize.boundingBox();
+        expect(before).not.toBeNull();
+        expect(resizeBox).not.toBeNull();
+
+        await page.evaluate(() => {
+          window.addEventListener('pointerdown', (event) => {
+            const target = event.target instanceof Element
+              ? event.target.closest<HTMLElement>('.motif-cs-floating-pane-resize')
+              : null;
+            if (!target) return;
+            const state = window as Window & { __motifFloatingGripTrusted?: boolean[] };
+            (state.__motifFloatingGripTrusted ??= []).push(event.isTrusted);
+          }, true);
+        });
+        await page.mouse.move(resizeBox!.x + resizeBox!.width / 2, resizeBox!.y + resizeBox!.height / 2);
+        expect(await page.evaluate(({ x, y }) => (
+          document.elementFromPoint(x, y)?.closest('.motif-cs-floating-pane-resize')?.getAttribute('data-testid')
+        ), { x: resizeBox!.x + resizeBox!.width / 2, y: resizeBox!.y + resizeBox!.height / 2 })).toBe(`floating-pane-resize-${pane.key}`);
+        await page.mouse.down();
+        await page.mouse.move(resizeBox!.x + 76, resizeBox!.y + 60, { steps: 5 });
+        await page.mouse.up();
+        const after = await paneElement.boundingBox();
+        const trusted = await page.evaluate(() => (window as Window & { __motifFloatingGripTrusted?: boolean[] }).__motifFloatingGripTrusted ?? []);
+        expect(trusted).toContain(true);
+        expect(after).not.toBeNull();
+        expect(after!.width > before!.width + 1 || after!.height > before!.height + 1).toBe(true);
+      }
+    }
+
+    await openArtifact(page, 390, 760);
+    const rail = page.locator('[data-pane-key="tools"]');
+    const notes = rail.locator('details[data-rail-tool="notes"]');
+    const summary = notes.locator(':scope > summary');
+    const summaryBox = await summary.boundingBox();
+    expect(summaryBox).not.toBeNull();
+    expect(await page.evaluate(({ x, y }) => (
+      document.elementFromPoint(x, y)?.closest('details[data-rail-tool="notes"] > summary') !== null
+    ), { x: summaryBox!.x + summaryBox!.width / 2, y: summaryBox!.y + summaryBox!.height / 2 })).toBe(true);
+    await summary.click();
+    await expect(notes).toHaveAttribute('open', '');
+
+    const inventory = page.locator('[data-pane-key="inventory"]');
+    await inventory.getByRole('button', { name: 'Pop out Inventory pane' }).click();
+    await expect(page.getByTestId('floating-pane-resize-inventory')).toBeHidden();
+    const sheet = await inventory.boundingBox();
+    expect(sheet).not.toBeNull();
+    expect(sheet!.x).toBeGreaterThanOrEqual(7);
+    expect(sheet!.x + sheet!.width).toBeLessThanOrEqual(383);
+    expect(sheet!.y + sheet!.height).toBeLessThanOrEqual(753);
+  });
+
   test('Notes retains one controlled draft owner through repeated pointer and keyboard placement changes', async ({ page }, testInfo) => {
     await openArtifact(page, 1180, 900);
     const tools = page.locator('[data-pane-key="tools"]');
@@ -261,7 +333,7 @@ test.describe('state-preserving pane placement', () => {
       const head = tools.locator(':scope > .motif-cs-pane-title');
       await head.focus();
       await head.press(cycle % 2 === 0 ? 'Alt+ArrowRight' : 'Alt+ArrowLeft');
-      const resize = tools.getByTestId('floating-pane-resize-tools');
+      const resize = page.getByTestId('floating-pane-resize-tools');
       await resize.focus();
       await resize.press(cycle % 2 === 0 ? 'ArrowDown' : 'ArrowUp');
 
@@ -316,7 +388,7 @@ test.describe('state-preserving pane placement', () => {
     expect(sheet!.x + sheet!.width).toBeLessThanOrEqual(383);
     expect(sheet!.y).toBeGreaterThan(38);
     expect(sheet!.y + sheet!.height).toBeLessThanOrEqual(753);
-    await expect(inventory.getByTestId('floating-pane-resize-inventory')).toBeHidden();
+    await expect(page.getByTestId('floating-pane-resize-inventory')).toBeHidden();
 
     await inventory.getByRole('button', { name: 'Add entry' }).click();
     const addEntry = inventory.locator('#motif-cs-add-entry');

--- a/e2e/claude-science-pcr-materialization.spec.ts
+++ b/e2e/claude-science-pcr-materialization.spec.ts
@@ -62,8 +62,8 @@ test.describe('Claude Science PCR materialization', () => {
       parameters: { topology: expect.any(String) },
       provenance: { metadata: { recordCreated: false } },
     });
-    expect(afterSimulation.simulations?.[0].kind === 'pcr'
-      ? afterSimulation.simulations[0].data.products[0]
+    expect(afterSimulation.simulations?.[0]?.kind === 'pcr'
+      ? afterSimulation.simulations[0].data.products?.[0]
       : null).not.toHaveProperty('recordId');
 
     await create.click();

--- a/e2e/claude-science-workspace-integrity.spec.ts
+++ b/e2e/claude-science-workspace-integrity.spec.ts
@@ -444,4 +444,36 @@ test.describe('Claude Science workspace integrity', () => {
     await dialog.getByRole('button', { name: 'Replace workspace' }).click();
     await expect(page.getByTestId('session-durability-status')).toHaveText('restored checkpoint');
   });
+
+  test('makes restore confirmation inert, focus-trapped, and shortcut-isolated', async ({ page }) => {
+    await openInjectedWorkspace(page);
+    const settings = page.locator('details[data-rail-tool="settings"]');
+    if (!(await settings.getAttribute('open'))) await settings.locator(':scope > summary').click();
+    await settings.getByTestId('restore-workspace-file').setInputFiles({
+      name: 'restore-focus.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(JSON.stringify(embeddedWorkspace)),
+    });
+
+    const dialog = page.getByTestId('database-restore-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(page.locator('[data-restore-background="inert"]')).toHaveAttribute('inert', '');
+    await expect(page.locator('[data-restore-background="inert"]')).toHaveAttribute('aria-hidden', 'true');
+    await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeFocused();
+
+    // The background is intentionally removed from the accessibility tree while
+    // the dialog is open, so inspect its DOM state through a scoped CSS locator.
+    const resetMap = page.locator('.motif-cs-map-reset');
+    const beforeShortcut = await resetMap.isDisabled();
+    await page.keyboard.press('+');
+    expect(await resetMap.isDisabled()).toBe(beforeShortcut);
+
+    await page.keyboard.press('Tab');
+    await expect(dialog.getByRole('button', { name: 'Replace workspace' })).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeFocused();
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+    await expect(page.locator('[data-restore-background="inert"]')).toHaveCount(0);
+  });
 });

--- a/e2e/motif-runtime.d.ts
+++ b/e2e/motif-runtime.d.ts
@@ -1,0 +1,124 @@
+type MotifE2eRecord = {
+  id: string;
+  name: string;
+  seq: string;
+  sequence?: string;
+  type?: string;
+  molecule?: string;
+  topology?: string;
+  features?: Array<Record<string, unknown>>;
+  annotations?: Array<Record<string, unknown>>;
+  provenance?: Record<string, unknown> & { parentRecordIds?: string[] };
+  [key: string]: unknown;
+};
+
+type MotifE2eAlignmentRow = {
+  id: string;
+  name: string;
+  aligned: string;
+  sourceRecordId?: string;
+  [key: string]: unknown;
+};
+
+type MotifE2eAlignmentEngine = {
+  id: string;
+  label?: string;
+  version?: string;
+  mode?: string;
+  [key: string]: unknown;
+};
+
+type MotifE2eAlignment = {
+  id: string;
+  name: string;
+  molecule?: string;
+  rows: MotifE2eAlignmentRow[];
+  engine: MotifE2eAlignmentEngine;
+  [key: string]: unknown;
+};
+
+type MotifE2eNote = {
+  id: string;
+  body?: string;
+  recordId?: string;
+  [key: string]: unknown;
+};
+
+type MotifE2eWorkflowResult = {
+  id: string;
+  kind?: string;
+  name?: string;
+  [key: string]: unknown;
+};
+
+type MotifE2eAnalysisResult = Record<string, unknown> & {
+  id: string;
+  name?: string;
+  kind: string;
+  provenance: Record<string, unknown> & {
+    operation?: string;
+    metadata?: Record<string, unknown>;
+  };
+  parameters?: Record<string, unknown>;
+  data: Record<string, unknown> & {
+    verificationReportAssetId?: string;
+    products?: Array<Record<string, unknown>>;
+  };
+};
+
+type MotifE2eAnalysisAsset = Record<string, unknown> & {
+  id: string;
+  name: string;
+  mediaType: string;
+  content: string;
+  sha256?: string;
+};
+
+type MotifE2eAnalysisWorkspace = {
+  analysisResults: MotifE2eAnalysisResult[];
+  analysisAssets: MotifE2eAnalysisAsset[];
+};
+
+type MotifE2eWorkspace = Record<string, unknown> & {
+  records: MotifE2eRecord[];
+  alignments: MotifE2eAlignment[];
+  notes: MotifE2eNote[];
+  workflowResults: MotifE2eWorkflowResult[];
+  artifactState: Record<string, unknown> & {
+    translationLayersByRecord: Record<string, Array<Record<string, unknown> & { id: string }>>;
+  };
+};
+
+type MotifE2eDescription = Record<string, unknown> & {
+  text: string;
+  data: {
+    selection?: unknown;
+    features?: Array<Record<string, unknown>>;
+    [key: string]: unknown;
+  };
+};
+
+declare global {
+  interface Window {
+    motifRenderInventory(value: unknown): void;
+    motifAddRecords(value: unknown): number;
+    motifGetInventory(): MotifE2eRecord[];
+    motifGetActiveRecord(): MotifE2eRecord | null;
+    motifRemoveRecords(value: string | string[]): number;
+    motifAddAlignments(value: unknown): number;
+    motifGetAlignments(): MotifE2eAlignment[];
+    motifAddNotes(value: unknown): number;
+    motifGetNotes(): MotifE2eNote[];
+    motifAddWorkflowResults(value: unknown): number;
+    motifGetWorkflowResults(): MotifE2eWorkflowResult[];
+    motifRemoveWorkflowResults(value: string | string[]): number;
+    motifAddAnalysisAssets(value: unknown): number;
+    motifAddAnalysisResults(value: unknown): number;
+    motifGetAnalysisWorkspace(): MotifE2eAnalysisWorkspace;
+    motifGetWorkspace(): MotifE2eWorkspace;
+    motifReplaceWorkspace(value: unknown, options?: { discardUnsavedChanges?: boolean }): number;
+    motifDescribe(): MotifE2eDescription | null;
+  }
+}
+
+export {};

--- a/e2e/playwright.msa.config.ts
+++ b/e2e/playwright.msa.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
   testMatch: 'claude-science-msa-interactions.spec.ts',
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
+  failOnFlakyTests: Boolean(process.env.CI),
+  retries: 0,
   workers: 1,
   reporter: process.env.CI ? 'line' : 'list',
   outputDir: resolve(root, 'test-results/msa-interactions'),
@@ -23,7 +25,8 @@ export default defineConfig({
     browserName: 'chromium',
     baseURL: `http://127.0.0.1:${port}`,
     contextOptions: { reducedMotion: 'reduce' },
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
     launchOptions: {
       args: ['--disable-gpu', '--force-color-profile=srgb', '--force-raster-color-profile=srgb'],
     },

--- a/e2e/playwright.pane-placement.config.ts
+++ b/e2e/playwright.pane-placement.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
   testMatch: 'claude-science-pane-placement.spec.ts',
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
+  failOnFlakyTests: Boolean(process.env.CI),
+  retries: 0,
   workers: 1,
   reporter: process.env.CI ? 'line' : 'list',
   outputDir: resolve(root, 'test-results/pane-placement'),
@@ -18,7 +20,8 @@ export default defineConfig({
     browserName: 'chromium',
     baseURL: `http://127.0.0.1:${port}`,
     contextOptions: { reducedMotion: 'reduce' },
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
   },
   webServer: {
     command: `node_modules/.bin/vite --config vite.claude-science.config.ts --port ${port} --strictPort --host 127.0.0.1`,

--- a/mcp/motif/__tests__/stdio-paths.test.ts
+++ b/mcp/motif/__tests__/stdio-paths.test.ts
@@ -1,8 +1,24 @@
 import { describe, expect, it } from 'vitest';
 import { resolve } from 'node:path';
-import { artifactTemplateCandidates } from '../stdio-paths';
+import { artifactTemplateCandidates, inferredConnectorRoot, trustedConfiguredRoot } from '../stdio-paths';
 
 describe('MCP stdio packaged paths', () => {
+  it('infers roots for source, release, and packaged plugin layouts', () => {
+    expect(inferredConnectorRoot('/checkout/mcp/motif')).toBe(resolve('/checkout'));
+    expect(inferredConnectorRoot('/release/dist-motif/claude-science')).toBe(resolve('/release'));
+    expect(inferredConnectorRoot('/plugin/server')).toBe(resolve('/plugin'));
+  });
+
+  it('rejects a configured root that names another checkout', () => {
+    expect(() => trustedConfiguredRoot('/other-checkout', '/current-checkout'))
+      .toThrow(/MOTIF_ROOT must resolve to this connector root/);
+  });
+
+  it('accepts a configured root that is the inferred checkout', () => {
+    expect(trustedConfiguredRoot('/current-checkout', '/current-checkout'))
+      .toBe(resolve('/current-checkout'));
+  });
+
   it('resolves the skill resource after omitting the duplicate server template', () => {
     const moduleDirectory = '/plugin/server';
     const candidates = artifactTemplateCandidates(moduleDirectory, undefined, '/plugin');

--- a/mcp/motif/artifact-export.ts
+++ b/mcp/motif/artifact-export.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import {
+  MAX_MOTIF_ARTIFACT_HTML_BYTES,
   MOTIF_ARTIFACT_EXPORT_SCHEMA,
   motifArtifactExportSummarySchema,
   type MotifArtifactExportSummary,
@@ -10,13 +11,25 @@ import {
 const DATA_TAG_PATTERN = /(<script type="application\/json" id="motif-artifact-data">)([\s\S]*?)(<\/script>)/u;
 const BUILD_ID_META_PATTERN = /<meta name="motif-build-id" content="([a-f0-9]{64})"\s*\/?>/u;
 
-function jsonForScriptTag(value: unknown): string {
-  return JSON.stringify(value)
+function escapeJsonForScriptTag(json: string): string {
+  return json
     .replace(/</gu, '\\u003C')
     .replace(/>/gu, '\\u003E')
     .replace(/&/gu, '\\u0026')
     .replace(/\u2028/gu, '\\u2028')
     .replace(/\u2029/gu, '\\u2029');
+}
+
+function escapedJsonByteLength(json: string): number {
+  let bytes = 0;
+  for (const character of json) {
+    if (character === '<' || character === '>' || character === '&' || character === '\u2028' || character === '\u2029') {
+      bytes += 6;
+    } else {
+      bytes += Buffer.byteLength(character, 'utf8');
+    }
+  }
+  return bytes;
 }
 
 function safeArtifactBase(value: string): string {
@@ -41,7 +54,8 @@ export type RenderMotifArtifactResult = {
 };
 
 export function renderMotifArtifact(request: RenderMotifArtifactRequest): RenderMotifArtifactResult {
-  if (!DATA_TAG_PATTERN.test(request.template)) {
+  const dataTag = DATA_TAG_PATTERN.exec(request.template);
+  if (!dataTag) {
     throw new Error('Motif artifact template is missing its embedded data tag.');
   }
   if (!request.workbench.payload) {
@@ -54,7 +68,18 @@ export function renderMotifArtifact(request: RenderMotifArtifactRequest): Render
   const title = request.title?.trim() || request.workbench.sourceName?.replace(/\.[^.]+$/u, '') || 'Motif workbench';
   const requestedFilename = request.filename?.trim().replace(/\.html?$/iu, '');
   const filename = `${safeArtifactBase(requestedFilename || title)}.html`;
-  const payloadJson = jsonForScriptTag(request.workbench.payload);
+  const rawPayloadJson = JSON.stringify(request.workbench.payload);
+  const escapedPayloadBytes = escapedJsonByteLength(rawPayloadJson);
+  const closingTagStart = dataTag.index + dataTag[0].length;
+  const fixedHtmlBytes = Buffer.byteLength(request.template.slice(0, dataTag.index), 'utf8')
+    + Buffer.byteLength(dataTag[1], 'utf8')
+    + Buffer.byteLength(dataTag[3], 'utf8')
+    + Buffer.byteLength(request.template.slice(closingTagStart), 'utf8');
+  const estimatedBytes = fixedHtmlBytes + escapedPayloadBytes;
+  if (estimatedBytes > MAX_MOTIF_ARTIFACT_HTML_BYTES) {
+    throw new Error(`Motif artifact HTML exceeds ${MAX_MOTIF_ARTIFACT_HTML_BYTES.toLocaleString()} bytes after safe payload escaping.`);
+  }
+  const payloadJson = escapeJsonForScriptTag(rawPayloadJson);
   const html = request.template.replace(
     DATA_TAG_PATTERN,
     (_match, openingTag: string, _payload: string, closingTag: string) => `${openingTag}${payloadJson}${closingTag}`,

--- a/mcp/motif/contracts.ts
+++ b/mcp/motif/contracts.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const MOTIF_WORKBENCH_RESOURCE_URI = 'ui://motif/workbench.html' as const;
 export const MOTIF_WORKBENCH_RESULT_SCHEMA = 'motif.mcp.workbench.v1' as const;
 export const MOTIF_ARTIFACT_EXPORT_SCHEMA = 'motif.mcp.artifact-export.v1' as const;
+export const MAX_MOTIF_ARTIFACT_HTML_BYTES = 40 * 1024 * 1024;
 
 export const motifWorkbenchPayloadSchema = z.record(z.string(), z.unknown());
 
@@ -28,7 +29,7 @@ export const motifArtifactExportSummarySchema = z.object({
   sourceName: z.string().min(1).max(512).optional(),
   recordCount: z.number().int().nonnegative().max(100),
   residueCount: z.number().int().nonnegative().max(25_000_000),
-  bytes: z.number().int().positive().max(40 * 1024 * 1024),
+  bytes: z.number().int().positive().max(MAX_MOTIF_ARTIFACT_HTML_BYTES),
   htmlSha256: z.string().regex(/^[a-f0-9]{64}$/u),
 }).strict();
 

--- a/mcp/motif/stdio-paths.ts
+++ b/mcp/motif/stdio-paths.ts
@@ -1,6 +1,30 @@
-import { resolve } from 'node:path';
+import { basename, resolve } from 'node:path';
 
 const PACKAGED_ARTIFACT_RESOURCE = '../skills/motif-for-claude-science/resources/motif-artifact.html';
+
+export function inferredConnectorRoot(moduleDirectory: string): string {
+  return basename(moduleDirectory) === 'server'
+    ? resolve(moduleDirectory, '..')
+    : resolve(moduleDirectory, '../..');
+}
+
+/**
+ * Accept an explicitly configured development root only when it names the
+ * same checkout inferred from this server module. A process-wide setting must
+ * not redirect a packaged server to an unrelated checkout.
+ */
+export function trustedConfiguredRoot(
+  configuredRoot: string | undefined,
+  inferredRoot: string,
+): string | undefined {
+  if (!configuredRoot?.trim()) return undefined;
+  const configured = resolve(configuredRoot);
+  const inferred = resolve(inferredRoot);
+  if (configured !== inferred) {
+    throw new Error('MOTIF_ROOT must resolve to this connector root');
+  }
+  return configured;
+}
 
 export function artifactTemplateCandidates(
   moduleDirectory: string,

--- a/mcp/motif/stdio-server.ts
+++ b/mcp/motif/stdio-server.ts
@@ -7,15 +7,12 @@ import { fileURLToPath } from 'node:url';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
 import { createMotifClaudeScienceServer } from './server.js';
-import { artifactTemplateCandidates } from './stdio-paths.js';
+import { artifactTemplateCandidates, inferredConnectorRoot, trustedConfiguredRoot } from './stdio-paths.js';
 
 type PackageManifest = { version?: unknown };
 
 const moduleDirectory = dirname(fileURLToPath(import.meta.url));
-const inferredRoot = resolve(moduleDirectory, '../..');
-const configuredRoot = process.env.MOTIF_ROOT?.trim()
-  ? resolve(process.env.MOTIF_ROOT)
-  : undefined;
+const inferredRoot = inferredConnectorRoot(moduleDirectory);
 
 async function firstExistingPath(candidates: string[], label: string): Promise<string> {
   for (const candidate of candidates) {
@@ -29,7 +26,7 @@ async function firstExistingPath(candidates: string[], label: string): Promise<s
   throw new Error(`${label} is missing. Rebuild or reinstall the Motif for Claude Science plugin.`);
 }
 
-async function readVersion(): Promise<string> {
+async function readVersion(configuredRoot: string | undefined): Promise<string> {
   const candidates = [
     ...(configuredRoot ? [resolve(configuredRoot, 'package.json')] : []),
     resolve(moduleDirectory, '../.claude-plugin/plugin.json'),
@@ -43,7 +40,7 @@ async function readVersion(): Promise<string> {
       // Fall through to the next supported manifest location.
     }
   }
-  return '0.3.2';
+  return '0.3.3';
 }
 
 async function readRuntimeBuildId(workbenchPath: string): Promise<string> {
@@ -56,9 +53,10 @@ async function readRuntimeBuildId(workbenchPath: string): Promise<string> {
 }
 
 async function main(): Promise<void> {
+  const configuredRoot = trustedConfiguredRoot(process.env.MOTIF_ROOT, inferredRoot);
   const traceEnabled = process.env.MOTIF_MCP_TRACE === '1'
     || process.env.MOTIF_MCP_TRACE === 'true';
-  const version = await readVersion();
+  const version = await readVersion(configuredRoot);
   const workbenchPath = await firstExistingPath([
     ...(configuredRoot ? [resolve(configuredRoot, 'dist-motif/claude-science/motif-mcp-app.html')] : []),
     resolve(moduleDirectory, 'motif-mcp-app.html'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "motif-for-claude-science",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "motif-for-claude-science",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "1.7.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "motif-for-claude-science",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "description": "Motif is a portable molecular-biology workbench, Claude plugin, and MCP App for sequence review, alignment, cloning design, traces, and analysis results.",
   "license": "MIT",
@@ -50,6 +50,7 @@
     "test": "vitest run",
     "security:audit": "npm audit --audit-level=moderate",
     "security:policy": "node scripts/check-supply-chain-policy.mjs",
+    "security:verify-release": "node scripts/check-supply-chain-policy.mjs --require-release",
     "security:lifecycle": "node scripts/run-reviewed-lifecycle.mjs",
     "security:cooling-off": "node scripts/check-dependency-cooling-off.mjs",
     "security:reproducibility": "node scripts/check-release-reproducibility.mjs",
@@ -76,7 +77,7 @@
     "claude-science:setup": "npm run claude-science:build && npm run claude-science:doctor:unregistered && npm run claude-science:install-local && npm run claude-science:check-local",
     "check:css-tokens": "node scripts/check-css-tokens.mjs",
     "check:aria-controls": "node scripts/check-aria-controls.mjs",
-    "gate": "npm run typecheck && npm run lint && npm run check:repository-language && npm test && npm run check:release-alignment && npm run check:runtime-compatibility && npm run security:audit && npm run security:policy && npm run security:lifecycle && npm run security:cooling-off && npm run test:plugin && npm run test:connector && npm run check:css-tokens && npm run check:aria-controls && npm run build:motif && npm run security:reproducibility && npm run security:budgets && npm run test:e2e && npm run test:e2e:msa && npm run report:gate-coverage"
+    "gate": "node scripts/run-gate.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "1.7.5",

--- a/scripts/__tests__/gate-parity.test.mjs
+++ b/scripts/__tests__/gate-parity.test.mjs
@@ -1,59 +1,67 @@
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { GATE_STEPS } from '../lib/gate-steps.mjs';
+import { checkSupplyChainPolicy } from '../check-supply-chain-policy.mjs';
 
-// `npm run gate` is the canonical local check sequence. This test turns any
-// drift between that sequence and CI into a local failure.
+// `npm run gate` is the canonical local and hosted check sequence. The runner
+// writes exact-commit receipts for these shared step declarations.
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const workflow = readFileSync(resolve(root, '.github/workflows/ci.yml'), 'utf8');
 const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
 
-// Steps that set the machine up rather than check the source. `npm ci
-// --ignore-scripts` installs dependencies and `npx playwright install` fetches
-// a browser; neither is
-// something a local run should repeat on every commit.
-const SETUP_ONLY = new Set(['npm ci --ignore-scripts']);
-
-function npmCommands(script) {
-  return script
-    .split('&&')
-    .map((part) => part.trim())
-    .filter((part) => /^npm (run |test\b)/.test(part) && !SETUP_ONLY.has(part));
-}
-
-const ciCommands = [
-  ...workflow.matchAll(/^\s*run:\s*(.+)$/gm),
-].flatMap((match) => npmCommands(match[1]));
-
-const gateCommands = npmCommands(pkg.scripts.gate ?? '');
-
 describe('npm run gate matches CI', () => {
-  it('reads a non-trivial list out of both sides', () => {
-    // Guard the guard: a regex that stopped matching would make every
-    // assertion below pass by comparing two empty lists.
-    expect(ciCommands.length).toBeGreaterThan(5);
-    expect(gateCommands.length).toBeGreaterThan(5);
+  it('uses the same receipt-producing runner locally and in hosted CI', () => {
+    expect(pkg.scripts.gate).toBe('node scripts/run-gate.mjs');
+    expect(workflow.match(/run: npm run gate/g)).toHaveLength(1);
+    expect(workflow).toContain('MOTIF_COOLING_OFF_BASE_SHA:');
   });
 
-  it('runs every check CI runs', () => {
-    const missing = ciCommands.filter((command) => !gateCommands.includes(command));
-    expect(missing, 'in CI but not in `npm run gate`').toEqual([]);
+  it('declares a non-trivial, safely ordered gate', () => {
+    const ids = GATE_STEPS.map(({ id }) => id);
+    expect(ids.length).toBeGreaterThan(15);
+    expect(ids.indexOf('supply-chain-policy')).toBeLessThan(ids.indexOf('reviewed-lifecycle'));
+    expect(ids.indexOf('build')).toBeLessThan(ids.indexOf('post-build-release-verification'));
+    expect(ids.indexOf('post-build-release-verification')).toBeLessThan(ids.indexOf('reproducibility'));
   });
 
-  it('runs nothing CI does not', () => {
-    // The other direction matters too: a gate that checks more than CI turns
-    // green CI into an unreliable signal about what the gate proved.
-    const extra = gateCommands.filter((command) => !ciCommands.includes(command));
-    expect(extra, 'in `npm run gate` but not in CI').toEqual([]);
-  });
-
-  it('disables npm lifecycle execution until the reviewed policy has passed', () => {
+  it('disables npm lifecycle execution during installation', () => {
     expect(workflow).toContain('run: npm ci --ignore-scripts');
-    expect(workflow.indexOf('run: npm ci --ignore-scripts')).toBeLessThan(workflow.indexOf('run: npm run security:policy'));
-    expect(workflow.indexOf('run: npm run security:policy')).toBeLessThan(workflow.indexOf('run: npm run security:lifecycle'));
-    expect(gateCommands.indexOf('npm run security:policy')).toBeLessThan(gateCommands.indexOf('npm run security:lifecycle'));
+    expect(workflow.indexOf('run: npm ci --ignore-scripts')).toBeLessThan(workflow.indexOf('run: npm run gate'));
+  });
+
+  it('retains browser and exact-commit gate evidence', () => {
+    expect(workflow).toContain('actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02');
+    expect(workflow).toContain('test-results/');
+    expect(workflow).toContain('dist-motif/gate-coverage.json');
+  });
+
+  it('pins every hosted action to an exact 40-character commit SHA', () => {
+    const actionRefs = [...workflow.matchAll(/^\s*uses:\s*([^\s#]+)/gm)].map((match) => match[1]);
+    expect(actionRefs.length).toBeGreaterThan(0);
+    for (const ref of actionRefs) expect(ref).toMatch(/^[^@]+@[a-f0-9]{40}$/);
+  });
+
+  it('executes the declared Node 24 compatibility branch', () => {
+    expect(workflow).toContain('node-24-compatibility:');
+    expect(workflow).toContain('node-version: 24');
+    expect(workflow).toContain('run: npm run typecheck');
+    expect(workflow).toContain('run: npm test');
+  });
+});
+
+describe('post-build release verification', () => {
+  it('fails before policy work when the generated release is missing', () => {
+    const emptyWorkspace = mkdtempSync(join(tmpdir(), 'motif-release-required-'));
+    try {
+      expect(() => checkSupplyChainPolicy(emptyWorkspace, { requireRelease: true }))
+        .toThrow(/Generated release bundle is required/);
+    } finally {
+      rmSync(emptyWorkspace, { recursive: true, force: true });
+    }
   });
 });
 
@@ -80,6 +88,9 @@ describe('the typecheck script builds the project references', () => {
     const rootConfig = JSON.parse(readFileSync(resolve(root, 'tsconfig.json'), 'utf8'));
     expect(rootConfig.files).toEqual([]);
     expect(rootConfig.include).toBeUndefined();
-    expect(rootConfig.references?.length ?? 0).toBeGreaterThan(0);
+    expect(rootConfig.references?.map(({ path }) => path)).toEqual(expect.arrayContaining([
+      './tsconfig.mcp.json',
+      './tsconfig.e2e.json',
+    ]));
   });
 });

--- a/scripts/__tests__/generate-sbom.test.mjs
+++ b/scripts/__tests__/generate-sbom.test.mjs
@@ -1,0 +1,53 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createDeterministicSbom } from '../generate-sbom.mjs';
+
+const fixtures = [];
+
+afterEach(() => {
+  for (const directory of fixtures.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function writePackage(directory, name, version) {
+  const packageDirectory = join(directory, 'node_modules', ...name.split('/'));
+  mkdirSync(packageDirectory, { recursive: true });
+  writeFileSync(join(packageDirectory, 'package.json'), `${JSON.stringify({ name, version })}\n`);
+}
+
+describe('deterministic SBOM dependency scopes', () => {
+  it('classifies declared identities as direct even when hoisted', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'motif-sbom-test-'));
+    fixtures.push(directory);
+    writeFileSync(join(directory, 'package.json'), `${JSON.stringify({
+      name: 'fixture-workspace',
+      version: '1.0.0',
+      dependencies: { 'declared-runtime': '1.0.0' },
+      devDependencies: { 'declared-build': '2.0.0' },
+    })}\n`);
+    writeFileSync(join(directory, 'package-lock.json'), `${JSON.stringify({
+      lockfileVersion: 3,
+      packages: {
+        '': { dependencies: { 'declared-runtime': '1.0.0' }, devDependencies: { 'declared-build': '2.0.0' } },
+        'node_modules/declared-runtime': { version: '1.0.0' },
+        'node_modules/declared-build': { version: '2.0.0' },
+        'node_modules/hoisted-transitive': { version: '3.0.0' },
+        'node_modules/declared-runtime/node_modules/nested-transitive': { version: '4.0.0' },
+      },
+    })}\n`);
+    writePackage(directory, 'declared-runtime', '1.0.0');
+    writePackage(directory, 'declared-build', '2.0.0');
+    writePackage(directory, 'hoisted-transitive', '3.0.0');
+    const nestedDirectory = join(directory, 'node_modules', 'declared-runtime', 'node_modules', 'nested-transitive');
+    mkdirSync(nestedDirectory, { recursive: true });
+    writeFileSync(join(nestedDirectory, 'package.json'), `${JSON.stringify({ name: 'nested-transitive', version: '4.0.0' })}\n`);
+
+    const byName = new Map(createDeterministicSbom(directory).components.map(component => [component.name, component]));
+    expect(byName.get('declared-runtime')?.scope).toBe('direct');
+    expect(byName.get('declared-build')?.scope).toBe('direct');
+    expect(byName.get('hoisted-transitive')?.scope).toBe('transitive');
+    expect(byName.get('nested-transitive')?.scope).toBe('transitive');
+  });
+});

--- a/scripts/__tests__/path-portability.test.mjs
+++ b/scripts/__tests__/path-portability.test.mjs
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = resolve(import.meta.dirname, '../..');
+const filesystemScripts = [
+  'scripts/build-preview.mjs',
+  'scripts/check-release-alignment.mjs',
+  'scripts/check-release-budgets.mjs',
+  'scripts/check-runtime-compatibility.mjs',
+  'scripts/report-gate-coverage.mjs',
+];
+
+describe('filesystem URL path portability', () => {
+  it('uses fileURLToPath for filesystem module-relative paths', () => {
+    for (const relativePath of filesystemScripts) {
+      const source = readFileSync(join(root, relativePath), 'utf8');
+      expect(source, relativePath).toContain('fileURLToPath');
+      expect(source, relativePath).not.toContain('new URL(\'..\', import.meta.url).pathname');
+    }
+  });
+
+  it('round-trips spaces and Unicode in a filesystem URL', () => {
+    const moduleUrl = pathToFileURL('/tmp/Motif release π/scripts/check.mjs');
+    expect(resolve(fileURLToPath(new URL('..', moduleUrl)))).toBe('/tmp/Motif release π');
+  });
+
+  it('decodes Windows drive URLs when running on Windows', () => {
+    if (process.platform !== 'win32') return;
+    expect(fileURLToPath(new URL('file:///C:/Motif%20release/%CF%80/scripts/check.mjs')))
+      .toBe('C:\\Motif release\\π\\scripts\\check.mjs');
+  });
+});

--- a/scripts/__tests__/release-security-defaults.test.mjs
+++ b/scripts/__tests__/release-security-defaults.test.mjs
@@ -12,6 +12,6 @@ describe('release security defaults', () => {
   });
 
   it('includes the MCP stdio fallback in release-version alignment', () => {
-    expect(checkReleaseAlignment()).toMatchObject({ version: '0.3.2', surfaces: 10 });
+    expect(checkReleaseAlignment()).toMatchObject({ version: '0.3.3', surfaces: 10 });
   });
 });

--- a/scripts/build-preview.mjs
+++ b/scripts/build-preview.mjs
@@ -13,9 +13,10 @@ import { spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { stampMotifBuildIdentity } from './motif-build-identity.mjs';
 
-const root = resolve(new URL('..', import.meta.url).pathname);
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const previewDir = join(root, 'preview');
 const previewHtml = join(previewDir, 'motif-artifact.html');
 const buildDir = mkdtempSync(join(tmpdir(), 'motif-preview-'));

--- a/scripts/check-release-alignment.mjs
+++ b/scripts/check-release-alignment.mjs
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const root = resolve(new URL('..', import.meta.url).pathname);
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 
 function readJson(relativePath) {
   return JSON.parse(readFileSync(join(root, relativePath), 'utf8'));
@@ -28,7 +28,7 @@ export function checkReleaseAlignment() {
     ['plugin manifest', plugin.version],
     ['artifact runtime', read('src/artifacts/motif-artifact.tsx').match(/const MOTIF_ARTIFACT_VERSION = '([^']+)'/u)?.[1]],
     ['MCP App bridge', read('src/mcp-app/motif-workbench-bridge.ts').match(/name: 'Motif for Claude Science', version: '([^']+)'/u)?.[1]],
-    ['MCP stdio fallback', stdioServer.match(/async function readVersion\(\): Promise<string>[\s\S]*?return '([^']+)'[;]?\s*\}\s*async function readRuntimeBuildId/u)?.[1]],
+    ['MCP stdio fallback', stdioServer.match(/async function readVersion\([^)]*\): Promise<string>[\s\S]*?return '([^']+)'[;]?\s*\}\s*async function readRuntimeBuildId/u)?.[1]],
   ];
   for (const [label, value] of surfaces) {
     if (value !== packageVersion) throw new Error(`${label} is ${String(value)}, expected ${packageVersion}`);

--- a/scripts/check-release-budgets.mjs
+++ b/scripts/check-release-budgets.mjs
@@ -5,7 +5,7 @@ import { join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { compareConnectorInventory, loadDependencyPolicy } from './lib/supply-chain-policy.mjs';
 
-const root = resolve(new URL('..', import.meta.url).pathname);
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const output = join(root, 'dist-motif');
 
 function readJson(path) {

--- a/scripts/check-runtime-compatibility.mjs
+++ b/scripts/check-runtime-compatibility.mjs
@@ -5,7 +5,7 @@ import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import semver from 'semver';
 
-const root = resolve(new URL('..', import.meta.url).pathname);
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const REVIEWED_NODE = '22.13.0';
 
 function json(relativePath) {

--- a/scripts/check-supply-chain-policy.mjs
+++ b/scripts/check-supply-chain-policy.mjs
@@ -16,22 +16,29 @@ function readJson(path, label) {
   }
 }
 
-export function checkSupplyChainPolicy(rootPath = root) {
+export function checkSupplyChainPolicy(rootPath = root, { requireRelease = false } = {}) {
   const workspace = resolve(rootPath);
+  const releasePath = join(workspace, 'dist-motif', 'motif-for-claude-science-release');
+  const releaseExists = existsSync(releasePath);
+  if (requireRelease && !releaseExists) {
+    throw new Error('Generated release bundle is required but does not exist; build distributables before final verification');
+  }
   const summary = checkLockfilePolicy(workspace);
   const { inventory } = loadDependencyPolicy(workspace);
-  const releasePath = join(workspace, 'dist-motif', 'motif-for-claude-science-release');
-  if (existsSync(releasePath)) {
+  if (releaseExists) {
     const generated = readJson(join(releasePath, 'connector-inventory.json'), 'Generated connector inventory');
     compareConnectorInventory(inventory, generated);
     verifyReleaseBundle(releasePath, { expectedVersion: readJson(join(workspace, 'package.json'), 'package.json').version });
   }
-  return { ...summary, releaseChecked: existsSync(releasePath) };
+  return { ...summary, releaseChecked: releaseExists };
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   try {
-    const result = checkSupplyChainPolicy();
+    const allowedArguments = new Set(['--require-release']);
+    const unknownArguments = process.argv.slice(2).filter((argument) => !allowedArguments.has(argument));
+    if (unknownArguments.length > 0) throw new Error(`Unknown argument: ${unknownArguments[0]}`);
+    const result = checkSupplyChainPolicy(root, { requireRelease: process.argv.includes('--require-release') });
     console.log(`Supply-chain policy passed: ${result.packageCount} lockfile packages; ${result.connectorPackageCount} bundled connector packages; release checked: ${result.releaseChecked}.`);
   } catch (error) {
     console.error(`Supply-chain policy failed: ${error instanceof Error ? error.message : String(error)}`);

--- a/scripts/generate-sbom.mjs
+++ b/scripts/generate-sbom.mjs
@@ -16,6 +16,14 @@ function readJson(path) {
   return JSON.parse(readFileSync(path, 'utf8'));
 }
 
+function declaredDependencyNames(packageJson) {
+  const names = new Set();
+  for (const field of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']) {
+    for (const name of Object.keys(packageJson[field] ?? {})) names.add(name);
+  }
+  return names;
+}
+
 function packageManifest(lockPath) {
   const path = join(root, lockPath, 'package.json');
   if (!existsSync(path)) return {};
@@ -38,6 +46,7 @@ export function createDeterministicSbom(rootPath = root) {
   const workspace = resolve(rootPath);
   const lock = readJson(join(workspace, 'package-lock.json'));
   const packageJson = readJson(join(workspace, 'package.json'));
+  const declaredDependencies = declaredDependencyNames(packageJson);
   const components = Object.entries(lock.packages ?? {})
     .filter(([lockPath]) => lockPath !== '')
     .map(([lockPath, metadata]) => {
@@ -48,7 +57,7 @@ export function createDeterministicSbom(rootPath = root) {
       return {
         name,
         version: metadata.version,
-        scope: lockPath.includes('/node_modules/') ? 'transitive' : 'direct',
+        scope: declaredDependencies.has(name) ? 'direct' : 'transitive',
         resolved: metadata.resolved,
         integrity: metadata.integrity,
         license: manifest.license ?? null,

--- a/scripts/lib/gate-steps.mjs
+++ b/scripts/lib/gate-steps.mjs
@@ -1,0 +1,25 @@
+export const GATE_STEPS = Object.freeze([
+  { id: 'typecheck', label: 'Typecheck', command: ['npm', 'run', 'typecheck'] },
+  { id: 'lint', label: 'Lint', command: ['npm', 'run', 'lint'] },
+  { id: 'repository-language', label: 'Repository language policy', command: ['npm', 'run', 'check:repository-language'] },
+  { id: 'unit-tests', label: 'Unit tests', command: ['npm', 'test'] },
+  { id: 'release-alignment', label: 'Release alignment', command: ['npm', 'run', 'check:release-alignment'] },
+  { id: 'runtime-compatibility', label: 'Runtime compatibility', command: ['npm', 'run', 'check:runtime-compatibility'] },
+  { id: 'security-audit', label: 'Security audit', command: ['npm', 'run', 'security:audit'] },
+  { id: 'supply-chain-policy', label: 'Supply-chain policy', command: ['npm', 'run', 'security:policy'] },
+  { id: 'reviewed-lifecycle', label: 'Motif-owned dependency preparation', command: ['npm', 'run', 'security:lifecycle'] },
+  { id: 'dependency-cooling-off', label: 'Dependency cooling-off policy', command: ['npm', 'run', 'security:cooling-off'] },
+  { id: 'plugin-checks', label: 'Plugin checks', command: ['npm', 'run', 'test:plugin'] },
+  { id: 'connector-checks', label: 'Connector checks', command: ['npm', 'run', 'test:connector'] },
+  { id: 'css-token-checks', label: 'CSS token checks', command: ['npm', 'run', 'check:css-tokens'] },
+  { id: 'aria-controls', label: 'ARIA control checks', command: ['npm', 'run', 'check:aria-controls'] },
+  { id: 'build', label: 'Build distributables', command: ['npm', 'run', 'build:motif'] },
+  { id: 'post-build-release-verification', label: 'Post-build release verification', command: ['npm', 'run', 'security:verify-release'] },
+  { id: 'reproducibility', label: 'Reproducible release build', command: ['npm', 'run', 'security:reproducibility'] },
+  { id: 'release-budgets', label: 'Release budgets', command: ['npm', 'run', 'security:budgets'] },
+  { id: 'core-browser-workflows', label: 'Core browser workflows', command: ['npm', 'run', 'test:e2e'] },
+  { id: 'msa-browser-workflows', label: 'MSA interaction workflows', command: ['npm', 'run', 'test:e2e:msa'] },
+]);
+
+export const GATE_RECEIPT_SCHEMA = 'motif.gate-step.v1';
+export const GATE_RUN_SCHEMA = 'motif.gate-run.v1';

--- a/scripts/playwright.claude-science.config.ts
+++ b/scripts/playwright.claude-science.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   testMatch: 'claude-science-*.spec.ts',
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
+  failOnFlakyTests: Boolean(process.env.CI),
   retries: process.env.CI ? 1 : 0,
   workers: 1,
   reporter: process.env.CI ? 'line' : 'list',
@@ -18,7 +19,8 @@ export default defineConfig({
     contextOptions: {
       reducedMotion: 'reduce',
     },
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
     launchOptions: {
       args: [
         '--disable-gpu',

--- a/scripts/report-gate-coverage.mjs
+++ b/scripts/report-gate-coverage.mjs
@@ -1,53 +1,71 @@
 #!/usr/bin/env node
 
-import { writeFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { GATE_RECEIPT_SCHEMA, GATE_RUN_SCHEMA, GATE_STEPS } from './lib/gate-steps.mjs';
 
-const root = resolve(new URL('..', import.meta.url).pathname);
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const receiptDirectory = join(root, 'test-results', 'gate-receipts');
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    throw new Error(`${label} is missing or invalid: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function currentCommit() {
+  const result = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' });
+  if (result.status !== 0 || !/^[0-9a-f]{40}\n?$/.test(result.stdout ?? '')) throw new Error('Cannot resolve current Git commit');
+  return result.stdout.trim();
+}
 
 export function reportGateCoverage(env = process.env) {
+  const run = readJson(join(receiptDirectory, 'run.json'), 'Gate run receipt');
+  const commit = currentCommit();
+  if (run.schema !== GATE_RUN_SCHEMA || run.commit !== commit || run.runId !== env.MOTIF_GATE_RUN_ID) {
+    throw new Error('Gate run receipt is stale or does not match this exact commit and invocation');
+  }
+  const expectedSteps = GATE_STEPS.map(({ id }) => id);
+  if (JSON.stringify(run.expectedSteps) !== JSON.stringify(expectedSteps)) throw new Error('Gate run step declaration is stale');
+
+  const receipts = GATE_STEPS.map((step) => {
+    const receipt = readJson(join(receiptDirectory, `${step.id}.json`), `Gate receipt for ${step.id}`);
+    if (
+      receipt.schema !== GATE_RECEIPT_SCHEMA
+      || receipt.runId !== run.runId
+      || receipt.commit !== commit
+      || receipt.step !== step.id
+      || receipt.exitCode !== 0
+      || JSON.stringify(receipt.command) !== JSON.stringify(step.command)
+    ) {
+      throw new Error(`Gate receipt for ${step.id} is stale, unsuccessful, or does not match the declared command`);
+    }
+    return receipt;
+  });
+
   const fixtureChecks = [
-    {
-      name: 'standalone artifact browser workflows',
-      status: env.MOTIF_ARTIFACT_URL ? 'executed' : 'fixture-gated',
-      requirement: 'MOTIF_ARTIFACT_URL is supplied by the canonical runner',
-    },
-    {
-      name: 'synthetic demo preflight',
-      status: env.MOTIF_DEMO_ARTIFACT_URL ? 'executed' : 'fixture-gated',
-      requirement: 'MOTIF_DEMO_ARTIFACT_URL',
-    },
-    {
-      name: 'pathway demo preflight',
-      status: env.MOTIF_PATHWAY_ARTIFACT_URL ? 'executed' : 'fixture-gated',
-      requirement: 'MOTIF_PATHWAY_ARTIFACT_URL',
-    },
-    {
-      name: 'real Sanger fixture audit',
-      status: env.MOTIF_REAL_AB1_DIR ? 'executed' : 'fixture-gated',
-      requirement: 'MOTIF_REAL_AB1_DIR',
-    },
-    {
-      name: 'external MSA payload audit',
-      status: env.MOTIF_REAL_MSA_PAYLOADS ? 'executed' : 'fixture-gated',
-      requirement: 'MOTIF_REAL_MSA_PAYLOADS',
-    },
-  ];
+    ['synthetic demo preflight', env.MOTIF_DEMO_ARTIFACT_URL, 'MOTIF_DEMO_ARTIFACT_URL'],
+    ['pathway demo preflight', env.MOTIF_PATHWAY_ARTIFACT_URL, 'MOTIF_PATHWAY_ARTIFACT_URL'],
+    ['real Sanger fixture audit', env.MOTIF_REAL_AB1_DIR, 'MOTIF_REAL_AB1_DIR'],
+    ['external MSA payload audit', env.MOTIF_REAL_MSA_PAYLOADS, 'MOTIF_REAL_MSA_PAYLOADS'],
+  ].map(([name, value, requirement]) => ({ name, status: value ? 'executed' : 'fixture-gated', requirement }));
   const report = {
-    schema: 'motif.gate-coverage.v1',
-    executed: [
-      'typecheck', 'lint', 'repository language policy', 'unit tests', 'release alignment', 'runtime compatibility',
-      'npm audit', 'supply-chain policy', 'Motif-owned dependency preparation', 'dependency cooling-off policy', 'plugin checks', 'connector checks',
-      'style/accessibility guards', 'build', 'reproducibility', 'release budgets',
-      'core browser workflows', 'MSA interaction workflows',
-    ],
+    schema: 'motif.gate-coverage.v2',
+    runId: run.runId,
+    commit,
+    executed: receipts.map(({ step, label, command, startedAt, finishedAt, durationMs }) => ({
+      step, label, command, startedAt, finishedAt, durationMs,
+    })),
     fixtureChecks,
-    note: 'Fixture-gated checks are intentionally reported separately from executed checks; no fixture is silently treated as a pass.',
+    note: 'Executed checks are supported by successful, exact-commit receipts. Fixture-gated checks remain explicitly separate.',
   };
-  writeFileSync(join(root, 'dist-motif/gate-coverage.json'), `${JSON.stringify(report, null, 2)}\n`);
-  console.log('Gate coverage:');
-  console.log(`  executed: ${report.executed.join(', ')}`);
+  mkdirSync(join(root, 'dist-motif'), { recursive: true });
+  writeFileSync(join(root, 'dist-motif', 'gate-coverage.json'), `${JSON.stringify(report, null, 2)}\n`);
+  console.log(`Gate coverage recorded ${receipts.length} successful exact-commit steps for ${commit}.`);
   for (const check of fixtureChecks) console.log(`  ${check.status}: ${check.name} (${check.requirement})`);
   return report;
 }

--- a/scripts/run-gate.mjs
+++ b/scripts/run-gate.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import { randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { GATE_RECEIPT_SCHEMA, GATE_RUN_SCHEMA, GATE_STEPS } from './lib/gate-steps.mjs';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const receiptDirectory = join(root, 'test-results', 'gate-receipts');
+
+function gitHead() {
+  const result = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' });
+  if (result.status !== 0 || !/^[0-9a-f]{40}\n?$/.test(result.stdout ?? '')) {
+    throw new Error('Canonical gate requires a Git commit so its receipts can be bound to exact source');
+  }
+  return result.stdout.trim();
+}
+
+function writeJson(path, value) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function runGate({ env = process.env } = {}) {
+  const commit = gitHead();
+  const runId = randomUUID();
+  rmSync(receiptDirectory, { recursive: true, force: true });
+  mkdirSync(receiptDirectory, { recursive: true });
+  writeJson(join(receiptDirectory, 'run.json'), {
+    schema: GATE_RUN_SCHEMA,
+    runId,
+    commit,
+    startedAt: new Date().toISOString(),
+    expectedSteps: GATE_STEPS.map(({ id }) => id),
+  });
+
+  for (const step of GATE_STEPS) {
+    const startedAt = new Date();
+    console.log(`\n=== ${step.label} ===`);
+    const executable = process.platform === 'win32' && step.command[0] === 'npm' ? 'npm.cmd' : step.command[0];
+    const result = spawnSync(executable, step.command.slice(1), {
+      cwd: root,
+      env: { ...env, MOTIF_GATE_RUN_ID: runId, MOTIF_GATE_COMMIT: commit },
+      stdio: 'inherit',
+      shell: false,
+    });
+    const finishedAt = new Date();
+    const exitCode = result.status ?? 1;
+    writeJson(join(receiptDirectory, `${step.id}.json`), {
+      schema: GATE_RECEIPT_SCHEMA,
+      runId,
+      commit,
+      step: step.id,
+      label: step.label,
+      command: step.command,
+      startedAt: startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+      durationMs: finishedAt.getTime() - startedAt.getTime(),
+      exitCode,
+      signal: result.signal ?? null,
+    });
+    if (exitCode !== 0) return exitCode;
+  }
+
+  const report = spawnSync(process.execPath, [join(root, 'scripts', 'report-gate-coverage.mjs')], {
+    cwd: root,
+    env: { ...env, MOTIF_GATE_RUN_ID: runId, MOTIF_GATE_COMMIT: commit },
+    stdio: 'inherit',
+    shell: false,
+  });
+  return report.status ?? 1;
+}
+
+try {
+  process.exitCode = runGate();
+} catch (error) {
+  console.error(`Gate failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+}

--- a/scripts/test-claude-science-plugin-packaging.mjs
+++ b/scripts/test-claude-science-plugin-packaging.mjs
@@ -95,16 +95,20 @@ function check(name, callback) {
 function writeFakeMsaExecutable(directory, name) {
   mkdirSync(directory, { recursive: true });
   const executablePath = join(directory, name);
-  writeFileSync(executablePath, String.raw`#!/usr/bin/env node
-import { readFileSync, writeFileSync } from 'node:fs';
+  writeFileSync(executablePath, `#!${process.execPath}\n${String.raw`import { readFileSync, writeFileSync } from 'node:fs';
 
 const args = process.argv.slice(2);
 const executable = process.argv[1].split(/[\\/]/).at(-1);
 if (args.includes('--version') || args.includes('-version')) {
-  process.stdout.write((process.env.FAKE_MSA_VERSION || ('fake-' + executable + ' 9.9.9')) + '\n');
+  const defaultVersion = executable === 'mafft'
+    ? 'v7.9.9'
+    : executable === 'muscle'
+      ? 'MUSCLE v5.9.9'
+      : 'Clustal Omega 1.9.9';
+  process.stdout.write((process.env.MOTIF_TEST_MSA_VERSION || defaultVersion) + '\n');
   process.exit(0);
 }
-if (process.env.FAKE_MSA_MODE === 'timeout') {
+if (process.env.MOTIF_TEST_MSA_MODE === 'timeout') {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5_000);
 }
 
@@ -131,7 +135,8 @@ for (const rawLine of input.split(/\r?\n/)) {
   }
 }
 
-const renderedRows = process.env.FAKE_MSA_MODE === 'duplicate'
+const renderedRows = process.env.MOTIF_TEST_MSA_MODE === 'duplicate'
+  || (process.env.MOTIF_TEST_MSA_MODE === 'ambient-check' && process.env.MOTIF_TEST_AMBIENT)
   ? [rows[0], rows[0]]
   : [...rows].reverse();
 const output = renderedRows.map((row) => {
@@ -141,7 +146,7 @@ const output = renderedRows.map((row) => {
 
 if (executable === 'mafft') process.stdout.write(output);
 else writeFileSync(outputPath, output);
-`, { mode: 0o755 });
+`}`, { mode: 0o755 });
   chmodSync(executablePath, 0o755);
   return executablePath;
 }
@@ -837,6 +842,14 @@ check('external MSA runner discovers the dedicated environment before PATH and h
       }),
       /--executable does not resolve/,
     );
+    assert.throws(
+      () => discoverMsaExecutable('mafft', {
+        executablePath: process.execPath,
+        env: { PATH: '' },
+        pathValue: '',
+      }),
+      /must resolve to a MAFFT executable named mafft/,
+    );
   } finally {
     rmSync(fixture, { recursive: true, force: true });
   }
@@ -868,7 +881,10 @@ check('external MSA runner maps reordered rows by safe header and records exact 
       assert.equal(alignment.engine.id, engine);
       assert.equal(alignment.engine.mode, 'local-command');
       assert.equal(alignment.engine.usedFallback, false);
-      assert.equal(alignment.engine.version, `fake-${executableName} 9.9.9`);
+      assert.equal(
+        alignment.engine.version,
+        executableName === 'mafft' ? 'v7.9.9' : executableName === 'muscle' ? 'MUSCLE v5.9.9' : 'Clustal Omega 1.9.9',
+      );
       assert.equal(alignment.provenance.executable, executableName);
       assert.match(alignment.provenance.executableSha256, /^[a-f0-9]{64}$/);
       assert.equal(alignment.provenance.argv[0], executableName);
@@ -900,7 +916,8 @@ check('external MSA runner rejects malformed output and never falls back', () =>
         molecule: 'dna',
         inputText: '>One\nATGC\n>Two\nATGGC\n',
         executablePath,
-        env: { ...process.env, FAKE_MSA_MODE: 'duplicate' },
+        env: { ...process.env },
+        childEnv: { MOTIF_TEST_MSA_MODE: 'duplicate' },
         temporaryRoot: fixture,
       }),
       /repeats header/,
@@ -911,7 +928,8 @@ check('external MSA runner rejects malformed output and never falls back', () =>
         molecule: 'dna',
         inputText: '>One\nATGC\n>Two\nATGGC\n',
         executablePath,
-        env: { ...process.env, FAKE_MSA_MODE: 'timeout' },
+        env: { ...process.env },
+        childEnv: { MOTIF_TEST_MSA_MODE: 'timeout' },
         temporaryRoot: fixture,
         timeoutMs: 100,
       }),
@@ -923,11 +941,40 @@ check('external MSA runner rejects malformed output and never falls back', () =>
         molecule: 'dna',
         inputText: '>One\nATGC\n>Two\nATGGC\n',
         executablePath,
-        env: { ...process.env, FAKE_MSA_VERSION: 'MUSCLE 3.8.31' },
+        env: { ...process.env },
+        childEnv: { MOTIF_TEST_MSA_VERSION: 'MUSCLE 3.8.31' },
         temporaryRoot: fixture,
       }),
-      /MUSCLE 5 or later is required/,
+      /version banner is not recognized/,
     );
+    for (const [engine, executableName, banner] of [
+      ['mafft', 'mafft', 'Node.js v22.13.0'],
+      ['clustal-omega', 'clustalo', 'clustalo 2.0.0'],
+    ]) {
+      const invalidExecutable = writeFakeMsaExecutable(join(fixture, `${engine}-invalid`), executableName);
+      assert.throws(
+        () => runExternalMsa({
+          engine,
+          molecule: 'dna',
+          inputText: '>One\nATGC\n>Two\nATGGC\n',
+          executablePath: invalidExecutable,
+          env: { ...process.env },
+          childEnv: { MOTIF_TEST_MSA_VERSION: banner },
+          temporaryRoot: fixture,
+        }),
+        /version banner is not recognized/,
+      );
+    }
+    const ambientExecutable = writeFakeMsaExecutable(join(fixture, 'ambient-check'), 'mafft');
+    assert.doesNotThrow(() => runExternalMsa({
+      engine: 'mafft',
+      molecule: 'dna',
+      inputText: '>One\nATGC\n>Two\nATGGC\n',
+      executablePath: ambientExecutable,
+      env: { ...process.env, MOTIF_TEST_AMBIENT: 'must-not-reach-child' },
+      childEnv: { MOTIF_TEST_MSA_MODE: 'ambient-check' },
+      temporaryRoot: fixture,
+    }));
   } finally {
     rmSync(fixture, { recursive: true, force: true });
   }

--- a/src/artifacts/ClaudeScienceMsaViewer.tsx
+++ b/src/artifacts/ClaudeScienceMsaViewer.tsx
@@ -1444,6 +1444,7 @@ function AlignmentMatrix({
   const [hoverCell, setHoverCell] = useState<HoverCell | null>(null);
   const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null);
   const [contextMenu, setContextMenu] = useState<MatrixContextMenu | null>(null);
+  const hasSelection = selection !== null;
   // The context menu's on-screen position after clamping to the viewport (raw
   // pointer coordinates in `contextMenu` would otherwise overflow near edges).
   const [menuPosition, setMenuPosition] = useState<{ x: number; y: number } | null>(null);
@@ -1479,6 +1480,9 @@ function AlignmentMatrix({
    * Measured-against-measured is the only version that holds at every width.
    */
   const [readoutHeight, setReadoutHeight] = useState(MSA_SELECTION_READOUT_FLOAT_HEIGHT);
+  // Selection drags update the range every animation frame. Keep one observer
+  // for the readout's mounted lifetime; re-subscribing and synchronously
+  // measuring on every render can re-enter the state update loop during a drag.
   useEffect(() => {
     const node = readoutRef.current;
     if (!node || typeof ResizeObserver === 'undefined') return undefined;
@@ -1490,7 +1494,7 @@ function AlignmentMatrix({
     const observer = new ResizeObserver(sync);
     observer.observe(node);
     return () => observer.disconnect();
-  });
+  }, [hasSelection]);
   useEffect(() => {
     const node = chromeRef.current;
     if (!node || typeof ResizeObserver === 'undefined') return undefined;

--- a/src/artifacts/__tests__/claude-science-accessibility-interaction-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-accessibility-interaction-guards.test.ts
@@ -185,6 +185,17 @@ describe('Claude Science accessibility and interaction guards', () => {
     expect(artifactCss).toContain('pointer-events: none');
   });
 
+  it('makes the destructive restore confirmation modal inert and shortcut-isolated', () => {
+    const restoreDialog = sliceBetween('function RestoreWorkspaceDialog({', 'function PanePlacementControl({');
+    expect(artifactSource).toContain('data-restore-background={pendingDatabaseRestore ? \'inert\' : undefined}');
+    expect(artifactSource).toContain('inert={pendingDatabaseRestore ? true : undefined}');
+    expect(artifactSource).toContain('aria-hidden={pendingDatabaseRestore ? \'true\' : undefined}');
+    expect(restoreDialog).toContain('aria-modal="true"');
+    expect(restoreDialog).toContain("if (event.key === 'Escape')");
+    expect(restoreDialog).toContain("if (event.key !== 'Tab') return;");
+    expect(artifactSource).toContain('if (pendingDatabaseRestore) return;');
+  });
+
   it('keeps validation feedback inline and polite', () => {
     expect(artifactSource).toContain('className="motif-cs-import-status" data-error={statusError || undefined} role={statusError ? \'alert\' : \'status\'} aria-live={statusError ? \'assertive\' : \'polite\'} aria-atomic="true"');
     expect(artifactSource).toContain('className="motif-cs-chip" role="status" aria-live="polite" aria-atomic="true"');

--- a/src/artifacts/__tests__/claude-science-inventory-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-inventory-guards.test.ts
@@ -151,7 +151,7 @@ describe('Claude Science Inventory regression guards', () => {
     expect(splitWorkspace).not.toContain('--compact-inventory-height');
     expect(splitWorkspace).not.toContain('.motif-cs-record-tabs[data-inventory-visible="true"]');
     expect(artifactCss).toContain(
-      '.motif-cs-shell:has(> .motif-cs-record-tabs[data-inventory-visible="true"])',
+      '.motif-cs-shell:has(.motif-cs-record-tabs[data-inventory-visible="true"])',
     );
     expect(artifactCss).toMatch(/@media \(max-width: 767px\)[\s\S]*?data-inventory-visible="true"\]\)\s*\{\s*grid-template-rows:\s*auto 1fr/);
   });

--- a/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-rail-popover-guards.test.ts
@@ -275,7 +275,7 @@ describe('Claude Science rail popover regression guards', () => {
     expect(artifactSource).toContain('data-rail-tool="settings"');
     expect(artifactSource).toContain('<Settings className="motif-cs-panel-icon"');
     expect(artifactSource).toContain('<strong>Motif for Claude Science</strong>');
-    expect(artifactSource).toContain("const MOTIF_ARTIFACT_VERSION = '0.3.2';");
+    expect(artifactSource).toContain("const MOTIF_ARTIFACT_VERSION = '0.3.3';");
     expect(artifactSource).toContain('Version {MOTIF_ARTIFACT_VERSION} · Build {MOTIF_ARTIFACT_BUILD_LABEL}');
     expect(artifactSource).not.toContain('__APP_VERSION__');
     expect(artifactSource).toContain('Motif is an open-source, AI-native molecular biology suite for researchers.');

--- a/src/artifacts/__tests__/claude-science-runtime-integrity.test.ts
+++ b/src/artifacts/__tests__/claude-science-runtime-integrity.test.ts
@@ -21,8 +21,10 @@ import {
   MotifArtifactRuntimeError,
   createCenteredBluntEnzyme,
   createArtifactDatabaseSnapshot,
+  createArtifactWorkspaceZipBlob,
   createDefensiveRuntimeSnapshot,
   describePayloadSnapshot,
+  getArtifactCheckpointExportIssues,
   normalizeCustomEnzymeRecognitionInput,
   inventoryReportHtml,
   normalizeRecord,
@@ -550,6 +552,104 @@ describe('Claude Science runtime data-integrity behavior', () => {
       sequence: 'ATGGAATTCTAA',
     });
     expect(prepareArtifactDatabaseRestore(snapshot).payload.analysisResults).toEqual([]);
+  });
+
+  it('round-trips the same accepted checkpoint through Database JSON and ZIP', async () => {
+    const payload = prepareInventoryReplacement([{
+      id: 'zip-roundtrip',
+      name: 'ZIP roundtrip',
+      type: 'dna',
+      topology: 'linear',
+      sequence: 'ATGGAATTCTAA',
+      features: [{ id: 'feature-a', name: 'feature', start: 3, end: 9, type: 'misc_feature' }],
+    }]);
+    const artifactState = {
+      customEnzymes: [],
+      translationLayersByRecord: {},
+      enzymeSourcesByRecord: {},
+      hiddenEnzymesByRecord: {},
+      hiddenFeatureTranslationsByRecord: {},
+      restrictionLabelsByRecord: {},
+      motifsByRecord: {},
+    };
+    const snapshot = createArtifactDatabaseSnapshot(payload, artifactState);
+    expect(prepareArtifactDatabaseRestore(JSON.parse(JSON.stringify(snapshot))).payload.records[0]).toMatchObject({
+      id: 'zip-roundtrip',
+      sequence: 'ATGGAATTCTAA',
+      features: [expect.objectContaining({ id: 'feature-a' })],
+    });
+
+    const zip = createArtifactWorkspaceZipBlob([{
+      name: 'inventory.json',
+      content: JSON.stringify(snapshot),
+    }]);
+    const bytes = new Uint8Array(await zip.arrayBuffer());
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    expect(view.getUint32(0, true)).toBe(0x04034b50);
+    const nameLength = view.getUint16(26, true);
+    const dataLength = view.getUint32(18, true);
+    const entryName = new TextDecoder().decode(bytes.slice(30, 30 + nameLength));
+    const entryText = new TextDecoder().decode(bytes.slice(30 + nameLength, 30 + nameLength + dataLength));
+    expect(entryName).toBe('inventory.json');
+    expect(prepareArtifactDatabaseRestore(JSON.parse(entryText)).payload.records[0].id).toBe('zip-roundtrip');
+  });
+
+  it('blocks Database JSON and ZIP checkpoint creation instead of truncating a 12,000-hit EcoRI repeat', () => {
+    const repeatCount = 12_000;
+    const sequence = 'GAATTC'.repeat(repeatCount);
+    const record = normalizeRecord({
+      id: 'oversized-site-inventory',
+      name: '12k EcoRI repeat',
+      type: 'dna',
+      topology: 'linear',
+      sequence,
+      sites: [{
+        enzyme: 'EcoRI',
+        motif: 'GAATTC',
+        indexBase: 0,
+        hits: Array.from({ length: repeatCount }, (_, index) => ({ position: index * 6, cutPosition: index * 6 })),
+      }],
+    }, 0);
+    expect(record).not.toBeNull();
+    if (!record) throw new Error('large-site fixture did not normalize');
+
+    const issues = getArtifactCheckpointExportIssues([record]);
+    expect(issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        recordId: 'oversized-site-inventory',
+        path: expect.stringContaining('.sites[0].hits'),
+        message: expect.stringContaining('10,000'),
+      }),
+    ]));
+    const payload = prepareInventoryReplacement([{
+      id: 'oversized-site-inventory',
+      name: '12k EcoRI repeat',
+      type: 'dna',
+      topology: 'linear',
+      sequence,
+    }]);
+    expect(() => createArtifactDatabaseSnapshot({ ...payload, records: [record] }, {
+      customEnzymes: [],
+      translationLayersByRecord: {},
+      enzymeSourcesByRecord: {},
+      hiddenEnzymesByRecord: {},
+      hiddenFeatureTranslationsByRecord: {},
+      restrictionLabelsByRecord: {},
+      motifsByRecord: {},
+    }, [record])).toThrowError(expect.objectContaining({
+      code: 'MOTIF_INPUT_LIMIT_EXCEEDED',
+      message: expect.stringMatching(/blocked|truncated/i),
+    }));
+    const unsafeInventory = {
+      schema: 'motif.claude-science.inventory.v2',
+      records: createDefensiveRuntimeSnapshot([record]),
+    };
+    expect(() => createArtifactWorkspaceZipBlob([{
+      name: 'inventory.json',
+      content: JSON.stringify(unsafeInventory),
+    }])).toThrowError(expect.objectContaining({
+      code: 'MOTIF_INPUT_LIMIT_EXCEEDED',
+    }));
   });
 
   it('normalizes allowlisted feature fields and escapes all report markup', () => {

--- a/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-workspace-layout-guards.test.ts
@@ -702,7 +702,7 @@ describe('Claude Science workspace layout guards', () => {
 
   it('copies reverse features in feature orientation from the keyboard path', () => {
     expect(artifactSource).toContain('text = sequenceForFeature(sequence, selectedFeature, sequenceType);');
-    expect(artifactSource).toContain('[selectedFeature, selectedMapRange, sequence, sequenceType, topology');
+    expect(artifactSource).toContain('[copyText, handleZoomIn, handleZoomOut, handleZoomReset, pendingDatabaseRestore, recordId, selectedFeature, selectedMapRange, sequence, sequenceType, topology]');
   });
 
   it('serializes native mouse-selected bases without embedded annotation text', () => {
@@ -754,7 +754,9 @@ describe('Claude Science workspace layout guards', () => {
   });
 
   it('previews the selected export payload instead of always showing raw sequence', () => {
-    expect(artifactSource).toContain('const exportPreview = exportChoice?.content');
+    expect(artifactSource).toContain('const exportFallbackPreview = exportChoice?.id');
+    expect(artifactSource).toContain('const exportPreview = exportChoice?.blocked');
+    expect(artifactSource).toContain(': exportChoice?.content ?? exportFallbackPreview;');
     expect(artifactSource).toContain("exportChoice?.id === 'inventory-zip'");
     expect(artifactSource).toContain("exportChoice?.id === 'report-print'");
     expect(artifactSource).toContain('value={exportPreview} aria-label="Selected export preview"');

--- a/src/artifacts/__tests__/export-loss-report.test.ts
+++ b/src/artifacts/__tests__/export-loss-report.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildArtifactExportLossReport, normalizeRecord } from '../motif-artifact';
+import { buildArtifactExportLossReport, buildArtifactExportLossReportForRecords, normalizeRecord } from '../motif-artifact';
 
 describe('structured export-loss report', () => {
   it('reuses source-preservation diagnostics and reports every lossy dimension', () => {
@@ -100,8 +100,41 @@ describe('structured export-loss report', () => {
     expect(record).not.toBeNull();
     if (!record) throw new Error('fixture did not normalize');
 
-    expect(buildArtifactExportLossReport(record, 'record-json')).toMatchObject({ faithful: true, lossy: false });
+    expect(buildArtifactExportLossReport(record, 'record-json')).toMatchObject({ faithful: true, lossy: false, summary: expect.stringMatching(/active record only/i) });
     expect(buildArtifactExportLossReport(record, 'zip')).toMatchObject({ faithful: true, lossy: false });
     expect(buildArtifactExportLossReport(record, 'genbank').summary).toMatch(/does not claim full INSDC round-trip|lossy/i);
+  });
+
+  it('aggregates whole-inventory loss receipts across inactive records', () => {
+    const active = normalizeRecord({
+      id: 'active-record',
+      name: 'Active record',
+      molecule: 'dna',
+      seq: 'ACGTACGT',
+    }, 0);
+    const inactive = normalizeRecord({
+      id: 'inactive-record',
+      name: 'Inactive annotated record',
+      molecule: 'dna',
+      seq: 'ACGTACGT',
+      active: false,
+      annotations: [{ id: 'inactive-feature', name: 'annotation omitted by FASTA', type: 'misc_feature', start: 1, end: 5 }],
+    }, 1);
+    expect(active).not.toBeNull();
+    expect(inactive).not.toBeNull();
+    if (!active || !inactive) throw new Error('multi-record fixture did not normalize');
+
+    const report = buildArtifactExportLossReportForRecords([active, inactive], 'fasta');
+    expect(report.faithful).toBe(false);
+    expect(report.recordReports).toEqual([
+      expect.objectContaining({ recordId: 'active-record', recordName: 'Active record', faithful: true, lossCount: 0 }),
+      expect.objectContaining({
+        recordId: 'inactive-record',
+        recordName: 'Inactive annotated record',
+        faithful: false,
+        lossCount: 1,
+      }),
+    ]);
+    expect(report.summary).toContain('Inactive annotated record');
   });
 });

--- a/src/artifacts/motif-artifact.css
+++ b/src/artifacts/motif-artifact.css
@@ -482,6 +482,13 @@ summary,
   background: var(--workspace-bg);
 }
 
+/* The restore guard is a semantic wrapper only. Keep the workbench's existing
+   shell grid direct-child geometry while allowing the whole background subtree
+   to become inert behind the destructive confirmation dialog. */
+.motif-cs-background {
+  display: contents;
+}
+
 .motif-cs-skip-link {
   position: absolute;
   top: 6px;
@@ -10009,7 +10016,7 @@ summary.motif-cs-panel-head:focus-visible {
 }
 
 @media (max-width: 767px) {
-  .motif-cs-shell:has(> .motif-cs-record-tabs[data-inventory-visible="true"]) {
+  .motif-cs-shell:has(.motif-cs-record-tabs[data-inventory-visible="true"]) {
     grid-template-rows: auto 1fr;
   }
 
@@ -11247,6 +11254,8 @@ summary.motif-cs-panel-head:focus-visible {
 .motif-cs-floating-pane-resize {
   position: fixed;
   z-index: 8;
+  /* The grip is a viewport-level sibling of the pane. Its layer is paired
+     with the pane layer so overlapping floating surfaces keep their order. */
   top: calc(var(--motif-cs-floating-pane-top, 8px) + var(--motif-cs-floating-pane-height, 520px) - 28px);
   left: calc(var(--motif-cs-floating-pane-left, 8px) + var(--motif-cs-floating-pane-width, 340px) - 28px);
   width: 28px;

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -228,7 +228,7 @@ import {
 } from './claude-science-download';
 import './motif-artifact.css';
 
-const MOTIF_ARTIFACT_VERSION = '0.3.2';
+const MOTIF_ARTIFACT_VERSION = '0.3.3';
 const MOTIF_ARTIFACT_BUILD_ID = (() => {
   if (typeof document === 'undefined') return 'development';
   const value = document.querySelector<HTMLMetaElement>('meta[name="motif-build-id"]')?.content.trim() ?? '';
@@ -2253,6 +2253,15 @@ export type ArtifactExportLossReport = {
   format: ArtifactExportLossFormat;
   faithful: boolean;
   lossy: boolean;
+  /** Per-record evidence for whole-inventory exports. */
+  recordReports: Array<{
+    recordId: string;
+    recordName: string;
+    faithful: boolean;
+    lossy: boolean;
+    lossCount: number;
+    summary: string;
+  }>;
   repeatedQualifiers: Array<{ featureId: string; key: string; count: number }>;
   truncatedQualifiers: Array<{
     featureId: string;
@@ -2271,6 +2280,14 @@ export type ArtifactExportLossReport = {
   unrepresentableMetadata: Array<{ featureId: string; keys: string[] }>;
   sequenceNormalization: Array<{ code: string; count?: number; detail: string }>;
   summary: string;
+};
+
+export type ArtifactCheckpointExportIssue = {
+  recordId?: string;
+  recordName?: string;
+  code: string;
+  path?: string;
+  message: string;
 };
 
 const EXPORT_LOSS_INTERNAL_METADATA_KEYS = new Set([
@@ -2427,7 +2444,7 @@ export function buildArtifactExportLossReport(
         ? true
         : format === 'csv' || format === 'report';
   const faithful = checkpoint || !hasInterchangeLoss;
-  const lossCount = repeatedQualifiers.length
+  const preservationItemCount = repeatedQualifiers.length
     + truncatedQualifiers.length
     + unsupportedOrRawLocations.length
     + fuzzyLocations.length
@@ -2435,8 +2452,12 @@ export function buildArtifactExportLossReport(
     + multipartBiologicalOrder.filter((entry) => !entry.preserved).length
     + unrepresentableMetadata.length
     + sequenceNormalization.length;
-  const summary = checkpoint
-    ? 'This Motif JSON/ZIP checkpoint preserves the complete structured workspace; interchange files inside a ZIP remain explicitly lossy where noted.'
+  const lossCount = preservationItemCount
+    + (hasInterchangeLoss && preservationItemCount === 0 ? 1 : 0);
+  const summary = format === 'record-json'
+    ? 'Record JSON preserves this active record only; it does not include other records, notes, results, assets, or workspace state. Use Database JSON or ZIP for a complete workspace checkpoint.'
+    : checkpoint
+      ? 'This Motif JSON/ZIP checkpoint preserves the complete structured workspace; interchange files inside a ZIP remain explicitly lossy where noted.'
     : faithful
       ? 'This export is faithful for the represented record content; it does not claim full INSDC round-trip support.'
       : `This ${format.toUpperCase()} export is lossy; ${lossCount} preservation item${lossCount === 1 ? '' : 's'} require review. Use Database JSON or ZIP for the complete Motif checkpoint.`;
@@ -2444,6 +2465,14 @@ export function buildArtifactExportLossReport(
     format,
     faithful,
     lossy: !faithful,
+    recordReports: [{
+      recordId: record.id,
+      recordName: record.name,
+      faithful,
+      lossy: !faithful,
+      lossCount,
+      summary,
+    }],
     repeatedQualifiers,
     truncatedQualifiers,
     unsupportedOrRawLocations,
@@ -2454,6 +2483,144 @@ export function buildArtifactExportLossReport(
     sequenceNormalization,
     summary,
   };
+}
+
+function mergeArtifactExportLossReports(
+  reports: readonly ArtifactExportLossReport[],
+  format: ArtifactExportLossFormat,
+): ArtifactExportLossReport {
+  const first = reports[0];
+  if (!first) {
+    return {
+      format,
+      faithful: true,
+      lossy: false,
+      recordReports: [],
+      repeatedQualifiers: [],
+      truncatedQualifiers: [],
+      unsupportedOrRawLocations: [],
+      fuzzyLocations: [],
+      originalFeatureKeys: [],
+      multipartBiologicalOrder: [],
+      unrepresentableMetadata: [],
+      sequenceNormalization: [],
+      summary: 'No records were represented by this export.',
+    };
+  }
+  const recordReports = reports.flatMap((report) => report.recordReports);
+  const faithful = reports.every((report) => report.faithful);
+  const lossCount = recordReports.reduce((total, report) => total + report.lossCount, 0);
+  const recordSummary = recordReports
+    .filter((report) => report.lossy)
+    .map((report) => `${report.recordName} (${report.lossCount} preservation item${report.lossCount === 1 ? '' : 's'})`)
+    .join('; ');
+  const summary = format === 'record-json'
+    ? first.summary
+    : format === 'database-json' || format === 'zip'
+      ? 'This Motif JSON/ZIP checkpoint preserves the complete structured workspace; interchange files inside a ZIP remain explicitly lossy where noted.'
+      : faithful
+        ? `This export is faithful for all ${recordReports.length} represented record${recordReports.length === 1 ? '' : 's'}; it does not claim full INSDC round-trip support.`
+        : `This ${format.toUpperCase()} export is lossy for ${recordSummary || `${lossCount} preservation item${lossCount === 1 ? '' : 's'}`}. Use Database JSON or ZIP for the complete Motif checkpoint.`;
+  return {
+    ...first,
+    format,
+    faithful,
+    lossy: !faithful,
+    recordReports,
+    repeatedQualifiers: reports.flatMap((report) => report.repeatedQualifiers),
+    truncatedQualifiers: reports.flatMap((report) => report.truncatedQualifiers),
+    unsupportedOrRawLocations: reports.flatMap((report) => report.unsupportedOrRawLocations),
+    fuzzyLocations: reports.flatMap((report) => report.fuzzyLocations),
+    originalFeatureKeys: reports.flatMap((report) => report.originalFeatureKeys),
+    multipartBiologicalOrder: reports.flatMap((report) => report.multipartBiologicalOrder),
+    unrepresentableMetadata: reports.flatMap((report) => report.unrepresentableMetadata),
+    sequenceNormalization: reports.flatMap((report) => report.sequenceNormalization),
+    summary,
+  };
+}
+
+/** Build one receipt for every record represented by a whole-inventory export. */
+export function buildArtifactExportLossReportForRecords(
+  records: readonly ArtifactVector[],
+  format: ArtifactExportLossFormat,
+): ArtifactExportLossReport {
+  return mergeArtifactExportLossReports(records.map((record) => buildArtifactExportLossReport(record, format)), format);
+}
+
+function checkpointExportIssuesFromError(
+  error: unknown,
+  records: readonly ArtifactVector[],
+): ArtifactCheckpointExportIssue[] {
+  const rawIssues = error instanceof MotifArtifactRuntimeError && Array.isArray(error.details.issues)
+    ? error.details.issues
+    : [];
+  if (rawIssues.length === 0) {
+    return [{
+      code: error instanceof MotifArtifactRuntimeError ? error.code : 'MOTIF_INPUT_LIMIT_EXCEEDED',
+      message: error instanceof Error ? error.message : String(error),
+    }];
+  }
+  return rawIssues.map((rawIssue) => {
+    const issue = isPlainObject(rawIssue) ? rawIssue : {};
+    const index = Number.isInteger(issue.index) ? Number(issue.index) : -1;
+    const record = index >= 0 ? records[index] : undefined;
+    return {
+      ...(record ? { recordId: record.id, recordName: record.name } : {}),
+      code: typeof issue.code === 'string' ? issue.code : 'resource_limit',
+      ...(typeof issue.path === 'string' ? { path: issue.path } : {}),
+      message: typeof issue.message === 'string' ? issue.message : 'The checkpoint exceeds a restore limit.',
+    };
+  });
+}
+
+/**
+ * A checkpoint must be accepted by the same record validator used on restore.
+ * This is intentionally fail-closed: no site or trace is truncated to make an
+ * export fit, because doing so would change the scientific record.
+ */
+export function getArtifactCheckpointExportIssues(
+  records: readonly ArtifactVector[],
+): ArtifactCheckpointExportIssue[] {
+  // Validate the JSON shape that is actually emitted. React-side vectors carry
+  // optional keys as `undefined`, which JSON.stringify omits and which should
+  // not be mistaken for an exportable value during this preflight.
+  const rawRecords = records.map((record) => (
+    omitUndefinedObjectProperties(serializeRecord(record))
+  ));
+  const issues: ArtifactCheckpointExportIssue[] = [];
+  rawRecords.forEach((rawRecord, index) => {
+    try {
+      validateRuntimeRecordInputs([rawRecord], 'motifRenderInventory');
+    } catch (error) {
+      issues.push(...checkpointExportIssuesFromError(error, [records[index]]));
+    }
+  });
+  try {
+    validateRuntimeRecordInputs(rawRecords, 'motifRenderInventory');
+  } catch (error) {
+    issues.push(...checkpointExportIssuesFromError(error, records));
+  }
+  const seen = new Set<string>();
+  return issues.filter((issue) => {
+    const key = `${issue.recordId ?? ''}|${issue.code}|${issue.path ?? ''}|${issue.message}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function assertArtifactCheckpointRecordsRestorable(records: readonly ArtifactVector[]): void {
+  const issues = getArtifactCheckpointExportIssues(records);
+  if (issues.length === 0) return;
+  const recordSummary = issues
+    .filter((issue) => issue.recordName)
+    .map((issue) => `${issue.recordName}: ${issue.message}`)
+    .join(' ');
+  throw new MotifArtifactRuntimeError(
+    'MOTIF_INPUT_LIMIT_EXCEEDED',
+    `Database JSON and workspace ZIP export were blocked because the checkpoint would not pass restore validation. ${recordSummary || issues[0].message} No data was truncated.`,
+    { operation: 'checkpointExport', issues, mutated: false },
+  );
 }
 
 function scanRestrictionSitesForRecord(
@@ -3217,7 +3384,7 @@ export function inventoryReportHtml(records: readonly ArtifactVector[]): string 
 </html>`;
 }
 
-type ZipTextFile = { name: string; content: string };
+export type ArtifactZipTextFile = { name: string; content: string };
 let zipCrcTable: Uint32Array | null = null;
 
 function zipCrc32(bytes: Uint8Array): number {
@@ -3241,7 +3408,27 @@ function zipDosDateTime(date = new Date()): { time: number; date: number } {
   return { time, date: packedDate };
 }
 
-function createZipBlob(files: readonly ZipTextFile[]): Blob {
+export function createArtifactWorkspaceZipBlob(files: readonly ArtifactZipTextFile[]): Blob {
+  const inventoryFile = files.find((file) => file.name === 'inventory.json');
+  if (!inventoryFile) {
+    throw new MotifArtifactRuntimeError(
+      'MOTIF_INVALID_INVENTORY_REPLACEMENT',
+      'Workspace ZIP export requires a restorable inventory.json entry. No archive was created.',
+      { operation: 'checkpointExport', mutated: false },
+    );
+  }
+  const parsedInventory = parseArtifactDatabaseJson(inventoryFile.content);
+  if (!parsedInventory) {
+    throw new MotifArtifactRuntimeError(
+      'MOTIF_INVALID_INVENTORY_REPLACEMENT',
+      'Workspace ZIP export requires a valid Database JSON inventory.json entry. No archive was created.',
+      { operation: 'checkpointExport', mutated: false },
+    );
+  }
+  // Validate the exact inventory entry that will be archived through the same
+  // transactional restore path used by Add Entry and file-drop recovery.
+  prepareArtifactDatabaseRestore(parsedInventory);
+
   const encoder = new TextEncoder();
   const localParts: BlobPart[] = [];
   const centralParts: BlobPart[] = [];
@@ -3295,6 +3482,10 @@ function createZipBlob(files: readonly ZipTextFile[]): Blob {
   endView.setUint32(16, centralOffset, true);
 
   return new Blob([...localParts, ...centralParts, end], { type: 'application/zip' });
+}
+
+function createZipBlob(files: readonly ArtifactZipTextFile[]): Blob {
+  return createArtifactWorkspaceZipBlob(files);
 }
 
 function recordInputFromGenBank(record: ReturnType<typeof parseGenBank>[number], index: number): ArtifactRecordInput {
@@ -4771,6 +4962,7 @@ export function createArtifactDatabaseSnapshot(
   artifactState: ArtifactDurableState,
   records: readonly ArtifactVector[] = payload.records,
 ): Record<string, unknown> {
+  assertArtifactCheckpointRecordsRestorable(records);
   const recordLengths = new Map(records.map((record) => [record.id, record.sequence.length]));
   return omitUndefinedObjectProperties({
     schema: DEFAULT_SCHEMA,
@@ -7537,6 +7729,10 @@ function App() {
   // a form field or when a native text selection is active.
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
+      // A destructive restore owns the document while its confirmation is
+      // visible. Background shortcuts (including map zoom) must not observe
+      // keys sent to the inert workspace.
+      if (pendingDatabaseRestore) return;
       const el = document.activeElement as HTMLElement | null;
       const inForm = !!el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT' || el.isContentEditable);
       const mod = event.metaKey || event.ctrlKey;
@@ -7579,7 +7775,7 @@ function App() {
     };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
-  }, [selectedFeature, selectedMapRange, sequence, sequenceType, topology, copyText, handleZoomIn, handleZoomOut, handleZoomReset, recordId]);
+  }, [copyText, handleZoomIn, handleZoomOut, handleZoomReset, pendingDatabaseRestore, recordId, selectedFeature, selectedMapRange, sequence, sequenceType, topology]);
 
   // ── Base editing ──────────────────────────────────────────────────────────
   // Mutations run through the real Motif mutate engine (feature/subRange
@@ -11092,6 +11288,7 @@ function App() {
   const renderedStackedSequenceHeight = effectiveStackedSequenceHeight
     ?? (workspaceRowResizeActive ? defaultCompactTopRowHeight : 360);
   const activeRecordTabIndex = Math.max(0, payload.records.findIndex((record) => record.id === recordId));
+  const floatingPaneZIndex = (pane: PaneKey) => 60 + (2 * Math.max(0, floatingPaneZOrder.indexOf(pane)));
   const floatingPaneStyle = (pane: PaneKey): CSSProperties => {
     if (panePlacements[pane] !== 'floating') return {};
     const safeViewport: FloatingSurfaceViewport = {
@@ -11100,7 +11297,8 @@ function App() {
       insets: { top: topbarHeight + 8, right: toolsRail ? TOOLS_RAIL_WIDTH + 8 : 8, bottom: 8, left: 8 },
     };
     const rect = clampFloatingSurfaceRect(floatingPaneRects[pane], safeViewport, FLOATING_PANE_LIMITS[pane]);
-    const zIndex = 60 + Math.max(0, floatingPaneZOrder.indexOf(pane));
+    // Leave one layer between panes for each pane's viewport-level resize grip.
+    const zIndex = floatingPaneZIndex(pane);
     return {
       '--motif-cs-floating-pane-left': `${rect.x}px`,
       '--motif-cs-floating-pane-top': `${rect.y}px`,
@@ -11111,6 +11309,16 @@ function App() {
       width: rect.w,
       height: rect.h,
       zIndex,
+    } as CSSProperties;
+  };
+  const floatingPaneResizeStyle = (pane: PaneKey): CSSProperties => {
+    const surfaceStyle = floatingPaneStyle(pane) as CSSProperties & Record<string, string | number | undefined>;
+    return {
+      '--motif-cs-floating-pane-left': surfaceStyle['--motif-cs-floating-pane-left'],
+      '--motif-cs-floating-pane-top': surfaceStyle['--motif-cs-floating-pane-top'],
+      '--motif-cs-floating-pane-width': surfaceStyle['--motif-cs-floating-pane-width'],
+      '--motif-cs-floating-pane-height': surfaceStyle['--motif-cs-floating-pane-height'],
+      zIndex: floatingPaneZIndex(pane) + 1,
     } as CSSProperties;
   };
 
@@ -11209,6 +11417,22 @@ function App() {
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
+      {pendingDatabaseRestore ? (
+        <RestoreWorkspaceDialog
+          sourceLabel={pendingDatabaseRestore.sourceLabel}
+          incomingRecordCount={pendingDatabaseRestore.prepared.payload.records.length}
+          currentRecordCount={payload.records.length}
+          hasUnsavedChanges={hasUnsavedChanges}
+          onCancel={cancelArtifactDatabaseRestore}
+          onConfirm={confirmArtifactDatabaseRestore}
+        />
+      ) : null}
+      <div
+        className="motif-cs-background"
+        inert={pendingDatabaseRestore ? true : undefined}
+        aria-hidden={pendingDatabaseRestore ? 'true' : undefined}
+        data-restore-background={pendingDatabaseRestore ? 'inert' : undefined}
+      >
       <a className="motif-cs-skip-link" href="#motif-cs-workspace">Skip to workspace</a>
       {/* The Tools rail is authored last, so its first tool was Tab stop 124 of
           139 at 1440x900 — measured with real keys, all fifteen tools behind
@@ -11239,16 +11463,6 @@ function App() {
         >
           {workbenchNotice.message}
         </div>
-      ) : null}
-      {pendingDatabaseRestore ? (
-        <RestoreWorkspaceDialog
-          sourceLabel={pendingDatabaseRestore.sourceLabel}
-          incomingRecordCount={pendingDatabaseRestore.prepared.payload.records.length}
-          currentRecordCount={payload.records.length}
-          hasUnsavedChanges={hasUnsavedChanges}
-          onCancel={cancelArtifactDatabaseRestore}
-          onConfirm={confirmArtifactDatabaseRestore}
-        />
       ) : null}
       <header ref={topbarRef} className="motif-cs-topbar" aria-label="Motif for Claude Science workspace">
         <div className="motif-cs-brand" aria-label="Motif for Claude Science">
@@ -11472,10 +11686,10 @@ function App() {
                 onRestoreDatabase={(database) => requestArtifactDatabaseRestore(database)}
               />
               <InventoryList records={payload.records} selectedRecordId={recordId} onSelect={selectRecord} />
-              {panePlacements.inventory === 'floating' ? (
-                <FloatingPaneResizeHandle pane="inventory" title="Inventory" onPointerDown={beginFloatingPaneInteraction} onKeyDown={resizeFloatingPaneFromKeyboard} />
-              ) : null}
             </aside>
+            {panePlacements.inventory === 'floating' ? (
+              <FloatingPaneResizeHandle pane="inventory" title="Inventory" style={floatingPaneResizeStyle('inventory')} onPointerDown={beginFloatingPaneInteraction} onKeyDown={resizeFloatingPaneFromKeyboard} />
+            ) : null}
             {panePlacements.inventory === 'docked' ? <PaneResizeHandle pane="inventory" label="Resize inventory pane" width={paneWidths.inventory} limits={paneWidthLimitsForCurrentLayout('inventory')} edge="after" onPointerDown={startPaneResize} onKeyDown={resizePaneFromKeyboard} style={{ order: paneCssOrder('inventory', 'after') }} /> : null}
             {panePlacements.inventory === 'docked' ? <StackedPaneResizeHandle
               pane="inventory"
@@ -11721,10 +11935,10 @@ function App() {
                   onSelectRange={selectSequenceRangeAndReveal}
                 />
               </div>
-              {panePlacements.map === 'floating' ? (
-                <FloatingPaneResizeHandle pane="map" title="Map" onPointerDown={beginFloatingPaneInteraction} onKeyDown={resizeFloatingPaneFromKeyboard} />
-              ) : null}
             </section>
+            {panePlacements.map === 'floating' ? (
+              <FloatingPaneResizeHandle pane="map" title="Map" style={floatingPaneResizeStyle('map')} onPointerDown={beginFloatingPaneInteraction} onKeyDown={resizeFloatingPaneFromKeyboard} />
+            ) : null}
             {showSequenceMapResizeHandle ? (
               <PaneResizeHandle
                 pane="sequence"
@@ -12055,10 +12269,10 @@ function App() {
               onAnnotateRange={handleAnnotateRange}
               canAnnotateRange={canAnnotateSelectedMapRange}
             />
-            {panePlacements.sequence === 'floating' ? (
-              <FloatingPaneResizeHandle pane="sequence" title="Sequence" onPointerDown={beginFloatingPaneInteraction} onKeyDown={resizeFloatingPaneFromKeyboard} />
-            ) : null}
             </section>
+            {panePlacements.sequence === 'floating' ? (
+              <FloatingPaneResizeHandle pane="sequence" title="Sequence" style={floatingPaneResizeStyle('sequence')} onPointerDown={beginFloatingPaneInteraction} onKeyDown={resizeFloatingPaneFromKeyboard} />
+            ) : null}
             {panePlacements.sequence === 'docked' ? <StackedPaneResizeHandle
               pane="sequence"
               label="Sequence"
@@ -12692,10 +12906,10 @@ function App() {
               </div>
             </div>
           </details>
-            {toolsFloating ? (
-              <FloatingPaneResizeHandle pane="tools" title="Tools" onPointerDown={beginFloatingPaneInteraction} onKeyDown={resizeFloatingPaneFromKeyboard} />
-            ) : null}
             </aside>
+            {toolsFloating ? (
+              <FloatingPaneResizeHandle pane="tools" title="Tools" style={floatingPaneResizeStyle('tools')} onPointerDown={beginFloatingPaneInteraction} onKeyDown={resizeFloatingPaneFromKeyboard} />
+            ) : null}
           </>
         ) : null}
       </main>
@@ -12943,6 +13157,7 @@ function App() {
           />
         </FloatingWindow>
       ) : null}
+      </div>
     </div>
   );
 }
@@ -13064,11 +13279,13 @@ function PanePlacementControl({
 function FloatingPaneResizeHandle({
   pane,
   title,
+  style,
   onPointerDown,
   onKeyDown,
 }: {
   pane: PaneKey;
   title: string;
+  style: CSSProperties;
   onPointerDown: (pane: PaneKey, mode: 'move' | 'resize', event: ReactPointerEvent<HTMLElement>) => void;
   onKeyDown: (pane: PaneKey, event: ReactKeyboardEvent<HTMLButtonElement>) => void;
 }) {
@@ -13077,6 +13294,7 @@ function FloatingPaneResizeHandle({
       className="motif-cs-floating-pane-resize"
       type="button"
       data-testid={`floating-pane-resize-${pane}`}
+      style={style}
       onPointerDown={(event) => onPointerDown(pane, 'resize', event)}
       onKeyDown={(event) => onKeyDown(pane, event)}
       aria-label={`Resize ${title} pane in 2 dimensions`}
@@ -16106,8 +16324,16 @@ function SequenceToolsPanel({
   const genbank = exportPanelOpen ? toGenBankLite(exportRecord, topology) : '';
   const gff3 = exportPanelOpen && exportChoiceId === 'record-gff3' ? toGff3Lite(record) : '';
   const recordJson = exportPanelOpen && exportChoiceId === 'record-json' ? JSON.stringify(serializeRecord(exportRecord), null, 2) : '';
+  const checkpointExportIssues = useMemo(
+    () => needsInventoryJson ? getArtifactCheckpointExportIssues(exportRecordsWithSites) : [],
+    [exportRecordsWithSites, needsInventoryJson],
+  );
+  const checkpointExportBlocked = checkpointExportIssues.length > 0;
+  const checkpointExportMessage = checkpointExportBlocked
+    ? `Database JSON and workspace ZIP export are unavailable because the checkpoint would not pass restore validation. ${checkpointExportIssues.map((issue) => `${issue.recordName ?? 'Workspace'}: ${issue.message}`).join(' ')} No data was truncated.`
+    : '';
   const inventoryJson = useMemo(() => (
-    needsInventoryJson
+    needsInventoryJson && !checkpointExportBlocked
       ? JSON.stringify(createArtifactDatabaseSnapshot({
         schema,
         inventory,
@@ -16121,7 +16347,7 @@ function SequenceToolsPanel({
         analysisAssets: [...analysisAssets],
       }, artifactState, exportRecordsWithSites))
       : ''
-  ), [alignments, analysisAssets, analysisResults, artifactState, defaultMotif, exportRecordsWithSites, inventory, needsInventoryJson, notes, schema, selectedRecordId, workflowResults]);
+  ), [alignments, analysisAssets, analysisResults, artifactState, checkpointExportBlocked, defaultMotif, exportRecordsWithSites, inventory, needsInventoryJson, notes, schema, selectedRecordId, workflowResults]);
   const inventoryCsv = exportChoiceId === 'inventory-csv' || needsZipExport ? inventoryToCsv(exportRecordsWithSites) : '';
   const featureCsv = exportChoiceId === 'features-csv' || needsZipExport ? featuresToCsv(exportRecordsWithSites) : '';
   const siteCsv = exportChoiceId === 'sites-csv' || needsZipExport ? sitesToCsv(exportRecordsWithSites) : '';
@@ -16132,7 +16358,7 @@ function SequenceToolsPanel({
   const zipFiles = useMemo(() => {
     if (!needsZipExport) return [];
     const usedNames = new Set<string>();
-    const file = (name: string, content: string): ZipTextFile => ({
+    const file = (name: string, content: string): ArtifactZipTextFile => ({
       name: uniqueArchiveName(name, usedNames),
       content,
     });
@@ -16168,6 +16394,7 @@ function SequenceToolsPanel({
     content?: string;
     downloadName?: string;
     mime?: string;
+    blocked?: boolean;
     download?: () => BrowserDownloadReceipt;
     print?: () => void;
   };
@@ -16179,7 +16406,7 @@ function SequenceToolsPanel({
       { id: 'record-gff3', group: 'Active record' as const, label: 'Basic GFF3 features', copyLabel: 'Basic GFF3', content: gff3, downloadName: `${safeSlug(record.name)}.gff3`, mime: 'text/gff3' },
       { id: 'record-json', group: 'Active record' as const, label: 'Record JSON', copyLabel: 'Record JSON', content: recordJson, downloadName: `${safeSlug(record.name)}.json`, mime: 'application/json' },
     ] : []),
-    { id: 'inventory-json', group: 'Whole inventory', label: 'Database JSON', copyLabel: 'Inventory JSON', content: inventoryJson, downloadName: 'motif-inventory.json', mime: 'application/json' },
+    { id: 'inventory-json', group: 'Whole inventory', label: 'Database JSON', copyLabel: 'Inventory JSON', content: inventoryJson, downloadName: 'motif-inventory.json', mime: 'application/json', blocked: checkpointExportBlocked },
     { id: 'inventory-csv', group: 'Whole inventory', label: 'Inventory CSV', copyLabel: 'Inventory CSV', content: inventoryCsv, downloadName: 'motif-inventory.csv', mime: 'text/csv' },
     { id: 'features-csv', group: 'Whole inventory', label: 'Feature CSV', copyLabel: 'Feature CSV', content: featureCsv, downloadName: 'motif-features.csv', mime: 'text/csv' },
     { id: 'sites-csv', group: 'Whole inventory', label: 'Restriction-site CSV', copyLabel: 'Restriction-site CSV', content: siteCsv, downloadName: 'motif-restriction-sites.csv', mime: 'text/csv' },
@@ -16188,18 +16415,29 @@ function SequenceToolsPanel({
     { id: 'report-md', group: 'Report', label: 'Pretty report Markdown', copyLabel: 'Report Markdown', content: reportMarkdown, downloadName: 'motif-inventory-report.md', mime: 'text/markdown' },
     { id: 'report-html', group: 'Report', label: 'Pretty report HTML', copyLabel: 'Report HTML', content: reportHtml, downloadName: 'motif-inventory-report.html', mime: 'text/html' },
     { id: 'report-print', group: 'Report', label: 'Pretty print / PDF', print: () => printHtmlReport(reportHtml) },
-    { id: 'inventory-zip', group: 'Whole inventory', label: 'ZIP package', download: () => downloadBlobFile('motif-inventory-export.zip', createZipBlob(zipFiles)) },
-  ], [fasta, featureCsv, genbank, gff3, hasActiveRecord, inventoryCsv, inventoryJson, multiFasta, multiGenbank, record.name, record.sequence, recordJson, reportHtml, reportMarkdown, siteCsv, zipFiles]);
+    { id: 'inventory-zip', group: 'Whole inventory', label: 'ZIP package', blocked: checkpointExportBlocked, download: checkpointExportBlocked ? undefined : () => downloadBlobFile('motif-inventory-export.zip', createZipBlob(zipFiles)) },
+  ], [checkpointExportBlocked, fasta, featureCsv, genbank, gff3, hasActiveRecord, inventoryCsv, inventoryJson, multiFasta, multiGenbank, record.name, record.sequence, recordJson, reportHtml, reportMarkdown, siteCsv, zipFiles]);
   const exportChoice = exportChoices.find((choice) => choice.id === exportChoiceId) ?? exportChoices[0];
-  const exportLossReport = hasActiveRecord
-    ? buildArtifactExportLossReport(record, exportLossFormatForChoice(exportChoice?.id ?? 'record-sequence'))
-    : null;
-  const exportPreview = exportChoice?.content
-    ?? (exportChoice?.id === 'inventory-zip'
-      ? `ZIP package · ${zipFiles.length} files\n\n${zipFiles.map((file) => file.name).join('\n')}`
-      : exportChoice?.id === 'report-print'
-        ? `Printable inventory report · ${exportRecordsWithSites.length} records\n\nUse Print / PDF to open the system print dialog.`
-        : preview);
+  const baseExportLossReport = useMemo(() => {
+    if (!hasActiveRecord) return null;
+    const format = exportLossFormatForChoice(exportChoice?.id ?? 'record-sequence');
+    return exportChoice?.group === 'Whole inventory'
+      ? buildArtifactExportLossReportForRecords(exportRecordsWithSites, format)
+      : buildArtifactExportLossReport(record, format);
+  }, [exportChoice?.group, exportChoice?.id, exportRecordsWithSites, hasActiveRecord, record]);
+  const exportLossReport = useMemo(() => (
+    baseExportLossReport && checkpointExportBlocked
+      ? { ...baseExportLossReport, faithful: false, lossy: true, summary: checkpointExportMessage }
+      : baseExportLossReport
+  ), [baseExportLossReport, checkpointExportBlocked, checkpointExportMessage]);
+  const exportFallbackPreview = exportChoice?.id === 'inventory-zip'
+    ? `ZIP package · ${zipFiles.length} files\n\n${zipFiles.map((file) => file.name).join('\n')}`
+    : exportChoice?.id === 'report-print'
+      ? `Printable inventory report · ${exportRecordsWithSites.length} records\n\nUse Print / PDF to open the system print dialog.`
+      : preview;
+  const exportPreview = exportChoice?.blocked
+    ? checkpointExportMessage
+    : exportChoice?.content ?? exportFallbackPreview;
 
   useEffect(() => {
     if (exportChoices.some((choice) => choice.id === exportChoiceId)) return;
@@ -16359,10 +16597,21 @@ function SequenceToolsPanel({
           </label>
           <div className="motif-cs-export-picker-actions">
             <button className="motif-cs-mini-button" type="button" onClick={copySelectedExport} disabled={!exportChoice?.content}>Copy</button>
-            <button className="motif-cs-mini-button" type="button" onClick={downloadSelectedExport} disabled={!(exportChoice?.download || (exportChoice?.content && exportChoice.downloadName))}>Download</button>
+            <button className="motif-cs-mini-button" type="button" onClick={downloadSelectedExport} disabled={Boolean(exportChoice?.blocked) || !(exportChoice?.download || (exportChoice?.content && exportChoice.downloadName))}>Download</button>
             <button className="motif-cs-mini-button motif-cs-mini-button-accent" type="button" onClick={exportChoice?.print} disabled={!exportChoice?.print}>Print / PDF</button>
           </div>
         </div>
+        {exportChoice?.blocked ? (
+          <div
+            className="motif-cs-form-note motif-cs-restore-warning"
+            data-testid="checkpoint-export-blocked"
+            role="alert"
+            aria-live="assertive"
+          >
+            <strong>Checkpoint export blocked.</strong>{' '}
+            {checkpointExportMessage}
+          </div>
+        ) : null}
         {exportLossReport ? (
           <div
             className="motif-cs-form-note"

--- a/src/artifacts/motif-for-claude-science-plugin/.claude-plugin/plugin.json
+++ b/src/artifacts/motif-for-claude-science-plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "motif-for-claude-science",
   "displayName": "Motif for Claude Science",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Motif creates a portable molecular-biology workbench with alignment, Sanger review, cloning design, typed results, and recovery workflows.",
   "author": {
     "name": "Jacob Vogan"

--- a/src/artifacts/motif-for-claude-science-plugin/CHANGELOG.md
+++ b/src/artifacts/motif-for-claude-science-plugin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.3.3 — 2026-08-08
+
+- Made checkpoint exports provably restorable and clarified active-record and
+  inventory-wide export receipts.
+- Hardened external MSA execution, connector-root selection, MCP output bounds,
+  portable paths, and destructive restore isolation.
+- Expanded exact-commit release validation, Node 24 coverage, action pinning,
+  and stable map and MSA browser interactions.
+
 ## 0.3.2 — 2026-08-08
 
 - Unified restriction geometry and methylation behavior across catalog views,

--- a/src/artifacts/motif-for-claude-science-plugin/README.md
+++ b/src/artifacts/motif-for-claude-science-plugin/README.md
@@ -123,8 +123,11 @@ node ./skills/motif-for-claude-science/scripts/create-artifact.mjs \
 Supported environment variables are `MOTIF_MSA_MAFFT_PATH`,
 `MOTIF_MSA_MUSCLE_PATH`, `MOTIF_MSA_CLUSTAL_OMEGA_PATH`,
 `MOTIF_MSA_EXECUTABLE`, and `MOTIF_MSA_TOOLS_DIR`. Invalid explicit
-configuration is an error. Windows batch wrappers are intentionally excluded
-because they require a shell.
+configuration is an error. Selected executables must use the exact engine
+basename, pass that engine's version-banner check, and remain hash-stable
+through execution. The child receives a minimal environment without ambient
+credentials, proxy, or agent settings. Windows batch wrappers are intentionally
+excluded because they require a shell.
 
 The HTML itself cannot start native executables. Its bounded local alignment
 preview is labeled as a Motif browser preview and must never be represented as

--- a/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/SKILL.md
+++ b/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/SKILL.md
@@ -110,6 +110,12 @@ explicit and ordered: `--executable`; `MOTIF_MSA_MAFFT_PATH` /
 invalid explicitly configured executable is an error, not permission to try a
 different engine or the browser preview.
 
+Every selected executable must use the exact engine basename (`mafft`,
+`muscle`, `clustalo`, or `clustalomega`). The runner hashes that executable
+before its version probe, accepts only the engine's recognized version banner,
+and verifies the hash again after execution. The child receives a minimal
+environment without ambient credentials, proxy, or agent settings.
+
 On Windows, configure a native executable (`.exe`/`.com`). The runner does not
 launch `.bat` or `.cmd` wrappers because doing so requires a command shell and
 would weaken the no-shell execution boundary.

--- a/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/run-msa.mjs
+++ b/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/run-msa.mjs
@@ -58,6 +58,14 @@ const ENGINE_CONFIG = Object.freeze({
   }),
 });
 
+const ENGINE_BANNER_PATTERNS = Object.freeze({
+  mafft: /^(?:mafft\s+)?v?7\.\d+(?:\.\d+)?(?:\s|\(|$)/iu,
+  muscle: /^muscle\b.*\bv?5(?:\.\d+)+/iu,
+  'clustal-omega': /^(?:clustal\s+omega|clustalo|clustalomega)\b.*\b1\.\d+(?:\.\d+)?/iu,
+});
+const WINDOWS_CHILD_ENVIRONMENT_KEYS = Object.freeze(['SystemRoot', 'SystemDrive', 'WINDIR']);
+const INVALID_CHILD_ENVIRONMENT_KEY = /(?:TOKEN|PASSWORD|PASSWD|SECRET|CREDENTIAL|AUTH|PROXY|AGENT|NODE_OPTIONS|LD_PRELOAD|DYLD_|AWS_|SSH_)/iu;
+
 function usage() {
   return `Run a real external MSA engine and produce a Motif artifact payload.
 
@@ -268,6 +276,17 @@ function executableVariants(name, env) {
   return [name, ...extensions.map((extension) => `${name}${extension.toLowerCase()}`)];
 }
 
+function normalizedExecutableName(path) {
+  return basename(path).toLowerCase().replace(/\.(?:exe|com)$/u, '');
+}
+
+function assertExecutableIdentity(executable, config, source) {
+  const name = normalizedExecutableName(executable);
+  if (!config.binaries.includes(name)) {
+    throw new Error(`${source} must resolve to a ${config.label} executable named ${config.binaries.join(' or ')}`);
+  }
+}
+
 function checkedExecutable(candidate) {
   if (!candidate || !existsSync(candidate)) return null;
   try {
@@ -319,6 +338,7 @@ export function discoverMsaExecutable(engineValue, options = {}) {
     if (value === undefined || value === null || String(value).trim() === '') continue;
     const executable = resolveConfiguredExecutable(value, pathValue, env, cwd);
     if (!executable) throw new Error(`${source} does not resolve to an executable ${config.label} binary: ${value}`);
+    assertExecutableIdentity(executable, config, source);
     return { path: executable, source };
   }
 
@@ -326,7 +346,10 @@ export function discoverMsaExecutable(engineValue, options = {}) {
     for (const binary of config.binaries) {
       for (const variant of executableVariants(binary, env)) {
         const executable = checkedExecutable(join(resolve(cwd, env.MOTIF_MSA_TOOLS_DIR), variant));
-        if (executable) return { path: executable, source: 'MOTIF_MSA_TOOLS_DIR' };
+        if (executable) {
+          assertExecutableIdentity(executable, config, 'MOTIF_MSA_TOOLS_DIR');
+          return { path: executable, source: 'MOTIF_MSA_TOOLS_DIR' };
+        }
       }
     }
     throw new Error(`MOTIF_MSA_TOOLS_DIR does not contain an executable ${config.label} binary`);
@@ -340,13 +363,19 @@ export function discoverMsaExecutable(engineValue, options = {}) {
     for (const binary of config.binaries) {
       for (const variant of executableVariants(binary, env)) {
         const executable = checkedExecutable(join(directory, variant));
-        if (executable) return { path: executable, source: '~/.claude-science/conda/envs/msa-tools' };
+        if (executable) {
+          assertExecutableIdentity(executable, config, '~/.claude-science/conda/envs/msa-tools');
+          return { path: executable, source: '~/.claude-science/conda/envs/msa-tools' };
+        }
       }
     }
   }
 
   const fromPath = findOnPath(config.binaries, pathValue, env);
-  if (fromPath) return { path: fromPath, source: 'PATH' };
+  if (fromPath) {
+    assertExecutableIdentity(fromPath, config, 'PATH');
+    return { path: fromPath, source: 'PATH' };
+  }
   throw new Error(
     `${config.label} was not found. Use --executable, ${config.envVar}, MOTIF_MSA_TOOLS_DIR, the Claude Science msa-tools environment, or PATH.`,
   );
@@ -376,6 +405,23 @@ function spawnChecked(executable, args, options) {
   return result;
 }
 
+function minimalMsaEnvironment(sourceEnv, explicitEnv = {}) {
+  const childEnv = {};
+  if (process.platform === 'win32') {
+    for (const key of WINDOWS_CHILD_ENVIRONMENT_KEYS) {
+      if (typeof sourceEnv?.[key] === 'string' && sourceEnv[key]) childEnv[key] = sourceEnv[key];
+    }
+  }
+  for (const [key, value] of Object.entries(explicitEnv ?? {})) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(key) || INVALID_CHILD_ENVIRONMENT_KEY.test(key)) {
+      throw new Error(`MSA child environment variable ${key} is not allowed`);
+    }
+    if (typeof value !== 'string') throw new Error(`MSA child environment variable ${key} must be a string`);
+    childEnv[key] = value;
+  }
+  return childEnv;
+}
+
 function detectEngineVersion(executable, config, options) {
   const result = spawnChecked(executable, [...config.versionArgs], {
     ...options,
@@ -391,10 +437,8 @@ function detectEngineVersion(executable, config, options) {
 }
 
 function validateEngineVersion(engine, version) {
-  if (engine !== 'muscle') return;
-  const major = version.match(/\bmuscle\s+v?(\d+)(?:\.|\s|$)/i)?.[1];
-  if (!major || Number(major) < 5) {
-    throw new Error(`MUSCLE 5 or later is required; detected version text: ${version}`);
+  if (!ENGINE_BANNER_PATTERNS[engine].test(version)) {
+    throw new Error(`${ENGINE_CONFIG[engine].label} version banner is not recognized: ${version}`);
   }
 }
 
@@ -515,7 +559,8 @@ export function runExternalMsa(options) {
     homeDir: options.homeDir,
     pathValue: options.pathValue,
   });
-  const env = options.env ?? process.env;
+  const discoveryEnv = options.env ?? process.env;
+  const childEnv = minimalMsaEnvironment(discoveryEnv, options.childEnv);
   const cwd = options.cwd ?? process.cwd();
   const temporaryRoot = options.temporaryRoot ?? tmpdir();
   const temporaryDirectory = mkdtempSync(join(temporaryRoot, 'motif-msa-'));
@@ -525,12 +570,13 @@ export function runExternalMsa(options) {
     const outputPath = join(temporaryDirectory, 'output.fasta');
     const inputFasta = createToolFasta(records);
     writeFileSync(inputPath, inputFasta, { encoding: 'utf8', mode: 0o600 });
-    const version = detectEngineVersion(discovery.path, config, { cwd, env, timeoutMs });
+    const executableSha256 = sha256File(discovery.path);
+    const version = detectEngineVersion(discovery.path, config, { cwd, env: childEnv, timeoutMs });
     validateEngineVersion(engine, version);
     const invocation = engineInvocation(engine, molecule, inputPath, outputPath);
     const result = spawnChecked(discovery.path, invocation.args, {
       cwd: temporaryDirectory,
-      env,
+      env: childEnv,
       timeoutMs,
       label: config.label,
       maxBuffer: invocation.outputMode === 'stdout' ? MAX_MSA_OUTPUT_BYTES : MAX_CAPTURE_BYTES,
@@ -541,10 +587,12 @@ export function runExternalMsa(options) {
     const rows = parseToolAlignment(rawOutput, records, molecule);
     const inputFastaSha256 = sha256(inputFasta);
     const outputFastaSha256 = sha256(rawOutput);
+    if (sha256File(discovery.path) !== executableSha256) {
+      throw new Error(`${config.label} executable changed during execution`);
+    }
     const createdAt = options.createdAt ?? new Date().toISOString();
     const alignmentName = safeAlignmentName(options.name, config.label, records.length);
     const executableName = basename(discovery.path);
-    const executableSha256 = sha256File(discovery.path);
     const portableArgs = portableInvocationArgs(invocation.args, inputPath, outputPath);
     const executableArgv = [executableName, ...portableArgs];
     const payload = {

--- a/src/mcp-app/__tests__/motif-connector.test.ts
+++ b/src/mcp-app/__tests__/motif-connector.test.ts
@@ -388,6 +388,22 @@ describe('Motif MCP payload boundary', () => {
 });
 
 describe('Motif embedded artifact export', () => {
+  it('rejects escaped payload expansion before constructing oversized HTML', () => {
+    const workbench = prepareMotifWorkbench({
+      payload: {
+        schema: 'motif.claude-science.inventory.v2',
+        records: [{ id: 'demo', name: 'Demo', sequence: 'ATGCGT', molecule: 'dna' }],
+        hostileText: '<'.repeat(7_000_000),
+      },
+    });
+    expect(() => renderMotifArtifact({
+      template: artifactTemplate,
+      workbench,
+      runtimeBuildId,
+      filename: 'expanded.html',
+    })).toThrow(/exceeds .* after safe payload escaping/i);
+  });
+
   it('injects escaped JSON, creates a safe filename, and hashes exact HTML', () => {
     const workbench = prepareMotifWorkbench({
       payload: {

--- a/src/mcp-app/motif-workbench-bridge.ts
+++ b/src/mcp-app/motif-workbench-bridge.ts
@@ -64,7 +64,7 @@ export async function applyMotifToolResult(result: CallToolResult): Promise<void
 export async function startMotifMcpBridge(): Promise<App> {
   setBridgeState('connecting');
   const app = new App(
-    { name: 'Motif for Claude Science', version: '0.3.2' },
+    { name: 'Motif for Claude Science', version: '0.3.3' },
     { availableDisplayModes: ['inline', 'fullscreen'] },
     { autoResize: false },
   );

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.e2e.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "types": ["node", "@playwright/test"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["e2e/**/*.ts", "e2e/**/*.d.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.mcp.json" },
+    { "path": "./tsconfig.e2e.json" }
   ]
 }

--- a/tsconfig.mcp.json
+++ b/tsconfig.mcp.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.mcp.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["mcp/**/*.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       'scripts/**/__tests__/**/*.test.mjs',
     ],
     pool: 'forks',
+    maxWorkers: 2,
     execArgv: ['--max-old-space-size=4096'],
     testTimeout: 15_000,
     environment: 'node',


### PR DESCRIPTION
## Summary

- make checkpoint exports verifiably restorable and clarify active-record and inventory-wide receipts
- harden external MSA execution, packaged-root selection, MCP output bounds, and portable paths
- isolate destructive restore confirmation and stabilize high-zoom map, MSA drag, and floating-pane resize interactions
- expand exact-commit validation with MCP/browser typechecking, post-build release verification, accurate SBOM scope, Node 24 coverage, and exact action pins

## Validation

- `npm run gate`
- `npm run validate:plugin`
- independent wide, narrow, light, dark, mouse, and keyboard acceptance
- extracted release integrity, doctor, and dry-run checks