### PR TITLE
Use current artifact upload runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Retain gate and release evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: motif-gate-evidence-node-22
           path: |

--- a/scripts/__tests__/gate-parity.test.mjs
+++ b/scripts/__tests__/gate-parity.test.mjs
@@ -34,7 +34,7 @@ describe('npm run gate matches CI', () => {
   });
 
   it('retains browser and exact-commit gate evidence', () => {
-    expect(workflow).toContain('actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02');
+    expect(workflow).toContain('actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a');
     expect(workflow).toContain('test-results/');
     expect(workflow).toContain('dist-motif/gate-coverage.json');
   });


### PR DESCRIPTION
## Summary

- update the exact-SHA artifact uploader pin to the current Node 24-based release
- keep the gate-parity assertion aligned with the hosted workflow

## Validation

- focused gate-parity and release-security tests
- repository metadata policy