### PR TITLE
Align Codex MCP manifest with plugin ingestion

### DIFF
--- a/docs/openai-submission.json
+++ b/docs/openai-submission.json
@@ -100,7 +100,7 @@
     "support_url": "https://github.com/jvogan/motif/issues",
     "privacy_url": "https://github.com/jvogan/motif/blob/main/PRIVACY.md",
     "terms_url": "https://github.com/jvogan/motif/blob/main/TERMS.md",
-    "category": "Scientific Research",
+    "category": "Education & Research",
     "type": "With MCP",
     "availability": "All portal-supported countries and regions",
     "description": "Open supplied FASTA, GenBank, raw DNA, RNA, protein, or Motif JSON in an interactive molecular-biology workbench. Inspect exact records and supported annotations together, or return a self-contained HTML workbench when embedded UI is unavailable. Motif does not retrieve missing records, compute alignments, validate experiments, write files, or modify remote systems."

--- a/package-lock.json
+++ b/package-lock.json
@@ -3227,9 +3227,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",

--- a/scripts/__tests__/motif-codex-marketplace.test.mjs
+++ b/scripts/__tests__/motif-codex-marketplace.test.mjs
@@ -47,7 +47,7 @@ describe('Motif private Codex marketplace', () => {
             installation: 'AVAILABLE',
             authentication: 'ON_INSTALL',
           },
-          category: 'Science',
+          category: 'Education & Research',
         },
       ],
     });

--- a/scripts/__tests__/motif-codex-plugin-doctor.test.mjs
+++ b/scripts/__tests__/motif-codex-plugin-doctor.test.mjs
@@ -35,7 +35,9 @@ function createFixture(options = {}) {
     skills: './skills/',
   }));
   writeFileSync(join(root, '.mcp.json'), JSON.stringify({
-    motif: { command: 'node', args: ['${PLUGIN_ROOT}/server/motif-mcp-server.mjs'] },
+    mcpServers: {
+      motif: { command: 'node', args: ['${PLUGIN_ROOT}/server/motif-mcp-server.mjs'] },
+    },
   }));
   writeFileSync(join(root, 'package.json'), JSON.stringify({
     name: 'motif-for-claude-science',

--- a/scripts/build-motif-codex-marketplace.mjs
+++ b/scripts/build-motif-codex-marketplace.mjs
@@ -31,7 +31,7 @@ export function motifCodexMarketplaceManifest() {
           installation: 'AVAILABLE',
           authentication: 'ON_INSTALL',
         },
-        category: 'Science',
+        category: 'Education & Research',
       },
     ],
   };

--- a/scripts/build-motif-codex-plugin.mjs
+++ b/scripts/build-motif-codex-plugin.mjs
@@ -114,7 +114,7 @@ function validatePluginSource({ rootDirectory = root, sourcePath = sourceDirecto
   }
 
   const mcpManifest = JSON.parse(readFileSync(join(sourcePath, '.mcp.json'), 'utf8'));
-  const args = mcpManifest?.motif?.args;
+  const args = mcpManifest?.mcpServers?.motif?.args;
   if (!Array.isArray(args) || args[0] !== '${PLUGIN_ROOT}/server/motif-mcp-server.mjs') {
     throw new Error('Codex MCP manifest must launch the bundled server from PLUGIN_ROOT.');
   }

--- a/scripts/doctor-motif-codex-plugin.mjs
+++ b/scripts/doctor-motif-codex-plugin.mjs
@@ -271,7 +271,8 @@ export async function inspectStagedPlugin(pluginRootInput) {
     }
   }
 
-  const server = mcpManifest.motif;
+  assertPlainObject(mcpManifest.mcpServers, 'Codex MCP server map');
+  const server = mcpManifest.mcpServers.motif;
   assertPlainObject(server, 'Codex MCP server entry');
   if (server.command !== 'node') {
     throw new Error('Codex MCP server command must be "node"; reinstall or rebuild the plugin.');

--- a/scripts/test-motif-codex-plugin-packaging.mjs
+++ b/scripts/test-motif-codex-plugin-packaging.mjs
@@ -95,7 +95,7 @@ function expandPluginRoot(value) {
 }
 
 async function verifyStagedMcp(mcpManifest) {
-  const server = mcpManifest.motif;
+  const server = mcpManifest.mcpServers?.motif;
   assert.equal(typeof server?.command, 'string', 'staged MCP server command is missing');
   assert.equal(Array.isArray(server?.args), true, 'staged MCP server args are missing');
   const command = expandPluginRoot(server.command);
@@ -229,12 +229,13 @@ try {
   assert.equal(basename(outputDirectory), manifest.name);
   assert.equal(
     Object.hasOwn(mcpManifest, 'mcpServers'),
-    false,
-    'Codex .mcp.json must use its documented direct server map, not the legacy camelCase wrapper.',
+    true,
+    'Codex .mcp.json must expose its server map under mcpServers.',
   );
-  assert.equal(mcpManifest.motif.command, 'node');
+  assert.deepEqual(Object.keys(mcpManifest), ['mcpServers']);
+  assert.equal(mcpManifest.mcpServers.motif.command, 'node');
   assert.equal(
-    mcpManifest.motif.args[0],
+    mcpManifest.mcpServers.motif.args[0],
     '${PLUGIN_ROOT}/server/motif-mcp-server.mjs',
   );
   assert.equal(checksums.schema, 'motif.codex-plugin-checksums.v1');

--- a/scripts/test-motif-codex-plugin-packaging.mjs
+++ b/scripts/test-motif-codex-plugin-packaging.mjs
@@ -206,6 +206,7 @@ try {
   assert.doesNotMatch(manifest.interface.longDescription, /FASTA alignment|GenBank summary|sequence inspection/u);
   assert.equal(manifest.interface.displayName, 'Motif');
   assert.equal(manifest.interface.shortDescription, 'Explore biological sequences');
+  assert.equal(manifest.interface.category, 'Education & Research');
   assert.ok(manifest.interface.shortDescription.length <= 30);
   assert.equal(manifest.interface.privacyPolicyURL, 'https://github.com/jvogan/motif/blob/main/PRIVACY.md');
   assert.equal(manifest.interface.termsOfServiceURL, 'https://github.com/jvogan/motif/blob/main/TERMS.md');

--- a/scripts/validate-openai-submission.mjs
+++ b/scripts/validate-openai-submission.mjs
@@ -96,6 +96,12 @@ assert.ok(listing.description.length > 0 && listing.description.length <= 4_000,
 assert.ok(listing.publisher.length <= 80, 'publisher must fit the 80-character directory field');
 assert.equal(listing.subtitle, manifest.interface.shortDescription, 'portal subtitle must match the plugin manifest');
 assert.equal(listing.description, manifest.interface.longDescription, 'portal description must match the plugin manifest');
+assert.equal(listing.category, manifest.interface.category, 'portal category must match the plugin manifest');
+assert.equal(
+  listing.category,
+  'Education & Research',
+  'portal category must use the current supported directory value',
+);
 
 assert.equal(submission.starter_prompts.length, 3, 'the portal draft must contain three starter prompts');
 assert.deepEqual(

--- a/src/artifacts/motif-for-codex-plugin/motif-for-claude-science/.codex-plugin/plugin.json
+++ b/src/artifacts/motif-for-codex-plugin/motif-for-claude-science/.codex-plugin/plugin.json
@@ -22,7 +22,7 @@
     "shortDescription": "Explore biological sequences",
     "longDescription": "Open supplied FASTA, GenBank, raw DNA, RNA, protein, or Motif JSON in an interactive molecular-biology workbench. Inspect exact records and supported annotations together, or return a self-contained HTML workbench when embedded UI is unavailable. Motif does not retrieve missing records, compute alignments, validate experiments, write files, or modify remote systems.",
     "developerName": "Jacob Vogan",
-    "category": "Science",
+    "category": "Education & Research",
     "capabilities": [
       "Interactive sequence workbench",
       "Portable HTML sharing",

--- a/src/artifacts/motif-for-codex-plugin/motif-for-claude-science/.mcp.json
+++ b/src/artifacts/motif-for-codex-plugin/motif-for-claude-science/.mcp.json
@@ -1,8 +1,10 @@
 {
-  "motif": {
-    "command": "node",
-    "args": [
-      "${PLUGIN_ROOT}/server/motif-mcp-server.mjs"
-    ]
+  "mcpServers": {
+    "motif": {
+      "command": "node",
+      "args": [
+        "${PLUGIN_ROOT}/server/motif-mcp-server.mjs"
+      ]
+    }
   }
 }

--- a/src/artifacts/motif-for-codex-plugin/motif-for-claude-science/README.md
+++ b/src/artifacts/motif-for-codex-plugin/motif-for-claude-science/README.md
@@ -194,7 +194,6 @@ JSON, ZIP, FASTA, GenBank, CLUSTAL, or CSV files.
   and use exact supported Motif JSON, FASTA, GenBank, or raw sequence. The
   server intentionally does not guess at arbitrary file formats.
 
-The bundled `.mcp.json` uses Codex's documented direct server map. The
-plugin-creator helper validator currently recognizes only a legacy camelCase
-`mcpServers` wrapper for that file, so it will reject this runtime-valid MCP
-shape; the focused packaging test verifies the direct map instead.
+The bundled `.mcp.json` declares its local stdio server under the current
+`mcpServers` envelope. The build, external plugin validator, staged doctor, and
+packaging test all verify that same installation contract.


### PR DESCRIPTION
## Summary
- wrap the bundled local stdio server map under the current `mcpServers` contract
- update the build, doctor, packaging tests, and installation documentation together
- preserve the existing bounded two-tool MCP surface and local-only runtime

## Verification
- focused unit tests: 9/9
- typecheck and scoped lint
- Codex plugin packaging test
- Motif staged and extracted ZIP doctors with real stdio handshake
- current Codex plugin-creator validator
- ZIP integrity test

No hosted service, telemetry, authentication, or remote mutation is introduced.