### PR TITLE
Harden validation and export boundaries

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,4 +1,8 @@
 # False positives: the generic-api-key rule interprets the standard
 # aria-keyshortcuts accessibility attribute as a credential assignment.
-src/artifacts/__tests__/claude-science-accessibility-interaction-guards.test.ts:generic-api-key:78
-src/artifacts/motif-artifact.tsx:generic-api-key:13794
+src/artifacts/__tests__/claude-science-accessibility-interaction-guards.test.ts:generic-api-key:155
+src/artifacts/motif-artifact.tsx:generic-api-key:19120
+# The initial public snapshot contains the same accessibility attributes at
+# these historical line numbers; keep full-history scans focused on real leaks.
+8b692e3ce55a49922593809d7ec6cb4545245d6c:src/artifacts/__tests__/claude-science-accessibility-interaction-guards.test.ts:generic-api-key:78
+8b692e3ce55a49922593809d7ec6cb4545245d6c:src/artifacts/motif-artifact.tsx:generic-api-key:13794

--- a/e2e/claude-science-feature-semantics.spec.ts
+++ b/e2e/claude-science-feature-semantics.spec.ts
@@ -133,6 +133,36 @@ test.describe('Claude Science multipart feature semantics', () => {
     await expect.poll(() => page.evaluate(() => window.motifGetActiveRecord?.()?.seq)).toBe('ATGCCA');
   });
 
+  test('describes raw sequence export receipts independently from FASTA', async ({ page }) => {
+    await page.evaluate(() => window.motifRenderInventory([{
+      id: 'raw-receipt-record',
+      name: 'Raw receipt record',
+      molecule: 'dna',
+      topology: 'linear',
+      seq: 'ACGTACGT',
+      annotations: [{
+        id: 'raw-receipt-feature',
+        name: 'annotation omitted by sequence text',
+        type: 'misc_feature',
+        start: 1,
+        end: 5,
+      }],
+    }]));
+    await expect.poll(() => page.evaluate(() => window.motifGetActiveRecord?.()?.id)).toBe('raw-receipt-record');
+
+    const exportPanel = page.locator('.motif-cs-sequence-tools-panel');
+    if ((await exportPanel.getAttribute('open')) === null) await exportPanel.locator(':scope > summary').click();
+    const exportFormat = exportPanel.locator('select[name="export-format"]');
+    const receipt = exportPanel.getByTestId('export-loss-receipt');
+
+    await exportFormat.selectOption('record-sequence');
+    await expect(receipt).toContainText('raw sequence export');
+    await expect(receipt).not.toContainText('FASTA export');
+
+    await exportFormat.selectOption('record-fasta');
+    await expect(receipt).toContainText('FASTA export');
+  });
+
   test('honors imported codon_start when translating a joined CDS', async ({ page }) => {
     await page.evaluate(() => window.motifRenderInventory([{
       id: 'frame-record',

--- a/e2e/fidelity-fixtures.ts
+++ b/e2e/fidelity-fixtures.ts
@@ -13,7 +13,7 @@ function writeTagName(view: DataView, offset: number, tag: string): void {
   for (let index = 0; index < 4; index += 1) view.setUint8(offset + index, tag.charCodeAt(index));
 }
 
-/** Minimal deterministic ABIF input used by the standalone browser campaign. */
+/** Minimal deterministic ABIF input used by the standalone browser fixture. */
 export function buildAbiFixture(): Uint8Array {
   const tags = [
     { name: 'PBAS', number: 2, type: 2, size: 1, count: 4, data: encodeAscii('ATGC') },

--- a/mcp/motif/payload.ts
+++ b/mcp/motif/payload.ts
@@ -110,7 +110,13 @@ function validateJsonValue(
 
   seen.add(value);
   if (Array.isArray(value)) {
-    value.forEach((entry, index) => validateJsonValue(entry, `${path}[${index}]`, budget, seen, depth + 1));
+    // Indexing (rather than forEach) deliberately visits sparse holes. JSON
+    // arrays must be dense; otherwise JSON.stringify would turn an unchecked
+    // hole into null after this validator returns and change the payload's
+    // shape at the artifact boundary.
+    for (let index = 0; index < value.length; index += 1) {
+      validateJsonValue(value[index], `${path}[${index}]`, budget, seen, depth + 1);
+    }
   } else {
     for (const [key, entry] of Object.entries(value)) {
       if (UNSAFE_OBJECT_KEYS.has(key)) throw new Error(`${path}.${key} is not an allowed object key.`);
@@ -321,8 +327,8 @@ function validateFeature(feature: unknown, path: string, sequenceLength: number)
     && (feature.color.length > 80 || !SAFE_FEATURE_COLOR.test(feature.color.trim()))) {
     throw new Error(`${path}.color must be a simple CSS color value no longer than 80 characters.`);
   }
-  if (!Number.isFinite(feature.start) || !Number.isFinite(feature.end)) {
-    throw new Error(`${path} must have finite start and end coordinates.`);
+  if (!Number.isInteger(feature.start) || !Number.isInteger(feature.end)) {
+    throw new Error(`${path} must have integer start and end coordinates.`);
   }
   const start = Number(feature.start);
   const end = Number(feature.end);
@@ -350,8 +356,8 @@ function validateFeature(feature: unknown, path: string, sequenceLength: number)
 }
 
 function validateFeatureRange(range: unknown, path: string, sequenceLength: number): void {
-  if (!isPlainObject(range) || !Number.isFinite(range.start) || !Number.isFinite(range.end)) {
-    throw new Error(`${path} must have finite start and end coordinates.`);
+  if (!isPlainObject(range) || !Number.isInteger(range.start) || !Number.isInteger(range.end)) {
+    throw new Error(`${path} must have integer start and end coordinates.`);
   }
   const start = Number(range.start);
   const end = Number(range.end);
@@ -393,11 +399,11 @@ function validateSites(sites: unknown, path: string): void {
     site.hits.forEach((hit, hitIndex) => {
       const hitPath = `${sitePath}.hits[${hitIndex}]`;
       if (!isPlainObject(hit)) throw new Error(`${hitPath} must be a plain object.`);
-      if (!Number.isFinite(hit.position) || Number(hit.position) < 0) {
-        throw new Error(`${hitPath}.position must be a non-negative finite number.`);
+      if (!Number.isSafeInteger(hit.position) || Number(hit.position) < 0) {
+        throw new Error(`${hitPath}.position must be a non-negative safe integer.`);
       }
-      if (hit.cutPosition !== undefined && (!Number.isFinite(hit.cutPosition) || Number(hit.cutPosition) < 0)) {
-        throw new Error(`${hitPath}.cutPosition must be a non-negative finite number.`);
+      if (hit.cutPosition !== undefined && (!Number.isSafeInteger(hit.cutPosition) || Number(hit.cutPosition) < 0)) {
+        throw new Error(`${hitPath}.cutPosition must be a non-negative safe integer.`);
       }
       if (hit.strand !== undefined && hit.strand !== -1 && hit.strand !== 1) {
         throw new Error(`${hitPath}.strand must be -1 or 1.`);

--- a/scripts/__tests__/dependency-cooling-off.test.mjs
+++ b/scripts/__tests__/dependency-cooling-off.test.mjs
@@ -58,6 +58,40 @@ function fetchFrom(text) {
   return async () => ({ ok: true, status: 200, text: async () => text });
 }
 
+function responseFromText(text, { stream = false, chunkSize = 23 } = {}) {
+  if (!stream) return { ok: true, status: 200, text: async () => text };
+  const bytes = new TextEncoder().encode(text);
+  let offset = 0;
+  return {
+    ok: true,
+    status: 200,
+    body: new ReadableStream({
+      pull(controller) {
+        if (offset >= bytes.byteLength) {
+          controller.close();
+          return;
+        }
+        const nextOffset = Math.min(offset + chunkSize, bytes.byteLength);
+        controller.enqueue(bytes.slice(offset, nextOffset));
+        offset = nextOffset;
+      },
+    }),
+  };
+}
+
+function routedFetch({ packument, versionMetadata, currentVersion = '1.0.0', stream = false, chunkSize = 23 } = {}) {
+  const requests = [];
+  const versionSuffix = `/${encodeURIComponent(currentVersion)}`;
+  return {
+    requests,
+    fetchImpl: async (url, options) => {
+      requests.push({ url, accept: options?.headers?.accept });
+      const body = new URL(url).pathname.endsWith(versionSuffix) ? versionMetadata : packument;
+      return responseFromText(typeof body === 'string' ? body : JSON.stringify(body), { stream, chunkSize });
+    },
+  };
+}
+
 describe('dependency cooling-off policy', () => {
   it('fails closed in CI without a real event baseline', async () => {
     const fixtureData = fixture();
@@ -163,6 +197,111 @@ describe('dependency cooling-off policy', () => {
       fetchImpl: fetchFrom(JSON.stringify(metadata)),
     })).rejects.toThrow(/tarball mismatch/);
     rmSync(tampered.directory, { recursive: true, force: true });
+  });
+
+  it('accepts a large streamed packument when the exact version response is small', async () => {
+    const fixtureData = fixture();
+    const packument = JSON.parse(fixtureData.metadata);
+    packument.auditPadding = 'x'.repeat(2_100_000);
+    const packumentText = JSON.stringify(packument);
+    expect(new TextEncoder().encode(packumentText).byteLength).toBeGreaterThan(2 * 1024 * 1024);
+    const exactVersion = {
+      name: 'reviewed-package',
+      version: '1.0.0',
+      dist: packument.versions['1.0.0'].dist,
+    };
+    const routed = routedFetch({ packument: packumentText, versionMetadata: exactVersion, stream: true, chunkSize: 11 });
+    await expect(checkDependencyCoolingOff(fixtureData.directory, {
+      baseLockfileText: fixtureData.baseline,
+      now: NOW,
+      fetchImpl: routed.fetchImpl,
+    })).resolves.toMatchObject({ changedPackageCount: 1 });
+    expect(routed.requests).toEqual(expect.arrayContaining([
+      expect.objectContaining({ accept: 'application/json' }),
+    ]));
+    expect(routed.requests).toHaveLength(2);
+    rmSync(fixtureData.directory, { recursive: true, force: true });
+  });
+
+  it('fails closed when a streamed packument exceeds its larger bounded cap', async () => {
+    const fixtureData = fixture();
+    const packument = JSON.parse(fixtureData.metadata);
+    packument.auditPadding = 'x'.repeat(16 * 1024 * 1024);
+    const metadata = JSON.parse(fixtureData.metadata);
+    const routed = routedFetch({
+      packument: JSON.stringify(packument),
+      versionMetadata: { name: 'reviewed-package', version: '1.0.0', dist: metadata.versions['1.0.0'].dist },
+      stream: true,
+      chunkSize: 65_536,
+    });
+    await expect(checkDependencyCoolingOff(fixtureData.directory, {
+      baseLockfileText: fixtureData.baseline,
+      now: NOW,
+      fetchImpl: routed.fetchImpl,
+    })).rejects.toThrow(/exceeded/iu);
+    rmSync(fixtureData.directory, { recursive: true, force: true });
+  });
+
+  it('requires the exact version endpoint to return the locked version', async () => {
+    const fixtureData = fixture();
+    const metadata = JSON.parse(fixtureData.metadata);
+    const routed = routedFetch({
+      packument: fixtureData.metadata,
+      versionMetadata: {
+        name: 'reviewed-package',
+        version: '0.9.0',
+        dist: metadata.versions['1.0.0'].dist,
+      },
+    });
+    await expect(checkDependencyCoolingOff(fixtureData.directory, {
+      baseLockfileText: fixtureData.baseline,
+      now: NOW,
+      fetchImpl: routed.fetchImpl,
+    })).rejects.toThrow(/no exact reviewed-package@1\.0\.0 version/);
+    rmSync(fixtureData.directory, { recursive: true, force: true });
+  });
+
+  it.each([
+    ['truncated publish metadata', '{"name":"reviewed-package","time":{"1.0.0":"2026-07-01T00:00:00.000Z"'],
+    ['publish metadata without the exact timestamp', JSON.stringify({ name: 'reviewed-package', time: { '0.9.0': '2026-07-01T00:00:00.000Z' } })],
+  ])('fails closed on %s', async (_label, packument) => {
+    const fixtureData = fixture();
+    const metadata = JSON.parse(fixtureData.metadata);
+    const routed = routedFetch({
+      packument,
+      versionMetadata: { name: 'reviewed-package', version: '1.0.0', dist: metadata.versions['1.0.0'].dist },
+      stream: true,
+      chunkSize: 7,
+    });
+    await expect(checkDependencyCoolingOff(fixtureData.directory, {
+      baseLockfileText: fixtureData.baseline,
+      now: NOW,
+      fetchImpl: routed.fetchImpl,
+    })).rejects.toThrow(/packument|publish|stream ended|stream failed/iu);
+    rmSync(fixtureData.directory, { recursive: true, force: true });
+  });
+
+  it('fails closed when the bounded exact-version response is too large', async () => {
+    const fixtureData = fixture();
+    const metadata = JSON.parse(fixtureData.metadata);
+    const oversizedVersion = JSON.stringify({
+      name: 'reviewed-package',
+      version: '1.0.0',
+      dist: metadata.versions['1.0.0'].dist,
+      auditPadding: 'x'.repeat(2_100_000),
+    });
+    const routed = routedFetch({
+      packument: fixtureData.metadata,
+      versionMetadata: oversizedVersion,
+      stream: true,
+      chunkSize: 31,
+    });
+    await expect(checkDependencyCoolingOff(fixtureData.directory, {
+      baseLockfileText: fixtureData.baseline,
+      now: NOW,
+      fetchImpl: routed.fetchImpl,
+    })).rejects.toThrow(/exceeded/iu);
+    rmSync(fixtureData.directory, { recursive: true, force: true });
   });
 
   it('does not make registry requests when the lockfile has no changed entries', async () => {

--- a/scripts/__tests__/generate-sbom.test.mjs
+++ b/scripts/__tests__/generate-sbom.test.mjs
@@ -50,4 +50,32 @@ describe('deterministic SBOM dependency scopes', () => {
     expect(byName.get('hoisted-transitive')?.scope).toBe('transitive');
     expect(byName.get('nested-transitive')?.scope).toBe('transitive');
   });
+
+  it('resolves license files relative to the requested workspace', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'motif-sbom-license-test-'));
+    fixtures.push(directory);
+    writeFileSync(join(directory, 'package.json'), `${JSON.stringify({
+      name: 'fixture-workspace',
+      version: '1.0.0',
+      dependencies: { 'fixture-license-package': '1.0.0' },
+    })}\n`);
+    writeFileSync(join(directory, 'package-lock.json'), `${JSON.stringify({
+      lockfileVersion: 3,
+      packages: {
+        '': { dependencies: { 'fixture-license-package': '1.0.0' } },
+        'node_modules/fixture-license-package': { version: '1.0.0' },
+      },
+    })}\n`);
+    writePackage(directory, 'fixture-license-package', '1.0.0');
+    writeFileSync(join(directory, 'node_modules/fixture-license-package/LICENSE'), 'fixture license\n');
+
+    const component = createDeterministicSbom(directory).components.find(
+      (candidate) => candidate.name === 'fixture-license-package',
+    );
+    expect(component).toMatchObject({
+      scope: 'direct',
+      licenseFile: 'node_modules/fixture-license-package/LICENSE',
+    });
+    expect(component?.licenseSha256).toMatch(/^[a-f0-9]{64}$/u);
+  });
 });

--- a/scripts/__tests__/motif-local-mcp-config.test.mjs
+++ b/scripts/__tests__/motif-local-mcp-config.test.mjs
@@ -199,6 +199,22 @@ describe('Motif Claude Science local connector configuration', () => {
     expect(readFileSync(targetPath, 'utf8')).toBe(targetBytes);
   });
 
+  it('refuses to create a config through a symlinked parent directory', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'motif-local-mcp-parent-link-test-'));
+    temporaryDirectories.push(directory);
+    const targetDirectory = mkdtempSync(join(tmpdir(), 'motif-local-mcp-parent-target-'));
+    temporaryDirectories.push(targetDirectory);
+    const linkedDirectory = join(directory, 'linked-config');
+    symlinkSync(targetDirectory, linkedDirectory, 'dir');
+    const configPath = join(linkedDirectory, 'local-mcp.json');
+
+    expect(() => updateLocalMcpConfigFile({
+      configPath,
+      desired: desiredServer(),
+    })).toThrow(/must not traverse a symbolic link/);
+    expect(existsSync(join(targetDirectory, 'local-mcp.json'))).toBe(false);
+  });
+
   it('rejects an oversized config before reading or parsing it', () => {
     const directory = mkdtempSync(join(tmpdir(), 'motif-local-mcp-size-test-'));
     temporaryDirectories.push(directory);

--- a/scripts/__tests__/validator-parity.test.mjs
+++ b/scripts/__tests__/validator-parity.test.mjs
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { validatePayload as validatePackagedPayload } from '../../src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/create-artifact.mjs';
+import { validateMotifPayload } from '../../mcp/motif/payload.ts';
+import { validateRuntimeRecordInputs } from '../../src/artifacts/motif-artifact.tsx';
+
+const baseRecord = { id: 'r1', name: 'r1', type: 'dna', sequence: 'GAATTC' };
+
+function accepts(validate) {
+  try {
+    validate();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function validatorOutcomes(payload) {
+  const records = payload.records;
+  return [
+    accepts(() => validatePackagedPayload(payload)),
+    accepts(() => validateMotifPayload(payload)),
+    accepts(() => validateRuntimeRecordInputs(records, 'motifAddRecords')),
+  ];
+}
+
+describe('public payload validator parity', () => {
+  it.each([
+    ['valid record', { records: [baseRecord] }, [true, true, true]],
+    ['sparse records array', { records: new Array(1) }, [false, false, false]],
+    ['sparse feature array', {
+      records: [{ ...baseRecord, features: new Array(1) }],
+    }, [false, false, false]],
+    ['sparse site array', {
+      records: [{ ...baseRecord, sites: new Array(1) }],
+    }, [false, false, false]],
+    ['sparse site-hit array', {
+      records: [{ ...baseRecord, sites: [{ hits: new Array(1) }] }],
+    }, [false, false, false]],
+    ['sparse feature-subrange array', {
+      records: [{ ...baseRecord, features: [{ start: 0, end: 2, subRanges: new Array(1) }] }],
+    }, [false, false, false]],
+  ])('%s has matching acceptance across all validator boundaries', (_name, payload, expected) => {
+    expect(validatorOutcomes(payload)).toEqual(expected);
+  });
+});

--- a/scripts/check-css-tokens.mjs
+++ b/scripts/check-css-tokens.mjs
@@ -4,9 +4,9 @@
  *
  * Verifies that every `var(--token)` reference in `src/` has a corresponding
  * `--token:` definition somewhere in `src/index.css`. This catches the recurring
- * "token-bypass" archetype that hit Phase 24 (`--bg-panel` undefined → transparent
- * popovers), Phase 28.5 (HC workbar invisible), and Phase 32 Pass-Tokens P0-3
- * (popover boxShadow referencing nonexistent `--shadow-popover`).
+ * "token-bypass" regressions such as an undefined `--bg-panel` making
+ * popovers transparent, an invisible high-contrast workbar, or a popover
+ * `boxShadow` referencing a nonexistent `--shadow-popover`.
  *
  * Run via: npm run check:css-tokens
  * Direct: node scripts/check-css-tokens.mjs [--quiet]
@@ -40,7 +40,7 @@ const ALLOWLIST = new Set([
   '--text-on-accent',
   // Selection highlight palette (4 user-pickable variants)
   '--selection-highlight', '--selection-highlight-rgb',
-  // VOG-2161 follow-up: `--selection-fg-override` is INLINE-SET by
+  // `--selection-fg-override` is set inline by
   // `applySelectionHighlightVars()` in `src/store/ui-store.ts` only for
   // palettes that demand a deliberate base-fg swap (charcoal +
   // monochrome). Default blue/amber/green/pink palettes leave it
@@ -53,7 +53,7 @@ const ALLOWLIST = new Set([
   // Monochrome theme — applied via ui-store setMonochrome at runtime
   '--mono', '--mono-softer', '--mono-border', '--mono-medium', '--mono-swatch',
   '--mono-feature-bg',
-  // Phase 35 P-Q (Fix #1+2): mono 3-stop ladder + feature foreground are also
+  // The monochrome three-stop ladder and feature foreground are also
   // applied dynamically at runtime through `MONOCHROME_INLINE_VARS`. They're
   // never defined in :root because they don't have a non-mono semantic — they
   // exist only as inline overrides.
@@ -94,8 +94,8 @@ function walkDir(dir, pattern, out = []) {
 }
 
 // 1. Collect every `--foo:` declaration across all src/ stylesheets
-// (Phase 41 W2: detail-mode.css is a sibling of index.css, paired with
-// the lazy DetailSequenceDisplay chunk).
+// `detail-mode.css` is a sibling of `index.css`, paired with the lazy
+// `DetailSequenceDisplay` chunk.
 const defs = new Set();
 for (const cssFile of CSS_DEF_FILES) {
   const cssText = stripCssComments(readFileSafe(cssFile));

--- a/scripts/check-dependency-cooling-off.mjs
+++ b/scripts/check-dependency-cooling-off.mjs
@@ -8,7 +8,9 @@ import { loadDependencyPolicy } from './lib/supply-chain-policy.mjs';
 
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const DAY_MS = 24 * 60 * 60 * 1000;
-const MAX_METADATA_BYTES = 2 * 1024 * 1024;
+const MAX_VERSION_METADATA_BYTES = 2 * 1024 * 1024;
+const MAX_PACKUMENT_BYTES = 16 * 1024 * 1024;
+const NPM_VERSION_METADATA_ACCEPT = 'application/json';
 const IMMUTABLE_COMMIT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/iu;
 
 function isImmutableCommitId(value) {
@@ -113,24 +115,133 @@ function registryUrl(registry, name) {
   return new URL(encodeURIComponent(name), base).toString();
 }
 
-async function readRegistryMetadata(fetchImpl, url) {
+function registryVersionUrl(registry, name, version) {
+  const packageUrl = registryUrl(registry, name);
+  return new URL(encodeURIComponent(version), `${packageUrl}/`).toString();
+}
+
+async function requestRegistry(fetchImpl, url, accept) {
   let response;
   try {
     response = await fetchImpl(url, {
-      headers: { accept: 'application/json' },
+      headers: { accept },
       redirect: 'error',
     });
   } catch (error) {
     throw new Error(`Registry metadata request failed for ${url}: ${error instanceof Error ? error.message : String(error)}`);
   }
   if (!response?.ok) throw new Error(`Registry metadata request failed for ${url}: HTTP ${response?.status ?? 'unknown'}`);
-  const text = await response.text();
-  if (new TextEncoder().encode(text).byteLength > MAX_METADATA_BYTES) throw new Error(`Registry metadata response exceeded ${MAX_METADATA_BYTES} bytes for ${url}`);
-  try {
-    return JSON.parse(text);
-  } catch (error) {
-    throw new Error(`Registry metadata response was not JSON for ${url}: ${error instanceof Error ? error.message : String(error)}`);
+  return response;
+}
+
+function chunkBytes(chunk) {
+  return typeof chunk === 'string' ? new TextEncoder().encode(chunk).byteLength : chunk?.byteLength ?? 0;
+}
+
+async function readBoundedResponseText(response, url, maxBytes, label) {
+  let bytes = 0;
+  const chunks = [];
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+  const append = (chunk) => {
+    bytes += chunkBytes(chunk);
+    if (bytes > maxBytes) throw new Error(`Registry ${label} response exceeded ${maxBytes} bytes for ${url}`);
+    try {
+      if (typeof chunk === 'string') {
+        chunks.push(decoder.decode());
+        chunks.push(chunk);
+      } else {
+        chunks.push(decoder.decode(chunk, { stream: true }));
+      }
+    } catch (error) {
+      throw new Error(`Registry metadata response was not valid UTF-8 for ${url}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  };
+
+  if (response.body?.getReader) {
+    const reader = response.body.getReader();
+    try {
+      while (true) {
+        const next = await reader.read();
+        if (next.done) break;
+        append(next.value);
+      }
+    } catch (error) {
+      await reader.cancel().catch(() => {});
+      throw error;
+    } finally {
+      reader.releaseLock();
+    }
+  } else if (response.body?.[Symbol.asyncIterator]) {
+    for await (const chunk of response.body) append(chunk);
+  } else if (typeof response.text === 'function') {
+    append(await response.text());
+  } else {
+    throw new Error(`Registry metadata response had no readable body for ${url}`);
   }
+  try {
+    chunks.push(decoder.decode());
+  } catch (error) {
+    throw new Error(`Registry metadata response was not valid UTF-8 for ${url}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  return chunks.join('');
+}
+
+async function readRegistryPublishMetadata(fetchImpl, url, version) {
+  const response = await requestRegistry(fetchImpl, url, 'application/json');
+  let metadata;
+  try {
+    metadata = JSON.parse(await readBoundedResponseText(response, url, MAX_PACKUMENT_BYTES, 'packument'));
+  } catch (error) {
+    if (error instanceof Error && /response exceeded/u.test(error.message)) throw error;
+    throw new Error(`Registry packument response was not JSON for ${url}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    throw new Error(`Registry packument response was not an object for ${url}`);
+  }
+  if (typeof metadata.name !== 'string') throw new Error(`Registry packument has no package name for ${url}`);
+  if (!metadata.time || typeof metadata.time !== 'object' || Array.isArray(metadata.time)) {
+    throw new Error(`Registry packument has no publish-time object for ${metadata.name}`);
+  }
+  const publishedAt = metadata.time[version];
+  if (typeof publishedAt !== 'string') throw new Error(`Registry packument has no exact ${version} publish timestamp for ${metadata.name}`);
+  return { name: metadata.name, publishedAt };
+}
+
+async function readRegistryVersionMetadata(fetchImpl, url, entry) {
+  const response = await requestRegistry(fetchImpl, url, NPM_VERSION_METADATA_ACCEPT);
+  let metadata;
+  try {
+    metadata = JSON.parse(await readBoundedResponseText(response, url, MAX_VERSION_METADATA_BYTES, 'version metadata'));
+  } catch (error) {
+    if (error instanceof Error && /response exceeded/u.test(error.message)) throw error;
+    throw new Error(`Registry version metadata response was not JSON for ${url}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    throw new Error(`Registry version metadata was not an object for ${url}`);
+  }
+  const version = metadata.versions?.[entry.version]
+    ?? (metadata.version === entry.version ? metadata : undefined);
+  if (!version || typeof version !== 'object' || Array.isArray(version) || version.version !== entry.version) {
+    throw new Error(`Registry metadata has no exact ${entry.name}@${entry.version} version`);
+  }
+  return { name: metadata.name ?? version.name, version };
+}
+
+async function readRegistryMetadata(fetchImpl, registry, entry) {
+  const versionUrl = registryVersionUrl(registry, entry.name, entry.version);
+  const packumentUrl = registryUrl(registry, entry.name);
+  const [versionMetadata, publishMetadata] = await Promise.all([
+    readRegistryVersionMetadata(fetchImpl, versionUrl, entry),
+    readRegistryPublishMetadata(fetchImpl, packumentUrl, entry.version),
+  ]);
+  if (versionMetadata.name !== entry.name || publishMetadata.name !== entry.name) {
+    throw new Error(`Registry metadata name mismatch for ${entry.name}@${entry.version}`);
+  }
+  return {
+    name: entry.name,
+    versions: { [entry.version]: versionMetadata.version },
+    time: { [entry.version]: publishMetadata.publishedAt },
+  };
 }
 
 function assertRegistryIdentity(entry, metadata, registry) {
@@ -164,7 +275,7 @@ export async function checkDependencyCoolingOff(rootPath = root, options = {}) {
   for (const entry of unique) {
     if (typeof entry.resolved !== 'string' || typeof entry.integrity !== 'string') throw new Error(`Changed dependency ${entry.name}@${entry.version} lacks a registry source or integrity`);
     const identity = `${entry.name}@${entry.version}`;
-    const metadata = await readRegistryMetadata(fetchImpl, registryUrl(policy.registry, entry.name));
+    const metadata = await readRegistryMetadata(fetchImpl, policy.registry, entry);
     const publishedMs = assertRegistryIdentity(entry, metadata, policy.registry);
     const ageDays = (now - publishedMs) / DAY_MS;
     if (ageDays < 0) throw new Error(`Registry publish timestamp is in the future for ${identity}`);

--- a/scripts/generate-sbom.mjs
+++ b/scripts/generate-sbom.mjs
@@ -32,8 +32,8 @@ function packageManifest(lockPath) {
   return readJson(path);
 }
 
-function licenseFile(lockPath, manifest) {
-  const directory = join(root, lockPath);
+function licenseFile(workspace, lockPath, manifest) {
+  const directory = join(workspace, lockPath);
   if (!existsSync(directory)) return null;
   const candidates = readdirSync(directory)
     .filter(name => /^(?:license|copying|notice)(?:\.|$)/iu.test(name))
@@ -53,7 +53,7 @@ export function createDeterministicSbom(rootPath = root) {
       const manifestPath = join(workspace, lockPath, 'package.json');
       const manifest = existsSync(manifestPath) ? readJson(manifestPath) : {};
       const name = typeof manifest.name === 'string' && manifest.name ? manifest.name : packageNameFromLockPath(lockPath);
-      const licensePath = licenseFile(lockPath, manifest);
+      const licensePath = licenseFile(workspace, lockPath, manifest);
       return {
         name,
         version: metadata.version,

--- a/scripts/lib/motif-local-mcp-config.mjs
+++ b/scripts/lib/motif-local-mcp-config.mjs
@@ -55,6 +55,49 @@ function assertRegularFile(path, purpose) {
   return stat;
 }
 
+/**
+ * Do not let a missing config file be created through a symlinked parent.
+ * `renameSync` and `mkdirSync` otherwise follow that parent and can write a
+ * supposedly local configuration into an unrelated directory. Missing path
+ * components are allowed, but every existing ancestor must be a real
+ * directory. Re-checking after mkdir also closes the simple replace-between-
+ * checks race before any file is committed.
+ */
+function assertRealDirectoryChain(directory, purpose) {
+  const isKnownSystemAlias = (path) => process.platform === 'darwin'
+    && (path === '/var' || path === '/tmp');
+  let current = resolve(directory);
+  while (true) {
+    let stat;
+    try {
+      stat = lstatSync(current);
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        const parent = dirname(current);
+        if (parent === current) return;
+        current = parent;
+        continue;
+      }
+      throw error;
+    }
+    if (stat.isSymbolicLink()) {
+      if (!isKnownSystemAlias(current)) {
+        throw new Error(`${purpose} must not traverse a symbolic link: ${current}`);
+      }
+      const parent = dirname(current);
+      if (parent === current) return;
+      current = parent;
+      continue;
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(`${purpose} parent must be a real directory: ${current}`);
+    }
+    const parent = dirname(current);
+    if (parent === current) return;
+    current = parent;
+  }
+}
+
 function executable(path) {
   try {
     assertRegularFile(path, 'Node.js executable');
@@ -140,7 +183,14 @@ export function validateLocalMcpConfig(config) {
 }
 
 export function readLocalMcpConfig(configPath) {
-  if (!existsSync(configPath)) {
+  assertRealDirectoryChain(dirname(configPath), 'Claude Science local MCP config path');
+  let configStat;
+  try {
+    configStat = lstatSync(configPath);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  if (!configStat) {
     return {
       config: { servers: [] },
       originalBytes: null,
@@ -234,8 +284,16 @@ export function removeMotifLocalServer(config) {
 }
 
 function fingerprintMatches(path, expected) {
-  if (!expected) return !existsSync(path);
-  if (!existsSync(path)) return false;
+  assertRealDirectoryChain(dirname(path), 'Claude Science local MCP config path');
+  let pathStat;
+  try {
+    pathStat = lstatSync(path);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return !expected;
+    throw error;
+  }
+  if (!expected) return false;
+  if (!pathStat) return false;
   const current = assertRegularFile(path, 'Claude Science local MCP config');
   return current.dev === expected.dev
     && current.ino === expected.ino
@@ -286,7 +344,9 @@ export function writeLocalMcpConfigAtomically(
     throw new MotifLocalMcpConfigLimitError(configPath, serializedBytes);
   }
   const directory = dirname(configPath);
+  assertRealDirectoryChain(directory, 'Claude Science local MCP config path');
   mkdirSync(directory, { recursive: true, mode: 0o700 });
+  assertRealDirectoryChain(directory, 'Claude Science local MCP config path');
   chmodSync(directory, 0o700);
 
   if (!fingerprintMatches(configPath, document.fingerprint)) {

--- a/scripts/test-claude-science-plugin-packaging.mjs
+++ b/scripts/test-claude-science-plugin-packaging.mjs
@@ -10,6 +10,7 @@ import {
   readdirSync,
   realpathSync,
   rmSync,
+  symlinkSync,
   utimesSync,
   writeFileSync,
 } from 'node:fs';
@@ -54,6 +55,7 @@ import {
   MAX_MSA_SEQUENCES,
   parseRunMsaArgs,
   parseUnalignedFasta,
+  portableInvocationArgs,
   runExternalMsa,
   writeMsaPayload,
 } from '../src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/run-msa.mjs';
@@ -648,6 +650,10 @@ check('bundled helper rejects malformed nested shapes and oversized records', ()
     { ...base, overhang5Type: '5prime' },
     { ...base, overhang3: 'AX' },
     { ...base, type: 'protein', sequence: 'MPEPTIDE', overhang5: 'AATT', overhang5Type: '5prime' },
+    { ...base, features: [{ start: 0.5, end: 2 }] },
+    { ...base, features: [{ start: 0, end: 2, subRanges: [{ start: 0, end: 1.5 }] }] },
+    { ...base, sites: [{ enzyme: 'EcoRI', hits: [{ position: 1.5 }] }] },
+    { ...base, sites: [{ enzyme: 'EcoRI', hits: [{ position: 1, cutPosition: 2.5 }] }] },
   ]) {
     assert.throws(() => validatePayload({ records: [record] }), /Payload record 1/);
   }
@@ -993,9 +999,33 @@ check('external MSA payload writer refuses races and preserves the old file on n
     assert.equal(writeMsaPayload(outputPath, payload, true), resolve(outputPath));
     assert.deepEqual(JSON.parse(readFileSync(outputPath, 'utf8')), payload);
     assert.equal(readdirSync(fixture).some((entry) => entry.startsWith('.motif-msa-output-')), false);
+
+    const targetDirectory = mkdtempSync(join(tmpdir(), 'motif-msa-output-target-'));
+    try {
+      const linkedDirectory = join(fixture, 'linked-output');
+      symlinkSync(targetDirectory, linkedDirectory, 'dir');
+      assert.throws(
+        () => writeMsaPayload(join(linkedDirectory, 'payload.json'), payload, true),
+        /output directory must not traverse a symbolic link/i,
+      );
+      assert.equal(existsSync(join(targetDirectory, 'payload.json')), false);
+    } finally {
+      rmSync(targetDirectory, { recursive: true, force: true });
+    }
   } finally {
     rmSync(fixture, { recursive: true, force: true });
   }
+});
+
+check('external MSA provenance redacts overlapping input and output paths completely', () => {
+  assert.deepEqual(
+    portableInvocationArgs(
+      ['--infile=/tmp/input.fasta', '--outfile=/tmp/input.fasta.bak'],
+      '/tmp/input.fasta',
+      '/tmp/input.fasta.bak',
+    ),
+    ['--infile=<input.fasta>', '--outfile=<output.fasta>'],
+  );
 });
 
 if (process.env.MOTIF_RUN_MSA_INTEGRATION === '1') {

--- a/src/artifacts/__tests__/claude-science-record-lifecycle-guards.test.ts
+++ b/src/artifacts/__tests__/claude-science-record-lifecycle-guards.test.ts
@@ -45,8 +45,7 @@ describe('Claude Science record lifecycle guards', () => {
   });
 
   it('stores topology on the record so the UI, API, and exports agree', () => {
-    // Renamed from toggleTopology when #34 moved conversion out of the map
-    // panel: it now takes a target rather than flipping, because the two
+    // Conversion now takes a target rather than flipping because the two
     // Entry Details buttons name the state they set. The invariant this guard
     // exists for is unchanged — topology lives on the record, one copy.
     const convertTopology = sliceBetween(
@@ -63,8 +62,8 @@ describe('Claude Science record lifecycle guards', () => {
   });
 
   it('lets the map be drawn as a line without converting the molecule', () => {
-    // #34. The map's shape control used to call the conversion above, so asking
-    // for a different picture rewrote the record. The drawing is now its own
+    // The map's shape control must not call record conversion: asking for a
+    // different picture must not rewrite the molecule. Drawing is its own
     // state.
     //
     // The size of the science it moved, measured against findRestrictionSites

--- a/src/artifacts/__tests__/claude-science-runtime-integrity.test.ts
+++ b/src/artifacts/__tests__/claude-science-runtime-integrity.test.ts
@@ -652,6 +652,39 @@ describe('Claude Science runtime data-integrity behavior', () => {
     }));
   });
 
+  it('blocks checkpoints that contain inactive records which restore would discard', () => {
+    const inactive = normalizeRecord({
+      id: 'inactive-checkpoint-record',
+      name: 'Inactive checkpoint record',
+      type: 'dna',
+      topology: 'linear',
+      sequence: 'ACGT',
+      active: false,
+    }, 0);
+    expect(inactive).not.toBeNull();
+    if (!inactive) throw new Error('inactive checkpoint fixture did not normalize');
+
+    const payload = prepareInventoryReplacement([{
+      id: inactive.id,
+      name: inactive.name,
+      type: inactive.type,
+      topology: inactive.topology,
+      sequence: inactive.sequence,
+    }]);
+    expect(() => createArtifactDatabaseSnapshot({ ...payload, records: [inactive] }, {
+      customEnzymes: [],
+      translationLayersByRecord: {},
+      enzymeSourcesByRecord: {},
+      hiddenEnzymesByRecord: {},
+      hiddenFeatureTranslationsByRecord: {},
+      restrictionLabelsByRecord: {},
+      motifsByRecord: {},
+    }, [inactive])).toThrowError(expect.objectContaining({
+      code: 'MOTIF_INPUT_LIMIT_EXCEEDED',
+      message: expect.stringMatching(/inactive|restore/i),
+    }));
+  });
+
   it('normalizes allowlisted feature fields and escapes all report markup', () => {
     const payload = prepareInventoryReplacement([{
       id: 'security-fixture',
@@ -875,6 +908,48 @@ describe('Claude Science runtime data-integrity behavior', () => {
         }),
       }),
     );
+  });
+
+  it('rejects fractional restriction-site coordinates before they reach map state', () => {
+    for (const hit of [
+      { position: 1.5 },
+      { position: 1, cutPosition: 2.5 },
+    ]) {
+      expect(() => validateRuntimeRecordInputs([{
+        id: 'fractional-site',
+        molecule: 'dna',
+        sequence: 'GAATTC',
+        sites: [{ enzyme: 'EcoRI', hits: [hit] }],
+      }], 'motifAddRecords')).toThrowError(expect.objectContaining({
+        details: expect.objectContaining({
+          mutated: false,
+          issues: expect.arrayContaining([
+            expect.objectContaining({ message: expect.stringMatching(/non-negative safe integer/i) }),
+          ]),
+        }),
+      }));
+    }
+  });
+
+  it('rejects fractional feature coordinates instead of rounding imported annotations', () => {
+    for (const feature of [
+      { start: 0.5, end: 2 },
+      { start: 0, end: 2, subRanges: [{ start: 0, end: 1.5 }] },
+    ]) {
+      expect(() => validateRuntimeRecordInputs([{
+        id: 'fractional-feature',
+        molecule: 'dna',
+        sequence: 'GAATTC',
+        features: [feature],
+      }], 'motifAddRecords')).toThrowError(expect.objectContaining({
+        details: expect.objectContaining({
+          mutated: false,
+          issues: expect.arrayContaining([
+            expect.objectContaining({ message: expect.stringMatching(/safe integer/i) }),
+          ]),
+        }),
+      }));
+    }
   });
 
   it('keeps ordinary FASTA records JSON-compatible for atomic UI imports', () => {

--- a/src/artifacts/__tests__/claude-science-session.test.ts
+++ b/src/artifacts/__tests__/claude-science-session.test.ts
@@ -139,6 +139,41 @@ describe('Claude Science durable session validation', () => {
     });
   });
 
+  it('preserves record-keyed state for the legal record id __proto__', () => {
+    const state = normalizeArtifactDurableState({
+      translationLayersByRecord: {
+        ['__proto__']: [{
+          id: 'layer',
+          label: 'candidate',
+          start: 0,
+          end: 3,
+          strand: 1,
+          frame: 0,
+          translationTableId: 1,
+        }],
+      },
+      enzymeSourcesByRecord: { ['__proto__']: ['common'] },
+      hiddenEnzymesByRecord: { ['__proto__']: ['EcoRI'] },
+      hiddenFeatureTranslationsByRecord: { ['__proto__']: ['feature-1'] },
+      restrictionLabelsByRecord: { ['__proto__']: true },
+      motifsByRecord: { ['__proto__']: 'GAATTC' },
+    }, new Map([['__proto__', 12]]));
+
+    expect(state.translationLayersByRecord['__proto__']).toHaveLength(1);
+    expect(state.enzymeSourcesByRecord['__proto__']).toEqual(['common']);
+    expect(state.hiddenEnzymesByRecord['__proto__']).toEqual(['EcoRI']);
+    expect(state.hiddenFeatureTranslationsByRecord['__proto__']).toEqual(['feature-1']);
+    expect(state.restrictionLabelsByRecord['__proto__']).toBe(true);
+    expect(state.motifsByRecord['__proto__']).toBe('GAATTC');
+
+    const roundTripped = normalizeArtifactDurableState(
+      JSON.parse(JSON.stringify(state)),
+      new Map([['__proto__', 12]]),
+    );
+    expect(roundTripped.translationLayersByRecord['__proto__']).toHaveLength(1);
+    expect(roundTripped.motifsByRecord['__proto__']).toBe('GAATTC');
+  });
+
   it('rejects malformed nested session state instead of letting it reach React', () => {
     expect(() => normalizeArtifactDurableState({ customEnzymes: {} }, recordLengths)).toThrow(/must be an array/i);
     expect(() => normalizeArtifactDurableState({

--- a/src/artifacts/__tests__/export-loss-report.test.ts
+++ b/src/artifacts/__tests__/export-loss-report.test.ts
@@ -105,6 +105,39 @@ describe('structured export-loss report', () => {
     expect(buildArtifactExportLossReport(record, 'genbank').summary).toMatch(/does not claim full INSDC round-trip|lossy/i);
   });
 
+  it('describes raw sequence exports separately from FASTA exports', () => {
+    const record = normalizeRecord({
+      id: 'raw-sequence',
+      name: 'Raw sequence fixture',
+      molecule: 'dna',
+      seq: 'ACGT',
+      annotations: [{
+        id: 'raw-feature',
+        name: 'annotation omitted by sequence text',
+        type: 'misc_feature',
+        start: 1,
+        end: 4,
+      }],
+    }, 0);
+    expect(record).not.toBeNull();
+    if (!record) throw new Error('fixture did not normalize');
+
+    const rawSequenceReport = buildArtifactExportLossReport(record, 'raw-sequence');
+    expect(rawSequenceReport).toMatchObject({ format: 'raw-sequence', faithful: false, lossy: true });
+    expect(rawSequenceReport.summary).toMatch(/raw sequence export contains sequence text only/i);
+    expect(rawSequenceReport.summary).not.toMatch(/FASTA/i);
+    expect(buildArtifactExportLossReport(record, 'fasta').summary).toMatch(/FASTA export/i);
+
+    const sequenceOnlyRecord = normalizeRecord({ id: 'sequence-only', molecule: 'dna', seq: 'ACGT' }, 0);
+    expect(sequenceOnlyRecord).not.toBeNull();
+    if (!sequenceOnlyRecord) throw new Error('sequence-only fixture did not normalize');
+    expect(buildArtifactExportLossReport(sequenceOnlyRecord, 'raw-sequence')).toMatchObject({
+      faithful: true,
+      lossy: false,
+      summary: expect.stringMatching(/raw sequence export contains the record sequence only/i),
+    });
+  });
+
   it('aggregates whole-inventory loss receipts across inactive records', () => {
     const active = normalizeRecord({
       id: 'active-record',

--- a/src/artifacts/claude-science-session.ts
+++ b/src/artifacts/claude-science-session.ts
@@ -61,6 +61,16 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+/**
+ * Record-keyed checkpoint maps must preserve every legal record id, including
+ * names such as `__proto__`. A normal object assignment treats that key as a
+ * prototype setter and silently drops the durable value. Null-prototype maps
+ * remain JSON-compatible while making every record id an ordinary data key.
+ */
+function createRecordMap<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
 const MOTIF_INVENTORY_SCHEMA_PREFIX = 'motif.claude-science.inventory.';
 const SUPPORTED_MOTIF_INVENTORY_SCHEMAS = new Set([
   MOTIF_INVENTORY_SCHEMA_V1,
@@ -206,7 +216,7 @@ function normalizeTranslationLayers(
 ): Record<string, PortableTranslationTrack[]> {
   if (value === undefined) return {};
   if (!isObject(value)) throw new Error('artifactState.translationLayersByRecord must be an object.');
-  const result: Record<string, PortableTranslationTrack[]> = {};
+  const result = createRecordMap<PortableTranslationTrack[]>();
 
   for (const [recordId, rawLayers] of Object.entries(value)) {
     const sequenceLength = recordLengths.get(recordId);
@@ -274,7 +284,7 @@ function normalizeStringArraysByRecord(
 ): Record<string, string[]> {
   if (value === undefined) return {};
   if (!isObject(value)) throw new Error(`${path} must be an object.`);
-  const result: Record<string, string[]> = {};
+  const result = createRecordMap<string[]>();
   for (const [recordId, rawValues] of Object.entries(value)) {
     if (!recordLengths.has(recordId)) continue;
     if (!Array.isArray(rawValues) || rawValues.some((item) => typeof item !== 'string')) {
@@ -293,7 +303,7 @@ function normalizeRestrictionSources(
   recordLengths: ReadonlyMap<string, number>,
 ): Record<string, RestrictionEnzymeSourceId[]> {
   const raw = normalizeStringArraysByRecord(value, 'artifactState.enzymeSourcesByRecord', recordLengths);
-  const result: Record<string, RestrictionEnzymeSourceId[]> = {};
+  const result = createRecordMap<RestrictionEnzymeSourceId[]>();
   for (const [recordId, sources] of Object.entries(raw)) {
     const validated = sources.filter((source): source is RestrictionEnzymeSourceId => VALID_SOURCE_IDS.has(source as RestrictionEnzymeSourceId));
     if (validated.length !== sources.length) throw new Error(`artifactState.enzymeSourcesByRecord.${recordId} contains an unknown source.`);
@@ -309,7 +319,7 @@ function normalizeBooleanByRecord(
 ): Record<string, boolean> {
   if (value === undefined) return {};
   if (!isObject(value)) throw new Error(`${path} must be an object.`);
-  const result: Record<string, boolean> = {};
+  const result = createRecordMap<boolean>();
   for (const [recordId, rawValue] of Object.entries(value)) {
     if (!recordLengths.has(recordId)) continue;
     if (typeof rawValue !== 'boolean') throw new Error(`${path}.${recordId} must be a boolean.`);
@@ -324,7 +334,7 @@ function normalizeMotifs(
 ): Record<string, string> {
   if (value === undefined) return {};
   if (!isObject(value)) throw new Error('artifactState.motifsByRecord must be an object.');
-  const result: Record<string, string> = {};
+  const result = createRecordMap<string>();
   for (const [recordId, rawValue] of Object.entries(value)) {
     if (!recordLengths.has(recordId)) continue;
     if (typeof rawValue !== 'string' || rawValue.length > MAX_MOTIF_LENGTH) {

--- a/src/artifacts/motif-artifact.tsx
+++ b/src/artifacts/motif-artifact.tsx
@@ -2247,7 +2247,7 @@ function rememberLastGoodRuntimePayload(
 
 type RecordSummary = { text: string; data: Record<string, unknown> };
 
-export type ArtifactExportLossFormat = 'fasta' | 'genbank' | 'gff3' | 'record-json' | 'database-json' | 'zip' | 'csv' | 'report';
+export type ArtifactExportLossFormat = 'raw-sequence' | 'fasta' | 'genbank' | 'gff3' | 'record-json' | 'database-json' | 'zip' | 'csv' | 'report';
 
 export type ArtifactExportLossReport = {
   format: ArtifactExportLossFormat;
@@ -2305,7 +2305,8 @@ const EXPORT_LOSS_INTERNAL_METADATA_KEYS = new Set([
 ]);
 
 function exportLossFormatForChoice(choiceId: string): ArtifactExportLossFormat {
-  if (choiceId === 'record-sequence' || choiceId === 'record-fasta' || choiceId === 'multi-fasta') return 'fasta';
+  if (choiceId === 'record-sequence') return 'raw-sequence';
+  if (choiceId === 'record-fasta' || choiceId === 'multi-fasta') return 'fasta';
   if (choiceId === 'record-gff3') return 'gff3';
   if (choiceId === 'record-json') return 'record-json';
   if (choiceId === 'inventory-json') return 'database-json';
@@ -2313,6 +2314,20 @@ function exportLossFormatForChoice(choiceId: string): ArtifactExportLossFormat {
   if (choiceId.endsWith('-csv')) return 'csv';
   if (choiceId.startsWith('report-')) return 'report';
   return 'genbank';
+}
+
+function exportLossFormatLabel(format: ArtifactExportLossFormat): string {
+  switch (format) {
+    case 'raw-sequence': return 'raw sequence';
+    case 'fasta': return 'FASTA';
+    case 'gff3': return 'GFF3';
+    case 'record-json': return 'Record JSON';
+    case 'database-json': return 'Database JSON';
+    case 'zip': return 'ZIP';
+    case 'csv': return 'CSV';
+    case 'report': return 'report';
+    case 'genbank': return 'GenBank';
+  }
 }
 
 /**
@@ -2436,7 +2451,7 @@ export function buildArtifactExportLossReport(
   }
 
   const checkpoint = format === 'record-json' || format === 'database-json' || format === 'zip';
-  const hasInterchangeLoss = format === 'fasta'
+  const hasInterchangeLoss = format === 'raw-sequence' || format === 'fasta'
     ? record.features.length > 0 || sequenceNormalization.length > 0
     : format === 'gff3'
       ? unsupportedLocationCount > 0 || repeatedQualifiers.length > 0 || truncatedQualifiers.length > 0 || fuzzyLocations.length > 0 || multipartBiologicalOrder.some((entry) => !entry.preserved) || unrepresentableMetadata.length > 0 || sequenceNormalization.length > 0
@@ -2459,8 +2474,12 @@ export function buildArtifactExportLossReport(
     : checkpoint
       ? 'This Motif JSON/ZIP checkpoint preserves the complete structured workspace; interchange files inside a ZIP remain explicitly lossy where noted.'
     : faithful
-      ? 'This export is faithful for the represented record content; it does not claim full INSDC round-trip support.'
-      : `This ${format.toUpperCase()} export is lossy; ${lossCount} preservation item${lossCount === 1 ? '' : 's'} require review. Use Database JSON or ZIP for the complete Motif checkpoint.`;
+      ? format === 'raw-sequence'
+        ? 'This raw sequence export contains the record sequence only; it does not claim feature or metadata round-trip support.'
+        : 'This export is faithful for the represented record content; it does not claim full INSDC round-trip support.'
+      : format === 'raw-sequence'
+        ? `This raw sequence export contains sequence text only and is lossy; ${lossCount} preservation item${lossCount === 1 ? '' : 's'} require review. Use Database JSON or ZIP for the complete Motif checkpoint.`
+        : `This ${exportLossFormatLabel(format)} export is lossy; ${lossCount} preservation item${lossCount === 1 ? '' : 's'} require review. Use Database JSON or ZIP for the complete Motif checkpoint.`;
   return {
     format,
     faithful,
@@ -2519,8 +2538,12 @@ function mergeArtifactExportLossReports(
     : format === 'database-json' || format === 'zip'
       ? 'This Motif JSON/ZIP checkpoint preserves the complete structured workspace; interchange files inside a ZIP remain explicitly lossy where noted.'
       : faithful
-        ? `This export is faithful for all ${recordReports.length} represented record${recordReports.length === 1 ? '' : 's'}; it does not claim full INSDC round-trip support.`
-        : `This ${format.toUpperCase()} export is lossy for ${recordSummary || `${lossCount} preservation item${lossCount === 1 ? '' : 's'}`}. Use Database JSON or ZIP for the complete Motif checkpoint.`;
+        ? format === 'raw-sequence'
+          ? `This raw sequence export contains sequence text only for ${recordReports.length} represented record${recordReports.length === 1 ? '' : 's'}; it does not claim feature or metadata round-trip support.`
+          : `This export is faithful for all ${recordReports.length} represented record${recordReports.length === 1 ? '' : 's'}; it does not claim full INSDC round-trip support.`
+        : format === 'raw-sequence'
+          ? `This raw sequence export contains sequence text only and is lossy for ${recordSummary || `${lossCount} preservation item${lossCount === 1 ? '' : 's'}`}. Use Database JSON or ZIP for the complete Motif checkpoint.`
+          : `This ${exportLossFormatLabel(format)} export is lossy for ${recordSummary || `${lossCount} preservation item${lossCount === 1 ? '' : 's'}`}. Use Database JSON or ZIP for the complete Motif checkpoint.`;
   return {
     ...first,
     format,
@@ -2589,6 +2612,15 @@ export function getArtifactCheckpointExportIssues(
   ));
   const issues: ArtifactCheckpointExportIssue[] = [];
   rawRecords.forEach((rawRecord, index) => {
+    if (rawRecord.active === false) {
+      issues.push({
+        recordId: records[index]?.id,
+        recordName: records[index]?.name,
+        code: 'inactive_record',
+        path: `records[${index}].active`,
+        message: 'Inactive records are omitted during restore and cannot be included in a durable checkpoint.',
+      });
+    }
     try {
       validateRuntimeRecordInputs([rawRecord], 'motifRenderInventory');
     } catch (error) {
@@ -4311,8 +4343,8 @@ function collectMalformedRecordIssues(
           }
         }
       }
-      if (!Number.isFinite(feature.start) || !Number.isFinite(feature.end)) {
-        add(featurePath, 'feature start and end must be finite numbers');
+      if (!Number.isSafeInteger(feature.start) || !Number.isSafeInteger(feature.end)) {
+        add(featurePath, 'feature start and end must be safe integers');
       } else {
         const start = Number(feature.start);
         const end = Number(feature.end);
@@ -4347,8 +4379,8 @@ function collectMalformedRecordIssues(
         } else {
           feature.subRanges.forEach((subRange, subRangeIndex) => {
             const subRangePath = `${featurePath}.subRanges[${subRangeIndex}]`;
-            if (!isPlainObject(subRange) || !Number.isFinite(subRange.start) || !Number.isFinite(subRange.end)) {
-              add(subRangePath, 'subRange must be an object with finite start and end numbers');
+            if (!isPlainObject(subRange) || !Number.isSafeInteger(subRange.start) || !Number.isSafeInteger(subRange.end)) {
+              add(subRangePath, 'subRange must be an object with safe integer start and end coordinates');
               return;
             }
             const start = Number(subRange.start);
@@ -4419,11 +4451,11 @@ function collectMalformedRecordIssues(
                 add(hitPath, 'hit must be a plain object');
                 return;
               }
-              if (!Number.isFinite(hit.position) || Number(hit.position) < 0) {
-                add(`${hitPath}.position`, 'position must be a non-negative finite number');
+              if (!Number.isSafeInteger(hit.position) || Number(hit.position) < 0) {
+                add(`${hitPath}.position`, 'position must be a non-negative safe integer');
               }
-              if (hit.cutPosition !== undefined && (!Number.isFinite(hit.cutPosition) || Number(hit.cutPosition) < 0)) {
-                add(`${hitPath}.cutPosition`, 'cutPosition must be a non-negative finite number');
+              if (hit.cutPosition !== undefined && (!Number.isSafeInteger(hit.cutPosition) || Number(hit.cutPosition) < 0)) {
+                add(`${hitPath}.cutPosition`, 'cutPosition must be a non-negative safe integer');
               }
               if (hit.strand !== undefined && hit.strand !== -1 && hit.strand !== 1) {
                 add(`${hitPath}.strand`, 'hit strand must be -1 or 1');
@@ -8969,7 +9001,8 @@ function App() {
   }, [addTranslationLayer]);
 
   /* Converts the MOLECULE. Reached from Entry Details only — the map's "Draw as"
-     control no longer comes here, which is the whole point of #34. Still clears
+     control no longer comes here, keeping drawing mode separate from molecule
+     topology. Still clears
      the selection, caret and map range, because after a conversion those really
      can mean something different. */
   const convertRecordTopology = useCallback((nextTopology: Topology) => {

--- a/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/create-artifact.mjs
+++ b/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/create-artifact.mjs
@@ -253,8 +253,8 @@ function validateFeature(feature, path, sequenceLength) {
   if (feature.color !== undefined && (feature.color.length > 80 || !SAFE_FEATURE_COLOR.test(feature.color.trim()))) {
     throw new Error(`${path}.color must be a simple CSS color value`);
   }
-  if (!Number.isFinite(feature.start) || !Number.isFinite(feature.end)) {
-    throw new Error(`${path} must have finite start and end numbers`);
+  if (!Number.isSafeInteger(feature.start) || !Number.isSafeInteger(feature.end)) {
+    throw new Error(`${path} must have safe integer start and end coordinates`);
   }
   if (feature.start < 0 || feature.end <= feature.start || feature.end > sequenceLength) {
     throw new Error(`${path} coordinates must satisfy 0 <= start < end <= ${sequenceLength}`);
@@ -276,8 +276,8 @@ function validateFeature(feature, path, sequenceLength) {
     }
     feature.subRanges.forEach((subRange, subRangeIndex) => {
       const subRangePath = `${path}.subRanges[${subRangeIndex}]`;
-      if (!isPlainObject(subRange) || !Number.isFinite(subRange.start) || !Number.isFinite(subRange.end)) {
-        throw new Error(`${subRangePath} must be an object with finite start and end numbers`);
+      if (!isPlainObject(subRange) || !Number.isSafeInteger(subRange.start) || !Number.isSafeInteger(subRange.end)) {
+        throw new Error(`${subRangePath} must be an object with safe integer start and end coordinates`);
       }
       if (subRange.start < 0 || subRange.end <= subRange.start || subRange.end > sequenceLength) {
         throw new Error(`${subRangePath} coordinates must satisfy 0 <= start < end <= ${sequenceLength}`);
@@ -317,9 +317,9 @@ function validateSites(sites, path) {
       site.hits.forEach((hit, hitIndex) => {
         const hitPath = `${sitePath}.hits[${hitIndex}]`;
         if (!isPlainObject(hit)) throw new Error(`${hitPath} must be a plain object`);
-        if (!Number.isFinite(hit.position) || hit.position < 0) throw new Error(`${hitPath}.position must be a non-negative finite number`);
-        if (hit.cutPosition !== undefined && (!Number.isFinite(hit.cutPosition) || hit.cutPosition < 0)) {
-          throw new Error(`${hitPath}.cutPosition must be a non-negative finite number`);
+        if (!Number.isSafeInteger(hit.position) || hit.position < 0) throw new Error(`${hitPath}.position must be a non-negative safe integer`);
+        if (hit.cutPosition !== undefined && (!Number.isSafeInteger(hit.cutPosition) || hit.cutPosition < 0)) {
+          throw new Error(`${hitPath}.cutPosition must be a non-negative safe integer`);
         }
         if (hit.strand !== undefined && ![-1, 1].includes(hit.strand)) throw new Error(`${hitPath}.strand must be -1 or 1`);
         if (hit.indexBase !== undefined && ![0, 1].includes(hit.indexBase)) throw new Error(`${hitPath}.indexBase must be 0 or 1`);

--- a/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/run-msa.mjs
+++ b/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/run-msa.mjs
@@ -8,6 +8,7 @@ import {
   constants,
   existsSync,
   linkSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   openSync,
@@ -469,10 +470,13 @@ function engineInvocation(engine, molecule, inputPath, outputPath) {
   };
 }
 
-function portableInvocationArgs(args, inputPath, outputPath) {
+export function portableInvocationArgs(args, inputPath, outputPath) {
   return args.map((arg) => arg
-    .replace(inputPath, '<input.fasta>')
-    .replace(outputPath, '<output.fasta>'));
+    // Replace the output path first: an output such as `/tmp/input.fasta.bak`
+    // can contain the input path as a prefix, and the old order produced a
+    // misleading partially-redacted provenance argument.
+    .replace(outputPath, '<output.fasta>')
+    .replace(inputPath, '<input.fasta>'));
 }
 
 function readBoundedOutput(path) {
@@ -691,8 +695,11 @@ export function writeMsaPayload(outputPath, payload, force = false) {
   }
   const resolved = resolve(outputPath);
   if (existsSync(resolved) && !force) throw new Error(`Output already exists: ${resolved}. Pass --force to replace it.`);
-  mkdirSync(dirname(resolved), { recursive: true });
-  const temporaryDirectory = mkdtempSync(join(dirname(resolved), '.motif-msa-output-'));
+  const outputDirectory = dirname(resolved);
+  assertRealDirectoryChain(outputDirectory);
+  mkdirSync(outputDirectory, { recursive: true });
+  assertRealDirectoryChain(outputDirectory);
+  const temporaryDirectory = mkdtempSync(join(outputDirectory, '.motif-msa-output-'));
   const temporaryPath = join(temporaryDirectory, 'payload.json');
   try {
     writeFileSync(temporaryPath, json, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
@@ -719,6 +726,41 @@ function preflightOutput(outputPath, force) {
   const resolved = resolve(outputPath);
   if (existsSync(resolved) && !force) {
     throw new Error(`Output already exists: ${resolved}. Pass --force to replace it.`);
+  }
+}
+
+function assertRealDirectoryChain(directory) {
+  const isKnownSystemAlias = (path) => process.platform === 'darwin'
+    && (path === '/var' || path === '/tmp');
+  let current = resolve(directory);
+  while (true) {
+    let stat;
+    try {
+      stat = lstatSync(current);
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        const parent = dirname(current);
+        if (parent === current) return;
+        current = parent;
+        continue;
+      }
+      throw error;
+    }
+    if (stat.isSymbolicLink()) {
+      if (!isKnownSystemAlias(current)) {
+        throw new Error(`MSA output directory must not traverse a symbolic link: ${current}`);
+      }
+      const parent = dirname(current);
+      if (parent === current) return;
+      current = parent;
+      continue;
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(`MSA output parent must be a real directory: ${current}`);
+    }
+    const parent = dirname(current);
+    if (parent === current) return;
+    current = parent;
   }
 }
 

--- a/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/workspace-validator.mjs
+++ b/src/artifacts/motif-for-claude-science-plugin/skills/motif-for-claude-science/scripts/workspace-validator.mjs
@@ -389,6 +389,9 @@ var VALID_TRANSLATION_TABLE_IDS = new Set(VALID_NCBI_TABLE_IDS);
 function isObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
+function createRecordMap() {
+  return /* @__PURE__ */ Object.create(null);
+}
 function requiredString(value, path, maxLength = MAX_TRANSLATION_LAYER_TEXT_LENGTH) {
   if (typeof value !== "string" || !value.trim() || value.length > maxLength) {
     throw new Error(`${path} must be a non-empty string no longer than ${maxLength} characters.`);
@@ -444,7 +447,7 @@ function normalizeCustomEnzymes(value) {
 function normalizeTranslationLayers(value, recordLengths) {
   if (value === void 0) return {};
   if (!isObject(value)) throw new Error("artifactState.translationLayersByRecord must be an object.");
-  const result = {};
+  const result = createRecordMap();
   for (const [recordId, rawLayers] of Object.entries(value)) {
     const sequenceLength = recordLengths.get(recordId);
     if (sequenceLength === void 0) continue;
@@ -503,7 +506,7 @@ function normalizeTranslationLayers(value, recordLengths) {
 function normalizeStringArraysByRecord(value, path, recordLengths, maxEntries) {
   if (value === void 0) return {};
   if (!isObject(value)) throw new Error(`${path} must be an object.`);
-  const result = {};
+  const result = createRecordMap();
   for (const [recordId, rawValues] of Object.entries(value)) {
     if (!recordLengths.has(recordId)) continue;
     if (!Array.isArray(rawValues) || rawValues.some((item) => typeof item !== "string")) {
@@ -518,7 +521,7 @@ function normalizeStringArraysByRecord(value, path, recordLengths, maxEntries) {
 }
 function normalizeRestrictionSources(value, recordLengths) {
   const raw = normalizeStringArraysByRecord(value, "artifactState.enzymeSourcesByRecord", recordLengths);
-  const result = {};
+  const result = createRecordMap();
   for (const [recordId, sources] of Object.entries(raw)) {
     const validated = sources.filter((source) => VALID_SOURCE_IDS.has(source));
     if (validated.length !== sources.length) throw new Error(`artifactState.enzymeSourcesByRecord.${recordId} contains an unknown source.`);
@@ -529,7 +532,7 @@ function normalizeRestrictionSources(value, recordLengths) {
 function normalizeBooleanByRecord(value, path, recordLengths) {
   if (value === void 0) return {};
   if (!isObject(value)) throw new Error(`${path} must be an object.`);
-  const result = {};
+  const result = createRecordMap();
   for (const [recordId, rawValue] of Object.entries(value)) {
     if (!recordLengths.has(recordId)) continue;
     if (typeof rawValue !== "boolean") throw new Error(`${path}.${recordId} must be a boolean.`);
@@ -540,7 +543,7 @@ function normalizeBooleanByRecord(value, path, recordLengths) {
 function normalizeMotifs(value, recordLengths) {
   if (value === void 0) return {};
   if (!isObject(value)) throw new Error("artifactState.motifsByRecord must be an object.");
-  const result = {};
+  const result = createRecordMap();
   for (const [recordId, rawValue] of Object.entries(value)) {
     if (!recordLengths.has(recordId)) continue;
     if (typeof rawValue !== "string" || rawValue.length > MAX_MOTIF_LENGTH) {

--- a/src/bio/__tests__/ancillary-integrity.test.ts
+++ b/src/bio/__tests__/ancillary-integrity.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_GEL_FRAGMENTS_PER_LANE,
+  MAX_GEL_LABEL_LENGTH,
+  MAX_GEL_SAMPLE_LANES,
+  simulateGel,
+} from '../gel-simulation';
+import { molecularWeight } from '../gc-content';
+import {
+  makeSequenceHighlight,
+  shiftSequenceHighlightsForRange,
+  shiftSequenceHighlightsForInsertion,
+} from '../sequence-highlights';
+import {
+  makeSequenceStyleRange,
+  shiftSequenceFormattingForInsertion,
+  shiftSequenceFormattingForRange,
+} from '../sequence-formatting';
+import { normalizeSequenceVariant, shiftSequenceVariants } from '../sequence-variants';
+
+describe('ancillary bio helper integrity', () => {
+  it('does not charge formatting whitespace as an unknown DNA residue', () => {
+    expect(molecularWeight('A C\n')).toBe(molecularWeight('AC'));
+  });
+
+  it('bounds core gel labels and cardinality before rendering', () => {
+    const result = simulateGel([{
+      name: 'X'.repeat(MAX_GEL_LABEL_LENGTH),
+      fragments: [1000],
+    }], { width: 2, height: 1 });
+    expect(result.ascii.length).toBeLessThan(100);
+    expect(() => simulateGel([{
+      name: 'X'.repeat(MAX_GEL_LABEL_LENGTH + 1),
+      fragments: [1000],
+    }])).toThrow(/name cannot exceed/i);
+    expect(() => simulateGel(Array.from(
+      { length: MAX_GEL_SAMPLE_LANES + 1 },
+      (_value, index) => ({ name: `lane-${index}`, fragments: [1000] }),
+    ))).toThrow(/lanes/i);
+    expect(() => simulateGel([{
+      name: 'sample',
+      fragments: Array.from({ length: MAX_GEL_FRAGMENTS_PER_LANE + 1 }, () => 1000),
+    }])).toThrow(/fragments cannot contain/i);
+  });
+
+  it('rejects fractional and negative variant coordinates instead of flooring them', () => {
+    expect(normalizeSequenceVariant({ id: 'fractional', start: 1.5, end: 3, kind: 'substitution' })).toBeNull();
+    expect(normalizeSequenceVariant({ id: 'negative', start: -1, end: 2, kind: 'deletion' })).toBeNull();
+    expect(normalizeSequenceVariant({ id: 'valid', start: 1, end: 3, kind: 'substitution' })).toMatchObject({
+      start: 1,
+      end: 3,
+    });
+    expect(() => shiftSequenceVariants([], 1, 0.5)).toThrow(/delta.*safe integer/i);
+  });
+
+  it('keeps formatting and highlight coordinates integral across creation and edits', () => {
+    expect(makeSequenceHighlight({ start: 1.5, end: 3.5 }, '#fff', 1)).toMatchObject({ start: 1, end: 3 });
+    expect(makeSequenceStyleRange({ start: 1.5, end: 3.5 }, { bold: true })).toMatchObject({ start: 1, end: 3 });
+    expect(() => shiftSequenceHighlightsForRange([], 1.5, 3)).toThrow(/safe integer/i);
+    expect(() => shiftSequenceHighlightsForInsertion([], 1, 2.5)).toThrow(/delta.*safe integer/i);
+    expect(() => shiftSequenceFormattingForRange(null, 1.5, 3)).toThrow(/safe integer/i);
+    expect(() => shiftSequenceFormattingForInsertion(null, 1, 2.5)).toThrow(/delta.*safe integer/i);
+  });
+});

--- a/src/bio/__tests__/defensive-bounds.test.ts
+++ b/src/bio/__tests__/defensive-bounds.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { toFasta } from '../fasta-parser';
-import { gcContentWindow } from '../gc-content';
+import { atContent, gcContentWindow } from '../gc-content';
 import { migrationDistance, renderGelASCII, simulateGel } from '../gel-simulation';
 import {
   buildSyntheticGoldenGateVector,
@@ -14,6 +14,16 @@ describe('defensive bounds', () => {
     expect(() => gcContentWindow('ACGTACGT', 4, 0)).toThrow(/step/);
     expect(() => gcContentWindow('ACGTACGT', 4, -1)).toThrow(/step/);
     expect(() => gcContentWindow('ACGTACGT', 4, Number.NaN)).toThrow(/step/);
+  });
+
+  it('keeps composition fractions defined on ambiguous or empty input', () => {
+    expect(atContent('')).toBe(0);
+    expect(atContent('NNN')).toBe(0);
+    expect(atContent('AATTGGCC')).toBe(0.5);
+  });
+
+  it('rejects fractional sliding-window steps before typed-array indexing', () => {
+    expect(() => gcContentWindow('ACGTACGT', 4, 0.5)).toThrow(/positive integer/i);
   });
 
   it('rejects non-positive FASTA line widths', () => {

--- a/src/bio/__tests__/mutate-feature-locations.test.ts
+++ b/src/bio/__tests__/mutate-feature-locations.test.ts
@@ -28,6 +28,16 @@ describe('mutation feature-location integrity', () => {
     }
   });
 
+  it('rejects fractional or non-finite edit coordinates before string indexing', () => {
+    expect(() => applySubstitution('ATGC', [], [], 1.5, 'C')).toThrow(/pos.*safe integer/i);
+    expect(() => applySubstitution('ATGC', [], [], Number.NaN, 'C')).toThrow(/pos.*safe integer/i);
+    expect(() => applyInsertion('ATGC', [], [], 1.5, 'AA')).toThrow(/pos.*safe integer/i);
+    expect(() => applyInsertion('ATGC', [], [], Number.NaN, 'AA')).toThrow(/pos.*safe integer/i);
+    expect(() => applyDeletion('ATGC', [], [], 1, 1.5)).toThrow(/count.*safe integer/i);
+    expect(() => applyDeletion('ATGC', [], [], 1, Number.NaN)).toThrow(/count.*safe integer/i);
+    expect(applyInsertion('ATGC', [], [], -1, 'AA').raw).toBe('AAATGC');
+  });
+
   it('uses half-open feature affinity at insertion boundaries', () => {
     const feature: Feature = {
       id: 'feature',

--- a/src/bio/__tests__/primer-pcr-integrity.test.ts
+++ b/src/bio/__tests__/primer-pcr-integrity.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../pcr';
 import { designForwardPrimerWithDiagnostics } from '../primer-design';
 import { predictHairpin, predictPrimerDimer } from '../primer-thermodynamics';
-import { calculateTm, saltCorrectedTm } from '../tm-calculator';
+import { calculateTm, duplexThermodynamics, saltCorrectedTm } from '../tm-calculator';
 import { reverseComplement } from '../reverse-complement';
 import type { Feature } from '../types';
 
@@ -36,6 +36,11 @@ describe('primer, PCR, and Tm integrity', () => {
       deltaS: Number.NaN,
       ctMolar: 250e-9,
     })).toThrow(/finite/i);
+  });
+
+  it('rejects empty and one-base inputs for nearest-neighbor duplex thermodynamics', () => {
+    expect(() => duplexThermodynamics('')).toThrow(/at least two canonical bases/i);
+    expect(() => duplexThermodynamics('A')).toThrow(/at least two canonical bases/i);
   });
 
   it('enumerates repeated binding sites and exposes a configurable mismatch policy', () => {

--- a/src/bio/codon-tables.ts
+++ b/src/bio/codon-tables.ts
@@ -30,7 +30,7 @@ export const STANDARD_CODE: CodonTable = {
 };
 
 /**
- * Phase 35 P0-A1: NCBI translation tables (2, 5, 11, 13, 22). Prior to this
+ * NCBI translation tables (2, 5, 11, 13, 22). Prior to this
  * change Motif exposed only table 1; mitochondrial sequences mistranslated
  * silently because the standard code treats UGA as a stop while the
  * mitochondrial codes use it for Trp. See:
@@ -540,7 +540,7 @@ export const YEAST_USAGE: CodonUsage = {
 };
 
 /**
- * Phase 35 P-I (P1-A11): expand codon usage to cover major non-E.coli/non-human
+ * Additional codon-usage profiles cover major non-E. coli/non-human
  * expression hosts. Sources: Kazusa codon usage database (Pichia/Sf9/CHO/B.subtilis).
  * Together with the existing three tables (E. coli, human, yeast), these
  * cover ~95% of customer expression workflows.
@@ -658,14 +658,14 @@ export const BSUBTILIS_USAGE: CodonUsage = {
 export type CodonOrganism = 'ecoli' | 'human' | 'yeast' | 'pichia' | 'sf9' | 'cho' | 'bsubtilis';
 
 /**
- * I11b: any codon-table identifier accepted by `getCodonUsage` — a built-in
+ * Any codon-table identifier accepted by `getCodonUsage` — a built-in
  * `CodonOrganism` or a user table referenced as `custom:<id>`. Kept as a plain
  * `string` so it round-trips through localStorage and the settings backup
  * without a brittle literal union; unknown ids resolve to HUMAN_USAGE.
  */
 export type CodonTableId = string;
 
-/** A user-uploaded codon usage table (I11b). Persisted in the UI store. */
+/** A user-uploaded codon usage table, persisted in the UI store. */
 export interface CustomCodonTable {
   /** Stable id; referenced elsewhere as `custom:<id>`. */
   id: string;

--- a/src/bio/enzyme-data.ts
+++ b/src/bio/enzyme-data.ts
@@ -59,7 +59,8 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   },
   // HaeIII: GGCC — blunt, cuts GG|CC
   { name: 'HaeIII',  recognitionSequence: 'GGCC',   cutOffset: 2, complementCutOffset: 2,  overhang: 'blunt'  },
-  // HhaI: GCGC — cuts GCG|C leaving a 2-nt 3′ overhang; cutOffset=3, compCutOffset=1 (QA2 W27: was 1/3, fragment boundary off by 2)
+  // HhaI: GCGC — cuts GCG|C leaving a 2-nt 3′ overhang; cutOffset=3,
+  // compCutOffset=1. The previous 1/3 geometry put the fragment boundary off by 2.
   {
     name: 'HhaI',
     recognitionSequence: 'GCGC',
@@ -138,7 +139,8 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   { name: 'TaqI',    recognitionSequence: 'TCGA',   cutOffset: 1, complementCutOffset: 3,  overhang: '5prime' },
   // Tsp509I: AATT — 5′ overhang
   { name: 'Tsp509I', recognitionSequence: 'AATT',   cutOffset: 0, complementCutOffset: 4,  overhang: '5prime' },
-  // CfoI: GCGC — isoschizomer of HhaI (GCG|C, 2-nt 3′ overhang); cutOffset=3, compCutOffset=1 (QA2 W27)
+  // CfoI: GCGC — isoschizomer of HhaI (GCG|C, 2-nt 3′ overhang); cutOffset=3,
+  // compCutOffset=1.
   { name: 'CfoI',    recognitionSequence: 'GCGC',   cutOffset: 3, complementCutOffset: 1,  overhang: '3prime' },
   // Csp6I: GTAC — isoschizomer of RsaI
   { name: 'Csp6I',   recognitionSequence: 'GTAC',   cutOffset: 1, complementCutOffset: 3,  overhang: '5prime' },
@@ -197,7 +199,8 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   { name: 'BclI',    recognitionSequence: 'TGATCA',  cutOffset: 1, complementCutOffset: 5,  overhang: '5prime' },
   // BlpI: GCTNAGC — cuts GC|TNAGC → 5′ TNA overhang (degenerate); cut after pos 2
   { name: 'BlpI',    recognitionSequence: 'GCTNAGC', cutOffset: 2, complementCutOffset: 5,  overhang: '5prime' },
-  // BmtI: GCTAGC — NheI neoschizomer that cuts GCTAG^C → 1-nt 3′ overhang C (NEB R0658); 5/1 3prime (QA2 W28: was 1/5 5prime = NheI's cut)
+  // BmtI: GCTAGC — NheI neoschizomer that cuts GCTAG^C → 1-nt 3′ overhang C
+  // (NEB R0658); 5/1 3prime, rather than NheI's 1/5 5prime cut.
   { name: 'BmtI',    recognitionSequence: 'GCTAGC',  cutOffset: 5, complementCutOffset: 1,  overhang: '3prime' },
   // BsiWI: CGTACG — cuts C|GTACG → 5′ GTAC overhang
   { name: 'BsiWI',   recognitionSequence: 'CGTACG',  cutOffset: 1, complementCutOffset: 5,  overhang: '5prime' },
@@ -211,7 +214,8 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   { name: 'BstBI',   recognitionSequence: 'TTCGAA',  cutOffset: 2, complementCutOffset: 4,  overhang: '5prime' },
   // BstEII: GGTNACC — cuts G|GTNACC → 5′ GTNAC overhang; cut at pos 1
   { name: 'BstEII',  recognitionSequence: 'GGTNACC', cutOffset: 1, complementCutOffset: 6,  overhang: '5prime' },
-  // BstXI: CCANNNNNNTGG — cuts CCANNNNN^NTGG → 4-nt 3′ overhang (NEB R0113); 8/4 3prime (QA2 W28: was 2/10 5prime)
+  // BstXI: CCANNNNNNTGG — cuts CCANNNNN^NTGG → 4-nt 3′ overhang (NEB R0113);
+  // 8/4 3prime, correcting the former 2/10 5prime geometry.
   { name: 'BstXI',   recognitionSequence: 'CCANNNNNNTGG', cutOffset: 8, complementCutOffset: 4, overhang: '3prime' },
   // DraI: TTTAAA — blunt; cuts TTT|AAA
   { name: 'DraI',    recognitionSequence: 'TTTAAA',  cutOffset: 3, complementCutOffset: 3,  overhang: 'blunt'  },
@@ -245,12 +249,14 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   { name: 'PmeI',    recognitionSequence: 'GTTTAAAC', cutOffset: 4, complementCutOffset: 4, overhang: 'blunt'  },
   // PmlI: CACGTG — blunt; cuts CAC|GTG
   { name: 'PmlI',    recognitionSequence: 'CACGTG',  cutOffset: 3, complementCutOffset: 3,  overhang: 'blunt'  },
-  // PpuMI: RGGWCCY — cuts RG^GWCCY → 3-nt 5′ overhang GWC (NEB R0506); 2/5 (QA2 W28: was 1/6, cut after lone R)
+  // PpuMI: RGGWCCY — cuts RG^GWCCY → 3-nt 5′ overhang GWC (NEB R0506); 2/5,
+  // with the cut after the recognition prefix rather than the lone R.
   { name: 'PpuMI',   recognitionSequence: 'RGGWCCY', cutOffset: 2, complementCutOffset: 5,  overhang: '5prime' },
   // PsiI: TTATAA — blunt; cuts TTT|AAA (cuts midpoint: TTT→ no, TTAT|AA)
   // Actually PsiI cuts TTA|TAA → blunt
   { name: 'PsiI',    recognitionSequence: 'TTATAA',  cutOffset: 3, complementCutOffset: 3,  overhang: 'blunt'  },
-  // PvuI: CGATCG — cuts CGAT|CG → 2-nt 3′ overhang AT (NEB R0150); cutOffset=4, compCutOffset=2 (QA2 W27: was 5/1)
+  // PvuI: CGATCG — cuts CGAT|CG → 2-nt 3′ overhang AT (NEB R0150);
+  // cutOffset=4, compCutOffset=2.
   { name: 'PvuI',    recognitionSequence: 'CGATCG',  cutOffset: 4, complementCutOffset: 2,  overhang: '3prime' },
   // PvuII: CAGCTG — blunt; cuts CAG|CTG
   { name: 'PvuII',   recognitionSequence: 'CAGCTG',  cutOffset: 3, complementCutOffset: 3,  overhang: 'blunt'  },
@@ -261,7 +267,8 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   { name: 'SbfI',    recognitionSequence: 'CCTGCAGG', cutOffset: 6, complementCutOffset: 2, overhang: '3prime' },
   // SfoI: GGCGCC — blunt; cuts GGC|GCC
   { name: 'SfoI',    recognitionSequence: 'GGCGCC',  cutOffset: 3, complementCutOffset: 3,  overhang: 'blunt'  },
-  // SgrAI: CRCCGGYG — cuts CR^CCGGYG → 4-nt 5′ overhang CCGG (NEB R0603); 2/6 (QA2 W28: was 1/7, cut after lone C)
+  // SgrAI: CRCCGGYG — cuts CR^CCGGYG → 4-nt 5′ overhang CCGG (NEB R0603);
+  // 2/6, with the cut after the recognition prefix rather than the lone C.
   { name: 'SgrAI',   recognitionSequence: 'CRCCGGYG', cutOffset: 2, complementCutOffset: 6, overhang: '5prime' },
   // SnaBI: TACGTA — blunt; cuts TAC|GTA
   { name: 'SnaBI',   recognitionSequence: 'TACGTA',  cutOffset: 3, complementCutOffset: 3,  overhang: 'blunt'  },
@@ -287,9 +294,11 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   { name: 'DraIII',  recognitionSequence: 'CACNNNGTG', cutOffset: 6, complementCutOffset: 3, overhang: '3prime' },
   // AlwNI: CAGNNNCTG — interrupted palindrome with a 3-N spacer, identical cut
   // geometry to DraIII: cuts CAGNNN|CTG / G|TCNNNCAC → 3-nt 3′ recessed overhang
-  // (REBASE). Mirrors DraIII's 6/3 offsets. (R18 #53a: was missing entirely.)
+  // (REBASE). Mirrors DraIII's 6/3 offsets; included explicitly because the
+  // catalog previously omitted this enzyme.
   { name: 'AlwNI',   recognitionSequence: 'CAGNNNCTG', cutOffset: 6, complementCutOffset: 3, overhang: '3prime' },
-  // EcoO109I: RGGNCCY — cuts RG^GNCCY → 3-nt 5′ overhang GNC (NEB R0503); 2/5 (QA2 W28: was 1/6, cut after lone R)
+  // EcoO109I: RGGNCCY — cuts RG^GNCCY → 3-nt 5′ overhang GNC (NEB R0503);
+  // 2/5, with the cut after the recognition prefix rather than the lone R.
   { name: 'EcoO109I',recognitionSequence: 'RGGNCCY', cutOffset: 2, complementCutOffset: 5,  overhang: '5prime' },
   // HpaI: already added above
   // MscI: TGGCCA — blunt; cuts TGG|CCA
@@ -330,7 +339,8 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   // SbfI: already added
   // Sse8387I: CCTGCAGG — isoschizomer of SbfI
   { name: 'Sse8387I',recognitionSequence: 'CCTGCAGG', cutOffset: 6, complementCutOffset: 2, overhang: '3prime' },
-  // Sse8647I: AGGWCCT — cuts AG^GWCCT → 3-nt 5′ overhang GWC (REBASE caret AG^GWCCT); 2/5 (QA2 W28: was 3/4)
+  // Sse8647I: AGGWCCT — cuts AG^GWCCT → 3-nt 5′ overhang GWC (REBASE caret
+  // AG^GWCCT); 2/5, correcting the former 3/4 geometry.
   { name: 'Sse8647I',recognitionSequence: 'AGGWCCT', cutOffset: 2, complementCutOffset: 5,  overhang: '5prime' },
 
   // ── Type IIS enzymes ─────────────────────────────────────────────────────────
@@ -355,7 +365,8 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   //   cutOffset = 7+1 = 8, complementCutOffset = 7+4 = 11
   { name: 'SapI',    recognitionSequence: 'GCTCTTC', cutOffset: 8,  complementCutOffset: 11, overhang: '5prime' },
   // BtgZI: GCGATG(10/14) — recognition 6 bp, 4-nt 5′ extension (NEB R0703)
-  //   cutOffset = 6+10 = 16, complementCutOffset = 6+14 = 20 (QA2 W27: was 2/10 = 8/16)
+  //   cutOffset = 6+10 = 16, complementCutOffset = 6+14 = 20 (the former
+  //   2/10 = 8/16 offsets were incorrect).
   { name: 'BtgZI',   recognitionSequence: 'GCGATG',  cutOffset: 16,  complementCutOffset: 20, overhang: '5prime' },
   // BpiI (alternative name for BbsI/isoschizomer): GAAGAC(2/6)
   { name: 'BpiI',    recognitionSequence: 'GAAGAC',  cutOffset: 8,  complementCutOffset: 12, overhang: '5prime' },
@@ -386,7 +397,8 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   { name: 'AclI',    recognitionSequence: 'AACGTT',  cutOffset: 2, complementCutOffset: 4,  overhang: '5prime' },
   // AflIII: ACRYGT — cuts A|CRYGT → 5′ CRYGТ overhang
   { name: 'AflIII',  recognitionSequence: 'ACRYGT',  cutOffset: 1, complementCutOffset: 5,  overhang: '5prime' },
-  // AhdI: GACNNNNNGTC — cuts GACNNN|NNGTC → 1-nt 3′ overhang (NEB R0584); cutOffset=6, compCutOffset=5 (QA2 W27: was mislabeled blunt)
+  // AhdI: GACNNNNNGTC — cuts GACNNN|NNGTC → 1-nt 3′ overhang (NEB R0584);
+  // cutOffset=6, compCutOffset=5, not blunt.
   { name: 'AhdI',    recognitionSequence: 'GACNNNNNGTC', cutOffset: 6, complementCutOffset: 5, overhang: '3prime' },
   // BaeGI: GKGCMC — cuts G|KGCMC → 5′ KGCM overhang
   // AleI: CACNNNNGTG — cuts CAC|NNNNGTG → blunt
@@ -399,20 +411,23 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   { name: 'BsaBI',   recognitionSequence: 'GATNNNNATC', cutOffset: 5, complementCutOffset: 5, overhang: 'blunt' },
   // BsiEI: CGRY|CG → 3′ overhang
   { name: 'BsiEI',   recognitionSequence: 'CGRYCG',  cutOffset: 4, complementCutOffset: 2,  overhang: '3prime' },
-  // BsiHKAI: GWGCWC — cuts GWGCW^C → 4-nt 3′ overhang WGCW (SphI/HgiAI family); 5/1 3prime (QA2 W28: was 1/5 5prime)
+  // BsiHKAI: GWGCWC — cuts GWGCW^C → 4-nt 3′ overhang WGCW (SphI/HgiAI
+  // family); 5/1 3prime, correcting the former 1/5 5prime geometry.
   { name: 'BsiHKAI', recognitionSequence: 'GWGCWC',  cutOffset: 5, complementCutOffset: 1,  overhang: '3prime' },
   // BsoBI: CYCGRG — cuts C|YCGRG → 5′ YCGR overhang (like XhoI family)
   { name: 'BsoBI',   recognitionSequence: 'CYCGRG',  cutOffset: 1, complementCutOffset: 5,  overhang: '5prime' },
   // BspHI: already added
   // BsrFαI: RCCGGY — cuts R|CCGGY → 5′ CCGG overhang
   { name: 'BsrFI',   recognitionSequence: 'RCCGGY',  cutOffset: 1, complementCutOffset: 5,  overhang: '5prime' },
-  // BstAPI: GCANNNNNTGC — cuts GCANNNN^NTGC → 3-nt 3′ overhang (NEB R0654); cutOffset 7 (QA2 W28: was 6, off by one)
+  // BstAPI: GCANNNNNTGC — cuts GCANNNN^NTGC → 3-nt 3′ overhang (NEB R0654);
+  // cutOffset 7, correcting the former off-by-one value of 6.
   { name: 'BstAPI',  recognitionSequence: 'GCANNNNNTGC', cutOffset: 7, complementCutOffset: 4, overhang: '3prime' },
   // BstZ17I: GTATAC — blunt; cuts GTA|TAC
   { name: 'BstZ17I', recognitionSequence: 'GTATAC',  cutOffset: 3, complementCutOffset: 3,  overhang: 'blunt'  },
   // BtgI: CCRYGG — cuts C|CRYGG → 5′ CRYG overhang
   { name: 'BtgI',    recognitionSequence: 'CCRYGG',  cutOffset: 1, complementCutOffset: 5,  overhang: '5prime' },
-  // DrdI: GACNNNNNNGTC — cuts GACNNNN|NNGTC → 3-nt 3′ overhang (NEB R0530); cutOffset=7, compCutOffset=4 (QA2 W27: was 7/5 blunt)
+  // DrdI: GACNNNNNNGTC — cuts GACNNNN|NNGTC → 3-nt 3′ overhang (NEB R0530);
+  // cutOffset=7, compCutOffset=4, not the former 7/5 blunt geometry.
   { name: 'DrdI',    recognitionSequence: 'GACNNNNNNGTC', cutOffset: 7, complementCutOffset: 4, overhang: '3prime' },
   // EarI: CTCTTC(1/4) — isoschizomer of SapI
   { name: 'EarI',    recognitionSequence: 'CTCTTC',  cutOffset: 7,  complementCutOffset: 10, overhang: '5prime' },
@@ -424,7 +439,8 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   { name: 'MlsI',    recognitionSequence: 'TGGCCA',  cutOffset: 3, complementCutOffset: 3,  overhang: 'blunt'  },
   // MluCI: AATT — 5′ overhang (isoschizomer of Tsp509I)
   { name: 'MluCI',   recognitionSequence: 'AATT',    cutOffset: 0, complementCutOffset: 4,  overhang: '5prime' },
-  // NspI: RCATGY — cuts RCATG^Y → 4-nt 3′ overhang CATG (NEB R0602; SphI family); 5/1 3prime (QA2 W28: was 1/5 5prime — the old comment's hedge guessed wrong)
+  // NspI: RCATGY — cuts RCATG^Y → 4-nt 3′ overhang CATG (NEB R0602; SphI
+  // family); 5/1 3prime, correcting the former 1/5 5prime geometry.
   { name: 'NspI',    recognitionSequence: 'RCATGY',  cutOffset: 5, complementCutOffset: 1,  overhang: '3prime' },
   // SfeI: CTRYAG — cuts C|TRYAG → 5′ TRYA overhang
   { name: 'SfeI',    recognitionSequence: 'CTRYAG',  cutOffset: 1, complementCutOffset: 5,  overhang: '5prime' },
@@ -433,7 +449,8 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   // Actually TaiI: ACGT — cuts between A and CGT? Not well characterized; skip.
   // XcmI: CCANNNNNNNNNTGG — cuts CCA(9/12)NNNNNNTGG → 3′ overhang
   { name: 'XcmI',    recognitionSequence: 'CCANNNNNNNNNTGG', cutOffset: 12, complementCutOffset: 9, overhang: '3prime' },
-  // ZraI: GACGTC — BLUNT neoschizomer of AatII; cuts GAC^GTC (NEB R0659); 3/3 blunt (QA2 W28: was 5/1 3prime = AatII's cut — losing the blunt-cutter point)
+  // ZraI: GACGTC — BLUNT neoschizomer of AatII; cuts GAC^GTC (NEB R0659);
+  // 3/3 blunt, rather than AatII's 5/1 3prime geometry.
   { name: 'ZraI',    recognitionSequence: 'GACGTC',  cutOffset: 3, complementCutOffset: 3,  overhang: 'blunt' },
 
   // ── Additional frequently used enzymes ───────────────────────────────────────
@@ -462,7 +479,9 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   { name: 'EcoT22I', recognitionSequence: 'ATGCAT',  cutOffset: 5, complementCutOffset: 1,  overhang: '3prime' },
   // HindII: GTYRAC — isoschizomer of HincII (blunt)
   { name: 'HindII',  recognitionSequence: 'GTYRAC',  cutOffset: 3, complementCutOffset: 3,  overhang: 'blunt'  },
-  // MboII: GAAGA(8/7) — Type IIS, single-base 3′ extension (NEB R0148); offsets 13/12 imply 3prime (QA2 W28: label was 5prime, wrong strand for this non-palindromic overhang)
+  // MboII: GAAGA(8/7) — Type IIS, single-base 3′ extension (NEB R0148);
+  // offsets 13/12 imply 3prime, the correct strand for this non-palindromic
+  // overhang.
   { name: 'MboII',   recognitionSequence: 'GAAGA',   cutOffset: 13, complementCutOffset: 12, overhang: '3prime' },
   // MfeI: already added
   // MluI: already added
@@ -476,7 +495,9 @@ export const RESTRICTION_ENZYMES_FULL: RestrictionEnzyme[] = [
   { name: 'TfiI',    recognitionSequence: 'GAWTC',   cutOffset: 1, complementCutOffset: 4,  overhang: '5prime' },
   // TseI: GCWGC — cuts G|CWGC → 5′ CWGC overhang? Actually TseI cuts G|CWGC but let's use:
   { name: 'TseI',    recognitionSequence: 'GCWGC',   cutOffset: 1, complementCutOffset: 4,  overhang: '5prime' },
-  // Tth111I: GACNNNGTC — cuts GACN^NNGTC → single-base 5′ overhang (NEB R0185; odd central spacer → 5′, unlike AhdI/DrdI 3′); 4/5 5prime (QA2 W28: was 5/4 3prime, swapped+inverted)
+  // Tth111I: GACNNNGTC — cuts GACN^NNGTC → single-base 5′ overhang (NEB
+  // R0185; odd central spacer → 5′, unlike AhdI/DrdI 3′); 4/5 5prime, with
+  // the former 5/4 3prime geometry corrected.
   { name: 'Tth111I', recognitionSequence: 'GACNNNGTC', cutOffset: 4, complementCutOffset: 5, overhang: '5prime' },
 ];
 

--- a/src/bio/fasta-parser.ts
+++ b/src/bio/fasta-parser.ts
@@ -76,7 +76,7 @@ export function parseFasta(input: string): FastaRecord[] {
     const line = lines[lineIndex];
     const lineStartOffset = inputOffset;
     const trimmed = line.trim();
-    // VOG-1812: legacy NBRF/PIR FASTA convention — `;` at line start is a
+    // NBRF/PIR FASTA convention — `;` at line start is a
     // comment. Skip these everywhere so they don't get treated as sequence
     // text and bleed AA-only letters into composition analysis downstream.
     if (trimmed.startsWith(';')) {
@@ -251,7 +251,7 @@ export function extractEmbeddedFastaContent(input: string): string | null {
 }
 
 /**
- * VOG-1983: FASTA headers are single-line records — the spec uses an
+ * FASTA headers are single-line records — the spec uses an
  * unescaped newline as the boundary between one record and the next.
  * If a block name (`r.header`) or description contains a literal `\n`
  * or `\r`, emitting it verbatim into the header silently splits the
@@ -278,7 +278,7 @@ export function toFasta(records: FastaRecord[], lineWidth = 80): string {
   }
   return records
     .map(r => {
-      // VOG-1983: collapse newlines so a multi-line block name does not
+      // Collapse newlines so a multi-line block name does not
       // silently fragment the export into multiple FASTA records.
       const safeHeader = sanitizeFastaHeaderField(r.header);
       const safeDescription = r.description ? sanitizeFastaHeaderField(r.description) : '';

--- a/src/bio/gc-content.ts
+++ b/src/bio/gc-content.ts
@@ -46,7 +46,10 @@ export function gcContentFromComposition(comp: NucleotideComposition): number {
  * Calculate AT content as a fraction (0-1).
  */
 export function atContent(seq: string): number {
-  return 1 - gcContent(seq);
+  const comp = nucleotideComposition(seq);
+  const total = comp.A + comp.T + (comp.U ?? 0) + comp.G + comp.C;
+  if (total === 0) return 0;
+  return (comp.A + comp.T + (comp.U ?? 0)) / total;
 }
 
 /**
@@ -67,8 +70,8 @@ export function gcContentWindow(
   if (!Number.isInteger(windowSize) || windowSize <= 0) {
     throw new Error('windowSize must be a positive integer.');
   }
-  if (!Number.isFinite(step) || step <= 0) {
-    throw new Error('step must be a finite number greater than zero.');
+  if (!Number.isInteger(step) || step <= 0) {
+    throw new Error('step must be a positive integer.');
   }
 
   if (upper.length < windowSize) {
@@ -105,7 +108,10 @@ const DNA_MW: Record<string, number> = {
  * Uses average internal nucleotide weights.
  */
 export function molecularWeight(seq: string): number {
-  const upper = seq.toUpperCase().replace(/U/g, 'T');
+  // Sequence text may come from a formatted editor/FASTA row. Formatting
+  // whitespace is not a nucleotide and must not be charged as an N-equivalent
+  // residue; retain the historical N fallback for other ambiguous symbols.
+  const upper = seq.toUpperCase().replace(/[ \t\r\n]/g, '').replace(/U/g, 'T');
   let mw = 0;
 
   for (const ch of upper) {
@@ -130,8 +136,9 @@ export function molecularWeight(seq: string): number {
  */
 // ── AA residue masses ────────────────────────────────────────────────────────
 //
-// Phase 35 P0-A6: previously this table claimed "Average molecular weights"
-// in its JSDoc but the actual numbers were monoisotopic. Sum-of-20 residues
+// The table is split into average and monoisotopic residue masses because the
+// earlier documentation called monoisotopic values "Average molecular weights".
+// Sum-of-20 residues
 // was 2394.12 Da versus ExPASy's 2395.65 Da (average) and 2394.05 Da
 // (monoisotopic). We now ship BOTH tables and let callers choose. Default
 // is `'average'` to match ExPASy ProtParam — the canonical reference.
@@ -144,9 +151,9 @@ export function molecularWeight(seq: string): number {
 // Sums of the 20 residue masses below (no water — residue masses, not chain MW):
 //   Average:      2377.737 Da  (+H2O 18.015  = 2395.752 for a 1-of-each 20-mer)
 //   Monoisotopic: 2376.114 Da  (+H2O 18.0106 = 2394.125)
-// QA2 W15 (bio-correctness agent P2): prior values (2395.652 / 2394.057) claimed
-// to be the residue sums but actually conflated the +water chain MW (and were
-// themselves slightly off). The residue tables are correct; this is doc-only.
+// Earlier summary values (2395.652 / 2394.057) conflated the +water chain MW
+// with residue sums and were slightly off. The residue tables are correct;
+// this distinction affects documentation only.
 
 /** Average residue masses, Daltons. Source: ExPASy ProtParam. */
 const AA_MW_AVERAGE: Record<string, number> = {
@@ -174,8 +181,8 @@ const H2O_MONOISOTOPIC = 18.0106;
 /**
  * Estimate molecular weight of a protein sequence in Daltons.
  *
- * Phase 35 P0-A6: previously this used monoisotopic values labeled as
- * "Average" — off by ~0.07% systematically vs ExPASy ProtParam. The default
+ * The default previously used monoisotopic values labeled as "Average" — off
+ * by ~0.07% systematically vs ExPASy ProtParam. The default
  * is now ExPASy-matching average mass. Pass `'monoisotopic'` for MALDI-TOF /
  * MS workflows that expect the lighter isotope chain.
  *

--- a/src/bio/gel-simulation.ts
+++ b/src/bio/gel-simulation.ts
@@ -33,6 +33,12 @@ const MAX_GEL_WIDTH = 512;
 const MIN_GEL_HEIGHT = 1;
 const MAX_GEL_HEIGHT = 1_000;
 const MAX_GEL_FRAGMENT_BP = 250_000;
+/** Input/output bounds for the standalone ASCII simulator. */
+export const MAX_GEL_SAMPLE_LANES = 64;
+export const MAX_GEL_FRAGMENTS_PER_LANE = 4_096;
+export const MAX_GEL_TOTAL_FRAGMENTS = 32_768;
+export const MAX_GEL_LABEL_LENGTH = 128;
+export const MAX_GEL_GRID_CELLS = 4_000_000;
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -115,11 +121,28 @@ export function simulateGel(
   if (!Array.isArray(ladderSizes) || ladderSizes.length === 0) {
     throw new Error('ladder must contain at least one fragment size.');
   }
+  if (ladderSizes.length > MAX_GEL_FRAGMENTS_PER_LANE) {
+    throw new Error(`ladder cannot contain more than ${MAX_GEL_FRAGMENTS_PER_LANE.toLocaleString()} fragment sizes.`);
+  }
   ladderSizes.forEach((size, index) => validateFragmentSize(size, `ladder[${index}]`));
   if (!Array.isArray(samples)) throw new Error('samples must be an array.');
+  if (samples.length > MAX_GEL_SAMPLE_LANES) {
+    throw new Error(`samples cannot contain more than ${MAX_GEL_SAMPLE_LANES.toLocaleString()} lanes.`);
+  }
+  let totalSampleFragments = 0;
   samples.forEach((sample, sampleIndex) => {
     if (!sample || typeof sample.name !== 'string') throw new Error(`samples[${sampleIndex}].name must be a string.`);
+    if (sample.name.length > MAX_GEL_LABEL_LENGTH) {
+      throw new Error(`samples[${sampleIndex}].name cannot exceed ${MAX_GEL_LABEL_LENGTH.toLocaleString()} characters.`);
+    }
     if (!Array.isArray(sample.fragments)) throw new Error(`samples[${sampleIndex}].fragments must be an array.`);
+    if (sample.fragments.length > MAX_GEL_FRAGMENTS_PER_LANE) {
+      throw new Error(`samples[${sampleIndex}].fragments cannot contain more than ${MAX_GEL_FRAGMENTS_PER_LANE.toLocaleString()} sizes.`);
+    }
+    totalSampleFragments += sample.fragments.length;
+    if (totalSampleFragments > MAX_GEL_TOTAL_FRAGMENTS) {
+      throw new Error(`samples cannot contain more than ${MAX_GEL_TOTAL_FRAGMENTS.toLocaleString()} fragment sizes in total.`);
+    }
     sample.fragments.forEach((size, fragmentIndex) => validateFragmentSize(size, `samples[${sampleIndex}].fragments[${fragmentIndex}]`));
   });
 
@@ -188,6 +211,10 @@ export function renderGelASCII(
   validateGelDimensions(laneWidth, gelHeight);
   validateGelResult(result);
   const numLanes = result.lanes.length;
+  const gridCells = numLanes * laneWidth * gelHeight;
+  if (!Number.isSafeInteger(gridCells) || gridCells > MAX_GEL_GRID_CELLS) {
+    throw new Error(`gel render grid cannot exceed ${MAX_GEL_GRID_CELLS.toLocaleString()} cells.`);
+  }
 
   // ── Build the size label column (right side) ──────────────────────────
   // Gather all unique migration distances and their size labels from ladder
@@ -224,7 +251,10 @@ export function renderGelASCII(
 
   // Header: lane labels
   const headerParts = result.lanes.map(name => {
-    const padded = name.slice(0, laneWidth).padStart(Math.floor(laneWidth / 2 + name.length / 2)).padEnd(laneWidth);
+    const boundedName = name.slice(0, laneWidth);
+    const padded = boundedName
+      .padStart(Math.floor(laneWidth / 2 + boundedName.length / 2))
+      .padEnd(laneWidth);
     return padded;
   });
   lines.push('     ' + headerParts.join(''));
@@ -285,6 +315,21 @@ function validateGelResult(result: Omit<GelResult, 'ascii'>): void {
   if (!Array.isArray(result.lanes) || result.lanes.length === 0) {
     throw new Error('lanes must contain at least one lane.');
   }
+  if (result.lanes.length > MAX_GEL_SAMPLE_LANES + 1) {
+    throw new Error(`lanes cannot contain more than ${(MAX_GEL_SAMPLE_LANES + 1).toLocaleString()} lanes including the marker.`);
+  }
+  if (!Array.isArray(result.bands) || !Array.isArray(result.ladderBands)) {
+    throw new Error('bands and ladderBands must be arrays.');
+  }
+  if (result.bands.length + result.ladderBands.length > MAX_GEL_TOTAL_FRAGMENTS + MAX_GEL_FRAGMENTS_PER_LANE) {
+    throw new Error('gel bands exceed the supported fragment limit.');
+  }
+  result.lanes.forEach((name, index) => {
+    if (typeof name !== 'string') throw new Error(`lanes[${index}] must be a string.`);
+    if (name.length > MAX_GEL_LABEL_LENGTH) {
+      throw new Error(`lanes[${index}] cannot exceed ${MAX_GEL_LABEL_LENGTH.toLocaleString()} characters.`);
+    }
+  });
   const bands = [...result.ladderBands, ...result.bands];
   for (const band of bands) {
     if (!Number.isInteger(band.size) || band.size <= 0 || band.size > MAX_GEL_FRAGMENT_BP) {

--- a/src/bio/genbank-parser.ts
+++ b/src/bio/genbank-parser.ts
@@ -1,7 +1,7 @@
 import type { Feature, FeatureStrand, FeatureType, Topology } from './types';
 import { featureLocationCoordinateSignature } from './feature-location';
 
-// Phase 35 P-H (P2-E2): individual qualifier values larger than 1 MB are
+// Individual qualifier values larger than 1 MB are
 // truncated to this cap and tagged with a suffix so consumers can detect
 // the truncation. The retained accumulator is bounded in UTF-8 bytes and the
 // original byte count is tracked separately so huge values cannot grow it.
@@ -133,12 +133,11 @@ function qualifierChunkStats(value: string, opening: boolean, closing: boolean):
  * `ds-` (double-stranded), or `ms-` (mixed). Absent on most modern records.
  * Preserving the literal token lets a parsed-then-exported record round-trip
  * the strand field that downstream GenBank consumers read from column 22-23.
- * VOG-2000.
  */
 export type GenBankStrandedness = 'ss' | 'ds' | 'ms';
 
 /**
- * VOG-1973: a GenBank file is "truncated" when the source is cut off before
+ * A GenBank file is "truncated" when the source is cut off before
  * the ORIGIN block finishes — either no ORIGIN section at all, or ORIGIN
  * present but missing most/all sequence rows. Without a guard the parser
  * silently emits a record with a non-zero LOCUS length, partial features,
@@ -194,7 +193,7 @@ export interface GenBankRecord {
   definition?: string;
   accession?: string;
   /**
-   * VOG-1973: present only when the parser detected a truncated record.
+   * Present only when the parser detected a truncated record.
    * The intake pipeline surfaces a `partial_record` warning and refuses
    * to materialize 0-bp blocks. Absent on healthy records to keep the
    * import metadata payload lean.
@@ -202,36 +201,35 @@ export interface GenBankRecord {
   truncated?: GenBankTruncationInfo;
   /**
    * Free-form COMMENT block. Preserved as a single string with embedded
-   * newlines so multi-line comments survive a round-trip. VOG-2004.
+   * newlines so multi-line comments survive a round-trip.
    */
   comment?: string;
-  /** SOURCE line (one-line summary above ORGANISM). VOG-2004. */
+  /** SOURCE line (one-line summary above ORGANISM). */
   source?: string;
   /**
    * ORGANISM block. The first line is the organism name; subsequent
    * indented lines form the taxonomic lineage joined with `; `. We retain
    * the parsed name+lineage as a single string so the exporter can re-emit
-   * the original layout. VOG-2004.
+   * the original layout.
    */
   organism?: string;
-  /** KEYWORDS line, semicolon-separated, period-terminated upstream. VOG-2004. */
+  /** KEYWORDS line, semicolon-separated, period-terminated upstream. */
   keywords?: string;
   /**
    * VERSION line value (e.g. `NM_001234.1` or `1`). Distinct from
    * `accession` because the version suffix is independent. Protein records
    * sometimes omit VERSION entirely; we record the absence as `undefined`
    * (vs `''`) so the exporter can decide whether to emit a fallback.
-   * VOG-2001.
    */
   version?: string;
-  /** LOCUS strand qualifier (`ss-` / `ds-` / `ms-`). VOG-2000. */
+  /** LOCUS strand qualifier (`ss-` / `ds-` / `ms-`). */
   strandedness?: GenBankStrandedness;
   /**
    * LOCUS division code (3-letter NCBI division like `BCT`, `PLN`, `SYN`,
-   * or `UNK`). VOG-1974.
+   * or `UNK`).
    */
   division?: string;
-  /** LOCUS date in `DD-MMM-YYYY` form, preserved verbatim. VOG-1974. */
+  /** LOCUS date in `DD-MMM-YYYY` form, preserved verbatim. */
   date?: string;
   /** Feature-specific warnings raised while retaining valid but unprojectable locations. */
   importDiagnostics?: GenBankImportDiagnostic[];
@@ -240,7 +238,7 @@ export interface GenBankRecord {
 }
 
 /**
- * VOG-2039 hotfix: qualifiers whose value is a continuous sequence (no
+ * Qualifiers whose value is a continuous sequence (no
  * intra-value whitespace) must NOT have a space inserted when joining
  * continuation lines. Today this is just `/translation` (protein
  * sequence). Without this special-case, a parsed protein sequence ends
@@ -273,7 +271,7 @@ const FEATURE_TYPE_MAP: Record<string, FeatureType> = {
   exon: 'exon',
   polya_signal: 'polyA_signal',
   enhancer: 'enhancer',
-  // QA2 W16c (export agent F1): Motif's GenBank exporter writes these internal
+  // Motif's GenBank exporter writes these internal
   // FeatureType keys verbatim (export.ts FEATURES table). Map them back so a
   // GenBank round-trip preserves the type instead of collapsing to `custom`.
   // (`rep_origin` above still maps to `origin` for standard external files.)
@@ -573,7 +571,7 @@ function parseLocation(loc: string, depth = 0): ParsedLocation {
  * syntax as GenBank, just with an `FT` line prefix instead of 5 leading
  * spaces. `parseEmbl` rewrites the prefix to the GenBank column layout and
  * delegates here, so location parsing, multi-line qualifiers, `""` escaping,
- * and the `/label`-first naming rule stay in one place. VOG-2149.
+ * and the `/label`-first naming rule stay in one place.
  */
 export function parseFeatures(featuresText: string): Feature[] {
   const features: Feature[] = [];
@@ -615,12 +613,12 @@ export function parseFeatures(featuresText: string): Feature[] {
     }
 
     // Parse qualifiers.
-    // Phase 35 P-H (P2-E1): null-prototype map so a malicious /__proto__= or
+    // Use a null-prototype map so a malicious /__proto__= or
     // /constructor= qualifier key cannot reach Object.prototype. Not exploitable
     // in V8 today (special-cased), but defense in depth.
-    // Phase 35 P-H (P2-E2): cap individual qualifier values at 1 MB to defend
+    // Cap individual qualifier values at 1 MB to defend
     // against malicious input. Larger values are truncated with a suffix.
-    // Phase 35 P1-A7: decode embedded `""` → `"` per NCBI feature-table spec
+    // Decode embedded `""` → `"` per NCBI feature-table spec
     // §3.4.2. The previous strip-outer-quotes-only behavior preserved `""`
     // as `""` in metadata, so spec-compliant input round-tripped wrong.
     // We also detect when a continuation line beginning with `/` is actually
@@ -662,7 +660,6 @@ export function parseFeatures(featuresText: string): Feature[] {
         // '' BEFORE reaching its `value === true` bare-flag branch, which is how
         // these flags were being dropped. Feature.metadata is
         // Record<string, unknown>, so the boolean is type-safe downstream.
-        // (QA2 W21, import/export agent F2.)
         value = true;
       } else {
         const truncated = currentQualOriginalBytes > QUALIFIER_VALUE_MAX_BYTES;
@@ -742,7 +739,7 @@ export function parseFeatures(featuresText: string): Feature[] {
         // measured, so a malicious 100 MB qualifier cannot grow the parser's
         // accumulator or lose its loss receipt.
         //
-        // VOG-2039 hotfix: `/translation` is a continuous protein sequence —
+        // `/translation` is a continuous protein sequence —
         // line breaks in the source are pure formatting and must NOT
         // introduce whitespace into the parsed value (or downstream consumers
         // would see `MVSK LKFI ...` instead of `MVSKLKFI...`, and the exporter
@@ -765,7 +762,7 @@ export function parseFeatures(featuresText: string): Feature[] {
     // Determine name from qualifiers. Each read is string-guarded: a valueless
     // qualifier is stored as `true` (see saveQualifier) and `name.replace()`
     // below assumes a string, so only adopt a qualifier whose value is a string.
-    // R11: /label is the canonical display-name carrier and MUST win — the
+    // `/label` is the canonical display-name carrier and MUST win — the
     // exporter (src/persistence/export.ts) always writes feature.name to /label,
     // so reading /gene first silently reverted a user-renamed feature to its
     // gene/product name on an export→import round-trip. /label-first matches
@@ -913,7 +910,7 @@ function parseLocusLine(line: string): LocusFields {
 
   // Strandedness — `ss-`, `ds-`, `ms-` prefix on the molecule type field.
   // We strip the prefix from `moleculeType` so the rest of the codebase
-  // continues to receive plain `DNA` / `RNA`. VOG-2000.
+  // continues to receive plain `DNA` / `RNA`.
   const strandMatch = line.match(/\b(ss|ds|ms)-(DNA|RNA|mRNA)\b/i);
   if (strandMatch) {
     result.strandedness = strandMatch[1].toLowerCase() as GenBankStrandedness;
@@ -928,14 +925,14 @@ function parseLocusLine(line: string): LocusFields {
   if (/\bcircular\b/i.test(line)) result.topology = 'circular';
   else if (/\blinear\b/i.test(line)) result.topology = 'linear';
 
-  // Date — DD-MMM-YYYY in trailing column. VOG-1974.
+  // Date — DD-MMM-YYYY in trailing column.
   const dateMatch = line.match(/(\d{2}-[A-Z]{3}-\d{4})\s*$/);
   if (dateMatch) result.date = dateMatch[1];
 
   // Division — 3 uppercase letters preceding the date (or trailing if
   // date absent). NCBI divisions: BCT PRI ROD MAM VRT INV PLN BCT VRL PHG
   // RNA SYN UNA EST PAT STS GSS HTG HTC ENV CON TSA UNK. Match any
-  // 3-letter uppercase token in that slot. VOG-1974.
+  // 3-letter uppercase token in that slot.
   const divMatch = result.date
     ? line.match(/\b([A-Z]{3})\s+\d{2}-[A-Z]{3}-\d{4}\s*$/)
     : line.match(/\b([A-Z]{3})\s*$/);
@@ -975,7 +972,7 @@ function parseSingleGenBankRecord(raw: string): GenBankRecord | null {
   let inOrganism = false;
   let keywordsLines: string[] = [];
   let inKeywords = false;
-  // VOG-1973: track whether the input ever entered ORIGIN. Combined with
+  // Track whether the input ever entered ORIGIN. Combined with
   // `locus.length` (the LOCUS-declared length) we use this to detect
   // truncation. A GenBank export that was cut off
   // mid-FEATURES (or mid-ORIGIN) shows up here as `originSeen = false`
@@ -1068,10 +1065,10 @@ function parseSingleGenBankRecord(raw: string): GenBankRecord | null {
 
     if (line.startsWith('ACCESSION')) {
       const rawAccession = line.replace(/^ACCESSION\s+/, '').trim();
-      // VOG-2039 hotfix: `ACCESSION unknown` is a placeholder used by
+      // `ACCESSION unknown` is a placeholder used by
       // Motif (and other tools) when no real NCBI accession exists.
       // Treat it as no-accession so the exporter doesn't later emit a
-      // phantom `VERSION unknown.1` (the VOG-2001 pathology). NCBI uses
+      // phantom `VERSION unknown.1`. NCBI uses
       // the same convention — accession is absent when no submission ID
       // has been assigned.
       accession = rawAccession.toLowerCase() === 'unknown' ? '' : rawAccession;
@@ -1162,13 +1159,12 @@ function parseSingleGenBankRecord(raw: string): GenBankRecord | null {
     length = sequence.length;
   }
 
-  // Phase 32 (Pass-Export P0-3): preserve source case verbatim. Phase 31 W13
-  // only preserved mixed-case; uniformly UPPERCASE input was still flattened
-  // to lowercase. Exporter now also preserves verbatim (export.ts), so a
-  // round-trip through GenBank now survives case identity for all inputs.
+  // Preserve source case verbatim. The exporter also preserves it, so a
+  // round-trip through GenBank survives case identity for all inputs,
+  // including uniformly uppercase records.
   const preservedSequence = sequence;
 
-  // VOG-1973: detect truncation. Three trip-wires, in order of severity:
+  // Detect truncation with three checks, in order of severity:
   //   (1) LOCUS declared a positive length but ORIGIN never appeared —
   //       the file was cut off before (or during) FEATURES emit. This is
   //       the canonical "0-bp block with partial features" reproducer.

--- a/src/bio/gibson-assembly.ts
+++ b/src/bio/gibson-assembly.ts
@@ -275,9 +275,8 @@ export function gibsonAssemble(
   // end. Detect that closing seam now — before the duplicate/low-Tm checks, so
   // they evaluate it too — and make a MISSING seam a hard error rather than a
   // silently-linear product with the closing overlap duplicated at both ends.
-  // (R10 #3: previously `topology` was a pure label; the assembly loop only ran
-  // i < length-1, so the seam was never tested and a cyclic fragment set yielded
-  // a linear product carrying the closing overlap twice.)
+  // The seam must be checked explicitly: otherwise a cyclic fragment set can
+  // become a linear product carrying the closing overlap twice.
   let closingOverlap: Overlap | null = null;
   if (topology === 'circular' && fragments.length >= 2) {
     const last = fragments[fragments.length - 1];
@@ -425,7 +424,7 @@ export function gibsonAssemble(
  * Checks Tm, length, and uniqueness between consecutive pairs. The
  * minOverlap/maxOverlap thresholds default to the Gibson defaults but are
  * forwarded by callers (e.g. the CLI's --min-overlap/--max-overlap) so that
- * validation matches the assembly the user actually requested (R10 #2).
+ * validation matches the assembly the user actually requested.
  */
 export function validateOverlaps(
   fragments: GibsonFragment[],

--- a/src/bio/golden-gate-kits.ts
+++ b/src/bio/golden-gate-kits.ts
@@ -4,7 +4,7 @@ import type { GoldenGateEnzymeName } from './golden-gate';
  * Catalog of common Golden Gate / MoClo kits with their canonical Type IIS
  * enzyme and the published set of fusion-site overhangs each kit defines.
  *
- * VOG-1790: Users with an existing pile of L0 parts can pick a kit here and
+ * Users with an existing pile of L0 parts can pick a kit here and
  * the dialog will sanity-check that loaded parts use overhangs the kit
  * actually recognizes. Mismatches are surfaced as warning chips — not
  * blockers — because users often have custom parts that extend the standard

--- a/src/bio/golden-gate.ts
+++ b/src/bio/golden-gate.ts
@@ -2076,7 +2076,7 @@ export function domesticateLegacyProjection(
  * Domesticate ONLY the internal insert of a flanked Type IIS part, preserving
  * the structural flanking recognition sites the assembly depends on.
  *
- * R10 #4: `domesticate()` removes every recognition site it finds, including the
+ * `domesticate()` removes every recognition site it finds, including the
  * flanking GGTCTC/GAGACC (BsaI) handles — so running it over a whole flanked
  * part strips the flanks and makes the part un-assemblable ("missing flanking
  * sites"), even when the part has zero INTERNAL sites. This helper uses

--- a/src/bio/mutate.ts
+++ b/src/bio/mutate.ts
@@ -15,6 +15,12 @@ export interface MutationResult {
 // Helpers (not exported)
 // ---------------------------------------------------------------------------
 
+function requireSafeInteger(value: number, label: string, minimum: number): void {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new RangeError(`${label} must be a safe integer greater than or equal to ${minimum}.`);
+  }
+}
+
 /**
  * Shift all scar positions by `delta` where the scar position is > editPos.
  * Returns a new array (does not mutate input).
@@ -109,6 +115,7 @@ export function applySubstitution(
   if (typeof newBase !== 'string' || !/^[A-Za-z*]$/.test(newBase)) {
     throw new Error('Substitution requires exactly one valid residue; use insertion or deletion for length-changing edits.');
   }
+  requireSafeInteger(pos, 'pos', 0);
 
   // Guard: pos out of range — return unchanged
   if (pos < 0 || pos >= raw.length) {
@@ -168,6 +175,10 @@ export function applyInsertion(
   pos: number,
   bases: string,
 ): MutationResult {
+  if (typeof bases !== 'string') {
+    throw new TypeError('Insertion bases must be a string.');
+  }
+  requireSafeInteger(pos, 'pos', -1);
   // Nothing to insert
   if (bases.length === 0) {
     return { raw, scars: [...scars], features: [...features] };
@@ -232,6 +243,8 @@ export function applyDeletion(
   pos: number,
   count: number,
 ): MutationResult {
+  requireSafeInteger(pos, 'pos', 0);
+  requireSafeInteger(count, 'count', 0);
   // Nothing to delete
   if (count <= 0) {
     return { raw, scars: [...scars], features: [...features] };

--- a/src/bio/primer-design.ts
+++ b/src/bio/primer-design.ts
@@ -13,7 +13,7 @@ import {
 import { inspectNucleotideSequence } from './nucleotide';
 
 /**
- * Phase 35 P0-A3: realistic PCR buffer defaults. SantaLucia 1998 NN-Tm
+ * Realistic PCR buffer defaults. SantaLucia 1998 NN-Tm
  * computed at the legacy default 50 mM Na, 0 Mg, 0 dNTP undershoots
  * real-PCR Tm by 5-7 °C — a thermal cycler annealing temp set at the
  * dialog-displayed Tm will mis-anneal in the actual reaction. Common
@@ -56,30 +56,30 @@ export interface PrimerDesignParams {
   maxGC?: number;
   forwardTail?: string;
   reverseTail?: string;
-  // Phase 32: Primer3-style 3' GC clamp — require at least one G/C in the
+  // Primer3-style 3' GC clamp — require at least one G/C in the
   // last 5 nt of the primer's 3' end. Default ON: prevents AAAA-tail
   // mispriming + slippage.
   requireGcClamp?: boolean;
-  // Phase 33 (Theme-D): Primer3-style flanking-region scan. Forward primers
+  // Primer3-style flanking-region scan. Forward primers
   // may start anywhere in [targetStart - flankingWindow, targetStart];
   // reverse primers may end anywhere in [targetEnd, targetEnd + flankingWindow].
   // Default 50 nt — same window Primer3 uses out of the box. Pass 0 to fall
   // back to legacy anchor-only behavior.
   flankingWindow?: number;
   /**
-   * Phase 35 P0-A3: Tm calculation buffer conditions. Defaults to
+   * Tm calculation buffer conditions. Defaults to
    * DEFAULT_TM_OPTIONS (50 mM Na, 1.5 mM Mg, 0.2 mM dNTP, 250 nM primer).
    * Passing `{}` or {mgConcentration: 0} reproduces legacy behavior.
    */
   tmOptions?: TmOptions;
   /**
-   * Phase 35 P0-A4: hairpin ΔG37 cutoff (kcal/mol). Candidates whose
+   * Hairpin ΔG37 cutoff (kcal/mol). Candidates whose
    * predicted hairpin ΔG is MORE NEGATIVE than this value are rejected.
    * Default -3.0 (Primer3 standard). Pass `null` or `+Infinity` to disable.
    */
   maxHairpinDeltaG?: number | null;
   /**
-   * Phase 35 P0-A4: self-dimer ΔG37 cutoff (kcal/mol). Candidates whose
+   * Self-dimer ΔG37 cutoff (kcal/mol). Candidates whose
    * predicted self-dimer ΔG is MORE NEGATIVE than this value are rejected.
    * Default -5.0 (Primer3 standard). Pass `null` or `+Infinity` to disable.
    */
@@ -97,7 +97,7 @@ export interface PrimerCandidate {
   tm: number;             // Tm of binding region only
   gcPercent: number;      // GC% of binding region only
   direction: 'forward' | 'reverse';
-  // Phase 33: distance (nt) from the user's target anchor. 0 = primer
+  // Distance (nt) from the user's target anchor. 0 = primer
   // begins/ends at the anchor exactly; positive = primer sits outside the
   // target window (forward to the 5' side of targetStart, reverse to the
   // 3' side of targetEnd). Used to rank candidates and penalize drift.
@@ -119,7 +119,7 @@ export interface PrimerPair {
 }
 
 /**
- * Phase 33 (Theme-D): per-filter rejection counts.
+ * Per-filter rejection counts.
  *
  * Tracks how many candidate positions × lengths fell out of consideration at
  * each filter step. Surfaced in the dialog when 0 candidates pass so the
@@ -137,20 +137,20 @@ export interface PrimerRejectionCounts {
   /** Calculator returned no result (sequence had non-canonical bases) */
   invalid: number;
   /**
-   * Phase 35 P0-A4: predicted hairpin ΔG below threshold (too stable).
+   * Predicted hairpin ΔG below threshold (too stable).
    * Optional for backward-compat with consumers that construct this shape
    * directly without specifying the new fields.
    */
   hairpin?: number;
   /**
-   * Phase 35 P0-A4: predicted self-dimer ΔG below threshold (too stable).
+   * Predicted self-dimer ΔG below threshold (too stable).
    * Optional for backward-compat (see above).
    */
   dimer?: number;
 }
 
 /**
- * Phase 34 P-G B1: secondary rejection counts — how many candidates that were
+ * Secondary rejection counts — how many candidates that were
  * rejected by the PRIMARY filter (e.g. gc) ALSO would have failed a later
  * filter (tm, clamp). Without these counts the diagnostic message implies the
  * only problem is the primary filter, but users widening one constraint find
@@ -172,7 +172,7 @@ export interface PrimerSecondaryRejectionCounts {
 export interface PrimerDesignResult {
   candidates: PrimerCandidate[];
   rejections: PrimerRejectionCounts;
-  /** Phase 34 P-G B1: per-rejection multi-criteria attribution counts. */
+  /** Per-rejection multi-criteria attribution counts. */
   secondaryRejections?: PrimerSecondaryRejectionCounts;
   /** Input/tail integrity warnings that prevented exact candidate evaluation. */
   warnings?: string[];
@@ -191,7 +191,7 @@ export interface PrimerPairResult {
   /** Diagnostics from the underlying forward/reverse scans, in case 0 pairs */
   forwardRejections: PrimerRejectionCounts;
   reverseRejections: PrimerRejectionCounts;
-  /** Phase 34 P-G B1: secondary (multi-criteria) rejection counts. */
+  /** Secondary (multi-criteria) rejection counts. */
   forwardSecondary?: PrimerSecondaryRejectionCounts;
   reverseSecondary?: PrimerSecondaryRejectionCounts;
   forwardCount: number;
@@ -211,14 +211,14 @@ const DEFAULT_FLANKING_WINDOW = 50;
 const MAX_TM_DIFF_PAIR = 5;
 const MAX_PAIRS_RETURNED = 10;
 const MAX_PAIRING_CANDIDATES_PER_DIRECTION = 240;
-// Phase 33: distance penalty weight — each nt away from the anchor adds this
+// Distance penalty weight — each nt away from the anchor adds this
 // many degrees of "virtual Tm error" in the sort. A primer 30 nt off-anchor
 // with a perfect Tm ranks below an on-anchor primer with ΔTm = 1.5 °C.
 // Empirical: 0.05 chosen so that 50 nt of drift ≈ 2.5 °C virtual Tm
 // penalty — roughly matches Primer3's POSITION_PENALTY default behavior.
 const ANCHOR_DISTANCE_PENALTY = 0.05;
 
-// Phase 32 Pass-Primer P0: 3' GC clamp filter. Returns true if the last 5 nt
+// 3' GC clamp filter. Returns true if the last 5 nt
 // of the primer contain at least one G or C (Primer3 standard).
 function has3PrimeGcClamp(primer: string): boolean {
   const tail = primer.slice(-5);
@@ -229,7 +229,7 @@ function emptyRejections(): Required<PrimerRejectionCounts> {
   return { gc: 0, tm: 0, length: 0, clamp: 0, invalid: 0, hairpin: 0, dimer: 0 };
 }
 
-// Phase 34 P-G B1: secondary rejection counter — populated by the design loops
+// Secondary rejection counter — populated by the design loops
 // to capture multi-criteria failure attribution (e.g. "rejected by gc, also
 // would have failed tm").
 function emptySecondaryRejections(): PrimerSecondaryRejectionCounts {
@@ -238,7 +238,7 @@ function emptySecondaryRejections(): PrimerSecondaryRejectionCounts {
 
 /**
  * Score a candidate for sorting — closer to anchor and closer to target Tm wins.
- * Phase 33: combines Tm distance + anchor distance penalty into a single rank.
+ * Combines Tm distance + anchor distance penalty into a single rank.
  */
 function rankScore(c: PrimerCandidate, targetTm: number): number {
   return Math.abs(c.tm - targetTm) + c.anchorDistance * ANCHOR_DISTANCE_PENALTY;
@@ -283,7 +283,7 @@ function pairRankScore(pair: PrimerPair, targetTm: number, enforceTargetTm: bool
 }
 
 /**
- * Phase 33 (Theme-D): Primer3-style flanking-region scan for forward primers.
+ * Primer3-style flanking-region scan for forward primers.
  *
  * Forward primers may start anywhere in [targetStart - flank, targetStart] —
  * the product MUST still cover targetStart (which is the user's region of
@@ -333,7 +333,7 @@ export function designForwardPrimerWithDiagnostics(
     return { candidates, rejections, secondaryRejections, warnings };
   }
 
-  // Phase 33: scan a window of start positions to the 5' side of targetStart.
+  // Scan a window of start positions to the 5' side of targetStart.
   // The product MUST cover targetStart, so start positions can range from
   // max(0, targetStart - flankingWindow) up to and including targetStart.
   const startMin = Math.max(0, targetStart - Math.max(0, flankingWindow));
@@ -364,7 +364,7 @@ export function designForwardPrimerWithDiagnostics(
       }
       const tm = tmResult.tm;
 
-      // Phase 34 P-G B1: evaluate ALL three filters before counting so that
+      // Evaluate ALL three filters before counting so that
       // multi-criteria failures are attributed correctly. The primary count
       // still goes to the first failing filter (short-circuit-compatible),
       // but secondaryRejections capture the "would also have failed X" stats.
@@ -389,7 +389,7 @@ export function designForwardPrimerWithDiagnostics(
         continue;
       }
 
-      // Phase 35 P0-A4: hairpin + self-dimer ΔG filters.
+      // Hairpin + self-dimer ΔG filters.
       const fullPrimerSeq = tail + primerSeq;
       let hairpinDeltaG: number | undefined;
       let selfDimerDeltaG: number | undefined;
@@ -443,7 +443,7 @@ export function designForwardPrimerWithDiagnostics(
 }
 
 /**
- * Phase 33 (Theme-D): Primer3-style flanking-region scan for reverse primers.
+ * Primer3-style flanking-region scan for reverse primers.
  *
  * Reverse primers may end anywhere in [targetEnd, targetEnd + flank] — the
  * product MUST still cover targetEnd. Same filter chain + rejection
@@ -520,7 +520,7 @@ export function designReversePrimerWithDiagnostics(
       }
       const tm = tmResult.tm;
 
-      // Phase 34 P-G B1: multi-criteria attribution (see forward variant).
+      // Multi-criteria attribution (see forward variant).
       const failsGc = gc < minGC || gc > maxGC;
       const failsTm = enforceTargetTm && Math.abs(tm - targetTm) > tmTolerance;
       const failsClamp = requireGcClamp && !has3PrimeGcClamp(primerSeq);
@@ -542,7 +542,7 @@ export function designReversePrimerWithDiagnostics(
         continue;
       }
 
-      // Phase 35 P0-A4: hairpin + self-dimer ΔG filters.
+      // Hairpin + self-dimer ΔG filters.
       const fullPrimerSeq = tail + primerSeq;
       let hairpinDeltaG: number | undefined;
       let selfDimerDeltaG: number | undefined;
@@ -619,7 +619,7 @@ export function designReversePrimer(
 }
 
 /**
- * Phase 33 (Theme-D): pair design with diagnostics.
+ * Pair design with diagnostics.
  *
  * Runs both flanking scans, then pairs forward × reverse and applies pair-
  * level filters (Tm difference, product length). Surfaces per-filter
@@ -698,7 +698,7 @@ export function designPrimerPairWithDiagnostics(
     rejections,
     forwardRejections: forwardResult.rejections,
     reverseRejections: reverseResult.rejections,
-    // Phase 34 P-G B1: pass secondary attribution counts through.
+    // Pass secondary attribution counts through.
     forwardSecondary: forwardResult.secondaryRejections,
     reverseSecondary: reverseResult.secondaryRejections,
     forwardCount: forwards.length,

--- a/src/bio/primer-thermodynamics.ts
+++ b/src/bio/primer-thermodynamics.ts
@@ -1,7 +1,7 @@
 /**
  * Primer thermodynamics — hairpin + dimer ΔG prediction.
  *
- * Phase 35 P0-A4: prior to this module, primer-design returned candidates
+ * Before this module, primer-design returned candidates
  * that could form strong self/hetero-duplexes silently. A perfectly matched
  * inverse-complement primer pair (e.g. F=CGCTCGGTACG + R=CGTACCGAGCG)
  * passes GC / Tm / clamp filters and ranks at the top — but in PCR forms a

--- a/src/bio/restriction-presets.ts
+++ b/src/bio/restriction-presets.ts
@@ -184,7 +184,7 @@ export function listRestrictionPresetNames(): string[] {
 export type RestrictionEnzymeSourceId = 'common' | 'all' | 'favorites' | RestrictionPresetId;
 
 /**
- * R17 — resolve a UNION of enzyme sources into a deduped enzyme list (by name,
+ * Resolve a UNION of enzyme sources into a deduped enzyme list (by name,
  * case-insensitive). Lets the restriction UI offer "pick any combination of
  * lists" — Common + Type IIS + Favorites + … — and scan one merged set so the
  * inspector AND the detail-view ticks reflect the same selection. `'all'`
@@ -232,7 +232,7 @@ export function resolveEnzymeUnion(
   return Array.from(byName.values());
 }
 
-// ── Isoschizomer canonical naming (R70) ─────────────────────────────────────
+// ── Isoschizomer canonical naming ────────────────────────────────────────────
 // Enzymes that share a recognition site (isoschizomers) fold into ONE inspector
 // row / detail tick, so a single representative name is shown. Picking it purely
 // alphabetically made the SAME physical site flip identity with the active

--- a/src/bio/restriction-sites.ts
+++ b/src/bio/restriction-sites.ts
@@ -13,7 +13,7 @@ import { reverseComplement } from './reverse-complement';
 
 /**
  * Options for [`findRestrictionSites`].
- * Phase 34 P-B B3: topology added so circular plasmids wrap-scan their origin.
+ * Circular topology causes the scanner to wrap across the origin.
  */
 export interface FindRestrictionSitesOptions {
   /**
@@ -369,7 +369,7 @@ function concreteIupacMatch(buffer: string, start: number, recognition: string):
  * Default working set of restriction enzymes used by the UI and digest functions.
  *
  * Originally the 25-enzyme 6-cutter / Type IIS panel preserved across releases.
- * VOG-1807: the eGFP onboarding sample (720 bp) has no canonical 6-cutter
+ * The eGFP onboarding sample (720 bp) has no canonical 6-cutter
  * site, so the Inspector "Common" tab opened to "0 cuts" — a dead end for
  * first-time users. Five canonical screening 4-cutters (AluI, HaeIII, TaqI,
  * HpaII, MspI) are appended so the default Inspector view yields useful
@@ -406,10 +406,10 @@ export const RESTRICTION_ENZYMES: RestrictionEnzyme[] = [
   { name: 'ScaI',   recognitionSequence: 'AGTACT',   cutOffset: 3, complementCutOffset: 3, overhang: 'blunt' },
   { name: 'ApaI',   recognitionSequence: 'GGGCCC',   cutOffset: 5, complementCutOffset: 1, overhang: '3prime' },
   { name: 'SphI',   recognitionSequence: 'GCATGC',   cutOffset: 5, complementCutOffset: 1, overhang: '3prime' },
-  // VOG-1807: canonical screening 4-cutters that appear in molecular biology
+  // Canonical screening 4-cutters that appear in molecular biology
   // kits (RFLP/diagnostic digests, methylation-sensitive pair, RAD-tag panel).
   // Order matches the AluI/HaeIII/TaqI/HpaII/MspI panel called out in the
-  // ticket. Mirrors RESTRICTION_ENZYMES_FULL entries 1:1 so the digest engine
+  // Mirrors RESTRICTION_ENZYMES_FULL entries 1:1 so the digest engine
   // returns identical cut/overhang shapes whichever set the caller passes.
   { name: 'AluI',   recognitionSequence: 'AGCT',     cutOffset: 2, complementCutOffset: 2, overhang: 'blunt'  },
   { name: 'HaeIII', recognitionSequence: 'GGCC',     cutOffset: 2, complementCutOffset: 2, overhang: 'blunt'  },
@@ -443,15 +443,15 @@ for (let index = 0; index < RESTRICTION_ENZYMES.length; index += 1) {
 /**
  * Find all restriction sites in a sequence for the given enzymes.
  *
- * Phase 34 P-B B1: now scans BOTH strands. For each non-palindromic enzyme,
+ * The scanner checks BOTH strands. For each non-palindromic enzyme,
  * the reverse-complement of the recognition sequence is also scanned and
- * matches are tagged `strand: -1`. This matches the Rust engine's output
- * structure and is critical for Type IIS enzymes (BsaI/BbsI/BsmBI/SapI/etc.)
+ * matches are tagged `strand: -1`. This preserves the scanner's strand-aware
+ * output structure and is critical for Type IIS enzymes (BsaI/BbsI/BsmBI/SapI/etc.)
  * whose binding sites are not symmetric. Empirically verified: BsaI on
  * `AAAAAAGAGACCTTTTT` (where `GAGACC = revcomp(GGTCTC)`) now correctly
  * returns 1 site at position 6.
  *
- * Phase 34 P-B B3: when `options.topology === 'circular'`, the scanner
+ * When `options.topology === 'circular'`, the scanner
  * appends a wrap window so that recognition strings straddling the origin
  * are matched. Returned `position` values stay in `[0, seq.length)`.
  *

--- a/src/bio/sequence-formatting.ts
+++ b/src/bio/sequence-formatting.ts
@@ -490,8 +490,10 @@ export function makeSequenceStyleRange(
   style: SequenceTextStyle,
   name?: string,
 ): SequenceStyleRange {
-  const start = Math.max(0, Math.min(range.start, range.end));
-  const end = Math.max(start + 1, Math.max(range.start, range.end));
+  const rawStart = Number.isFinite(range.start) ? Math.floor(range.start) : 0;
+  const rawEnd = Number.isFinite(range.end) ? Math.floor(range.end) : rawStart;
+  const start = Math.max(0, Math.min(rawStart, rawEnd));
+  const end = Math.max(start + 1, Math.max(rawStart, rawEnd));
   return {
     id: randomId('style-range'),
     start,
@@ -505,7 +507,7 @@ export function makeSequenceStyleRange(
 export function makeSequenceLayoutMark(position: number, kind: SequenceLayoutMarkKind, indentLevel?: number): SequenceLayoutMark {
   return {
     id: randomId('layout-mark'),
-    position: Math.max(0, Math.floor(position)),
+    position: Number.isFinite(position) ? Math.max(0, Math.floor(position)) : 0,
     kind,
     createdAt: nextSequenceFormattingCreatedAt(),
     indentLevel,
@@ -827,6 +829,9 @@ export function shiftSequenceFormattingForRange(
   start: number,
   end: number,
 ): SequenceFormatting {
+  if (!Number.isSafeInteger(start) || start < 0 || !Number.isSafeInteger(end) || end < start) {
+    throw new RangeError('formatting range must use non-negative safe integer coordinates.');
+  }
   const normalized = normalizeSequenceFormatting(formatting);
   return {
     ranges: normalized.ranges
@@ -856,6 +861,12 @@ export function shiftSequenceFormattingForInsertion(
   editPos: number,
   delta: number,
 ): SequenceFormatting {
+  if (!Number.isSafeInteger(editPos) || editPos < 0) {
+    throw new RangeError('editPos must be a non-negative safe integer.');
+  }
+  if (!Number.isSafeInteger(delta)) {
+    throw new RangeError('delta must be a safe integer.');
+  }
   const normalized = normalizeSequenceFormatting(formatting);
   if (delta <= 0) return normalized;
   return {
@@ -878,6 +889,15 @@ export function shiftSequenceFormattingForDeletion(
   count: number,
   rawLength: number,
 ): SequenceFormatting {
+  if (!Number.isSafeInteger(pos) || pos < 0) {
+    throw new RangeError('pos must be a non-negative safe integer.');
+  }
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new RangeError('count must be a non-negative safe integer.');
+  }
+  if (!Number.isSafeInteger(rawLength) || rawLength < 0) {
+    throw new RangeError('rawLength must be a non-negative safe integer.');
+  }
   const normalized = normalizeSequenceFormatting(formatting);
   if (count <= 0 || pos < 0 || pos >= rawLength) return normalized;
   const effectiveCount = Math.min(count, rawLength - pos);
@@ -916,8 +936,10 @@ export function clearSequenceStyleRangesInRange(
   end: number,
 ): SequenceFormatting {
   const normalized = normalizeSequenceFormatting(formatting);
-  const rangeStart = Math.max(0, Math.min(start, end));
-  const rangeEnd = Math.max(rangeStart, Math.max(start, end));
+  const rawStart = Number.isFinite(start) ? Math.floor(start) : 0;
+  const rawEnd = Number.isFinite(end) ? Math.floor(end) : rawStart;
+  const rangeStart = Math.max(0, Math.min(rawStart, rawEnd));
+  const rangeEnd = Math.max(rangeStart, Math.max(rawStart, rawEnd));
   if (rangeEnd <= rangeStart) return normalized;
 
   const nextRanges: SequenceStyleRange[] = [];

--- a/src/bio/sequence-highlights.ts
+++ b/src/bio/sequence-highlights.ts
@@ -2,15 +2,10 @@ import type { Feature } from './types';
 import { NO_COLOR_VALUE } from './color-values';
 
 export const SEQUENCE_HIGHLIGHT_KIND = 'sequence_highlight';
-// #10b RE-BRIGHTEN (2026-06-02): a prior calm campaign muted this palette to a
-// quiet sage/clay/teal trio + a muted gold default. Per direct user direction
-// ("the highlight colors are not good — need more std colors and a custom
-// palette"), the highlight palette is re-brightened and expanded to a full
-// 12-swatch set: a vivid rainbow (amber → green → blue → … → purple) plus the
-// dark "redact" swatch last. The default still LEADS the array (index 0 — the
-// create-highlight path uses the first swatch as its default) and is a bright
-// amber, kept distinct from the G-base hue used by base-coloring. Tests pass
-// `#facc15` as a literal, so changing this constant stays safe.
+// The highlight palette uses a full 12-swatch vivid set (amber → green →
+// blue → … → purple) plus a dark "redact" swatch last. The default still
+// leads the array (index 0 — the create-highlight path uses the first swatch)
+// and remains a bright amber distinct from the G-base hue used by base-coloring.
 export const DEFAULT_SEQUENCE_HIGHLIGHT_COLOR = '#e0b83c';
 export const DARK_SEQUENCE_HIGHLIGHT_COLOR = '#111827';
 export const DARK_THEME_DARK_HIGHLIGHT_BACKGROUND = '#f8fafc';
@@ -191,13 +186,13 @@ export function sequenceHighlightForeground(
 /**
  * Default name format for a newly-created saved highlight ("Region N").
  *
- * Phase 39 W4 (D8 P0-3): renamed from "Highlight N" so the persisted entity
+ * Saved highlights use the "Region N" prefix so the persisted entity
  * does not collide with the live range-selection chip ("Selected bases X-Y").
  * Legacy snapshots are normalised in `normalizeSequenceHighlights()`.
  */
 export const DEFAULT_SEQUENCE_HIGHLIGHT_NAME_PREFIX = 'Region';
 
-/** Legacy default name format we used to emit before Phase 39 W4. */
+/** Legacy default name format emitted by older snapshots. */
 const LEGACY_HIGHLIGHT_DEFAULT_NAME_PATTERN = /^Highlight (\d+)$/;
 
 export function makeSequenceHighlight(
@@ -205,8 +200,10 @@ export function makeSequenceHighlight(
   color: string,
   ordinal: number,
 ): SequenceHighlight {
-  const start = Math.max(0, Math.min(range.start, range.end));
-  const end = Math.max(start + 1, Math.max(range.start, range.end));
+  const rawStart = Number.isFinite(range.start) ? Math.floor(range.start) : 0;
+  const rawEnd = Number.isFinite(range.end) ? Math.floor(range.end) : rawStart;
+  const start = Math.max(0, Math.min(rawStart, rawEnd));
+  const end = Math.max(start + 1, Math.max(rawStart, rawEnd));
   const randomId = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
     ? crypto.randomUUID()
     : `highlight-${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -253,7 +250,7 @@ export function normalizeSequenceHighlights(value: unknown): SequenceHighlight[]
       const start = Math.max(0, Math.floor(Number(record.start)));
       const end = Math.max(start, Math.floor(Number(record.end)));
       if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return null;
-      // Phase 39 W4 (D8 P0-3) backfill: legacy `Highlight N` → `Region N`.
+      // Backfill the legacy `Highlight N` form to `Region N`.
       const rawName = typeof record.name === 'string' && record.name
         ? record.name
         : `${DEFAULT_SEQUENCE_HIGHLIGHT_NAME_PREFIX} ${index + 1}`;
@@ -279,6 +276,9 @@ export function shiftSequenceHighlightsForRange(
   start: number,
   end: number,
 ): SequenceHighlight[] {
+  if (!Number.isSafeInteger(start) || start < 0 || !Number.isSafeInteger(end) || end < start) {
+    throw new RangeError('highlight range must use non-negative safe integer coordinates.');
+  }
   return highlights
     .filter((highlight) => highlight.start < end && highlight.end > start)
     .map((highlight) => ({
@@ -298,6 +298,12 @@ export function shiftSequenceHighlightsForInsertion(
   editPos: number,
   delta: number,
 ): SequenceHighlight[] {
+  if (!Number.isSafeInteger(editPos) || editPos < 0) {
+    throw new RangeError('editPos must be a non-negative safe integer.');
+  }
+  if (!Number.isSafeInteger(delta)) {
+    throw new RangeError('delta must be a safe integer.');
+  }
   if (delta <= 0) return cloneSequenceHighlights(highlights);
   return highlights.map((highlight) => ({
     ...highlight,
@@ -312,6 +318,15 @@ export function shiftSequenceHighlightsForDeletion(
   count: number,
   rawLength: number,
 ): SequenceHighlight[] {
+  if (!Number.isSafeInteger(pos) || pos < 0) {
+    throw new RangeError('pos must be a non-negative safe integer.');
+  }
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new RangeError('count must be a non-negative safe integer.');
+  }
+  if (!Number.isSafeInteger(rawLength) || rawLength < 0) {
+    throw new RangeError('rawLength must be a non-negative safe integer.');
+  }
   if (count <= 0 || pos < 0 || pos >= rawLength) return cloneSequenceHighlights(highlights);
   const effectiveCount = Math.min(count, rawLength - pos);
   const endOfDeletion = pos + effectiveCount;

--- a/src/bio/sequence-variants.ts
+++ b/src/bio/sequence-variants.ts
@@ -33,6 +33,10 @@ function finiteNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
+function safeCoordinate(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) ? value : null;
+}
+
 function stringValue(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
@@ -45,9 +49,12 @@ export function normalizeSequenceVariant(value: unknown): SequenceVariant | null
   const record = asRecord(value);
   if (!record) return null;
   const id = stringValue(record.id);
-  const start = finiteNumber(record.start ?? record.position);
-  if (!id || start === null) return null;
-  const end = finiteNumber(record.end);
+  const start = safeCoordinate(record.start ?? record.position);
+  if (!id || start === null || start < 0) return null;
+  const end = record.end === undefined || record.end === null
+    ? null
+    : safeCoordinate(record.end);
+  if (record.end !== undefined && record.end !== null && (end === null || end < start)) return null;
   const rawKind = record.kind ?? record.type;
   const kind = isSequenceVariantKind(rawKind) ? rawKind : 'other';
   const confidence = finiteNumber(record.confidence);
@@ -55,8 +62,8 @@ export function normalizeSequenceVariant(value: unknown): SequenceVariant | null
   const updatedAt = finiteNumber(record.updatedAt);
   return {
     id,
-    start: Math.floor(start),
-    ...(end === null ? {} : { end: Math.floor(end) }),
+    start,
+    ...(end === null ? {} : { end }),
     kind,
     ...(stringValue(record.label) ? { label: stringValue(record.label) } : {}),
     ...(stringValue(record.reference ?? record.ref) ? { reference: stringValue(record.reference ?? record.ref) } : {}),
@@ -99,6 +106,12 @@ export function shiftSequenceVariants(
   pos: number,
   delta: number,
 ): SequenceVariant[] {
+  if (!Number.isSafeInteger(pos) || pos < 0) {
+    throw new RangeError('pos must be a non-negative safe integer.');
+  }
+  if (!Number.isSafeInteger(delta)) {
+    throw new RangeError('delta must be a safe integer.');
+  }
   if (delta === 0 || variants.length === 0) return variants.map((variant) => ({ ...variant }));
   if (delta > 0) {
     return variants.map((variant) => ({

--- a/src/bio/tm-calculator.ts
+++ b/src/bio/tm-calculator.ts
@@ -165,6 +165,9 @@ export function duplexThermodynamics(seq: string): {
   if (!isCanonicalDna(upper)) {
     throw new Error('Nearest-neighbor thermodynamics requires an unambiguous A/C/G/T sequence.');
   }
+  if (upper.length < 2) {
+    throw new Error('Nearest-neighbor thermodynamics requires at least two canonical bases.');
+  }
 
   // Initiation: 2 terminal base-pairs
   // dH in kcal/mol → convert to cal/mol for consistency
@@ -279,7 +282,7 @@ function owczarzyMg(
  *
  * naConc in mM. Returns corrected Tm in °C.
  *
- * (R10 #5: the previous implementation applied the entropy coefficient 0.368
+ * The previous implementation applied the entropy coefficient 0.368
  * — units cal/mol·K — straight to 1/Tm with `1/seqLength` standing in for the
  * proper (N−1)/ΔH, an ~345× units error that returned sub-absolute-zero Tm
  * (≈ −254 °C) for any [Na+] below 1 M, non-monotonically. The only test
@@ -435,7 +438,7 @@ export function calculateTm(seq: string, options?: TmOptions): TmResult {
 
   // Wallace rule — always used for very short oligos (< 14 nt).
   //
-  // Phase 35 P-I (P1-A13): the Owczarzy / SantaLucia / Wetmur salt-correction
+  // The Owczarzy / SantaLucia / Wetmur salt-correction
   // formulas are derived for oligos ≥ 14 nt. Applying them to a 6-mer produces
   // non-physical Tm values (e.g. negative Tm for `AAAAAA` at default 50mM Na+).
   // Wallace's rule assumes ~1 M Na+ implicitly, so for the short-oligo regime
@@ -500,7 +503,7 @@ export function calculateTm(seq: string, options?: TmOptions): TmResult {
 
   // Apply salt correction. The SantaLucia method needs the duplex ΔH/ΔS (and
   // Ct), which only exist here on the NN path — thread them through so its
-  // entropy-based correction is unit-correct (R10 #5).
+  // entropy-based correction is unit-correct.
   let correctedTm = tmC;
   if (naConc !== 1000 || freeMg > 0) {
     correctedTm = saltCorrectedTm(tmK, naConc, freeMg, fGC, upper.length, saltCorrMethod, {

--- a/src/bio/types.ts
+++ b/src/bio/types.ts
@@ -117,7 +117,7 @@ export interface RestrictionSite {
    * reverse-complement of the recognition sequence appears at this `position`
    * on the forward strand. This is critical for Type IIS enzymes
    * (BsaI/BbsI/BsmBI/SapI etc.) which are non-palindromic.
-   * Phase 34 P-B B1: added when JS scanner was extended to match Rust parity.
+   * Added when the scanner was extended to report the matching strand.
    */
   strand?: 1 | -1;
 }
@@ -232,7 +232,7 @@ export interface FastaRecord {
    */
   rawHeader?: string;
   /**
-   * Phase 35 P-I (P2-A22): when an aligned input contained `-` / `.` gap
+   * When an aligned input contains `-` / `.` gap
    * characters, the parser silently degaps but reports the count here so a
    * caller can disclose the transformation. Only present when gaps existed.
    */
@@ -269,7 +269,7 @@ export const BASE_COLORS_DARK: Record<string, string> = {
 
 /** DNA/RNA base colors for light backgrounds — WCAG AA ≥4.5:1.
  *
- * VOG-1991: the previous values (#198841/#ed0c0c/#8f7303/#0870f2) passed on
+ * The previous values (#198841/#ed0c0c/#8f7303/#0870f2) passed on
  * pure white at ~4.51-4.56:1 but composited at only ~4.18-4.22:1 against the
  * `--bg-secondary: #f5f5f5` workspace card surface — under the 4.5 normal-text
  * floor on every base. Darkened lightness only (Wong 2011 hue preserved) so

--- a/src/components/plasmid-map/__tests__/background-affordance.test.tsx
+++ b/src/components/plasmid-map/__tests__/background-affordance.test.tsx
@@ -143,8 +143,8 @@ describe('the map background claims only the gestures it can perform', () => {
   });
 
   it('still keeps touch drags from being stolen by page scroll', () => {
-    // The one genuinely functional property in the old data-pannable block; it now
-    // applies always, not just once the viewport happens to be transformed.
+    // This functional property applies in every state, not just after the
+    // viewport happens to be transformed.
     const bgRule = mapCss.slice(
       mapCss.indexOf('.motif-pm-bg {'),
       mapCss.indexOf('}', mapCss.indexOf('.motif-pm-bg {')),

--- a/src/components/plasmid-map/plasmid-map.css
+++ b/src/components/plasmid-map/plasmid-map.css
@@ -643,7 +643,7 @@
   fill: var(--text-primary, #131313);
   font-family: var(--font-ui, var(--font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif));
   font-size: 11px;
-  /* Clickable so the readable name (incl. Wave-B outside-leader labels sitting
+  /* Clickable so the readable name (including outside-leader labels sitting
      away from the arc) selects its feature via the group handler, instead of
      falling through to the background and CLEARING the selection. */
   pointer-events: auto;

--- a/src/components/sequence-stack/feature-display-colors.ts
+++ b/src/components/sequence-stack/feature-display-colors.ts
@@ -6,7 +6,7 @@ import { getCssVar, getFeatureColorToken } from '../../lib/css-tokens';
  * Dark palette: bright colors for dark backgrounds.
  * Light palette: darkened equivalents that pass WCAG AA as small text on light sequence panels.
  *
- * Phase 32 P0-6: these constants stay as the canonical TS-side source of truth
+ * These constants stay as the canonical TS-side source of truth
  * (consumed directly by importers and tests), but `featureTypeDisplayColor()`
  * now prefers the live CSS token (`--feature-{type}`) when one is defined so
  * HC + theme switches reach the renderers. The constants serve as the SSR /
@@ -170,7 +170,7 @@ export function featureTypeDisplayColor(type: FeatureType, theme: ThemeName): st
     theme === 'light'
       ? (GENBANK_FEATURE_COLORS_LIGHT[type] ?? GENBANK_FEATURE_COLORS_LIGHT.custom)
       : (GENBANK_FEATURE_COLORS[type] ?? GENBANK_FEATURE_COLORS.custom);
-  // Phase 32 P0-6: prefer the live CSS token so HC + theme switches reach
+  // Prefer the live CSS token so high-contrast and theme switches reach
   // every renderer that lands here (FeatureAnnotationTrack, FeatureSelector,
   // DetailSequenceDisplay). Hex constants above remain the SSR fallback.
   return getFeatureColorToken(type, fallback);

--- a/src/lib/css-tokens.ts
+++ b/src/lib/css-tokens.ts
@@ -1,5 +1,5 @@
 /**
- * Phase 32 — JS ↔ CSS token bridge
+ * JS ↔ CSS token bridge
  *
  * Read CSS custom properties from `:root` at runtime so theme/HC switches
  * propagate to renderers that previously hardcoded color literals. Falls back
@@ -15,7 +15,7 @@ function readToken(name: string, fallback: string): string {
   const value = getComputedStyle(document.documentElement)
     .getPropertyValue(name)
     .trim();
-  // Phase 38 W1 defensive guard: a CSS variable resolved to `transparent` or
+  // A CSS variable resolved to `transparent` or
   // `rgba(0, 0, 0, 0)` makes any character it colors invisible. That was the
   // exact bug shape for `--aa-class-stop` in the compact renderers — the token
   // was intentionally `transparent` for DetailSequenceDisplay's anchor-only
@@ -31,7 +31,7 @@ function readToken(name: string, fallback: string): string {
 }
 
 /**
- * Phase 38 Tier 5 (Pass 4 F1 fix): build a `var(--name, fallback)` CSS value
+ * Build a `var(--name, fallback)` CSS value
  * string that the browser resolves on every paint. Using this instead of
  * `readToken()` for inline `style={{ color }}` makes theme/HC switches
  * propagate to already-mounted spans without re-rendering. The earlier
@@ -51,7 +51,7 @@ function readTokenAsCssVar(name: string, fallback: string): string {
   // `readToken()`. If the live token is `transparent`, return the static
   // fallback (the caller's per-theme palette) instead of routing through
   // `var(...)` — otherwise the browser would paint the invisible token
-  // every repaint and the W1 fix would regress.
+  // every repaint and the transparency guard would regress.
   const probe = getComputedStyle(document.documentElement)
     .getPropertyValue(name)
     .trim();
@@ -100,13 +100,13 @@ export function getAAColorToken(aa: string, fallback = '#9ca3af'): string {
 }
 
 /**
- * Phase 38 Tier 5 (Pass 4 F1 fix): return a CSS-var reference string for
+ * Return a CSS-var reference string for
  * an AA letter so the browser repaints on theme switch. The returned form
  * is one of `var(--aa-class-stop, fallback)`, `var(--aa-class-polar, fallback)`,
  * etc. — one of the five token names defined per-theme in `src/index.css`.
  *
- * Bug shape: Pass 4 measured the stop-codon asterisk dropping to 2.54:1 on
- * dark bg after a live `light to dark` toggle. The colorMap useMemo had
+ * A contrast check found the stop-codon asterisk dropping to 2.54:1 on dark
+ * background after a live `light to dark` toggle. The colorMap useMemo had
  * `effectiveTheme` as a dep and DID recompute, but `getAAColorToken`
  * resolved values via `getComputedStyle` at render time. React renders the
  * new memo BEFORE ThemeProvider's `useEffect` fires the `data-theme=dark`
@@ -125,16 +125,16 @@ export function getAAColorVar(aa: string, fallback = '#9ca3af'): string {
  * `AA_COLORS_LIGHT` from `bio/types.ts`. Pass the per-theme fallback palette
  * to preserve SSR/jsdom behavior when the CSS variable is unavailable.
  *
- * Phase 32 P0-1: bridges the compact renderers (SequenceDisplay,
+ * Bridges the compact renderers (SequenceDisplay,
  * CanvasSequenceDisplay, MSAPanel, ProteinAnalysisPanel) to the same token
  * layer the detail renderer reads via `data-aa-class`. Without this, HC
- * mode skipped the compact AA palette — same bug shape as the Phase 28.5
- * workbar regression.
+ * mode skipped the compact AA palette — the same failure mode as an earlier
+ * high-contrast workbar regression.
  *
- * Phase 38 Tier 5: now returns CSS-var reference strings (one of the five
+ * Returns CSS-var reference strings (one of the five
  * `--aa-class-*` names) for DOM consumers (SequenceDisplay,
  * LineSequenceDisplay) so theme toggles propagate to already-mounted
- * spans (Pass 4 F1 fix). Canvas-only consumers should call
+ * spans. Canvas-only consumers should call
  * `resolveAaPaletteLiteral()` for hex strings.
  */
 export function resolveAaPalette(
@@ -148,12 +148,12 @@ export function resolveAaPalette(
 }
 
 /**
- * Phase 38 Tier 5: Canvas-only variant of `resolveAaPalette()`. Returns a
+ * Canvas-only variant of `resolveAaPalette()`. Returns a
  * literal hex color per AA (resolved via `getComputedStyle`), suitable for
  * Canvas `fillStyle` which cannot interpret `var(...)`. Loses live theme
  * propagation in exchange — Canvas re-renders are gated by the `colorMap`
  * useMemo, which already re-runs on theme change, so Canvas was never the
- * surface that exhibited the F1 bug.
+ * surface that exhibited the live-theme timing bug.
  */
 export function resolveAaPaletteLiteral(
   fallback: Record<string, string>,

--- a/src/mcp-app/__tests__/motif-connector.test.ts
+++ b/src/mcp-app/__tests__/motif-connector.test.ts
@@ -317,6 +317,18 @@ describe('Motif MCP payload boundary', () => {
     expect(() => validateMotifPayload({
       records: [{ molecule: 'dna', sequence: 'AT-GC', features: [{ start: 0, end: 99 }] }],
     })).toThrow(/invalid character "-" at offset 2/i);
+    expect(() => validateMotifPayload({
+      records: [{ molecule: 'dna', sequence: 'ATGC', features: [{ start: 0.5, end: 2 }] }],
+    })).toThrow(/integer start and end coordinates/i);
+    expect(() => validateMotifPayload({
+      records: [{ molecule: 'dna', sequence: 'ATGC', features: [{ start: 0, end: 2, subRanges: [{ start: 1, end: 2.5 }] }] }],
+    })).toThrow(/integer start and end coordinates/i);
+    expect(() => validateMotifPayload({
+      records: [{ molecule: 'dna', sequence: 'ATGC', sites: [{ enzyme: 'EcoRI', hits: [{ position: 1.5 }] }] }],
+    })).toThrow(/position must be a non-negative safe integer/i);
+    expect(() => validateMotifPayload({
+      records: [{ molecule: 'dna', sequence: 'ATGC', sites: [{ enzyme: 'EcoRI', hits: [{ position: 1, cutPosition: 2.5 }] }] }],
+    })).toThrow(/cutPosition must be a non-negative safe integer/i);
   });
 
   it('matches browser record validation for nested metadata and DNA end chemistry', () => {

--- a/src/plasmid-map/__tests__/layout.test.ts
+++ b/src/plasmid-map/__tests__/layout.test.ts
@@ -1025,67 +1025,15 @@ describe('computeMapLayout: circular pUC19', () => {
   });
 
   it('keeps the circular pUC19 layout byte-stable', () => {
-    // P2 changed this pin (centerTitle + fitted-title keep-out). WaveC-c1 changed it
-    // again: circular restriction renders now carry additive per-enzyme labelSegments
-    // for Type IIS per-token coloring (label.text itself is unchanged).
-    // W3 text polish re-pinned it for circular-only nested outside labels and
-    // signed readable inline rotations; circular geometry is unchanged.
-    // Rebaselined after feature/restriction labels stopped treating the circle's
-    // enclosing square as an obstacle and now test against actual ring geometry.
-    // Rebaselined after inline labels gained a middle dominant-baseline so text sits
-    // centered inside the feature band instead of riding the glyph edge.
-    // Rebaselined after circular outside labels became individual, capped,
-    // direct-leader radial-tier placements with feature labels winning over enzymes.
-    // Rebaselined after coordinate labels started yielding to feature leaders.
-    // Rebaselined after side outside labels centered on radial leaders, coordinate
-    // labels rotated tangentially, and thin bands stopped accepting inline labels.
-    // Rebaselined after circular outside-label leaders stopped before padded label boxes.
-    // Rebaselined after inline (on-arc) feature labels gained an additive `arcPath`
-    // (baseline arc for <textPath> rendering); x/y/rotate/geometry are unchanged —
-    // verified by hashing the arcPath-stripped layout back to the prior pin.
+    // This byte-stable circular baseline covers Type IIS per-enzyme label
+    // segments, nested outside labels, radial leaders, feature-label priority,
+    // and coordinate-label keep-out. The expected output intentionally stays
+    // fixed while those geometry contracts evolve.
     // Direct leaders remain the default when their chord is unobstructed; the
     // radial-first elbow is reserved for a real collision escape. Label positions
     // and the represented label set remain fixed.
-    // Rebaselined after a crowded label began preferring an outward tier over a
-    // tangential slide (TIER_ESCALATION_ANGLE_EQUIV_DEG 4 -> 1.5). Verified to be
-    // the minimal consequence of that change: the label SET, every label's text
-    // and the viewBox are byte-identical to the previous pin, and exactly one
-    // label moved — "EcoRI,SacI,KpnI +2" from 524,123 to 544,117, i.e. one tier
-    // out rather than sideways. Leader straightness itself is pinned by
-    // 'keeps circular restriction leaders pointing at their own tick' below.
-    // Rebaselined again for the ", " name separator (and the width cap raised to keep
-    // the same enzyme content fitting). Verified minimal: exactly one label changed —
-    // "EcoRI,SacI,KpnI +2" -> "EcoRI, SacI, KpnI +2", which recentres it from 544,117
-    // to 548,114. No label gained, lost, or shed a name; feature labels and the viewBox
-    // are byte-identical.
-    // Rebaselined for the cluster tooltip naming its enzyme count alongside its site
-    // count, so the drawn label's "+N" (enzyme NAMES) stops reading as a contradiction
-    // of the tooltip's "N sites". NOTHING DRAWN MOVED: hashing this layout with
-    // restrictions[].title stripped gives d304bb878f6a569d82df3f30aa4fc0ea457543c5f96
-    // ef7ed9286292111e2777f both before and after, so geometry, the label set and every
-    // label's text are byte-identical. The only delta is one tooltip string,
-    // "EcoRI, SacI, KpnI, BamHI, HindIII · 5 sites" -> "... · 5 enzymes · 5 sites".
-    // Rebaselined for the additive overflow-chip hit rect. NOTHING DRAWN MOVED:
-    // hashing this layout with overflows[].hit stripped gives
-    // 35262ad877aa6404ff777c734b5b9bb42d1416c886b3d63e36265a09290078a6, i.e. the
-    // previous pin exactly, so geometry, the label set, every label's text and the
-    // viewBox are byte-identical. The only delta is the new pointer target, which the
-    // renderer draws and the SVG export ignores.
-    // Rebaselined again for the additive overflow `count`, which lets the map dock
-    // state the chip's number to a keyboard user without re-deriving it from the
-    // chip's display text. NOTHING DRAWN MOVED: hashing this layout with
-    // overflows[].count stripped gives
-    // 59f8c609fd6b0f01efd27b54882b97c15d04bac12efc7b72f8a8d6f4e3a77ec3, the previous
-    // pin exactly.
-    // Rebaselined once more for splitting that `count` into overflows[].hiddenBodies
-    // + overflows[].unlabelled, because one integer holding "bodies not drawn plus
-    // labels not drawn" is a quantity no reader can state truthfully. NOTHING DRAWN
-    // MOVED: hashing this layout with all three of count/hiddenBodies/unlabelled
-    // stripped gives 59f8c609fd6b0f01efd27b54882b97c15d04bac12efc7b72f8a8d6f4e3a77ec3
-    // both before and after — the same digest recorded above — and a line diff of the
-    // two full layouts is exactly `"count": 1` -> `"hiddenBodies": 0, "unlabelled": 1`
-    // on the single overflow entry, with every path, label, tick and the viewBox
-    // byte-identical.
+    // Tooltip text, overflow metadata, and hit rectangles are not part of the
+    // geometric hash; their contracts are asserted separately where needed.
     expect(layoutHash(layout)).toBe(
       '36be85f8350cb3a6108bd002c490af9ad1b04a34bb93ec15a8bbbbb27661d09c',
     );
@@ -1259,11 +1207,9 @@ describe('computeMapLayout: circular pUC19', () => {
     expect(visibleFeatureLabels).toBe(22);
     expect(featureOverflow(layout)).toBeNull();
     expect(visibleRestrictionLabels).toBeLessThanOrEqual(visibleFeatureLabels);
-    // Rebaselined for round-4 center-of-mass labels: side outside labels are now
-    // text-anchor:middle and straddle their leader endpoint, so they extend ~half a
-    // label-width further out than the old edge-anchored labels and the ring yields a
-    // few percent of radius to keep every label clear. Still a large, comfortable ring
-    // (visually verified on dense docks); all 22 feature labels stay visible (above).
+    // Centered side labels straddle their leader endpoint and therefore extend
+    // about half a label width beyond it. The ring yields a small radius margin
+    // so all 22 feature labels remain visible.
     expect(layout.radius / viewBoxHalfExtent).toBeGreaterThanOrEqual(0.54);
   });
 
@@ -1315,11 +1261,9 @@ describe('computeMapLayout: circular pUC19', () => {
     ).length;
 
     expect(labels.length).toBeGreaterThanOrEqual(18);
-    // Rebaselined for round-4 center-of-mass labels: a side outside label's leader now
-    // ends at the label's horizontal center (not its ring-side edge), so a few leaders run
-    // marginally longer / less strictly radial and fall just outside the "short near-radial"
-    // window. 86%+ still sit in-arc or on short radial leaders; the rest read clean (visually
-    // verified on dense docks — no long angled spokes).
+    // Side-label leaders end at the label's horizontal center, so a few run
+    // marginally longer or less strictly radial. At least 85% remain in-arc or
+    // on short radial leaders; the remaining labels avoid long angled spokes.
     expect((inArc + radialOutside) / labels.length).toBeGreaterThanOrEqual(0.85);
   });
 
@@ -2114,17 +2058,9 @@ describe('computeMapLayout: linear + protein', () => {
       height: 420,
     });
 
-    // Rebaselined after linear labels gained middle baselines and the dock-fill path
-    // stopped baking vertical centering into content coordinates.
-    // Rebaselined after beside-glyph labels used 4px clearance and stopped forcing
-    // decorative leaders for adjacent labels.
-    // Rebaselined after outside feature labels clear the arrowhead TIP (edgeX pushed
-    // to the visual tip on the pointing side), not just the flat body edge.
-    // Rebaselined after MapLayout gained explicit linearAxis geometry.
-    // Rebaselined after inline labels centered on rendered arrow glyphs and
-    // linear restriction labels used center-entering callout leaders.
-    // Rebaselined after linear feature bars adopted the artifact's square-ended
-    // feature treatment.
+    // This baseline covers middle baselines, four-pixel beside-glyph clearance,
+    // arrowhead-tip clearance, explicit linear-axis geometry, center-entering
+    // restriction leaders, and square-ended feature bars.
     expect(layoutHash(layout)).toBe(
       '52c8c1aff95c22cace479fb781b544371c6e54ff277bedce586d95ba4dc5ab90',
     );

--- a/src/plasmid-map/__tests__/render-mode-independence.test.ts
+++ b/src/plasmid-map/__tests__/render-mode-independence.test.ts
@@ -5,7 +5,7 @@ import type { Feature } from '../../bio/types';
 import { normalizeSpan } from '../geometry/ranges';
 
 /**
- * #34. The map can draw a circular molecule as a line WITHOUT converting it.
+ * The map can draw a circular molecule as a line WITHOUT converting it.
  *
  * `computeMapLayout` has always taken `mode` as a first-class input and
  * consulted `topology` only as a fallback, so the capability was built and

--- a/src/plasmid-map/__tests__/w1-correctness.test.ts
+++ b/src/plasmid-map/__tests__/w1-correctness.test.ts
@@ -1,5 +1,5 @@
 /**
- * W1 correctness hardening — pure-layout guards.
+ * Pure-layout robustness guards.
  * (1) Non-finite length/width/height never produce a NaN viewBox (which would blank
  *     the whole SVG). (2) Restriction clustering is fully deterministic (order-
  *     independent) after the cutPosition/strand tie-breakers.

--- a/src/plasmid-map/__tests__/w2-lane-sizing.test.ts
+++ b/src/plasmid-map/__tests__/w2-lane-sizing.test.ts
@@ -1,5 +1,5 @@
 /**
- * W2 — adaptive circular lane sizing (fitLaneStack + laneBand). Proves the
+ * Adaptive circular lane sizing (fitLaneStack + laneBand). Proves the
  * lane-collapse bug is gone: deep overlapping lanes get DISTINCT descending radii
  * instead of clamping onto a shared floor, thickness/gap compress before any lane
  * is dropped, and genuine overflow is arc-less + counted (never silently overdrawn).

--- a/src/plasmid-map/geometry/__tests__/radial-labels.test.ts
+++ b/src/plasmid-map/geometry/__tests__/radial-labels.test.ts
@@ -258,7 +258,8 @@ describe('layoutRadialTierLabels', () => {
     // packer now prefers spots that keep a readable horizontal gap between same-row
     // neighbors, so a label may be nudged off its true angle by up to the angular-shift
     // budget (default max(DEFAULT_ANGLE_STEP_DEG=1.5, angularThresholdDeg/2)) rather than
-    // sitting at the exact tick angle. Previously this asserted zero drift (< 1e-6).
+    // sitting at the exact tick angle; the layout intentionally permits the
+    // bounded angular shift above to maintain readable row spacing.
     const maxAngleShiftDeg = Math.max(1.5, opts.angularThresholdDeg / 2);
     for (const source of candidates) {
       const out = placed.find((item) => item.id === source.id);

--- a/src/plasmid-map/layout.ts
+++ b/src/plasmid-map/layout.ts
@@ -107,7 +107,7 @@ const TARGET_COORD_TICKS = 8; // aim for ~6-10 nice coordinate ticks
 const REC_CLUSTER_MIN_SEP_DEG = 6; // circular restriction clustering threshold
 const REC_CLUSTER_MAX_SPAN_BP = 128; // prevents transitive all-enzyme mega-clusters
 const REC_MAX_NAMES = 3; // enzyme names shown before "+N"
-// Adaptive lane compression (W2): when overlapping features stack into many lanes,
+// Adaptive lane compression: when overlapping features stack into many lanes,
 // thickness + gap shrink toward these floors so deep lanes keep DISTINCT descending
 // radii instead of collapsing onto a shared minimum; only when even the floor stack
 // overflows the radial depth do the deepest lanes drop to overflow (arc-less, still
@@ -462,7 +462,7 @@ function computeCircularLayout(input: MapInput): MapLayout {
   const coordLabelInset = coordBand / 2; // center the number in the band (clears ring + lanes)
   const coordTickLenR = Math.min(COORD_TICK_LEN, coordBand * 0.4);
 
-  // Adaptive lane geometry (W2): compress thickness/gap to fit the radial depth
+  // Adaptive lane geometry: compress thickness/gap to fit the radial depth
   // BEFORE dropping any lane, so deep lanes get DISTINCT descending radii instead
   // of collapsing onto a shared floor (the old laneOuterR clamp bug). laneBand(lane)
   // returns null for overflow lanes beyond what the floor stack fits.


### PR DESCRIPTION
## Summary

- Reject non-restorable checkpoint states and sparse or invalid payload structures.
- Align coordinate, path, provenance, and export-loss validation.
- Harden supporting sequence helpers, SBOM generation, and bounded dependency metadata checks.

## Validation

- `npm run gate` — 1,440 unit tests, 166 core browser workflows, and 59 MSA workflows.
- `npm run validate:plugin`
- `npm audit` — 0 vulnerabilities.
- Repository-language and full-history secret scans.
- Headed wide/narrow Light/Dark workflow acceptance.